### PR TITLE
Add logging and handle duplicate data versions in AdminAppService

### DIFF
--- a/src/BBT.Workflow.Application/Definitions/AdminAppService.cs
+++ b/src/BBT.Workflow.Application/Definitions/AdminAppService.cs
@@ -10,6 +10,7 @@ using BBT.Workflow.Instances;
 using BBT.Workflow.Runtime;
 using BBT.Workflow.Schemas;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Nito.Disposables;
 
@@ -137,7 +138,14 @@ public sealed class AdminAppService(
     {
         var existingInstanceData = instance.FindData(input.Version);
         if (existingInstanceData != null)
-            throw new ConflictException();
+        {
+            Logger.LogWarning("Instance {InstanceKey} already has data version {Version}", instance.Key, input.Version);
+            if (input.Data?.Any() == true)
+            {
+                await HandleAdditionalDataVersionsAsync(input, cancellationToken);
+            }
+            return;
+        }   
 
         var workflow = CreateAndValidateWorkflow(input);
 
@@ -176,6 +184,12 @@ public sealed class AdminAppService(
                                    input.Key,
                                    dataItem.Key
                                );
+
+                if (instance.FindData(dataItem.Version) != null)
+                {
+                    Logger.LogWarning("Instance {InstanceKey} already has data version {Version}", dataItem.Key, dataItem.Version);
+                    continue;
+                }
 
                 instance.AddTags(dataItem.Tags.ToArray());
                 instance.AddDataWithVersion(

--- a/src/BBT.Workflow.Application/Definitions/IAdminAppService.cs
+++ b/src/BBT.Workflow.Application/Definitions/IAdminAppService.cs
@@ -1,4 +1,7 @@
 using BBT.Aether.Application;
+using BBT.Aether.Domain.Entities;
+using BBT.Aether.Validation;
+using BBT.Workflow.ExceptionHandling;
 
 namespace BBT.Workflow.Definitions;
 


### PR DESCRIPTION
Enhanced AdminAppService to log warnings when attempting to add data with an existing version and to handle additional data versions if provided. This improves traceability and prevents exceptions when duplicate data versions are encountered.

## Summary by Sourcery

Add warning logs and graceful handling of duplicate data versions in AdminAppService

Enhancements:
- Log warnings instead of throwing exceptions when an instance already contains the given data version
- Skip duplicate data versions and process additional versions in Publish operations
- Introduce ILogger dependency in AdminAppService and update interface usings for logging and validation support