### PR TITLE
Improve property access and timeout handling logic

### DIFF
--- a/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Functions/ScriptHelper.cs
+++ b/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Functions/ScriptHelper.cs
@@ -53,7 +53,7 @@ public static class ScriptHelper
 
         if (string.IsNullOrWhiteSpace(storeName))
             throw new ArgumentException("Dapr Store name cannot be null or empty", nameof(storeName));
-        
+
         if (string.IsNullOrWhiteSpace(secretStore))
             throw new ArgumentException("Store name cannot be null or empty", nameof(secretStore));
 
@@ -84,7 +84,7 @@ public static class ScriptHelper
     /// <returns>Dictionary of secret keys and values</returns>
     public static Dictionary<string, string> GetSecrets(string storeName, string secretStore)
     {
-        return GetSecretsAsync(storeName,  secretStore).GetAwaiter().GetResult();
+        return GetSecretsAsync(storeName, secretStore).GetAwaiter().GetResult();
     }
 
     /// <summary>
@@ -97,13 +97,13 @@ public static class ScriptHelper
     {
         if (_daprClient == null)
             throw new InvalidOperationException("Dapr client is not initialized. Call SetDaprClient first.");
-        
+
         if (string.IsNullOrWhiteSpace(storeName))
             throw new ArgumentException("Dapr Store name cannot be null or empty", nameof(storeName));
 
         if (string.IsNullOrWhiteSpace(secretStore))
             throw new ArgumentException("Store name cannot be null or empty", nameof(storeName));
-        
+
         var secretsResponse = await _daprClient.GetSecretAsync(storeName, secretStore);
         return secretsResponse ?? new Dictionary<string, string>();
     }
@@ -116,26 +116,30 @@ public static class ScriptHelper
     /// <returns>True if the property exists, false otherwise</returns>
     public static bool HasProperty(object obj, string propertyName)
     {
-        if (obj == null) return false;
-        
+        if (obj == null || string.IsNullOrWhiteSpace(propertyName)) return false;
+
         // Check if it's an ExpandoObject
-        if (obj is ExpandoObject expando)
+        if (obj is IDictionary<string, object> dict)
         {
-            return ((IDictionary<string, object>)expando).ContainsKey(propertyName);
+            return dict.ContainsKey(propertyName);
         }
-        
+
         // Check if it's another IDictionary<string, object>
         if (obj is IDictionary<string, object> dictionary)
         {
             return dictionary.ContainsKey(propertyName);
         }
-        
+
         // For other dynamic objects, try to access the property using reflection
         var objType = obj.GetType();
-        return objType.GetProperty(propertyName) != null || 
-               objType.GetField(propertyName) != null;
+        return objType.GetProperty(propertyName,
+                   System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance |
+                   System.Reflection.BindingFlags.IgnoreCase) != null ||
+               objType.GetField(propertyName,
+                   System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance |
+                   System.Reflection.BindingFlags.IgnoreCase) != null;
     }
-    
+
     /// <summary>
     /// Gets a property value from a dynamic object safely
     /// </summary>
@@ -144,35 +148,30 @@ public static class ScriptHelper
     /// <returns>The property value or null if not found</returns>
     public static object? GetPropertyValue(object obj, string propertyName)
     {
-        if (obj == null) return null;
-        
-        // Check if it's an ExpandoObject
-        if (obj is ExpandoObject expando)
+        if (obj == null || string.IsNullOrWhiteSpace(propertyName)) return null;
+
+        if (obj is IDictionary<string, object> dict)
         {
-            IDictionary<string, object> dict = (IDictionary<string, object>)expando;
             return dict.TryGetValue(propertyName, out var value) ? value : null;
         }
-        
-        // Check if it's another IDictionary<string, object>
-        if (obj is IDictionary<string, object> dictionary)
-        {
-            return dictionary.TryGetValue(propertyName, out var value) ? value : null;
-        }
-        
-        // For other dynamic objects, try to access the property using reflection
+
         var objType = obj.GetType();
-        var property = objType.GetProperty(propertyName);
+        var property = objType.GetProperty(propertyName,
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance |
+            System.Reflection.BindingFlags.IgnoreCase);
         if (property != null)
         {
             return property.GetValue(obj);
         }
         
-        var field = objType.GetField(propertyName);
+        var field = objType.GetField(propertyName,
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance |
+            System.Reflection.BindingFlags.IgnoreCase);
         if (field != null)
         {
             return field.GetValue(obj);
         }
-        
+
         return null;
     }
 }

--- a/src/BBT.Workflow.Application/BackgroundJobs/Handlers/FlowTimeoutJobHandler.cs
+++ b/src/BBT.Workflow.Application/BackgroundJobs/Handlers/FlowTimeoutJobHandler.cs
@@ -89,7 +89,7 @@ public sealed class FlowTimeoutJobHandler(
 
             jobInfo.IsTriggered = true;
             await jobStore.SaveAsync(jobInfo.JobId, jobInfo, cancellationToken);
-            
+
             var workflow =
                 await componentCacheStore.GetFlowAsync(jobInfo.Payload.Domain, jobInfo.Payload.FlowName,
                     jobInfo.Payload.Version, cancellationToken);
@@ -107,13 +107,20 @@ public sealed class FlowTimeoutJobHandler(
             {
                 // Record current status before timeout
                 var currentStatus = instance.Status.Code;
-                
+
+                if (workflow.Timeout is null)
+                {
+                    logger.LogWarning("FlowTimeoutJobHandler: Timeout configuration missing for {Flow}", instance.Flow);
+                    return;
+                }
+
                 instance.ChangeState(workflow.Timeout!);
                 instance.Complete(); // This calculates the Duration
-                
+
                 // Record timeout metrics with duration - this will also decrement the current status gauge
                 var durationSeconds = instance.Duration?.TotalSeconds;
-                workflowMetrics.RecordInstanceTimedOut(instance.Flow, runtimeInfoProvider.Domain, currentStatus, durationSeconds);
+                workflowMetrics.RecordInstanceTimedOut(instance.Flow, runtimeInfoProvider.Domain, currentStatus,
+                    durationSeconds);
                 await instanceRepository.UpdateAsync(instance, true, cancellationToken);
             }
         }

--- a/src/BBT.Workflow.Application/Tasks/Execution/LocalTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Execution/LocalTaskExecutor.cs
@@ -73,7 +73,6 @@ public sealed class LocalTaskExecutor(
         // Record task execution start 
         workflowMetrics.RecordTaskExecution(taskType, "started");
         
-        var stopwatch = Stopwatch.StartNew();
         try
         {
             var response = await taskExecutor.ExecuteAsync(
@@ -102,12 +101,10 @@ public sealed class LocalTaskExecutor(
                 new JsonData(JsonSerializer.Serialize(response, JsonSerializerConstants.JsonOptions)));
             
             // Record successful task completion 
-            stopwatch.Stop();
             workflowMetrics.RecordTaskExecution(taskType, "success");
         }
         catch (Exception e)
         {
-            stopwatch.Stop();
             instanceTask.Faulted(e.Message);
             
             // Record task failure


### PR DESCRIPTION
Enhanced ScriptHelper to better handle property access on dynamic objects, including case-insensitive reflection and null/empty checks. Updated FlowTimeoutJobHandler to log and exit early if timeout configuration is missing. Removed unused stopwatch logic from LocalTaskExecutor for cleaner metrics recording.

## Summary by Sourcery

Improve dynamic property access, refine flow timeout handling, and clean up unused metrics code

Bug Fixes:
- Log a warning and exit early in FlowTimeoutJobHandler when timeout configuration is missing

Enhancements:
- Enhance ScriptHelper dynamic property access by adding null/empty input checks, case-insensitive reflection, and unified dictionary handling

Chores:
- Remove unused stopwatch logic from LocalTaskExecutor to streamline metrics recording