### PR TITLE
Signalr Notf Added

### DIFF
--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/appsettings.json
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/appsettings.json
@@ -112,5 +112,9 @@
       "InstanceTransitions": "instance_transitions",
       "InstanceTasks": "instance_tasks"
     }
+  },
+  "SignalR": {
+    "AppId": "http://localhost:6203",
+    "Method": "/sendMessage/public"
   }
 }

--- a/src/BBT.Workflow.Application/Execution/StateMachine/StateMachineExecutor.cs
+++ b/src/BBT.Workflow.Application/Execution/StateMachine/StateMachineExecutor.cs
@@ -14,6 +14,7 @@ using BBT.Workflow.Tasks;
 using Dapr.Client;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using BBT.Workflow.Notifications;
 
 namespace BBT.Workflow.Execution.StateMachine;
 
@@ -34,6 +35,7 @@ public sealed class StateMachineExecutor(
     IConfiguration configuration,
     IAutoTransitionService autoTransitionService,
     IInstanceRefreshStrategy instanceRefreshStrategy,
+    ISignalRNotificationService signalRNotificationService,
     ILogger<StateMachineExecutor> logger
 ) : IStateMachineExecutor
 {
@@ -107,7 +109,10 @@ public sealed class StateMachineExecutor(
 
         // State and data changes are reflected.
         await instanceRepository.UpdateAsync(context.Instance, true, cancellationToken);
+        // Send SignalR notification for workflow completion
 
+        
+       
         if (targetState.StateType != StateType.Finish)
         {
             //WARNING!: If a state has a subflow, the auto transition process must continue when the subflow is completed. The main flow is already preserving the state.
@@ -168,7 +173,7 @@ public sealed class StateMachineExecutor(
             }
         }
 
-        await InstanceStatusHandleAsync(context.Instance, targetState, context.Transition, context.Workflow,
+        await InstanceStatusHandleAsync(context.Instance, targetState, context.Transition, context.Workflow, context,
             cancellationToken);
 
         instanceTransition.Completed(context.Instance.GetCurrentState);
@@ -185,7 +190,16 @@ public sealed class StateMachineExecutor(
 
         await instanceTransitionRepository.UpdateCompletedAsync(instanceTransition, cancellationToken);
     }
-
+    private async Task SendNotification(Guid instanceId, string key, Dictionary<string, string?>? headers,
+        CancellationToken cancellationToken = default)
+    {
+         await signalRNotificationService.SendWorkflowCompletedNotificationAsync(
+            instanceId,
+            runtimeInfoProvider.Domain,
+            key,
+            headers,
+            cancellationToken);
+    }
     /// <inheritdoc />
     public async Task FlowTimeoutAsync(
         Definitions.Workflow workflow,
@@ -267,6 +281,7 @@ public sealed class StateMachineExecutor(
         State targetState,
         Transition transition,
         Definitions.Workflow workflow,
+        ScriptContext context,
         CancellationToken cancellationToken = default)
     {
         // Refresh instance to get latest status before processing
@@ -280,12 +295,14 @@ public sealed class StateMachineExecutor(
             {
                 await PublishFlowCompletionEventAsync(instance, workflow, cancellationToken);
             }
+            await SendNotification(instance.Id, workflow.Key, context.Headers, cancellationToken);
         }
         else
         {
             if (transition.TriggerType == TriggerType.Manual && instance.TrySetStatusBasedOnState())
             {
                 await instanceRepository.UpdateStatusAsync(instance, cancellationToken);
+                await SendNotification(instance.Id, workflow.Key, context.Headers, cancellationToken);
             }
         }
     }

--- a/src/BBT.Workflow.Domain/Notifications/ISignalRNotificationService.cs
+++ b/src/BBT.Workflow.Domain/Notifications/ISignalRNotificationService.cs
@@ -1,0 +1,25 @@
+using BBT.Workflow.Instances;
+
+namespace BBT.Workflow.Notifications;
+
+/// <summary>
+/// Service interface for sending SignalR notifications
+/// </summary>
+public interface ISignalRNotificationService
+{
+    /// <summary>
+    /// Sends a workflow completion notification via SignalR
+    /// </summary>
+    /// <param name="instanceId">The instance ID</param>
+    /// <param name="domain">The workflow domain</param>
+    /// <param name="workflow">The workflow key</param>
+    /// <param name="headers">Request headers to include in the HTTP request</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Task representing the async operation</returns>
+    Task SendWorkflowCompletedNotificationAsync(
+        Guid instanceId,
+        string domain,
+        string workflow,
+        Dictionary<string, string?>? headers,
+        CancellationToken cancellationToken = default);
+}

--- a/src/BBT.Workflow.Domain/Notifications/SignalRRequest.cs
+++ b/src/BBT.Workflow.Domain/Notifications/SignalRRequest.cs
@@ -1,0 +1,35 @@
+using System.Text.Json;
+
+namespace BBT.Workflow.Notifications;
+
+/// <summary>
+/// SignalR request DTO for workflow notifications
+/// </summary>
+public class SignalRRequest
+{
+    /// <summary>
+    /// Gets or sets the request ID
+    /// </summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the source of the request
+    /// </summary>
+    public string Source { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the type of the request
+    /// </summary>
+    public string Type { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the subject of the request
+    /// </summary>
+    public string Subject { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the data payload
+    /// </summary>
+    public JsonElement? Data { get; set; }
+}
+

--- a/src/BBT.Workflow.Infrastructure/Microsoft/Extensions/DependencyInjection/WorkflowInfrastructureModuleServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Infrastructure/Microsoft/Extensions/DependencyInjection/WorkflowInfrastructureModuleServiceCollectionExtensions.cs
@@ -2,8 +2,10 @@ using BBT.Workflow.BackgroundJobs;
 using BBT.Workflow.Data;
 using BBT.Workflow.Infrastructure.DataSink;
 using BBT.Workflow.Infrastructure.HostedServices;
+using BBT.Workflow.Infrastructure.Notifications;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Monitoring;
+using BBT.Workflow.Notifications;
 using BBT.Workflow.Remote.Extensions;
 using BBT.Workflow.Schemas;
 using Microsoft.EntityFrameworkCore;
@@ -59,6 +61,9 @@ public static class WorkflowInfrastructureModuleServiceCollectionExtensions
         services.AddDataSinkServices();
         services.AddClickHouseDataSinks();
         services.RegisterDataSinks();
+        
+        // SignalR Notification Service
+        services.AddHttpClient<ISignalRNotificationService, SignalRNotificationService>();
         
         return services;
     }

--- a/src/BBT.Workflow.Infrastructure/Notifications/SignalRNotificationService.cs
+++ b/src/BBT.Workflow.Infrastructure/Notifications/SignalRNotificationService.cs
@@ -1,0 +1,161 @@
+using System.Text;
+using System.Text.Json;
+using BBT.Workflow.Notifications;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Caching;
+using BBT.Workflow.Scripting;
+using BBT.Workflow.Runtime;
+using BBT.Workflow.Extentions;
+using BBT.Workflow.Schemas;
+using BBT.Workflow.Shared;
+using BBT.Workflow.Definitions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace BBT.Workflow.Infrastructure.Notifications;
+
+/// <summary>
+/// Implementation of SignalR notification service
+/// </summary>
+public sealed class SignalRNotificationService(
+    HttpClient httpClient,
+    IConfiguration configuration,
+    IInstanceRepository instanceRepository,
+    IComponentCacheStore componentCacheStore,
+    IScriptContextFactory scriptContextFactory,
+    IRuntimeInfoProvider runtimeInfoProvider,
+    IInstanceExtensionService instanceExtensionService,
+    ICurrentSchema currentSchema,
+    ILogger<SignalRNotificationService> logger) : ISignalRNotificationService
+{
+    private readonly HttpClient _httpClient = httpClient;
+    private readonly IConfiguration _configuration = configuration;
+    private readonly IInstanceRepository _instanceRepository = instanceRepository;
+    private readonly IComponentCacheStore _componentCacheStore = componentCacheStore;
+    private readonly IScriptContextFactory _scriptContextFactory = scriptContextFactory;
+    private readonly IRuntimeInfoProvider _runtimeInfoProvider = runtimeInfoProvider;
+    private readonly IInstanceExtensionService _instanceExtensionService = instanceExtensionService;
+    private readonly ICurrentSchema _currentSchema = currentSchema;
+    private readonly ILogger<SignalRNotificationService> _logger = logger;
+
+    /// <inheritdoc />
+    public async Task SendWorkflowCompletedNotificationAsync(
+        Guid instanceId,
+        string domain,
+        string workflow,
+        Dictionary<string, string?>? headers,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var appId = _configuration["SignalR:AppId"];
+            var method = _configuration["SignalR:Method"];
+
+            if (string.IsNullOrEmpty(appId) || string.IsNullOrEmpty(method))
+            {
+                _logger.LogWarning("SignalR configuration is missing. AppId: {AppId}, Method: {Method}", appId, method);
+                return;
+            }
+
+            // Get instance data to create GetInstanceOutput
+            var instance = await _instanceRepository.FindAsync(instanceId, true, cancellationToken);
+            if (instance == null)
+            {
+                _logger.LogWarning("Instance {InstanceId} not found for SignalR notification", instanceId);
+                return;
+            }
+
+            // Get workflow for extension processing
+            var flow = await _componentCacheStore.GetFlowAsync(domain, workflow, null, cancellationToken);
+
+            // Create GetInstanceOutput from instance data
+            var instanceOutput = new GetInstanceOutput
+            {
+                Id = instance.Id,
+                Key = instance.Key,
+                Flow = instance.Flow,
+                Domain = domain,
+                FlowVersion = instance.LatestData?.Version ?? string.Empty,
+                Etag = instance.LatestData?.ETag ?? string.Empty,
+                Tags = instance.Tags
+            };
+
+            // Process extensions for data enrichment (same as InstanceQueryAppService)
+            var scriptContext = await _scriptContextFactory.NewBuilder()
+                .WithWorkflow(flow)
+                .WithInstance(instance)
+                .WithRuntime(_runtimeInfoProvider)
+                .WithTransition(string.Empty)
+                .WithBody(instance.LatestData?.Data ?? new JsonData("{}"))
+                .BuildAsync(cancellationToken);
+
+            instanceOutput.Extensions = await _instanceExtensionService.ProcessExtensionsAsync(
+                null, // No specific extensions requested, process all available
+                scriptContext,
+                flow,
+                ExtensionScope.GetInstance,
+                cancellationToken);
+            var signalRRequest = new SignalRRequest
+            {
+                Id = instanceId.ToString(),
+                Source = "vnext",
+                Type = "vnext.workflow",
+                Subject = "workflow-completed",
+                Data = JsonSerializer.SerializeToElement(instanceOutput)
+            };
+
+            var jsonContent = JsonSerializer.Serialize(signalRRequest);
+            var content = new StringContent(jsonContent, Encoding.UTF8, "application/json");
+
+            var requestUrl = $"{appId}{method}";
+            
+            // Create HTTP request message to add headers
+            using var request = new HttpRequestMessage(HttpMethod.Post, requestUrl)
+            {
+                Content = content
+            };
+
+            // Add headers from context if available
+            if (headers != null)
+            {
+                foreach (var header in headers)
+                {
+                    if (!string.IsNullOrEmpty(header.Key) && !string.IsNullOrEmpty(header.Value))
+                    {
+                        // Skip content-type and other content headers as they are set by StringContent
+                        if (!header.Key.Equals("content-type", StringComparison.OrdinalIgnoreCase) &&
+                            !header.Key.Equals("content-length", StringComparison.OrdinalIgnoreCase))
+                        {
+                            request.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                        }
+                    }
+                }
+            }
+            
+            _logger.LogInformation(
+                "Sending SignalR notification for instance {InstanceId} to {RequestUrl} with {HeaderCount} headers",
+                instanceId, requestUrl, headers?.Count ?? 0);
+
+            var response = await _httpClient.SendAsync(request, cancellationToken);
+
+            if (response.IsSuccessStatusCode)
+            {
+                _logger.LogInformation(
+                    "Successfully sent SignalR notification for instance {InstanceId}",
+                    instanceId);
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "Failed to send SignalR notification for instance {InstanceId}. Status: {StatusCode}",
+                    instanceId, response.StatusCode);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Error sending SignalR notification for instance {InstanceId}",
+                instanceId);
+        }
+    }
+}

--- a/src/BBT.Workflow.Infrastructure/Notifications/SignalRNotificationService.cs
+++ b/src/BBT.Workflow.Infrastructure/Notifications/SignalRNotificationService.cs
@@ -120,14 +120,11 @@ public sealed class SignalRNotificationService(
             {
                 foreach (var header in headers)
                 {
-                    if (!string.IsNullOrEmpty(header.Key) && !string.IsNullOrEmpty(header.Value))
+                    if (!string.IsNullOrEmpty(header.Key) && !string.IsNullOrEmpty(header.Value)&&!header.Key.Equals("content-type", StringComparison.OrdinalIgnoreCase) &&
+                            !header.Key.Equals("content-length", StringComparison.OrdinalIgnoreCase))
                     {
                         // Skip content-type and other content headers as they are set by StringContent
-                        if (!header.Key.Equals("content-type", StringComparison.OrdinalIgnoreCase) &&
-                            !header.Key.Equals("content-length", StringComparison.OrdinalIgnoreCase))
-                        {
-                            request.Headers.TryAddWithoutValidation(header.Key, header.Value);
-                        }
+                        request.Headers.TryAddWithoutValidation(header.Key, header.Value);
                     }
                 }
             }


### PR DESCRIPTION
## Summary by Sourcery

Add SignalR-based workflow completion notifications by introducing a notification service, integrating it into the state machine executor, and configuring its dependency injection and settings.

New Features:
- Introduce ISignalRNotificationService and SignalRNotificationService to send workflow completion events via HTTP to a SignalR endpoint
- Integrate SignalR notifications in the state machine executor for flow completion and manual transitions
- Register SignalRNotificationService via HttpClient in the DI container

Enhancements:
- Extend InstanceStatusHandleAsync to accept ScriptContext for propagating headers to notifications
- Add SignalR configuration settings (AppId and Method) to appsettings.json