### PR TITLE
Sprint 17

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,4 @@
+version = 1
+
+[[analyzers]]
+name = "csharp"

--- a/src/BBT.Workflow.Application/Definitions/AdminAppService.cs
+++ b/src/BBT.Workflow.Application/Definitions/AdminAppService.cs
@@ -10,6 +10,7 @@ using BBT.Workflow.Instances;
 using BBT.Workflow.Runtime;
 using BBT.Workflow.Schemas;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Nito.Disposables;
 
@@ -137,7 +138,14 @@ public sealed class AdminAppService(
     {
         var existingInstanceData = instance.FindData(input.Version);
         if (existingInstanceData != null)
-            throw new ConflictException();
+        {
+            Logger.LogWarning("Instance {InstanceKey} already has data version {Version}", instance.Key, input.Version);
+            if (input.Data?.Any() == true)
+            {
+                await HandleAdditionalDataVersionsAsync(input, cancellationToken);
+            }
+            return;
+        }   
 
         var workflow = CreateAndValidateWorkflow(input);
 
@@ -176,6 +184,12 @@ public sealed class AdminAppService(
                                    input.Key,
                                    dataItem.Key
                                );
+
+                if (instance.FindData(dataItem.Version) != null)
+                {
+                    Logger.LogWarning("Instance {InstanceKey} already has data version {Version}", dataItem.Key, dataItem.Version);
+                    continue;
+                }
 
                 instance.AddTags(dataItem.Tags.ToArray());
                 instance.AddDataWithVersion(

--- a/src/BBT.Workflow.Application/Definitions/IAdminAppService.cs
+++ b/src/BBT.Workflow.Application/Definitions/IAdminAppService.cs
@@ -1,4 +1,7 @@
 using BBT.Aether.Application;
+using BBT.Aether.Domain.Entities;
+using BBT.Aether.Validation;
+using BBT.Workflow.ExceptionHandling;
 
 namespace BBT.Workflow.Definitions;
 


### PR DESCRIPTION
## Summary by Sourcery

Enhance instance data handling to log warnings for duplicate versions instead of throwing exceptions, extend processing of additional data versions, update service interface dependencies, and add DeepSource configuration for static analysis

Enhancements:
- Replace ConflictException on existing data with warning logs and conditional handling of additional data versions
- Add warning logs in HandleAdditionalDataVersionsAsync to skip already-present data versions
- Inject Microsoft.Extensions.Logging into AdminAppService for structured logging
- Update IAdminAppService imports to include domain entities, validation, and exception handling

Build:
- Add .deepsource.toml to enable C# static analysis

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Publishing an already-existing instance version no longer blocks the workflow; it now logs a warning and safely skips duplicates.
  - Additional data versions included in a publish request are processed when possible; duplicate data versions are skipped with a warning.
- Bug Fixes
  - Reduced false conflict errors during publish by handling duplicate versions gracefully.
- Chores
  - Added DeepSource configuration to enable C# analysis (no impact on app functionality).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->