### PR TITLE
Sprint 17

### DIFF
--- a/src/BBT.Workflow.Application/Definitions/AdminAppService.cs
+++ b/src/BBT.Workflow.Application/Definitions/AdminAppService.cs
@@ -10,6 +10,7 @@ using BBT.Workflow.Instances;
 using BBT.Workflow.Runtime;
 using BBT.Workflow.Schemas;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Nito.Disposables;
 
@@ -137,7 +138,14 @@ public sealed class AdminAppService(
     {
         var existingInstanceData = instance.FindData(input.Version);
         if (existingInstanceData != null)
-            throw new ConflictException();
+        {
+            Logger.LogWarning("Instance {InstanceKey} already has data version {Version}", instance.Key, input.Version);
+            if (input.Data?.Any() == true)
+            {
+                await HandleAdditionalDataVersionsAsync(input, cancellationToken);
+            }
+            return;
+        }   
 
         var workflow = CreateAndValidateWorkflow(input);
 
@@ -176,6 +184,12 @@ public sealed class AdminAppService(
                                    input.Key,
                                    dataItem.Key
                                );
+
+                if (instance.FindData(dataItem.Version) != null)
+                {
+                    Logger.LogWarning("Instance {InstanceKey} already has data version {Version}", dataItem.Key, dataItem.Version);
+                    continue;
+                }
 
                 instance.AddTags(dataItem.Tags.ToArray());
                 instance.AddDataWithVersion(

--- a/src/BBT.Workflow.Application/Definitions/IAdminAppService.cs
+++ b/src/BBT.Workflow.Application/Definitions/IAdminAppService.cs
@@ -1,4 +1,7 @@
 using BBT.Aether.Application;
+using BBT.Aether.Domain.Entities;
+using BBT.Aether.Validation;
+using BBT.Workflow.ExceptionHandling;
 
 namespace BBT.Workflow.Definitions;
 


### PR DESCRIPTION
## Summary by Sourcery

Gracefully handle duplicate workflow instance data by logging warnings instead of throwing exceptions and continue processing additional data.

Enhancements:
- Inject ILogger into AdminAppService and add warning logs for existing instance data duplicates
- Replace throwing ConflictException in HandleExistingInstanceAsync with logging and optional processing of additional data versions
- Add duplicate-version check and warning log in HandleAdditionalDataVersionsAsync to skip already existing data
- Update IAdminAppService with additional using directives for domain entities, validation, and exception handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicate publish attempts no longer fail with conflicts. The process is now idempotent: existing versions are skipped, and only new data versions (if provided) are added.

* **New Features**
  * Clear warning messages replace hard failures on duplicate/version conflicts, improving usability and reducing interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->