### PR TITLE
Refactor merge logic in ScriptContext and add XML docs

### DIFF
--- a/src/BBT.Workflow.Domain/Instances/IInstanceTransitionRepository.cs
+++ b/src/BBT.Workflow.Domain/Instances/IInstanceTransitionRepository.cs
@@ -4,5 +4,11 @@ namespace BBT.Workflow.Instances;
 
 public interface IInstanceTransitionRepository : IRepository<InstanceTransition, Guid>
 {
+    /// <summary>
+    /// Updates a transition to mark it as completed.
+    /// </summary>
+    /// <param name="transition">The transition to update.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
     Task UpdateCompletedAsync(InstanceTransition transition, CancellationToken cancellationToken);
 }

--- a/src/BBT.Workflow.Domain/Scripting/Models.cs
+++ b/src/BBT.Workflow.Domain/Scripting/Models.cs
@@ -378,25 +378,12 @@ public sealed class ScriptContext
         foreach (var kvp in sourceDict)
         {
             targetDict[kvp.Key] = targetDict.TryGetValue(kvp.Key, out var existingValue)
-            ? MergeValues(existingValue, kvp.Value)
+            ? ObjectMerger.MergeValues(existingValue, kvp.Value)
             : kvp.Value;
         }
 
         return target;
     }
-
-    /// <summary>
-    /// Recursively merges two values of any type, handling ExpandoObjects, JsonElements, arrays, and other complex types.
-    /// Uses the unified merge strategy system for consistent merging behavior.
-    /// </summary>
-    /// <param name="targetValue">The target value to merge into.</param>
-    /// <param name="sourceValue">The source value to merge from.</param>
-    /// <returns>The merged value.</returns>
-    private static object? MergeValues(object? targetValue, object? sourceValue)
-    {
-        return ObjectMerger.MergeValues(targetValue, sourceValue);
-    }
-
     
     private ScriptContext()
     {


### PR DESCRIPTION
Replaced the private MergeValues method in ScriptContext with direct calls to ObjectMerger.MergeValues for clarity and maintainability. Added XML documentation to UpdateCompletedAsync in IInstanceTransitionRepository to improve code readability.

## Summary by Sourcery

Refactor merge handling in ScriptContext to eliminate the redundant MergeValues method and call ObjectMerger directly, and enhance code clarity by adding XML docs to IInstanceTransitionRepository's UpdateCompletedAsync method

Enhancements:
- Streamline script context merge logic by removing the private MergeValues wrapper and invoking ObjectMerger.MergeValues directly

Documentation:
- Add XML documentation to UpdateCompletedAsync in IInstanceTransitionRepository