### PR TITLE
Sprint 17

### DIFF
--- a/src/BBT.Workflow.Application/Definitions/AdminAppService.cs
+++ b/src/BBT.Workflow.Application/Definitions/AdminAppService.cs
@@ -10,6 +10,7 @@ using BBT.Workflow.Instances;
 using BBT.Workflow.Runtime;
 using BBT.Workflow.Schemas;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Nito.Disposables;
 
@@ -137,7 +138,14 @@ public sealed class AdminAppService(
     {
         var existingInstanceData = instance.FindData(input.Version);
         if (existingInstanceData != null)
-            throw new ConflictException();
+        {
+            Logger.LogWarning("Instance {InstanceKey} already has data version {Version}", instance.Key, input.Version);
+            if (input.Data?.Any() == true)
+            {
+                await HandleAdditionalDataVersionsAsync(input, cancellationToken);
+            }
+            return;
+        }   
 
         var workflow = CreateAndValidateWorkflow(input);
 
@@ -176,6 +184,12 @@ public sealed class AdminAppService(
                                    input.Key,
                                    dataItem.Key
                                );
+
+                if (instance.FindData(dataItem.Version) != null)
+                {
+                    Logger.LogWarning("Instance {InstanceKey} already has data version {Version}", dataItem.Key, dataItem.Version);
+                    continue;
+                }
 
                 instance.AddTags(dataItem.Tags.ToArray());
                 instance.AddDataWithVersion(

--- a/src/BBT.Workflow.Application/Definitions/IAdminAppService.cs
+++ b/src/BBT.Workflow.Application/Definitions/IAdminAppService.cs
@@ -1,4 +1,7 @@
 using BBT.Aether.Application;
+using BBT.Aether.Domain.Entities;
+using BBT.Aether.Validation;
+using BBT.Workflow.ExceptionHandling;
 
 namespace BBT.Workflow.Definitions;
 


### PR DESCRIPTION
## Summary by Sourcery

Improve duplicate data version handling in AdminAppService by logging warnings and processing additional versions instead of throwing conflict exceptions, and add necessary namespace imports.

Enhancements:
- Replace exception thrown for existing data versions with warning logs and optional processing of additional data in HandleExistingInstanceAsync
- Skip and log warnings for duplicate versions in HandleAdditionalDataVersionsAsync instead of failing
- Add logging, domain entity, validation, and exception handling namespaces to support new behaviors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Submitting an already existing data version no longer triggers an error; duplicates are skipped gracefully.
  * Additional data versions in a single request are processed when provided, improving reliability.

* **Chores**
  * Added warning logs for duplicate data versions to aid troubleshooting.
  * No changes to public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->