### PR TITLE
49 normal flow stuck in busy state

### DIFF
--- a/src/BBT.Workflow.Application/Execution/Services/AutoTransitionService.cs
+++ b/src/BBT.Workflow.Application/Execution/Services/AutoTransitionService.cs
@@ -1,6 +1,5 @@
 using BBT.Workflow.Definitions;
 using BBT.Workflow.ExceptionHandling;
-using BBT.Workflow.Execution.StateMachine;
 using BBT.Workflow.Instances;
 using BBT.Workflow.States;
 using Microsoft.Extensions.DependencyInjection;
@@ -64,7 +63,7 @@ public sealed class AutoTransitionService(
                 // This avoids circular dependency since we're not injecting it in constructor
                 using var scope = serviceProvider.CreateScope();
                 var workflowExecutionService = scope.ServiceProvider.GetRequiredService<IWorkflowExecutionService>();
-                
+
                 await workflowExecutionService.ExecuteTransitionAsync(
                     instance.Id,
                     transition.Key,
@@ -73,7 +72,7 @@ public sealed class AutoTransitionService(
 
                 // If we reach here, the transition was successful
                 anySuccess = true;
-                
+
                 logger.LogInformation(
                     "AutoTransition succeeded. InstanceId={InstanceId}, Transition={TransitionKey}",
                     instance.Id, transition.Key);
@@ -86,14 +85,16 @@ public sealed class AutoTransitionService(
                 // Operation was cancelled, re-throw to propagate cancellation
                 throw;
             }
+            catch (TransitionRuleFailedException)
+            {
+                // Continue to next transition
+            }
             catch (Exception ex)
             {
                 logger.LogWarning(ex,
                     "AutoTransition failed. InstanceId={InstanceId}, Transition={TransitionKey}. Trying next transition.",
                     instance.Id, transition.Key);
-
-                // Continue to next transition
-                continue;
+                throw;
             }
         }
 

--- a/src/BBT.Workflow.Application/Execution/Services/AutoTransitionService.cs
+++ b/src/BBT.Workflow.Application/Execution/Services/AutoTransitionService.cs
@@ -85,8 +85,11 @@ public sealed class AutoTransitionService(
                 // Operation was cancelled, re-throw to propagate cancellation
                 throw;
             }
-            catch (TransitionRuleFailedException)
+            catch (TransitionRuleFailedException ex)
             {
+                logger.LogWarning(ex,
+                    "AutoTransition transition rule failed. InstanceId={InstanceId}, Transition={TransitionKey}. Continuing to next transition.",
+                    instance.Id, transition.Key);
                 // Continue to next transition
             }
             catch (Exception ex)

--- a/src/BBT.Workflow.Application/Execution/Services/IInstanceRefreshStrategy.cs
+++ b/src/BBT.Workflow.Application/Execution/Services/IInstanceRefreshStrategy.cs
@@ -1,0 +1,24 @@
+using BBT.Workflow.Instances;
+
+namespace BBT.Workflow.Execution.Services;
+
+/// <summary>
+/// Interface for instance refresh strategy operations.
+/// </summary>
+public interface IInstanceRefreshStrategy
+{
+    /// <summary>
+    /// Gets the latest instance state with minimal database overhead.
+    /// </summary>
+    Task<Instance?> GetLatestInstanceAsync(Guid instanceId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks if an instance needs refresh based on its current state and context.
+    /// </summary>
+    bool ShouldRefreshInstance(Instance instance, bool afterAutoTransition = false);
+
+    /// <summary>
+    /// Conditionally refreshes an instance only if needed.
+    /// </summary>
+    Task<Instance> RefreshIfNeededAsync(Instance instance, bool afterAutoTransition = false, CancellationToken cancellationToken = default);
+}

--- a/src/BBT.Workflow.Application/Execution/Services/InstanceRefreshStrategy.cs
+++ b/src/BBT.Workflow.Application/Execution/Services/InstanceRefreshStrategy.cs
@@ -1,0 +1,91 @@
+using BBT.Workflow.Instances;
+using Microsoft.Extensions.Logging;
+
+namespace BBT.Workflow.Execution.Services;
+
+/// <summary>
+/// Strategy for managing instance refresh operations to minimize database calls
+/// while ensuring data consistency across different service scopes.
+/// </summary>
+public sealed class InstanceRefreshStrategy(
+    IInstanceRepository instanceRepository,
+    ILogger<InstanceRefreshStrategy> logger) : IInstanceRefreshStrategy
+{
+    /// <summary>
+    /// Gets the latest instance state with minimal database overhead.
+    /// Uses read-only queries for performance optimization.
+    /// </summary>
+    /// <param name="instanceId">The instance ID to refresh</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The refreshed instance or null if not found</returns>
+    public async Task<Instance?> GetLatestInstanceAsync(
+        Guid instanceId, 
+        CancellationToken cancellationToken = default)
+    {
+        logger.LogDebug("Refreshing instance {InstanceId} with read-only query", instanceId);
+        
+        return await instanceRepository.FindByIdAsReadOnlyAsync(instanceId, cancellationToken);
+    }
+
+    /// <summary>
+    /// Checks if an instance needs refresh based on its current state and context.
+    /// This helps avoid unnecessary database calls when the instance is already up-to-date.
+    /// </summary>
+    /// <param name="instance">The current instance</param>
+    /// <param name="afterAutoTransition">Whether this check is after an auto transition</param>
+    /// <returns>True if refresh is needed, false otherwise</returns>
+    public bool ShouldRefreshInstance(Instance instance, bool afterAutoTransition = false)
+    {
+        // Always refresh after auto transitions as they run in separate scopes
+        if (afterAutoTransition)
+        {
+            logger.LogDebug("Instance {InstanceId} needs refresh after auto transition", instance.Id);
+            return true;
+        }
+
+        // Refresh if instance is in a transitional state
+        if (instance.Status.Equals(InstanceStatus.Busy))
+        {
+            logger.LogDebug("Instance {InstanceId} needs refresh due to Busy status", instance.Id);
+            return true;
+        }
+
+        // No refresh needed for completed instances
+        if (instance.IsCompleted)
+        {
+            logger.LogDebug("Instance {InstanceId} is completed, no refresh needed", instance.Id);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Conditionally refreshes an instance only if needed, reducing unnecessary database calls.
+    /// </summary>
+    /// <param name="instance">The current instance</param>
+    /// <param name="afterAutoTransition">Whether this is after an auto transition</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The refreshed instance if refresh was needed, otherwise the original instance</returns>
+    public async Task<Instance> RefreshIfNeededAsync(
+        Instance instance, 
+        bool afterAutoTransition = false,
+        CancellationToken cancellationToken = default)
+    {
+        if (!ShouldRefreshInstance(instance, afterAutoTransition))
+        {
+            logger.LogDebug("Instance {InstanceId} refresh skipped - not needed", instance.Id);
+            return instance;
+        }
+
+        var refreshedInstance = await GetLatestInstanceAsync(instance.Id, cancellationToken);
+        
+        if (refreshedInstance == null)
+        {
+            logger.LogWarning("Instance {InstanceId} not found during refresh, returning original", instance.Id);
+            return instance;
+        }
+
+        logger.LogDebug("Instance {InstanceId} successfully refreshed", instance.Id);
+        return refreshedInstance;
+    }
+}

--- a/src/BBT.Workflow.Application/Execution/Services/WorkflowExecutionService.cs
+++ b/src/BBT.Workflow.Application/Execution/Services/WorkflowExecutionService.cs
@@ -218,6 +218,7 @@ public sealed class WorkflowExecutionService(
         // Set metadata
         metadata.TryAdd(DomainConsts.MetaDataKeys.Sync, isSync.ToString().ToLower());
         metadata.TryAdd(DomainConsts.MetaDataKeys.Callback, callback ?? string.Empty);
+        metadata.TryAdd(DomainConsts.MetaDataKeys.FlowType, workflow.Type.Code);
         instance.SetMetaData(metadata);
 
         // Initialize instance state and tags (always for new instances)

--- a/src/BBT.Workflow.Application/Execution/StateMachine/StateMachineExecutor.cs
+++ b/src/BBT.Workflow.Application/Execution/StateMachine/StateMachineExecutor.cs
@@ -148,7 +148,8 @@ public sealed class StateMachineExecutor(
             }
         }
 
-        await InstanceStatusHandleAsync(context.Instance, targetState, context.Workflow, cancellationToken);
+        await InstanceStatusHandleAsync(context.Instance, targetState, context.Transition, context.Workflow,
+            cancellationToken);
 
         instanceTransition.Completed(context.Instance.GetCurrentState);
 
@@ -162,7 +163,7 @@ public sealed class StateMachineExecutor(
             );
         }
 
-        await instanceTransitionRepository.UpdateAsync(instanceTransition, true, cancellationToken);
+        await instanceTransitionRepository.UpdateCompletedAsync(instanceTransition, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -244,18 +245,25 @@ public sealed class StateMachineExecutor(
     private async Task InstanceStatusHandleAsync(
         Instance instance,
         State targetState,
+        Transition transition,
         Definitions.Workflow workflow,
         CancellationToken cancellationToken = default)
     {
+        instance = await instanceRepository.GetActiveAsync(instance.Id, cancellationToken);
         if (targetState.StateType == StateType.Finish)
         {
             // Complete the instance
             instance.Complete();
             await instanceRepository.UpdateStatusAsync(instance, cancellationToken);
-            if (instance is { IsSubItem: true, IsCompleted: true })
+            if (instance.ShouldPublishCompletionEvent())
             {
                 await PublishFlowCompletionEventAsync(instance, workflow, cancellationToken);
             }
+        }
+        else
+        {
+            instance.SetStatusBasedOnState();
+            await instanceRepository.UpdateStatusAsync(instance, cancellationToken);
         }
     }
 

--- a/src/BBT.Workflow.Application/Execution/StateMachine/StateMachineExecutor.cs
+++ b/src/BBT.Workflow.Application/Execution/StateMachine/StateMachineExecutor.cs
@@ -33,6 +33,7 @@ public sealed class StateMachineExecutor(
     DaprClient daprClient,
     IConfiguration configuration,
     IAutoTransitionService autoTransitionService,
+    IInstanceRefreshStrategy instanceRefreshStrategy,
     ILogger<StateMachineExecutor> logger
 ) : IStateMachineExecutor
 {
@@ -123,12 +124,21 @@ public sealed class StateMachineExecutor(
                         context.Instance,
                         cancellationToken);
 
-                    // Check for delay transition and execution
-                    await ScheduleTransitionsForLaterExecutionAsync(
-                        context.Workflow,
-                        context.Instance,
-                        context,
+                    // Refresh instance only if needed after auto transitions
+                    var refreshedInstance = await instanceRefreshStrategy.RefreshIfNeededAsync(
+                        context.Instance, 
+                        afterAutoTransition: true, 
                         cancellationToken);
+
+                    if (refreshedInstance is { IsCompleted: false })
+                    {
+                        // Check for delay transition and execution
+                        await ScheduleTransitionsForLaterExecutionAsync(
+                            context.Workflow,
+                            refreshedInstance,
+                            context,
+                            cancellationToken);
+                    }
                 }
             }
             else
@@ -138,13 +148,23 @@ public sealed class StateMachineExecutor(
                     context.Workflow,
                     context.Instance,
                     cancellationToken);
-
-                // Check for delay transition and execution
-                await ScheduleTransitionsForLaterExecutionAsync(
-                    context.Workflow,
-                    context.Instance,
-                    context,
+                
+                // Refresh instance only if needed after auto transitions
+                var refreshedInstance = await instanceRefreshStrategy.RefreshIfNeededAsync(
+                    context.Instance, 
+                    afterAutoTransition: true, 
                     cancellationToken);
+
+                if (refreshedInstance is { IsCompleted: false })
+                {
+                    // Check for delay transition and execution
+                    await ScheduleTransitionsForLaterExecutionAsync(
+                        context.Workflow,
+                        refreshedInstance,
+                        context,
+                        cancellationToken);
+                }
+                
             }
         }
 
@@ -242,14 +262,15 @@ public sealed class StateMachineExecutor(
             cancellationToken);
     }
 
-    private async Task InstanceStatusHandleAsync(
+    public async Task InstanceStatusHandleAsync(
         Instance instance,
         State targetState,
         Transition transition,
         Definitions.Workflow workflow,
         CancellationToken cancellationToken = default)
     {
-        instance = await instanceRepository.GetActiveAsync(instance.Id, cancellationToken);
+        // Refresh instance to get latest status before processing
+        instance = await instanceRefreshStrategy.GetLatestInstanceAsync(instance.Id, cancellationToken) ?? instance;
         if (targetState.StateType == StateType.Finish)
         {
             // Complete the instance
@@ -262,8 +283,10 @@ public sealed class StateMachineExecutor(
         }
         else
         {
-            instance.SetStatusBasedOnState();
-            await instanceRepository.UpdateStatusAsync(instance, cancellationToken);
+            if (transition.TriggerType == TriggerType.Manual && instance.TrySetStatusBasedOnState())
+            {
+                await instanceRepository.UpdateStatusAsync(instance, cancellationToken);
+            }
         }
     }
 

--- a/src/BBT.Workflow.Application/Execution/Strategies/Instances/AsyncInstanceStartStrategy.cs
+++ b/src/BBT.Workflow.Application/Execution/Strategies/Instances/AsyncInstanceStartStrategy.cs
@@ -34,7 +34,6 @@ public sealed class AsyncInstanceStartStrategy(
             // Schedule flow timeout if configured
             await stateMachineExecutor.FlowTimeoutAsync(context.Workflow, context.Instance, cancellationToken);
             
-            // Set instance to busy for background processing
             context.Instance.Busy();
             await instanceRepository.UpdateStatusAsync(context.Instance, cancellationToken);
 

--- a/src/BBT.Workflow.Application/Execution/Strategies/Instances/SyncInstanceStartStrategy.cs
+++ b/src/BBT.Workflow.Application/Execution/Strategies/Instances/SyncInstanceStartStrategy.cs
@@ -4,6 +4,7 @@ using BBT.Workflow.Instances;
 using Microsoft.AspNetCore.Http;
 using BBT.Workflow.Runtime;
 using Microsoft.Extensions.Logging;
+#pragma warning disable CS8602 // Dereference of a possibly null reference.
 
 namespace BBT.Workflow.Execution.Strategies;
 
@@ -15,6 +16,7 @@ public sealed class SyncInstanceStartStrategy(
     IStateMachineExecutor stateMachineExecutor,
     IHeaderService headerService,
     IRuntimeInfoProvider runtimeInfoProvider,
+    IInstanceRepository instanceRepository,
     ILogger<SyncInstanceStartStrategy> logger) : IInstanceStartStrategy
 {
     /// <inheritdoc />
@@ -39,11 +41,13 @@ public sealed class SyncInstanceStartStrategy(
             WorkflowInfo.Generate(runtimeInfoProvider.Domain, context.Workflow.Key, context.Workflow.Version, context.Instance.Id)
         );
 
+        var refreshedInstance =  await instanceRepository.FindByIdAsReadOnlyAsync(context.Instance.Id, cancellationToken);
+        
         // Build and return response
         return new InstanceServiceResponse<StartInstanceOutput>(new StartInstanceOutput
         {
-            Id = context.Instance.Id,
-            Status = context.Instance.Status
+            Id = refreshedInstance.Id,
+            Status = refreshedInstance.Status
         });
     }
 }

--- a/src/BBT.Workflow.Application/Execution/Strategies/Transitions/SyncTransitionStrategy.cs
+++ b/src/BBT.Workflow.Application/Execution/Strategies/Transitions/SyncTransitionStrategy.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http;
 using BBT.Workflow.Runtime;
 using Microsoft.Extensions.Logging;
 using ExecutionContext = BBT.Workflow.Shared.ExecutionContext;
+#pragma warning disable CS8603 // Possible null reference return.
 
 namespace BBT.Workflow.Execution.Strategies;
 
@@ -99,7 +100,6 @@ public sealed class SyncTransitionStrategy(
         await operation();
 
         // Return the fresh instance from database to ensure caller gets the latest correlations
-        return instance;
-        //await instanceRepository.GetAsync(instance.Id, true, cancellationToken);
+        return await instanceRepository.FindByIdAsReadOnlyAsync(instance.Id, cancellationToken);
     }
 }

--- a/src/BBT.Workflow.Application/Execution/Strategies/Transitions/SyncTransitionStrategy.cs
+++ b/src/BBT.Workflow.Application/Execution/Strategies/Transitions/SyncTransitionStrategy.cs
@@ -1,3 +1,4 @@
+using BBT.Aether.Guids;
 using BBT.Workflow.Execution.StateMachine;
 using BBT.Workflow.Headers;
 using BBT.Workflow.Instances;
@@ -17,6 +18,7 @@ public sealed class SyncTransitionStrategy(
     IInstanceRepository instanceRepository,
     IHeaderService headerService,
     IRuntimeInfoProvider runtimeInfoProvider,
+    IGuidGenerator guidGenerator,
     ILogger<SyncTransitionStrategy> logger) : ITransitionStrategy
 {
     /// <inheritdoc />
@@ -53,15 +55,25 @@ public sealed class SyncTransitionStrategy(
         TransitionExecutionContext context,
         CancellationToken cancellationToken = default)
     {
-        var updatedInstance = await ExecuteWithBusyStatusAsync(context.Instance, context.Input.ExecutionContext, async () =>
-        {
-            var scriptContext = await context.ScriptContextBuilder.BuildAsync(cancellationToken);
+        var updatedInstance = await ExecuteWithBusyStatusAsync(context.Instance, context.Input.ExecutionContext,
+            async () =>
+            {
+                if (context.Input.Data.HasValue)
+                {
+                    context.Instance.AddData(
+                        guidGenerator.Create(),
+                        new JsonData(context.Input.Data),
+                        context.Transition.VersionStrategy
+                    );
+                }
 
-            // Delegate to StateMachineExecutor for actual transition execution
-            await stateMachineExecutor.ExecuteTransitionAsync(scriptContext, cancellationToken);
+                var scriptContext = await context.ScriptContextBuilder.BuildAsync(cancellationToken);
 
-            return context.Instance;
-        }, cancellationToken);
+                // Delegate to StateMachineExecutor for actual transition execution
+                await stateMachineExecutor.ExecuteTransitionAsync(scriptContext, cancellationToken);
+
+                return context.Instance;
+            }, cancellationToken);
 
         // Return the updated instance to ensure caller gets the latest state
         return updatedInstance;
@@ -87,6 +99,7 @@ public sealed class SyncTransitionStrategy(
         await operation();
 
         // Return the fresh instance from database to ensure caller gets the latest correlations
-        return await instanceRepository.GetAsync(instance.Id, true, cancellationToken);
+        return instance;
+        //await instanceRepository.GetAsync(instance.Id, true, cancellationToken);
     }
 }

--- a/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
@@ -78,6 +78,9 @@ public static class WorkflowApplicationModuleServiceCollectionExtensions
         // Register auto transition service
         services.AddScoped<IAutoTransitionService, AutoTransitionService>();
         
+        // Register instance refresh strategy
+        services.AddScoped<IInstanceRefreshStrategy, InstanceRefreshStrategy>();
+        
         // Register strategy factory
         services.AddScoped<IExecutionStrategyFactory, ExecutionStrategyFactory>();
         

--- a/src/BBT.Workflow.Application/SubFlow/Services/SubFlowCompletionService.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubFlowCompletionService.cs
@@ -10,6 +10,7 @@ using BBT.Workflow.Scripting;
 using BBT.Workflow.Schemas;
 using Microsoft.Extensions.Logging;
 using BBT.Workflow.ExceptionHandling;
+using BBT.Workflow.Execution.Services;
 
 namespace BBT.Workflow.SubFlow;
 
@@ -25,7 +26,8 @@ public sealed class SubFlowCompletionService(
     IRuntimeInfoProvider runtimeInfoProvider,
     IGuidGenerator guidGenerator,
     ILogger<SubFlowCompletionService> logger,
-    IStateMachineExecutor stateMachineExecutor)
+    IStateMachineExecutor stateMachineExecutor,
+    IInstanceRefreshStrategy instanceRefreshStrategy)
     : ApplicationService(serviceProvider), ISubFlowCompletionService
 {
     /// <inheritdoc />
@@ -181,7 +183,7 @@ public sealed class SubFlowCompletionService(
             parentWorkflow,
             await scriptContextBuilder.BuildAsync(cancellationToken),
             cancellationToken);
-
+        
         // Get fresh instance because auto transition runs in separate scope
         parentInstance = await instanceRepository.GetActiveAsync(parentInstance.Id, cancellationToken);
         if(parentInstance.TryActivateIfBusyWithoutSubFlow())
@@ -199,7 +201,7 @@ public sealed class SubFlowCompletionService(
     /// <param name="cancellationToken">Cancellation token</param>
     private async Task ProcessSubFlowOutputMappingAsync(
         Instance parentInstance,
-        Definitions.State parentState,
+        State parentState,
         ScriptContext scriptContext,
         CancellationToken cancellationToken)
     {
@@ -285,12 +287,21 @@ public sealed class SubFlowCompletionService(
             await stateMachineExecutor.CheckAndExecuteAutomaticTransitionsAsync(parentWorkflow, parentInstance,
                 cancellationToken);
             
-            await stateMachineExecutor.ScheduleTransitionsForLaterExecutionAsync(
-                parentWorkflow, 
-                parentInstance,
-                scriptContext,
+            // Refresh instance only if needed after auto transitions
+            var refreshedInstance = await instanceRefreshStrategy.RefreshIfNeededAsync(
+                parentInstance, 
+                afterAutoTransition: true, 
                 cancellationToken);
-            
+
+            if (refreshedInstance is { IsCompleted: false })
+            {
+                await stateMachineExecutor.ScheduleTransitionsForLaterExecutionAsync(
+                    parentWorkflow,
+                    refreshedInstance,
+                    scriptContext,
+                    cancellationToken);
+            }
+
             logger.LogInformation(
                 "Successfully resumed automatic processes for parent instance {ParentInstanceId}",
                 parentInstance.Id);

--- a/src/BBT.Workflow.Application/SubFlow/Services/SubFlowCompletionService.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubFlowCompletionService.cs
@@ -184,9 +184,8 @@ public sealed class SubFlowCompletionService(
 
         // Get fresh instance because auto transition runs in separate scope
         parentInstance = await instanceRepository.GetActiveAsync(parentInstance.Id, cancellationToken);
-        if(parentInstance is { IsBusy: true, IsActiveSubFlow: false })
+        if(parentInstance.TryActivateIfBusyWithoutSubFlow())
         {
-            parentInstance.Active();
             await instanceRepository.UpdateStatusAsync(parentInstance, cancellationToken);
         }
     }

--- a/src/BBT.Workflow.Application/SubFlow/Services/SubFlowService.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubFlowService.cs
@@ -96,7 +96,7 @@ public sealed class SubFlowService(
                 [DomainConsts.MetaDataKeys.Flow] = workflow.Key,
                 [DomainConsts.MetaDataKeys.Version] = workflow.Version,
                 [DomainConsts.MetaDataKeys.State] = targetState.Key,
-                [DomainConsts.MetaDataKeys.SubType] = subFlowConfig.Type.Code
+                [DomainConsts.MetaDataKeys.FlowType] = subFlowConfig.Type.Code
             }
         };
 

--- a/src/BBT.Workflow.Application/SubFlow/Services/SubFlowService.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubFlowService.cs
@@ -108,20 +108,14 @@ public sealed class SubFlowService(
                 createInstanceInput.Key = inputMappingResult.Key;
             }
 
-            if (inputMappingResult.Tags?.Length > 0)
+            if (!inputMappingResult.Tags.IsNullOrEmpty())
             {
                 var existingTags = createInstanceInput.Tags?.ToList() ?? new List<string>();
                 existingTags.AddRange(inputMappingResult.Tags);
                 createInstanceInput.Tags = existingTags.ToArray();
             }
         }
-
-        // TODO: will be removed
-        // var sync = Convert.ToBoolean(parentInstance.MetaData[DomainConsts.MetaDataKeys.Sync]!.ToString());
-        // if (subFlowConfig.Type.Equals(SubFlowType.SubProcess))
-        // {
-        //     sync = false;
-        // }
+        
         var subFlowStartInput = new StartInstanceInput(
             subFlowConfig.Process.Domain,
             subFlowConfig.Process.Key,
@@ -148,9 +142,13 @@ public sealed class SubFlowService(
             subFlowConfig.Process.Version);
 
         parentInstance.AddCorrelation(correlation);
-        parentInstance.Busy();
-        await instanceRepository.UpdateAsync(parentInstance, true, cancellationToken);
 
+        if (subFlowConfig.Type.Equals(SubFlowType.SubFlow))
+        {
+            parentInstance.Busy();
+            await instanceRepository.UpdateAsync(parentInstance, true, cancellationToken);
+        }
+       
         await remoteInstanceCommandAppService.StartSubAsync(subFlowStartInput, cancellationToken);
     }
 

--- a/src/BBT.Workflow.Domain/Definitions/States/Policies/StateTransitionPolicy.cs
+++ b/src/BBT.Workflow.Domain/Definitions/States/Policies/StateTransitionPolicy.cs
@@ -11,12 +11,17 @@ public class StateTransitionPolicy(IRuleEngine<State> ruleEngine)
     {
         var rules = new List<BaseRule<State>>();
 
+        if (!transition.From.IsNullOrEmpty())
+        {
+            rules.Add(new FromStateRule(transition));
+        }
+        
         if (transition.AvailableIn.Any())
         {
             rules.Add(new AvailableInRule(transition));
         }
 
-        rules.Add(new ManualTriggerRule(transition));
+        rules.Add(new ManualTriggerRule(transition, executionContext));
         
         rules.Add(new TransitionAuthorizationRule(transition, executionContext));
 

--- a/src/BBT.Workflow.Domain/Definitions/States/Rules/FromStateRule.cs
+++ b/src/BBT.Workflow.Domain/Definitions/States/Rules/FromStateRule.cs
@@ -1,0 +1,17 @@
+using BBT.Workflow.ExceptionHandling;
+using BBT.Workflow.Rules;
+
+namespace BBT.Workflow.Definitions.Rules;
+
+public class FromStateRule(Transition transition): BaseRule<State>
+{
+    public override bool IsApplicable(State context)
+    {
+        return !string.IsNullOrEmpty(transition.From) && transition.From != context.Key;
+    }
+
+    public override void Execute(State context)
+    {
+        throw new InvalidStateException(transition.Key, transition.Target, context.Key);
+    }
+}

--- a/src/BBT.Workflow.Domain/Definitions/States/Rules/ManualTriggerRule.cs
+++ b/src/BBT.Workflow.Domain/Definitions/States/Rules/ManualTriggerRule.cs
@@ -1,18 +1,23 @@
 using BBT.Workflow.ExceptionHandling;
 using BBT.Workflow.Rules;
+using WorkflowExecutionContext = BBT.Workflow.Shared.ExecutionContext;
 
 namespace BBT.Workflow.Definitions.Rules;
 
-public class ManualTriggerRule(Transition transition) : BaseRule<State>
+public class ManualTriggerRule(Transition transition, WorkflowExecutionContext executionContext) : BaseRule<State>
 {
     public override bool IsApplicable(State context)
     {
-        return context.Key == transition.Target &&
-               context.StateType != StateType.Initial;
+        if (transition.TriggerType == TriggerType.Manual)
+        {
+            return executionContext != WorkflowExecutionContext.User;
+        }
+
+        return false;
     }
 
     public override void Execute(State context)
     {
-        throw new InvalidStateException(transition.Key, transition.Target, context.Key);
+        throw new UnauthorizedTransitionException(transition.Key, transition.TriggerType, executionContext);
     }
 }

--- a/src/BBT.Workflow.Domain/Definitions/States/Rules/TransitionAuthorizationRule.cs
+++ b/src/BBT.Workflow.Domain/Definitions/States/Rules/TransitionAuthorizationRule.cs
@@ -12,26 +12,21 @@ public class TransitionAuthorizationRule(Transition transition, WorkflowExecutio
 {
     public override bool IsApplicable(State context)
     {
-        // Always apply this rule for authorization check
-        return true;
+        if (transition.TriggerType == TriggerType.Automatic
+            ||
+            transition.TriggerType == TriggerType.Scheduled)
+        {
+            return executionContext != WorkflowExecutionContext.System;
+        }
+        
+        return false;
     }
 
     public override void Execute(State context)
     {
-        // User context can only execute Manual and Event transitions
-        if (executionContext == WorkflowExecutionContext.User
-            && (transition.TriggerType == TriggerType.Automatic
-                ||
-                transition.TriggerType == TriggerType.Scheduled)
-           )
-        {
-            throw new UnauthorizedTransitionException(
-                transition.Key,
-                transition.TriggerType,
-                executionContext);
-        }
-
-        // System context can execute any transition type
-        // No additional validation needed for system context
+        throw new UnauthorizedTransitionException(
+            transition.Key,
+            transition.TriggerType,
+            executionContext);
     }
 }

--- a/src/BBT.Workflow.Domain/Definitions/WorkflowConstants.cs
+++ b/src/BBT.Workflow.Domain/Definitions/WorkflowConstants.cs
@@ -12,6 +12,7 @@ public class WorkflowConstants
     public const int MaxFlowLength = 100;
     public const int MaxDurationLength = 100;
     public const int MaxETagLength = 26;
+    public const int MaxDataHashLength = 40;
     public const int MaxTimerResetLength = 26;
 }
 

--- a/src/BBT.Workflow.Domain/DomainConsts.cs
+++ b/src/BBT.Workflow.Domain/DomainConsts.cs
@@ -12,7 +12,7 @@ public class DomainConsts
         public const string Flow = "parent.flow";
         public const string Version = "parent.version";
         public const string State = "parent.state";
-        public const string SubType = "parent.subtype";
+        public const string FlowType = "parent.flowtype";
         public const string Sync = "sync";
         public const string Callback = "callback";
     }

--- a/src/BBT.Workflow.Domain/Instances/IInstanceRepository.cs
+++ b/src/BBT.Workflow.Domain/Instances/IInstanceRepository.cs
@@ -11,6 +11,9 @@ public interface IInstanceRepository : IRepository<Instance, Guid>
     Task<Instance?> FindByKeyAsReadOnlyAsync(string key,
         CancellationToken cancellationToken = default);
 
+    Task<Instance?> FindByIdAsReadOnlyAsync(Guid id,
+        CancellationToken cancellationToken = default);
+
     Task<Instance> GetActiveAsync(Guid id, CancellationToken cancellationToken = default);
     Task<List<InstanceAndDataModel>> GetActiveDataListAsync(CancellationToken cancellationToken = default);
 

--- a/src/BBT.Workflow.Domain/Instances/IInstanceTransitionRepository.cs
+++ b/src/BBT.Workflow.Domain/Instances/IInstanceTransitionRepository.cs
@@ -4,5 +4,5 @@ namespace BBT.Workflow.Instances;
 
 public interface IInstanceTransitionRepository : IRepository<InstanceTransition, Guid>
 {
-    
+    Task UpdateCompletedAsync(InstanceTransition transition, CancellationToken cancellationToken);
 }

--- a/src/BBT.Workflow.Domain/Instances/Instance.cs
+++ b/src/BBT.Workflow.Domain/Instances/Instance.cs
@@ -83,9 +83,14 @@ public sealed class Instance : AggregateRoot<Guid>, IHasCreatedAt, IHasModifyTim
 
     public bool IsBusy => Status.Equals(InstanceStatus.Busy);
     public bool IsActive => Status.Equals(InstanceStatus.Active);
-    public bool IsSubFlow => this.ToFlowType()?.Equals(WorkflowType.SubFlow) ?? false;
-    public bool IsSubItem => (this.ToFlowType()?.Equals(WorkflowType.SubFlow) ?? false) || (this.ToFlowType()?.Equals(WorkflowType.SubProcess) ?? false);
-    public bool HasActiveSubFlow => _childCorrelations.Any(p => !p.IsCompleted && p.SubFlowType.Equals(SubFlowType.SubFlow));
+    public bool IsSubFlow => this.ToFlowType() == WorkflowType.SubFlow;
+
+    public bool IsSubItem => this.ToFlowType() == WorkflowType.SubFlow ||
+                             this.ToFlowType() == WorkflowType.SubProcess;
+
+    public bool HasActiveSubFlow =>
+        _childCorrelations.Any(p => !p.IsCompleted && p.SubFlowType.Equals(SubFlowType.SubFlow));
+
     public TimeSpan? Duration { get; private set; }
     public List<string> Tags { get; private set; }
 
@@ -169,6 +174,9 @@ public sealed class Instance : AggregateRoot<Guid>, IHasCreatedAt, IHasModifyTim
     /// </summary>
     public void Busy()
     {
+        if(IsCompleted)
+            return;
+        
         Status = InstanceStatus.Busy;
     }
 
@@ -178,6 +186,9 @@ public sealed class Instance : AggregateRoot<Guid>, IHasCreatedAt, IHasModifyTim
     /// </summary>
     public void Active()
     {
+        if(IsCompleted)
+            return;
+        
         Status = InstanceStatus.Active;
     }
 
@@ -185,22 +196,26 @@ public sealed class Instance : AggregateRoot<Guid>, IHasCreatedAt, IHasModifyTim
     /// Sets the instance status based on its completion and active subflow state.
     /// This encapsulates the business logic for determining whether an instance should be Active or Busy.
     /// </summary>
-    public void SetStatusBasedOnState()
+    public bool TrySetStatusBasedOnState()
     {
-        if (IsCompleted) 
-            return;
+        if (IsCompleted)
+        {
+            return false;
+        }
 
         if (HasActiveSubFlow)
         {
             Busy();
+            return true;
         }
-        else
+
+        if (IsBusy)
         {
-            if (IsBusy)
-            {
-                Active();    
-            }
+            Active();
+            return true;
         }
+
+        return false;
     }
 
     /// <summary>
@@ -214,7 +229,7 @@ public sealed class Instance : AggregateRoot<Guid>, IHasCreatedAt, IHasModifyTim
             Active();
             return true;
         }
-        
+
         return false;
     }
 
@@ -284,20 +299,20 @@ public sealed class Instance : AggregateRoot<Guid>, IHasCreatedAt, IHasModifyTim
         lock (_dataListLock)
         {
             var latestData = _dataList.OrderByDescending(x => x, InstanceDataVersionComparer.Instance).FirstOrDefault();
-            
+
             // If we have existing data, check if the new data is different
-            if (latestData != null && latestData.HasSameData(inputData))
+            if (latestData?.HasSameData(inputData) == true)
             {
                 // Data hasn't changed, return the existing latest data
                 return latestData;
             }
-            
+
             // Mark previous latest as not latest
             if (latestData != null)
             {
                 latestData.MarkAsNotLatest();
             }
-            
+
             var newData = new InstanceData(
                 id,
                 Id,
@@ -314,14 +329,14 @@ public sealed class Instance : AggregateRoot<Guid>, IHasCreatedAt, IHasModifyTim
         lock (_dataListLock)
         {
             var lastData = _dataList.LastOrDefault();
-            
+
             // If we have existing data, check if the new data is different
-            if (lastData != null && lastData.HasSameData(inputData))
+            if (lastData?.HasSameData(inputData) == true)
             {
                 // Data hasn't changed, return the existing data
                 return lastData;
             }
-            
+
             InstanceData newData = lastData is null
                 ? new InstanceData(
                     id,

--- a/src/BBT.Workflow.Domain/Instances/Instance.cs
+++ b/src/BBT.Workflow.Domain/Instances/Instance.cs
@@ -85,7 +85,7 @@ public sealed class Instance : AggregateRoot<Guid>, IHasCreatedAt, IHasModifyTim
     public bool IsActive => Status.Equals(InstanceStatus.Active);
     public bool IsSubFlow => this.ToFlowType()?.Equals(WorkflowType.SubFlow) ?? false;
     public bool IsSubItem => (this.ToFlowType()?.Equals(WorkflowType.SubFlow) ?? false) || (this.ToFlowType()?.Equals(WorkflowType.SubProcess) ?? false);
-    public bool IsActiveSubFlow => _childCorrelations.Any(p => p.IsCompleted && p.SubFlowType.Equals(SubFlowType.SubFlow));
+    public bool HasActiveSubFlow => _childCorrelations.Any(p => !p.IsCompleted && p.SubFlowType.Equals(SubFlowType.SubFlow));
     public TimeSpan? Duration { get; private set; }
     public List<string> Tags { get; private set; }
 
@@ -181,18 +181,50 @@ public sealed class Instance : AggregateRoot<Guid>, IHasCreatedAt, IHasModifyTim
         Status = InstanceStatus.Active;
     }
 
-    public void SetToActiveOrBusyBasedOnSubFlow()
+    /// <summary>
+    /// Sets the instance status based on its completion and active subflow state.
+    /// This encapsulates the business logic for determining whether an instance should be Active or Busy.
+    /// </summary>
+    public void SetStatusBasedOnState()
     {
         if (IsCompleted) 
             return;
-            
-        if (IsActiveSubFlow)
+
+        if (HasActiveSubFlow)
         {
             Busy();
-            return;
+        }
+        else
+        {
+            if (IsBusy)
+            {
+                Active();    
+            }
+        }
+    }
+
+    /// <summary>
+    /// Sets the parent instance status to Active if it's currently Busy but has no active subflows.
+    /// This is typically used when a subflow completes and the parent should return to Active state.
+    /// </summary>
+    public bool TryActivateIfBusyWithoutSubFlow()
+    {
+        if (IsBusy && !HasActiveSubFlow)
+        {
+            Active();
+            return true;
         }
         
-        Active();
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether this instance should publish a completion event.
+    /// This is typically true for SubItems (SubFlow or SubProcess) that have completed.
+    /// </summary>
+    public bool ShouldPublishCompletionEvent()
+    {
+        return IsSubItem && IsCompleted;
     }
 
     public void AddCorrelation(InstanceCorrelation correlation)
@@ -249,14 +281,32 @@ public sealed class Instance : AggregateRoot<Guid>, IHasCreatedAt, IHasModifyTim
 
     public InstanceData AddDataWithVersion(Guid id, JsonData inputData, string version)
     {
-        var newData = new InstanceData(
-            id,
-            Id,
-            version,
-            inputData, true
-        );
-        _dataList.Add(newData);
-        return newData;
+        lock (_dataListLock)
+        {
+            var latestData = _dataList.OrderByDescending(x => x, InstanceDataVersionComparer.Instance).FirstOrDefault();
+            
+            // If we have existing data, check if the new data is different
+            if (latestData != null && latestData.HasSameData(inputData))
+            {
+                // Data hasn't changed, return the existing latest data
+                return latestData;
+            }
+            
+            // Mark previous latest as not latest
+            if (latestData != null)
+            {
+                latestData.MarkAsNotLatest();
+            }
+            
+            var newData = new InstanceData(
+                id,
+                Id,
+                version,
+                inputData, true
+            );
+            _dataList.Add(newData);
+            return newData;
+        }
     }
 
     public InstanceData AddData(Guid id, JsonData inputData, VersionStrategy? versionStrategy = null)
@@ -264,6 +314,14 @@ public sealed class Instance : AggregateRoot<Guid>, IHasCreatedAt, IHasModifyTim
         lock (_dataListLock)
         {
             var lastData = _dataList.LastOrDefault();
+            
+            // If we have existing data, check if the new data is different
+            if (lastData != null && lastData.HasSameData(inputData))
+            {
+                // Data hasn't changed, return the existing data
+                return lastData;
+            }
+            
             InstanceData newData = lastData is null
                 ? new InstanceData(
                     id,
@@ -293,7 +351,7 @@ public sealed class Instance : AggregateRoot<Guid>, IHasCreatedAt, IHasModifyTim
             if (exactMatch != null)
                 return exactMatch;
 
-            // Partial versiyon: 1.0 → tüm 1.0.x versiyonları içinde en büyük olanı bul
+            // Partial version: 1.0 → find the highest version among all 1.0.x versions
             var match = Regex.Match(version, @"^(\d+)\.(\d+)$");
             if (match.Success)
             {

--- a/src/BBT.Workflow.Domain/Instances/InstanceData.cs
+++ b/src/BBT.Workflow.Domain/Instances/InstanceData.cs
@@ -133,9 +133,9 @@ public sealed class InstanceData : Entity<Guid>, IHasVersion, IHasEtag
         if (!match.Success)
             return currentVersion;
 
-        var major = int.Parse(match.Groups[1].Value);
-        var minor = int.Parse(match.Groups[2].Value);
-        var patch = int.Parse(match.Groups[3].Value);
+        int.TryParse(match.Groups[1].Value, out var major);
+        int.TryParse(match.Groups[2].Value, out var minor);
+        int.TryParse(match.Groups[3].Value, out var patch);
 
         return versionStrategy.Code switch
         {

--- a/src/BBT.Workflow.Domain/Instances/InstanceData.cs
+++ b/src/BBT.Workflow.Domain/Instances/InstanceData.cs
@@ -1,4 +1,7 @@
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using BBT.Aether;
 using BBT.Aether.Domain.Entities;
@@ -24,6 +27,7 @@ public sealed class InstanceData : Entity<Guid>, IHasVersion, IHasEtag
         InstanceId = instanceId;
         SetVersion(version);
         Data = data;
+        DataHash = ComputeDataHash(data);
         EnteredAt = DateTime.UtcNow;
         ETag = Ulid.NewUlid().ToString();
         IsLatest = isLatest;
@@ -47,6 +51,11 @@ public sealed class InstanceData : Entity<Guid>, IHasVersion, IHasEtag
     /// ETag
     /// </summary>
     public string ETag { get; private set; }
+    
+    /// <summary>
+    /// SHA1 hash of the data payload for change detection
+    /// </summary>
+    public string DataHash { get; private set; }
     
     /// <summary>
     /// <see cref="JsonData"/>
@@ -81,6 +90,41 @@ public sealed class InstanceData : Entity<Guid>, IHasVersion, IHasEtag
             newData,
             true
         );
+    }
+
+    /// <summary>
+    /// Computes SHA1 hash of the JSON data for change detection
+    /// </summary>
+    /// <param name="data">The JSON data to hash</param>
+    /// <returns>SHA1 hash as hex string</returns>
+    private static string ComputeDataHash(JsonData data)
+    {
+        using var sha1 = SHA1.Create();
+        
+        // Use normalized JSON from JsonData for consistent hashing
+        var jsonBytes = Encoding.UTF8.GetBytes(data.NormalizedJson);
+        var hashBytes = sha1.ComputeHash(jsonBytes);
+        return Convert.ToHexString(hashBytes).ToLowerInvariant();
+    }
+
+
+    /// <summary>
+    /// Checks if the provided JSON data has the same content as this instance's data
+    /// </summary>
+    /// <param name="jsonData">The JSON data to compare</param>
+    /// <returns>True if the data is the same, false otherwise</returns>
+    public bool HasSameData(JsonData jsonData)
+    {
+        var otherHash = ComputeDataHash(jsonData);
+        return DataHash.Equals(otherHash, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Marks this instance data as not the latest version
+    /// </summary>
+    internal void MarkAsNotLatest()
+    {
+        IsLatest = false;
     }
 
     private string IncrementVersion(string currentVersion, VersionStrategy versionStrategy)

--- a/src/BBT.Workflow.Domain/Instances/InstanceMetadataExtensions.cs
+++ b/src/BBT.Workflow.Domain/Instances/InstanceMetadataExtensions.cs
@@ -10,7 +10,7 @@ public static class InstanceMetadataExtensions
         if (instance is null)
             throw new ArgumentNullException(nameof(instance));
 
-        var md = instance.MetaData ?? new ObjectDictionary();
+        var md = instance.MetaData;
 
         return new SubFlowContractInfo
         {
@@ -20,7 +20,7 @@ public static class InstanceMetadataExtensions
             Flow    = GetString(md, DomainConsts.MetaDataKeys.Flow) ?? string.Empty,
             Version = GetString(md, DomainConsts.MetaDataKeys.Version),
             State   = GetString(md, DomainConsts.MetaDataKeys.State),
-            SubType = GetString(md, DomainConsts.MetaDataKeys.SubType) ?? string.Empty
+            SubType = GetString(md, DomainConsts.MetaDataKeys.FlowType) ?? string.Empty
         };
     }
     
@@ -34,14 +34,14 @@ public static class InstanceMetadataExtensions
             Flow    = GetString(metaData, DomainConsts.MetaDataKeys.Flow) ?? string.Empty,
             Version = GetString(metaData, DomainConsts.MetaDataKeys.Version),
             State   = GetString(metaData, DomainConsts.MetaDataKeys.State),
-            SubType = GetString(metaData, DomainConsts.MetaDataKeys.SubType) ?? string.Empty
+            SubType = GetString(metaData, DomainConsts.MetaDataKeys.FlowType) ?? string.Empty
         };
     }
 
     public static WorkflowType? ToFlowType(this Instance instance)
     {
         var md = instance.MetaData;
-        var type = GetString(md, DomainConsts.MetaDataKeys.SubType);
+        var type = GetString(md, DomainConsts.MetaDataKeys.FlowType);
         return !string.IsNullOrEmpty(type) 
             ? WorkflowType.FromCode(type)
             : null;
@@ -75,7 +75,7 @@ public static class InstanceMetadataExtensions
 
     public static T? GetValue<T>(this Instance instance, string key)
     {
-        if (instance?.MetaData == null)
+        if (instance.MetaData == null)
             return default;
 
         if (instance.MetaData.TryGetValue(key, out var value) && value is T typed)

--- a/src/BBT.Workflow.Domain/Scripting/Factory/Services/ScriptContextBuilder.cs
+++ b/src/BBT.Workflow.Domain/Scripting/Factory/Services/ScriptContextBuilder.cs
@@ -89,7 +89,7 @@ internal sealed class ScriptContextBuilder(
 
     public IScriptContextBuilder WithTransition(string? transitionKey)
     {
-        _transitionKey = transitionKey ?? throw new ArgumentNullException(nameof(transitionKey));
+        _transitionKey = transitionKey;
         _transition = null; // Clear direct transition if set
         return this;
     }
@@ -223,7 +223,7 @@ internal sealed class ScriptContextBuilder(
         if (_transition != null)
             return _transition;
 
-        if (_transitionKey != null)
+        if (!string.IsNullOrEmpty(_transitionKey))
         {
             var transition = workflow.FindTransitionInContext(_transitionKey);
             if (transition == null)

--- a/src/BBT.Workflow.Domain/Scripting/Models.cs
+++ b/src/BBT.Workflow.Domain/Scripting/Models.cs
@@ -1,9 +1,11 @@
+using System.Collections;
 using System.Dynamic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Runtime;
+using BBT.Workflow.Shared.Merging;
 
 namespace BBT.Workflow.Scripting;
 
@@ -59,9 +61,9 @@ public sealed class ScriptResponse
     /// Tags can be used for workflow analytics, debugging, conditional processing, or organizational purposes.
     /// </summary>
     /// <value>Array of string tags. Initialize as empty array if no tags are needed.</value>
-    public string[] Tags { get; set; }
+    public string[] Tags { get; set; } = Array.Empty<string>();
 }
-
+    
 /// <summary>
 /// Standardized task execution response that provides consistent structure for all task types.
 /// This model includes execution status, data, metadata, and error information.
@@ -358,14 +360,7 @@ public sealed class ScriptContext
             return;
         }
 
-        if (Body == null)
-        {
-            Body = newExpando;
-        }
-        else
-        {
-            Body = MergeExpandoObjects(Body, newExpando);
-        }
+        Body = Body == null ? newExpando : MergeExpandoObjects(Body, newExpando);
     }
 
     /// <summary>
@@ -382,16 +377,9 @@ public sealed class ScriptContext
 
         foreach (var kvp in sourceDict)
         {
-            if (targetDict.ContainsKey(kvp.Key))
-            {
-                var mergedValue = MergeValues(targetDict[kvp.Key], kvp.Value);
-                targetDict[kvp.Key] = mergedValue;
-            }
-            else
-            {
-                // Add new property
-                targetDict[kvp.Key] = kvp.Value;
-            }
+            targetDict[kvp.Key] = targetDict.TryGetValue(kvp.Key, out var existingValue)
+            ? MergeValues(existingValue, kvp.Value)
+            : kvp.Value;
         }
 
         return target;
@@ -399,126 +387,17 @@ public sealed class ScriptContext
 
     /// <summary>
     /// Recursively merges two values of any type, handling ExpandoObjects, JsonElements, arrays, and other complex types.
+    /// Uses the unified merge strategy system for consistent merging behavior.
     /// </summary>
     /// <param name="targetValue">The target value to merge into.</param>
     /// <param name="sourceValue">The source value to merge from.</param>
     /// <returns>The merged value.</returns>
     private static object? MergeValues(object? targetValue, object? sourceValue)
     {
-        // If source is null, keep target
-        if (sourceValue == null)
-        {
-            return targetValue;
-        }
-
-        // If target is null, use source
-        if (targetValue == null)
-        {
-            return sourceValue;
-        }
-
-        // Both are ExpandoObjects - merge recursively
-        if (targetValue is ExpandoObject targetExpando && sourceValue is ExpandoObject sourceExpando)
-        {
-            return MergeExpandoObjects(targetExpando, sourceExpando);
-        }
-
-        // Handle JsonElement objects by converting them to ExpandoObjects first
-        if (targetValue is JsonElement targetJsonElement && sourceValue is JsonElement sourceJsonElement)
-        {
-            if (targetJsonElement.ValueKind == JsonValueKind.Object &&
-                sourceJsonElement.ValueKind == JsonValueKind.Object)
-            {
-                var targetExpandoFromJson =
-                    JsonSerializer.Deserialize<ExpandoObject>(targetJsonElement.GetRawText(), JsonScriptBodyOptions);
-                var sourceExpandoFromJson =
-                    JsonSerializer.Deserialize<ExpandoObject>(sourceJsonElement.GetRawText(), JsonScriptBodyOptions);
-
-                if (targetExpandoFromJson != null && sourceExpandoFromJson != null)
-                {
-                    return MergeExpandoObjects(targetExpandoFromJson, sourceExpandoFromJson);
-                }
-            }
-        }
-
-        // Handle mixed JsonElement and ExpandoObject
-        if (targetValue is JsonElement targetJson && sourceValue is ExpandoObject sourceExp)
-        {
-            if (targetJson.ValueKind == JsonValueKind.Object)
-            {
-                var targetExpandoFromJson =
-                    JsonSerializer.Deserialize<ExpandoObject>(targetJson.GetRawText(), JsonScriptBodyOptions);
-                if (targetExpandoFromJson != null)
-                {
-                    return MergeExpandoObjects(targetExpandoFromJson, sourceExp);
-                }
-            }
-        }
-
-        if (targetValue is ExpandoObject targetExp && sourceValue is JsonElement sourceJson)
-        {
-            if (sourceJson.ValueKind == JsonValueKind.Object)
-            {
-                var sourceExpandoFromJson =
-                    JsonSerializer.Deserialize<ExpandoObject>(sourceJson.GetRawText(), JsonScriptBodyOptions);
-                if (sourceExpandoFromJson != null)
-                {
-                    return MergeExpandoObjects(targetExp, sourceExpandoFromJson);
-                }
-            }
-        }
-
-        // Handle arrays - concatenate or merge based on content
-        if (targetValue is JsonElement targetArray && sourceValue is JsonElement sourceArray)
-        {
-            if (targetArray.ValueKind == JsonValueKind.Array && sourceArray.ValueKind == JsonValueKind.Array)
-            {
-                var targetList = targetArray.EnumerateArray().ToList();
-                var sourceList = sourceArray.EnumerateArray().ToList();
-
-                // For arrays, we append source items to target
-                var mergedArray = new List<JsonElement>();
-                mergedArray.AddRange(targetList);
-                mergedArray.AddRange(sourceList);
-
-                // Convert back to JsonElement
-                var mergedJson = JsonSerializer.Serialize(mergedArray.Select(e => e.GetRawText()).ToArray());
-                return JsonSerializer.Deserialize<JsonElement>(mergedJson);
-            }
-        }
-
-        // Handle Dictionary<string, object> types that might come from different serialization contexts
-        if (targetValue is IDictionary<string, object?> targetDict &&
-            sourceValue is IDictionary<string, object?> sourceDict)
-        {
-            var result = new ExpandoObject() as IDictionary<string, object?>;
-
-            // Add all target properties
-            foreach (var kvp in targetDict)
-            {
-                result[kvp.Key] = kvp.Value;
-            }
-
-            // Merge source properties
-            foreach (var kvp in sourceDict)
-            {
-                if (result.ContainsKey(kvp.Key))
-                {
-                    result[kvp.Key] = MergeValues(result[kvp.Key], kvp.Value);
-                }
-                else
-                {
-                    result[kvp.Key] = kvp.Value;
-                }
-            }
-
-            return (ExpandoObject)result;
-        }
-
-        // For all other types, source takes precedence
-        return sourceValue;
+        return ObjectMerger.MergeValues(targetValue, sourceValue);
     }
 
+    
     private ScriptContext()
     {
     }

--- a/src/BBT.Workflow.Domain/Shared/JsonData.cs
+++ b/src/BBT.Workflow.Domain/Shared/JsonData.cs
@@ -29,6 +29,23 @@ public class JsonData : ValueObject
 
     public string Json { get; private set; } = "{}";
     
+    private string? _normalizedJson;
+    
+    /// <summary>
+    /// Gets the normalized JSON string for consistent hashing and comparison
+    /// </summary>
+    public string NormalizedJson
+    {
+        get
+        {
+            if (_normalizedJson == null)
+            {
+                _normalizedJson = NormalizeJson(Json);
+            }
+            return _normalizedJson;
+        }
+    }
+    
     public JsonElement JsonElement =>
         JsonSerializer.Deserialize<JsonElement>(Json, JsonSerializerConstants.JsonOptions)!;
 
@@ -74,6 +91,72 @@ public class JsonData : ValueObject
     protected override IEnumerable<object> GetAtomicValues()
     {
         yield return Json;
+    }
+
+    /// <summary>
+    /// Normalizes JSON string to ensure consistent hashing regardless of formatting
+    /// </summary>
+    /// <param name="json">The JSON string to normalize</param>
+    /// <returns>Normalized JSON string</returns>
+    private static string NormalizeJson(string json)
+    {
+        try
+        {
+            // Parse JSON to remove formatting differences
+            var jsonElement = JsonSerializer.Deserialize<JsonElement>(json);
+            
+            // Normalize the JSON element by sorting properties recursively
+            var normalizedElement = NormalizeJsonElement(jsonElement);
+            
+            // Re-serialize with consistent options for deterministic output
+            var options = new JsonSerializerOptions
+            {
+                WriteIndented = false,
+                PropertyNamingPolicy = null, // Keep original property names
+                Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+            };
+            
+            return JsonSerializer.Serialize(normalizedElement, options);
+        }
+        catch
+        {
+            // If JSON parsing fails, return original string
+            return json;
+        }
+    }
+
+    /// <summary>
+    /// Recursively normalizes a JsonElement by sorting object properties
+    /// </summary>
+    /// <param name="element">The JsonElement to normalize</param>
+    /// <returns>Normalized JsonElement</returns>
+    private static JsonElement NormalizeJsonElement(JsonElement element)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+                // Sort properties by name for consistent ordering
+                var sortedProperties = element.EnumerateObject()
+                    .OrderBy(prop => prop.Name, StringComparer.Ordinal)
+                    .ToDictionary(
+                        prop => prop.Name,
+                        prop => NormalizeJsonElement(prop.Value) // Recursive normalization
+                    );
+                
+                return JsonSerializer.SerializeToElement(sortedProperties);
+                
+            case JsonValueKind.Array:
+                // Normalize each array element
+                var normalizedArray = element.EnumerateArray()
+                    .Select(NormalizeJsonElement)
+                    .ToArray();
+                
+                return JsonSerializer.SerializeToElement(normalizedArray);
+                
+            default:
+                // For primitive values, return as-is
+                return element;
+        }
     }
 
     public static JsonData CreateFrom(string json)

--- a/src/BBT.Workflow.Domain/Shared/JsonData.cs
+++ b/src/BBT.Workflow.Domain/Shared/JsonData.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using BBT.Aether.Domain.Values;
+using BBT.Workflow.Shared.Merging;
 
 namespace BBT.Workflow;
 
@@ -51,41 +52,18 @@ public class JsonData : ValueObject
 
     public JsonData Merge(JsonData newData)
     {
-        if (JsonElement.ValueKind != JsonValueKind.Object || newData.JsonElement.ValueKind != JsonValueKind.Object)
+        // Use the unified merge strategy for JsonElement objects
+        var mergedElement = ObjectMerger.MergeValues(JsonElement, newData.JsonElement);
+        
+        // Convert back to JsonData
+        if (mergedElement is JsonElement jsonElement)
         {
-            // If either is not an object, return the new data
-            return newData;
+            return new JsonData(jsonElement);
         }
-
-        var mergedDict = new Dictionary<string, JsonElement>();
-
-        // First add all properties from the current object
-        foreach (var property in JsonElement.EnumerateObject())
-        {
-            mergedDict[property.Name] = property.Value;
-        }
-
-        // Then merge/override with properties from new data
-        foreach (var property in newData.JsonElement.EnumerateObject())
-        {
-            if (mergedDict.ContainsKey(property.Name) && 
-                mergedDict[property.Name].ValueKind == JsonValueKind.Object && 
-                property.Value.ValueKind == JsonValueKind.Object)
-            {
-                // Deep merge nested objects
-                var currentNestedData = new JsonData(mergedDict[property.Name]);
-                var newNestedData = new JsonData(property.Value);
-                var mergedNestedData = currentNestedData.Merge(newNestedData);
-                mergedDict[property.Name] = mergedNestedData.JsonElement;
-            }
-            else
-            {
-                // Override or add new property
-                mergedDict[property.Name] = property.Value;
-            }
-        }
-
-        return new JsonData(JsonSerializer.Serialize(mergedDict, JsonSerializerConstants.JsonOptions));
+        
+        // Fallback: if merge result is not JsonElement, serialize it
+        var serializedResult = JsonSerializer.Serialize(mergedElement, JsonSerializerConstants.JsonOptions);
+        return new JsonData(serializedResult);
     }
 
     protected override IEnumerable<object> GetAtomicValues()

--- a/src/BBT.Workflow.Domain/Shared/Merging/IMergeStrategy.cs
+++ b/src/BBT.Workflow.Domain/Shared/Merging/IMergeStrategy.cs
@@ -1,0 +1,16 @@
+namespace BBT.Workflow.Shared.Merging;
+
+/// <summary>
+/// Defines a strategy for merging two objects of any type.
+/// Implementations should handle specific type combinations and merging logic.
+/// </summary>
+public interface IMergeStrategy
+{
+    /// <summary>
+    /// Merges two objects according to the strategy's specific logic.
+    /// </summary>
+    /// <param name="target">The target object to merge into.</param>
+    /// <param name="source">The source object to merge from.</param>
+    /// <returns>The merged result object.</returns>
+    object? Merge(object? target, object? source);
+}

--- a/src/BBT.Workflow.Domain/Shared/Merging/MergeStrategyFactory.cs
+++ b/src/BBT.Workflow.Domain/Shared/Merging/MergeStrategyFactory.cs
@@ -1,0 +1,56 @@
+using System.Collections;
+using System.Dynamic;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+
+namespace BBT.Workflow.Shared.Merging;
+
+/// <summary>
+/// Factory class responsible for selecting the appropriate merge strategy based on object types.
+/// Uses singleton instances for optimal performance in high-frequency scenarios.
+/// </summary>
+public static class MergeStrategyFactory
+{
+    // Singleton instances for performance optimization - initialized once at startup
+    private static readonly IMergeStrategy _expandoObjectStrategy = new ExpandoObjectMergeStrategy();
+    private static readonly IMergeStrategy _jsonElementStrategy = new JsonElementMergeStrategy();
+    private static readonly IMergeStrategy _collectionStrategy = new CollectionMergeStrategy();
+    private static readonly IMergeStrategy _defaultStrategy = new DefaultMergeStrategy();
+
+    /// <summary>
+    /// Gets the appropriate merge strategy for the given target and source objects.
+    /// Returns singleton instances to avoid memory allocations in high-frequency scenarios.
+    /// </summary>
+    /// <param name="target">The target object.</param>
+    /// <param name="source">The source object.</param>
+    /// <returns>The most suitable merge strategy for the given object types.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static IMergeStrategy GetStrategy(object? target, object? source)
+    {
+        // Handle null cases
+        if (target == null || source == null)
+            return _defaultStrategy;
+
+        // Handle ExpandoObject merging (highest priority)
+        if (target is ExpandoObject && source is ExpandoObject)
+            return _expandoObjectStrategy;
+    
+        // Handle JsonElement merging
+        if (target is JsonElement && source is JsonElement)
+            return _jsonElementStrategy;
+
+        // Handle mixed JsonElement and ExpandoObject scenarios
+        if ((target is JsonElement && source is ExpandoObject) ||
+            (target is ExpandoObject && source is JsonElement))
+        {
+            return _jsonElementStrategy;
+        }
+    
+        // Handle collections (but not strings, as they implement IEnumerable)
+        if (target is IEnumerable && source is IEnumerable && 
+            target is not string && source is not string)
+            return _collectionStrategy;
+        
+        return _defaultStrategy;
+    }
+}

--- a/src/BBT.Workflow.Domain/Shared/Merging/ObjectMerger.cs
+++ b/src/BBT.Workflow.Domain/Shared/Merging/ObjectMerger.cs
@@ -1,0 +1,30 @@
+using System.Runtime.CompilerServices;
+
+namespace BBT.Workflow.Shared.Merging;
+
+/// <summary>
+/// Central object merger that coordinates different merge strategies.
+/// Provides a unified entry point for all object merging operations with performance optimizations.
+/// </summary>
+public static class ObjectMerger
+{
+    /// <summary>
+    /// Merges two objects using the most appropriate strategy based on their types.
+    /// Handles null cases, type-specific merging, and recursive deep merging.
+    /// Optimized for high-frequency usage with aggressive inlining.
+    /// </summary>
+    /// <param name="target">The target object to merge into.</param>
+    /// <param name="source">The source object to merge from.</param>
+    /// <returns>The merged result object.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static object? MergeValues(object? target, object? source)
+    {
+        // Handle null cases first
+        if (source == null) return target;
+        if (target == null) return source;
+
+        // Use type-specific merge strategies (singleton instances)
+        var strategy = MergeStrategyFactory.GetStrategy(target, source);
+        return strategy.Merge(target, source);
+    }
+}

--- a/src/BBT.Workflow.Domain/Shared/Merging/Strategies/CollectionMergeStrategy.cs
+++ b/src/BBT.Workflow.Domain/Shared/Merging/Strategies/CollectionMergeStrategy.cs
@@ -1,0 +1,113 @@
+using System.Collections;
+using System.Dynamic;
+using System.Text.Json;
+
+namespace BBT.Workflow.Shared.Merging;
+
+/// <summary>
+/// Merge strategy for collection types including dictionaries and enumerable objects.
+/// Handles dictionary merging with recursive value merging and collection concatenation.
+/// </summary>
+public class CollectionMergeStrategy : IMergeStrategy
+{
+    /// <summary>
+    /// Merges two collections by concatenating them or merging their contents.
+    /// </summary>
+    /// <param name="target">The target collection.</param>
+    /// <param name="source">The source collection.</param>
+    /// <returns>The merged collection.</returns>
+    public object? Merge(object? target, object? source)
+    {
+        if (target is not IEnumerable targetCollection || source is not IEnumerable sourceCollection)
+            return source;
+
+        return MergeCollections(targetCollection, sourceCollection);
+    }
+
+    /// <summary>
+    /// Merges two collections by concatenating them or merging dictionary contents.
+    /// </summary>
+    /// <param name="target">The target collection.</param>
+    /// <param name="source">The source collection.</param>
+    /// <returns>The merged collection.</returns>
+    private static object? MergeCollections(IEnumerable target, IEnumerable source)
+    {
+        // Handle Dictionary<string, object> types
+        if (target is IDictionary<string, object?> targetDict && source is IDictionary<string, object?> sourceDict)
+        {
+            var result = new ExpandoObject() as IDictionary<string, object?>;
+
+            // Add all target properties
+            foreach (var kvp in targetDict)
+            {
+                result[kvp.Key] = kvp.Value;
+            }
+
+            // Merge source properties
+            foreach (var kvp in sourceDict)
+            {
+                if (result.ContainsKey(kvp.Key))
+                {
+                    result[kvp.Key] = ObjectMerger.MergeValues(result[kvp.Key], kvp.Value);
+                }
+                else
+                {
+                    result[kvp.Key] = kvp.Value;
+                }
+            }
+
+            return (ExpandoObject)result;
+        }
+
+        // For other enumerable types, perform full deep merge
+        try
+        {
+            var targetList = target.Cast<object>().ToList();
+            var sourceList = source.Cast<object>().ToList();
+            
+            return PerformFullDeepMerge(targetList, sourceList);
+        }
+        catch
+        {
+            // If casting fails, return source
+            return source;
+        }
+    }
+
+    /// <summary>
+    /// Performs full deep merge of two object lists without any key-based restrictions.
+    /// Merges objects at same positions and appends remaining items.
+    /// </summary>
+    /// <param name="targetList">The target object list.</param>
+    /// <param name="sourceList">The source object list.</param>
+    /// <returns>The fully merged object list.</returns>
+    private static List<object> PerformFullDeepMerge(List<object> targetList, List<object> sourceList)
+    {
+        var mergedItems = new List<object>();
+        var maxLength = Math.Max(targetList.Count, sourceList.Count);
+
+        // Merge items at same positions
+        for (int i = 0; i < maxLength; i++)
+        {
+            if (i < targetList.Count && i < sourceList.Count)
+            {
+                // Both lists have items at this position - deep merge them
+                var mergedItem = ObjectMerger.MergeValues(targetList[i], sourceList[i]);
+                mergedItems.Add(mergedItem ?? sourceList[i]);
+            }
+            else if (i < targetList.Count)
+            {
+                // Only target has item at this position
+                mergedItems.Add(targetList[i]);
+            }
+            else
+            {
+                // Only source has item at this position
+                mergedItems.Add(sourceList[i]);
+            }
+        }
+
+        return mergedItems;
+    }
+
+}

--- a/src/BBT.Workflow.Domain/Shared/Merging/Strategies/CollectionMergeStrategy.cs
+++ b/src/BBT.Workflow.Domain/Shared/Merging/Strategies/CollectionMergeStrategy.cs
@@ -46,14 +46,9 @@ public class CollectionMergeStrategy : IMergeStrategy
             // Merge source properties
             foreach (var kvp in sourceDict)
             {
-                if (result.ContainsKey(kvp.Key))
-                {
-                    result[kvp.Key] = ObjectMerger.MergeValues(result[kvp.Key], kvp.Value);
-                }
-                else
-                {
-                    result[kvp.Key] = kvp.Value;
-                }
+                result[kvp.Key] = result.TryGetValue(kvp.Key, out var value)
+                    ? ObjectMerger.MergeValues(value, kvp.Value)
+                    : kvp.Value;
             }
 
             return (ExpandoObject)result;
@@ -64,7 +59,7 @@ public class CollectionMergeStrategy : IMergeStrategy
         {
             var targetList = target.Cast<object>().ToList();
             var sourceList = source.Cast<object>().ToList();
-            
+
             return PerformFullDeepMerge(targetList, sourceList);
         }
         catch
@@ -109,5 +104,4 @@ public class CollectionMergeStrategy : IMergeStrategy
 
         return mergedItems;
     }
-
 }

--- a/src/BBT.Workflow.Domain/Shared/Merging/Strategies/DefaultMergeStrategy.cs
+++ b/src/BBT.Workflow.Domain/Shared/Merging/Strategies/DefaultMergeStrategy.cs
@@ -1,0 +1,20 @@
+namespace BBT.Workflow.Shared.Merging;
+
+/// <summary>
+/// Default merge strategy that simply returns the source value.
+/// Used as a fallback when no specific merge strategy is applicable.
+/// </summary>
+public class DefaultMergeStrategy : IMergeStrategy
+{
+    /// <summary>
+    /// Returns the source value, effectively overriding the target.
+    /// </summary>
+    /// <param name="target">The target object (ignored).</param>
+    /// <param name="source">The source object to return.</param>
+    /// <returns>The source object.</returns>
+    public object? Merge(object? target, object? source)
+    {
+        // Use source value for non-mergeable types
+        return source;
+    }
+}

--- a/src/BBT.Workflow.Domain/Shared/Merging/Strategies/ExpandoObjectMergeStrategy.cs
+++ b/src/BBT.Workflow.Domain/Shared/Merging/Strategies/ExpandoObjectMergeStrategy.cs
@@ -36,16 +36,10 @@ public class ExpandoObjectMergeStrategy : IMergeStrategy
 
         foreach (var kvp in sourceDict)
         {
-            if (targetDict.TryGetValue(kvp.Key, out var existingValue))
-            {
-                // Key exists - merge values recursively
-                targetDict[kvp.Key] = ObjectMerger.MergeValues(existingValue, kvp.Value);
-            }
-            else
-            {
-                // Add new property
-                targetDict[kvp.Key] = kvp.Value;
-            }
+            targetDict[kvp.Key] =
+                targetDict.TryGetValue(kvp.Key, out var existingValue)
+                    ? ObjectMerger.MergeValues(existingValue, kvp.Value)
+                    : kvp.Value;
         }
 
         return target;

--- a/src/BBT.Workflow.Domain/Shared/Merging/Strategies/ExpandoObjectMergeStrategy.cs
+++ b/src/BBT.Workflow.Domain/Shared/Merging/Strategies/ExpandoObjectMergeStrategy.cs
@@ -1,0 +1,53 @@
+using System.Dynamic;
+
+namespace BBT.Workflow.Shared.Merging;
+
+/// <summary>
+/// Merge strategy for ExpandoObject instances.
+/// Performs deep recursive merging of ExpandoObject properties.
+/// </summary>
+public class ExpandoObjectMergeStrategy : IMergeStrategy
+{
+    /// <summary>
+    /// Merges two ExpandoObject instances recursively.
+    /// </summary>
+    /// <param name="target">The target ExpandoObject.</param>
+    /// <param name="source">The source ExpandoObject.</param>
+    /// <returns>The merged ExpandoObject.</returns>
+    public object? Merge(object? target, object? source)
+    {
+        if (target is not ExpandoObject targetExpando || source is not ExpandoObject sourceExpando)
+            return source;
+
+        return MergeExpandoObjects(targetExpando, sourceExpando);
+    }
+
+    /// <summary>
+    /// Merges two ExpandoObject instances, with properties from the source taking precedence.
+    /// Handles all nested structures recursively.
+    /// </summary>
+    /// <param name="target">The target ExpandoObject to merge into.</param>
+    /// <param name="source">The source ExpandoObject to merge from.</param>
+    /// <returns>The merged ExpandoObject.</returns>
+    private static ExpandoObject MergeExpandoObjects(ExpandoObject target, ExpandoObject source)
+    {
+        var targetDict = (IDictionary<string, object?>)target;
+        var sourceDict = (IDictionary<string, object?>)source;
+
+        foreach (var kvp in sourceDict)
+        {
+            if (targetDict.TryGetValue(kvp.Key, out var existingValue))
+            {
+                // Key exists - merge values recursively
+                targetDict[kvp.Key] = ObjectMerger.MergeValues(existingValue, kvp.Value);
+            }
+            else
+            {
+                // Add new property
+                targetDict[kvp.Key] = kvp.Value;
+            }
+        }
+
+        return target;
+    }
+}

--- a/src/BBT.Workflow.Domain/Shared/Merging/Strategies/JsonElementMergeStrategy.cs
+++ b/src/BBT.Workflow.Domain/Shared/Merging/Strategies/JsonElementMergeStrategy.cs
@@ -1,0 +1,141 @@
+using System.Dynamic;
+using System.Text.Json;
+using BBT.Workflow.Scripting;
+
+namespace BBT.Workflow.Shared.Merging;
+
+/// <summary>
+/// Merge strategy for JsonElement instances and mixed JsonElement/ExpandoObject scenarios.
+/// Handles object merging, array concatenation, and type conversions.
+/// </summary>
+public class JsonElementMergeStrategy : IMergeStrategy
+{
+    /// <summary>
+    /// Merges JsonElement objects and handles mixed JsonElement/ExpandoObject scenarios.
+    /// </summary>
+    /// <param name="target">The target value (JsonElement or ExpandoObject).</param>
+    /// <param name="source">The source value (JsonElement or ExpandoObject).</param>
+    /// <returns>The merged result.</returns>
+    public object? Merge(object? target, object? source)
+    {
+        if (target == null || source == null)
+            return source ?? target;
+
+        return MergeJsonElements(target, source);
+    }
+
+    /// <summary>
+    /// Merges JsonElement objects and handles mixed JsonElement/ExpandoObject scenarios.
+    /// </summary>
+    /// <param name="target">The target value (JsonElement or ExpandoObject).</param>
+    /// <param name="source">The source value (JsonElement or ExpandoObject).</param>
+    /// <returns>The merged result.</returns>
+    private static object? MergeJsonElements(object target, object source)
+    {
+        // Handle JsonElement to JsonElement merging
+        if (target is JsonElement targetElement && source is JsonElement sourceElement)
+        {
+            // Handle object merging
+            if (targetElement.ValueKind == JsonValueKind.Object && sourceElement.ValueKind == JsonValueKind.Object)
+            {
+                var targetExpandoFromJson = JsonSerializer.Deserialize<ExpandoObject>(targetElement.GetRawText(), ScriptContext.JsonScriptBodyOptions);
+                var sourceExpandoFromJson = JsonSerializer.Deserialize<ExpandoObject>(sourceElement.GetRawText(), ScriptContext.JsonScriptBodyOptions);
+
+                if (targetExpandoFromJson != null && sourceExpandoFromJson != null)
+                {
+                    var expandoStrategy = new ExpandoObjectMergeStrategy();
+                    return expandoStrategy.Merge(targetExpandoFromJson, sourceExpandoFromJson);
+                }
+            }
+
+            // Handle array merging with full deep merge
+            if (targetElement.ValueKind == JsonValueKind.Array && sourceElement.ValueKind == JsonValueKind.Array)
+            {
+                return MergeJsonArraysDeep(targetElement, sourceElement);
+            }
+
+            // For other JsonElement types, source takes precedence
+            return sourceElement;
+        }
+
+        // Handle mixed JsonElement and ExpandoObject scenarios
+        if (target is JsonElement targetJson && source is ExpandoObject sourceExp)
+        {
+            if (targetJson.ValueKind == JsonValueKind.Object)
+            {
+                var targetExpandoFromMixed = JsonSerializer.Deserialize<ExpandoObject>(targetJson.GetRawText(), ScriptContext.JsonScriptBodyOptions);
+                if (targetExpandoFromMixed != null)
+                {
+                    var expandoStrategy = new ExpandoObjectMergeStrategy();
+                    return expandoStrategy.Merge(targetExpandoFromMixed, sourceExp);
+                }
+            }
+            return sourceExp;
+        }
+
+        if (target is ExpandoObject targetExp && source is JsonElement sourceJson)
+        {
+            if (sourceJson.ValueKind == JsonValueKind.Object)
+            {
+                var sourceExpandoFromMixed = JsonSerializer.Deserialize<ExpandoObject>(sourceJson.GetRawText(), ScriptContext.JsonScriptBodyOptions);
+                if (sourceExpandoFromMixed != null)
+                {
+                    var expandoStrategy = new ExpandoObjectMergeStrategy();
+                    return expandoStrategy.Merge(targetExp, sourceExpandoFromMixed);
+                }
+            }
+            return sourceJson;
+        }
+
+        // For all other cases, source takes precedence
+        return source;
+    }
+
+    /// <summary>
+    /// Performs full deep merge of two JSON arrays without key-based restrictions.
+    /// Merges objects at same positions and appends remaining items.
+    /// </summary>
+    /// <param name="targetArray">The target JSON array.</param>
+    /// <param name="sourceArray">The source JSON array.</param>
+    /// <returns>The fully merged JSON array.</returns>
+    private static JsonElement MergeJsonArraysDeep(JsonElement targetArray, JsonElement sourceArray)
+    {
+        var targetList = targetArray.EnumerateArray().ToList();
+        var sourceList = sourceArray.EnumerateArray().ToList();
+        var mergedItems = new List<JsonElement>();
+        var maxLength = Math.Max(targetList.Count, sourceList.Count);
+
+        // Merge items at same positions
+        for (int i = 0; i < maxLength; i++)
+        {
+            if (i < targetList.Count && i < sourceList.Count)
+            {
+                // Both arrays have items at this position - deep merge them
+                var mergedItem = MergeJsonElements(targetList[i], sourceList[i]);
+                if (mergedItem is JsonElement jsonElement)
+                {
+                    mergedItems.Add(jsonElement);
+                }
+                else
+                {
+                    // Fallback to source item if merge fails
+                    mergedItems.Add(sourceList[i]);
+                }
+            }
+            else if (i < targetList.Count)
+            {
+                // Only target has item at this position
+                mergedItems.Add(targetList[i]);
+            }
+            else
+            {
+                // Only source has item at this position
+                mergedItems.Add(sourceList[i]);
+            }
+        }
+
+        // Convert back to JsonElement
+        var mergedJson = JsonSerializer.Serialize(mergedItems.Select(e => e.GetRawText()).ToArray());
+        return JsonSerializer.Deserialize<JsonElement>(mergedJson);
+    }
+}

--- a/src/BBT.Workflow.Domain/System/ETagExtensions.cs
+++ b/src/BBT.Workflow.Domain/System/ETagExtensions.cs
@@ -14,6 +14,6 @@ public static class ETagExtensions
     /// <returns>True if the ETags match, false otherwise</returns>
     public static bool MatchesIfNoneMatch(this string currentETag, string ifNoneMatch)
     {
-        return currentETag == ifNoneMatch;
+        return currentETag.Equals(ifNoneMatch, StringComparison.OrdinalIgnoreCase);
     }
 } 

--- a/src/BBT.Workflow.Infrastructure/Data/InstancesModelCreatingExtensions.cs
+++ b/src/BBT.Workflow.Infrastructure/Data/InstancesModelCreatingExtensions.cs
@@ -100,6 +100,11 @@ public static class InstancesModelCreatingExtensions
             b.Property(p => p.ETag)
                 .IsRequired()
                 .HasMaxLength(WorkflowConstants.MaxETagLength);
+            
+            b.Property(p => p.DataHash)
+                .IsRequired()
+                .HasDefaultValue("99914b932bd37a50b983c5e7c90ae93b") // Default Value: {}
+                .HasMaxLength(WorkflowConstants.MaxDataHashLength);
 
             b.OwnsOne(p => p.Data, d =>
             {

--- a/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceRepository.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceRepository.cs
@@ -8,7 +8,6 @@ using BBT.Workflow.Runtime;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
-using System.Text.Json;
 
 namespace BBT.Workflow.Instances;
 
@@ -129,16 +128,14 @@ public sealed class EfCoreInstanceRepository(
         string key,
         CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
-            .Include(i => i.DataList)
+        return await (await WithDetailsAsync())
             .FirstOrDefaultAsync(
                 p => p.Key == key, cancellationToken);
     }
 
     public async Task<Instance?> FindByKeyAsReadOnlyAsync(string key, CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
-            .Include(i => i.DataList)
+        return await (await WithDetailsAsync())
             .AsNoTracking()
             .FirstOrDefaultAsync(
                 p => p.Key == key, cancellationToken);
@@ -148,12 +145,18 @@ public sealed class EfCoreInstanceRepository(
         Guid id,
         CancellationToken cancellationToken = default)
     {
-        return await (await GetDbSetAsync())
-            .Include(i => i.DataList)
+        return await (await WithDetailsAsync())
             .FirstOrDefaultAsync(
                 p => p.Id == id, cancellationToken);
     }
 
+    public async Task<Instance?> FindByIdAsReadOnlyAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        return await (await WithDetailsAsync())
+            .AsNoTracking()
+            .FirstOrDefaultAsync(
+                p => p.Id == id, cancellationToken);
+    }
 
     public async Task<InstanceAndDataModel?> FindActiveDataAsync(string key, string version,
         CancellationToken cancellationToken = default)
@@ -278,7 +281,7 @@ public sealed class EfCoreInstanceRepository(
         return query;
     }
 
-    public async Task<Definitions.PaginationResult<Instance>> GetPagedResultsAsync(
+    public async Task<PaginationResult<Instance>> GetPagedResultsAsync(
         int page,
         int pageSize,
         string route,
@@ -286,7 +289,7 @@ public sealed class EfCoreInstanceRepository(
         IQueryable<Instance>? instance = null,
         CancellationToken cancellationToken = default)
     {
-        var query = instance ?? (await base.GetQueryableAsync()).Include(i => i.DataList);
+        var query = instance ?? (await GetQueryableAsync()).Include(i => i.DataList);
         return query.Paginate(page, pageSize, route, configuration, queryParams);
     }
 
@@ -295,10 +298,15 @@ public sealed class EfCoreInstanceRepository(
         var context = await GetDbContextAsync();
         await context.Instances
             .Where(p => p.Id == instance.Id)
-            .ExecuteUpdateAsync(sp =>
-                    sp.SetProperty(p => p.Status, instance.Status),
-                cancellationToken
-            );
+            .ExecuteUpdateAsync(s => s
+                    .SetProperty(p => p.Status, instance.Status)
+                    .SetProperty(p => p.CompletedAt, instance.IsCompleted 
+                        ? instance.CompletedAt 
+                        : null)
+                    .SetProperty(p => p.Duration, instance.IsCompleted 
+                        ? instance.Duration 
+                        : null),
+                cancellationToken);
     }
 
     public async Task<Instance> GetActiveAsync(Guid id, CancellationToken cancellationToken = default)

--- a/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceTransitionRepository.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceTransitionRepository.cs
@@ -2,6 +2,7 @@ using BBT.Aether.Domain.EntityFrameworkCore;
 using BBT.Aether.Domain.Services;
 using BBT.Workflow.Data;
 using BBT.Workflow.DataSink;
+using Microsoft.EntityFrameworkCore;
 
 namespace BBT.Workflow.Instances;
 
@@ -53,5 +54,18 @@ public class EfCoreInstanceTransitionRepository(
         }
         
         return result;
+    }
+
+    public async Task UpdateCompletedAsync(InstanceTransition transition, CancellationToken cancellationToken)
+    {
+        var context = await GetDbContextAsync();
+        await context.InstanceTransitions
+            .Where(p => p.Id == transition.Id)
+            .ExecuteUpdateAsync(sp => sp
+                    .SetProperty(p => p.ToState, transition.ToState)
+                    .SetProperty(p => p.FinishedAt, transition.FinishedAt)
+                    .SetProperty(p => p.Duration, transition.Duration),
+                cancellationToken
+            );
     }
 }

--- a/src/BBT.Workflow.Infrastructure/Migrations/20250929141651_Added_DataHash_InstanceData.Designer.cs
+++ b/src/BBT.Workflow.Infrastructure/Migrations/20250929141651_Added_DataHash_InstanceData.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using BBT.Workflow.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BBT.Workflow.Migrations
 {
     [DbContext(typeof(WorkflowDbContext))]
-    partial class WorkflowDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250929141651_Added_DataHash_InstanceData")]
+    partial class Added_DataHash_InstanceData
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/BBT.Workflow.Infrastructure/Migrations/20250929141651_Added_DataHash_InstanceData.cs
+++ b/src/BBT.Workflow.Infrastructure/Migrations/20250929141651_Added_DataHash_InstanceData.cs
@@ -1,8 +1,6 @@
 ﻿using BBT.Workflow.Data;
 using Microsoft.EntityFrameworkCore.Migrations;
 
-#nullable disable
-
 namespace BBT.Workflow.Migrations
 {
     /// <inheritdoc />

--- a/src/BBT.Workflow.Infrastructure/Migrations/20250929141651_Added_DataHash_InstanceData.cs
+++ b/src/BBT.Workflow.Infrastructure/Migrations/20250929141651_Added_DataHash_InstanceData.cs
@@ -1,0 +1,39 @@
+﻿using BBT.Workflow.Data;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BBT.Workflow.Migrations
+{
+    /// <inheritdoc />
+    public partial class Added_DataHash_InstanceData : Migration
+    {
+        private readonly IDbContextSchema _schema;
+        
+        public Added_DataHash_InstanceData(IDbContextSchema schema)
+        {
+            _schema = schema;
+        }
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "DataHash",
+                schema: _schema.SchemaName,
+                table: "InstancesData",
+                type: "character varying(40)",
+                maxLength: 40,
+                nullable: false,
+                defaultValue: "99914b932bd37a50b983c5e7c90ae93b");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DataHash",
+                schema: _schema.SchemaName,
+                table: "InstancesData");
+        }
+    }
+}

--- a/test/BBT.Workflow.Domain.Tests/Instances/InstanceTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Instances/InstanceTests.cs
@@ -246,6 +246,184 @@ public class InstanceTests : DomainTestBase<DomainEntryPoint>
     }
 
     [Fact]
+    public void AddData_ShouldNotCreateNewVersion_WhenDataIsSame()
+    {
+        // Arrange
+        var instance = InstanceFactory.CreateDefault();
+        var dataId1 = Guid.NewGuid();
+        var dataId2 = Guid.NewGuid();
+        var sameData = JsonData.CreateFrom("{\"key\":\"value\"}");
+        
+        // Act
+        var result1 = instance.AddData(dataId1, sameData);
+        var result2 = instance.AddData(dataId2, sameData);
+        
+        // Assert
+        Assert.Single(instance.DataList);
+        Assert.Equal(result1.Id, result2.Id); // Same instance returned
+        Assert.Equal(result1.Version, result2.Version);
+        Assert.Equal(result1.DataHash, result2.DataHash);
+    }
+
+    [Fact]
+    public void AddData_ShouldCreateNewVersion_WhenDataIsDifferent()
+    {
+        // Arrange
+        var instance = InstanceFactory.CreateDefault();
+        var dataId1 = Guid.NewGuid();
+        var dataId2 = Guid.NewGuid();
+        var data1 = JsonData.CreateFrom("{\"key\":\"value1\"}");
+        var data2 = JsonData.CreateFrom("{\"key\":\"value2\"}");
+        
+        // Act
+        var result1 = instance.AddData(dataId1, data1);
+        var result2 = instance.AddData(dataId2, data2);
+        
+        // Assert
+        Assert.Equal(2, instance.DataList.Count);
+        Assert.NotEqual(result1.Id, result2.Id);
+        Assert.NotEqual(result1.Version, result2.Version);
+        Assert.NotEqual(result1.DataHash, result2.DataHash);
+        Assert.False(result1.IsLatest);
+        Assert.True(result2.IsLatest);
+    }
+
+    [Fact]
+    public void AddDataWithVersion_ShouldNotCreateNewVersion_WhenDataIsSame()
+    {
+        // Arrange
+        var instance = InstanceFactory.CreateDefault();
+        var dataId1 = Guid.NewGuid();
+        var dataId2 = Guid.NewGuid();
+        var sameData = JsonData.CreateFrom("{\"key\":\"value\"}");
+        
+        // Act
+        var result1 = instance.AddDataWithVersion(dataId1, sameData, "1.0.0");
+        var result2 = instance.AddDataWithVersion(dataId2, sameData, "2.0.0");
+        
+        // Assert
+        Assert.Single(instance.DataList);
+        Assert.Equal(result1.Id, result2.Id); // Same instance returned
+        Assert.Equal("1.0.0", result2.Version); // Original version maintained
+        Assert.Equal(result1.DataHash, result2.DataHash);
+    }
+
+    [Fact]
+    public void AddDataWithVersion_ShouldCreateNewVersion_WhenDataIsDifferent()
+    {
+        // Arrange
+        var instance = InstanceFactory.CreateDefault();
+        var dataId1 = Guid.NewGuid();
+        var dataId2 = Guid.NewGuid();
+        var data1 = JsonData.CreateFrom("{\"key\":\"value1\"}");
+        var data2 = JsonData.CreateFrom("{\"key\":\"value2\"}");
+        
+        // Act
+        var result1 = instance.AddDataWithVersion(dataId1, data1, "1.0.0");
+        var result2 = instance.AddDataWithVersion(dataId2, data2, "2.0.0");
+        
+        // Assert
+        Assert.Equal(2, instance.DataList.Count);
+        Assert.NotEqual(result1.Id, result2.Id);
+        Assert.Equal("1.0.0", result1.Version);
+        Assert.Equal("2.0.0", result2.Version);
+        Assert.NotEqual(result1.DataHash, result2.DataHash);
+        Assert.False(result1.IsLatest);
+        Assert.True(result2.IsLatest);
+    }
+
+    [Fact]
+    public void InstanceData_HasSameData_ShouldReturnTrue_WhenDataIsIdentical()
+    {
+        // Arrange
+        var data1 = JsonData.CreateFrom("{\"key\":\"value\"}");
+        var data2 = JsonData.CreateFrom("{\"key\":\"value\"}");
+        var instance = InstanceFactory.CreateDefault();
+        var instanceData = instance.AddDataWithVersion(Guid.NewGuid(), data1, "1.0.0");
+        
+        // Act
+        var result = instanceData.HasSameData(data2);
+        
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void InstanceData_HasSameData_ShouldReturnFalse_WhenDataIsDifferent()
+    {
+        // Arrange
+        var data1 = JsonData.CreateFrom("{\"key\":\"value1\"}");
+        var data2 = JsonData.CreateFrom("{\"key\":\"value2\"}");
+        var instance = InstanceFactory.CreateDefault();
+        var instanceData = instance.AddDataWithVersion(Guid.NewGuid(), data1, "1.0.0");
+        
+        // Act
+        var result = instanceData.HasSameData(data2);
+        
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void InstanceData_HasSameData_ShouldReturnTrue_WithDifferentJsonFormatting()
+    {
+        // Arrange - Same semantic content but different formatting
+        var data1 = JsonData.CreateFrom("{\"key\":\"value\",\"number\":123}");
+        var data2 = JsonData.CreateFrom("{ \"number\": 123, \"key\": \"value\" }"); // Different order & spacing
+        var instance = InstanceFactory.CreateDefault();
+        var instanceData = instance.AddDataWithVersion(Guid.NewGuid(), data1, "1.0.0");
+        
+        // Act
+        var result = instanceData.HasSameData(data2);
+        
+        // Assert
+        Assert.True(result); // Should be true because semantic content is same
+    }
+
+    [Fact]
+    public void AddData_ShouldNotCreateNewVersion_WithDifferentJsonFormatting()
+    {
+        // Arrange - Same semantic content but different formatting
+        var instance = InstanceFactory.CreateDefault();
+        var dataId1 = Guid.NewGuid();
+        var dataId2 = Guid.NewGuid();
+        var data1 = JsonData.CreateFrom("{\"key\":\"value\",\"items\":[1,2,3]}");
+        var data2 = JsonData.CreateFrom("{ \"items\": [1, 2, 3], \"key\": \"value\" }"); // Different formatting
+        
+        // Act
+        var result1 = instance.AddData(dataId1, data1);
+        var result2 = instance.AddData(dataId2, data2);
+        
+        // Assert
+        Assert.Single(instance.DataList);
+        Assert.Equal(result1.Id, result2.Id); // Same instance returned
+        Assert.Equal(result1.DataHash, result2.DataHash); // Same hash
+    }
+
+    [Fact]
+    public void JsonData_NormalizedJson_ShouldReturnConsistentFormat()
+    {
+        // Arrange - Same semantic content but different formatting
+        var json1 = JsonData.CreateFrom("{\"key\":\"value\",\"items\":[1,2,3]}");
+        var json2 = JsonData.CreateFrom("{ \"items\": [1, 2, 3], \"key\": \"value\" }");
+        var json3 = JsonData.CreateFrom("{\n  \"key\": \"value\",\n  \"items\": [\n    1,\n    2,\n    3\n  ]\n}");
+        
+        // Act
+        var normalized1 = json1.NormalizedJson;
+        var normalized2 = json2.NormalizedJson;
+        var normalized3 = json3.NormalizedJson;
+        
+        // Assert
+        Assert.Equal(normalized1, normalized2);
+        Assert.Equal(normalized2, normalized3);
+        Assert.Equal(normalized1, normalized3);
+        
+        // Verify it's deterministic (property order should be consistent)
+        Assert.Contains("\"items\"", normalized1);
+        Assert.Contains("\"key\"", normalized1);
+    }
+
+    [Fact]
     public void LatestData_ShouldReturnCorrectResult_DuringConcurrentAccess()
     {
         // Arrange


### PR DESCRIPTION
## Summary by Sourcery

Enable semantic JSON comparison with normalization and hashing for instance data, introduce a unified merge strategy framework, refactor instance status and refresh logic to prevent flows from getting stuck in Busy state, extend repository and DI support, and add comprehensive unit tests.

New Features:
- Add JSON normalization and hashing in JsonData and InstanceData to enable semantic comparisons and avoid duplicate versions.
- Introduce a unified merging infrastructure (ObjectMerger and IMergeStrategy implementations) for deep merging of ExpandoObject, JsonElement, and collections.
- Implement IInstanceRefreshStrategy and integrate conditional instance refresh after auto-transitions to maintain up-to-date state.
- Add subflow-aware status management methods (TrySetStatusBasedOnState, TryActivateIfBusyWithoutSubFlow, ShouldPublishCompletionEvent) to handle Busy/Active transitions correctly.
- Extend IInstanceRepository and IInstanceTransitionRepository with read-only find and UpdateCompletedAsync methods, optimize EF Core queries, and register new services in DI.

Bug Fixes:
- Prevent Busy and Active calls from changing status on completed instances.
- Automatically reactivate parent instances when subflows complete and ensure instance state is refreshed before scheduling transitions.

Enhancements:
- Simplify ScriptContext merging logic by replacing ad-hoc code with ObjectMerger.
- Initialize ScriptResponse.Tags to an empty array by default.
- Revise state transition rules to enforce FromStateRule and context-based authorization for manual and automatic triggers.

Tests:
- Add unit tests for Instance.AddData and AddDataWithVersion covering identical/different JSON content, formatting invariance, and version handling.
- Add tests for JsonData.NormalizedJson to ensure consistent formatting and hashing semantics.