### PR TITLE
Sprint21/Wizard State

### DIFF
--- a/src/BBT.Workflow.Application/Execution/StateMachine/StateMachineExecutor.cs
+++ b/src/BBT.Workflow.Application/Execution/StateMachine/StateMachineExecutor.cs
@@ -109,7 +109,7 @@ public sealed class StateMachineExecutor(
         await instanceRepository.UpdateAsync(context.Instance, true, cancellationToken);
         
        
-        if (targetState.StateType != StateType.Finish)
+        if (targetState.StateType  == StateType.SubFlow)
         {
             await HandleSubFlowAsync(context.Workflow, context.Instance, targetState, context, cancellationToken);
 

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -369,19 +369,6 @@ public sealed class InstanceQueryAppService(
         return response;
     }
 
-    private string BuildDataUrl(string domain, string workflow, Instance instance)
-    {
-        var httpContext = httpContextAccessor.HttpContext;
-        if (httpContext == null)
-        {
-            return $"/api/v1/{domain}/workflows/{workflow}/instances/{instance.Id}/data";
-        }
-
-        var request = httpContext.Request;
-        var baseUrl = $"{request.Scheme}://{request.Host}";
-        return $"{baseUrl}/api/v1/{domain}/workflows/{workflow}/instances/{instance.Id}/data";
-    }
-
     public async Task<InstanceServiceResult<GetInstanceDataOutput>> GetInstanceDataAsync(
         GetInstanceDataInput input,
         CancellationToken cancellationToken = default)
@@ -573,7 +560,7 @@ public sealed class InstanceQueryAppService(
                 SubFlowName = correlation.SubFlowName,
                 SubFlowVersion = correlation.SubFlowVersion,
                 IsCompleted = correlation.IsCompleted,
-                Href = $"/{correlation.SubFlowDomain}/workflows/{correlation.SubFlowName}/instances/{correlation.SubFlowInstanceId}/data"
+                Href = string.Format(InstanceUrlTemplates.SubFlowData, correlation.SubFlowDomain, correlation.SubFlowName, correlation.SubFlowInstanceId)
             }).ToList();
 
             var result = new GetActiveCorrelationsOutput

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -351,20 +351,20 @@ public sealed class InstanceQueryAppService(
         };
 
 
-            var scriptContext = await scriptContextFactory.NewBuilder()
-                .WithWorkflow(flow)
-                .WithInstance(instance)
-                .WithRuntime(runtimeInfoProvider)
-                .WithTransition(string.Empty)
-                .WithBody(instanceData?.Data ?? new JsonData("{}"))
-                .BuildAsync(cancellationToken);
+        var scriptContext = await scriptContextFactory.NewBuilder()
+            .WithWorkflow(flow)
+            .WithInstance(instance)
+            .WithRuntime(runtimeInfoProvider)
+            .WithTransition(string.Empty)
+            .WithBody(instanceData?.Data ?? new JsonData("{}"))
+            .BuildAsync(cancellationToken);
 
-            response.Extensions = await instanceExtensionService.ProcessExtensionsAsync(
-                extensionRequested,
-                scriptContext,
-                flow,
-                currentScope,
-                cancellationToken);
+        response.Extensions = await instanceExtensionService.ProcessExtensionsAsync(
+            extensionRequested,
+            scriptContext,
+            flow,
+            currentScope,
+            cancellationToken);
 
         return response;
     }
@@ -760,9 +760,16 @@ public sealed class InstanceQueryAppService(
                 input.Workflow,
                 input.Version,
                 cancellationToken);
-
+            // Get current  state
+            var currentState = currentWorkflow.GetState(instance.CurrentState!);
+            bool IsWizardState = false;
+            if (currentState.StateType == StateType.Wizard)
+            {
+                IsWizardState = true;
+            }
             // Get available transitions
             var availableTransitions = new List<string>();
+
             if (instance.Status.Equals(InstanceStatus.Active))
             {
                 availableTransitions = stateMachineService.AvailableUserTransitionKeys(currentWorkflow, instance);
@@ -771,9 +778,8 @@ public sealed class InstanceQueryAppService(
             View? view = null;
 
             // If there's exactly one transition, get its view
-            if (availableTransitions.Count == 1 && !string.IsNullOrEmpty(instance.CurrentState))
+            if (IsWizardState)
             {
-                var currentState = currentWorkflow.GetState(instance.CurrentState);
                 var transition = currentState.FindTransition(availableTransitions[0]);
                 if (transition?.view != null)
                 {
@@ -785,17 +791,15 @@ public sealed class InstanceQueryAppService(
                 }
             }
             // If there are multiple transitions or no transitions, get the state view
-            else if (!string.IsNullOrEmpty(instance.CurrentState))
+            else if (!string.IsNullOrEmpty(instance.CurrentState) && currentState.View != null)
             {
-                var currentState = currentWorkflow.GetState(instance.CurrentState);
-                if (currentState.View != null)
-                {
-                    view = await componentCacheStore.GetViewAsync(
-                        currentState.View.Domain,
-                        currentState.View.Key,
-                        currentState.View.Version,
-                        cancellationToken);
-                }
+
+                view = await componentCacheStore.GetViewAsync(
+                    currentState.View.Domain,
+                    currentState.View.Key,
+                    currentState.View.Version,
+                    cancellationToken);
+
             }
 
             // If no platform specified, return the default view content
@@ -825,8 +829,8 @@ public sealed class InstanceQueryAppService(
                 case PlatformConst.ios:
                     platformContent = view.PlatformOverrides.Ios?.JsonContent?.RootElement;
                     break;
-                default: 
-                  platformContent = view?.JsonContent?.RootElement;
+                default:
+                    platformContent = view?.JsonContent?.RootElement;
                     break;
             }
 

--- a/src/BBT.Workflow.Domain/Definitions/States/StateEnums.cs
+++ b/src/BBT.Workflow.Domain/Definitions/States/StateEnums.cs
@@ -23,7 +23,11 @@ public enum StateType
     /// <summary>
     /// State that executes another workflow
     /// </summary>
-    SubFlow = 4
+    SubFlow = 4,
+    /// <summary>
+    /// State that has wizard view
+    /// </summary>
+    Wizard = 5
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary by Sourcery

Introduce a Wizard state to the workflow engine, update view resolution to treat wizard states specially, refine state machine executor to only process SubFlow states, and apply minor formatting cleanups.

New Features:
- Add Wizard state type in state enums and handle it in view rendering

Enhancements:
- Refactor GetPlatformSpecificView to unify state retrieval, enforce view presence, and introduce a dedicated path for Wizard states
- Limit subflow execution in StateMachineExecutor to only SubFlow states