### PR TITLE
Sprint 17

### DIFF
--- a/src/BBT.Workflow.Application/Definitions/AdminAppService.cs
+++ b/src/BBT.Workflow.Application/Definitions/AdminAppService.cs
@@ -10,6 +10,7 @@ using BBT.Workflow.Instances;
 using BBT.Workflow.Runtime;
 using BBT.Workflow.Schemas;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Nito.Disposables;
 
@@ -137,7 +138,14 @@ public sealed class AdminAppService(
     {
         var existingInstanceData = instance.FindData(input.Version);
         if (existingInstanceData != null)
-            throw new ConflictException();
+        {
+            Logger.LogWarning("Instance {InstanceKey} already has data version {Version}", instance.Key, input.Version);
+            if (input.Data?.Any() == true)
+            {
+                await HandleAdditionalDataVersionsAsync(input, cancellationToken);
+            }
+            return;
+        }   
 
         var workflow = CreateAndValidateWorkflow(input);
 
@@ -176,6 +184,12 @@ public sealed class AdminAppService(
                                    input.Key,
                                    dataItem.Key
                                );
+
+                if (instance.FindData(dataItem.Version) != null)
+                {
+                    Logger.LogWarning("Instance {InstanceKey} already has data version {Version}", dataItem.Key, dataItem.Version);
+                    continue;
+                }
 
                 instance.AddTags(dataItem.Tags.ToArray());
                 instance.AddDataWithVersion(

--- a/src/BBT.Workflow.Application/Definitions/IAdminAppService.cs
+++ b/src/BBT.Workflow.Application/Definitions/IAdminAppService.cs
@@ -1,4 +1,7 @@
 using BBT.Aether.Application;
+using BBT.Aether.Domain.Entities;
+using BBT.Aether.Validation;
+using BBT.Workflow.ExceptionHandling;
 
 namespace BBT.Workflow.Definitions;
 


### PR DESCRIPTION
## Summary by Sourcery

Inject ILogger into AdminAppService and change duplicate data version handling to log warnings and process additional data versions instead of throwing exceptions

Enhancements:
- Inject ILogger into AdminAppService and add warning logs for duplicate data versions
- Update HandleExistingInstanceAsync to log and optionally process extra data versions rather than throwing ConflictException
- Modify HandleAdditionalDataVersionsAsync to log and skip already existing data versions
- Add necessary using directives in IAdminAppService interface

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents errors when a submitted data version already exists by handling duplicates gracefully and returning without failing.
  * Processes any additional data versions in the same request when possible, while skipping duplicates to avoid unnecessary failures.

* **Chores**
  * Enhanced internal logging to record duplicate data version attempts, improving traceability without impacting public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->