### PR TITLE
Sprint 22

### DIFF
--- a/src/BBT.Workflow.HttpApi.Shared/Microsoft/Extensions/DependencyInjection/VNextTelemetryServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.HttpApi.Shared/Microsoft/Extensions/DependencyInjection/VNextTelemetryServiceCollectionExtensions.cs
@@ -232,7 +232,7 @@ public static class VNextTelemetryServiceCollectionExtensions
         return services;
     }
 
-    private static void ConfigureOtlpExporter(OtlpExporterOptions options, string otlpProtocol, string otlpEndpoint,
+    private static void ConfigureOtlpExporter(OtlpExporterOptions options, string otlpEndpoint, string otlpProtocol,
         string signalPath)
     {
         var protocol = otlpProtocol.Equals("grpc", StringComparison.OrdinalIgnoreCase)


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Swap the order of otlpEndpoint and otlpProtocol parameters in ConfigureOtlpExporter to ensure correct mapping

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal telemetry service configuration parameters for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->