### PR TITLE
Update CODEOWNERS and SonarQube workflow triggers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # For all repo
-*   @burgan-tech/code-owners
+*   @burgan-tech/code-owners @burgan-tech/vnext-developer

--- a/.github/workflows/check-sonar.yml
+++ b/.github/workflows/check-sonar.yml
@@ -1,9 +1,9 @@
 name: SonarQube
 on:
-  push:
-    branches:
-      - master
-      - 'release-v*'
+  pull_request:
+    branches: [ master, 'release-v*']
+    types: [opened, synchronize, reopened]
+    
 jobs:
   build:
     name: Build and analyze


### PR DESCRIPTION
Added @burgan-tech/vnext-developer to CODEOWNERS for broader code review coverage. Modified the SonarQube workflow to trigger on pull requests to master and release branches instead of direct pushes.

## Summary by Sourcery

Add vnext-developer team to CODEOWNERS and switch SonarQube checks to run on pull requests for master and release branches

CI:
- Change SonarQube workflow trigger to pull_request events (opened, synchronize, reopened) on master and release-v* branches

Chores:
- Include @burgan-tech/vnext-developer in CODEOWNERS for broader code review coverage