### PR TITLE
NotificationTask

### DIFF
--- a/etc/execution/dapr/components/notification-http-binding.yaml
+++ b/etc/execution/dapr/components/notification-http-binding.yaml
@@ -1,0 +1,11 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: notificationbinding
+spec:
+  type: bindings.http
+  version: v1
+  metadata:
+    - name: url
+      value: https://test-amorphie-workflow-hub.burgan.com.tr/sendMessage/public
+    

--- a/etc/execution/dapr/components/notification-http-binding.yaml
+++ b/etc/execution/dapr/components/notification-http-binding.yaml
@@ -7,5 +7,5 @@ spec:
   version: v1
   metadata:
     - name: url
-      value: https://test-amorphie-workflow-hub.burgan.com.tr/sendMessage/public
+      value: https://{HubUrl}/sendMessage/public
     

--- a/execution/BBT.Workflow.Execution.HttpApi.Host/appsettings.json
+++ b/execution/BBT.Workflow.Execution.HttpApi.Host/appsettings.json
@@ -119,5 +119,8 @@
     "ContinueOnError": false,
     "ThrowAggregateException": false,
     "TopicNamingStrategy": "AggregateType"
+  },
+  "DaprNotification": {
+    "ComponentName": "notificationbinding"
   }
 }

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Tasks/Execution/DaprTaskExecutor.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Tasks/Execution/DaprTaskExecutor.cs
@@ -211,6 +211,7 @@ public sealed class DaprTaskExecutor(
                 },
                 Mapping = new ScriptCodeInput()
                 {
+                    Type=onExecuteTask.Mapping.Type,
                     Location = onExecuteTask.Mapping.Location,
                     Code = onExecuteTask.Mapping.Code
                 }

--- a/src/BBT.Workflow.Application/Definitions/DTOs/WorkflowFactory.cs
+++ b/src/BBT.Workflow.Application/Definitions/DTOs/WorkflowFactory.cs
@@ -195,7 +195,7 @@ public static class WorkflowFactory
                     OnExecuteTask.Create(
                         taskInput.Order,
                         taskInput.Task,
-                        new ScriptCode(taskInput.Mapping.Location, taskInput.Mapping.Code)
+                        new ScriptCode(taskInput.Mapping.Location, taskInput.Mapping.Code,taskInput.Mapping.Type)
                     )
                 );
             }
@@ -246,7 +246,7 @@ public static class WorkflowFactory
                         OnExecuteTask.Create(
                             taskInput.Order,
                             taskInput.Task,
-                            new ScriptCode(taskInput.Mapping.Location, taskInput.Mapping.Code)
+                            new ScriptCode(taskInput.Mapping.Location, taskInput.Mapping.Code,taskInput.Mapping.Type)
                         )
                     );
                 }
@@ -257,7 +257,7 @@ public static class WorkflowFactory
                     state.AddOnExit(OnExecuteTask.Create(
                             taskInput.Order,
                             taskInput.Task,
-                            new ScriptCode(taskInput.Mapping.Location, taskInput.Mapping.Code)
+                            new ScriptCode(taskInput.Mapping.Location, taskInput.Mapping.Code,taskInput.Mapping.Type)
                         )
                     );
                 }

--- a/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
@@ -24,6 +24,7 @@ using BBT.Workflow.Execution.Pipeline.Steps;
 using BBT.Workflow.Execution.ReEntry;
 using BBT.Workflow.Execution.Transitions.Factory;
 using BBT.Workflow.Execution.Validation;
+using BBT.Workflow.Application.Notifications;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -106,6 +107,9 @@ public static class WorkflowApplicationModuleServiceCollectionExtensions
         services.AddScoped<ISubflowCompletionService, SubflowCompletionService>();
         
         services.AddScoped<IRuntimeService, RuntimeService>();
+
+        // Notifications
+        services.AddScoped<DaprComponentDetector>();
     }
 
     /// <summary>
@@ -175,6 +179,7 @@ public static class WorkflowApplicationModuleServiceCollectionExtensions
         services.AddScoped<ScriptTaskExecutor>();
         services.AddScoped<ConditionTaskExecutor>();
         services.AddScoped<TimerTaskExecutor>();
+        services.AddScoped<NotificationTaskExecutor>();
         
         // Scripting service
         services.AddScoped<IScriptContextFactory, ScriptContextFactory>();

--- a/src/BBT.Workflow.Application/Notifications/DaprComponentDetector.cs
+++ b/src/BBT.Workflow.Application/Notifications/DaprComponentDetector.cs
@@ -84,7 +84,7 @@ public sealed class DaprComponentDetector(
         }
         catch
         {
-            // Ignore and fallback to configuration
+            return null;
         }
         return null;
     }

--- a/src/BBT.Workflow.Application/Notifications/DaprComponentDetector.cs
+++ b/src/BBT.Workflow.Application/Notifications/DaprComponentDetector.cs
@@ -8,7 +8,7 @@ namespace BBT.Workflow.Application.Notifications;
 public sealed class DaprComponentDetector(
     DaprClient daprClient,
     IConfiguration configuration,
-    ILogger<DaprComponentDetector> _)
+    ILogger<DaprComponentDetector> logger)
 {
     public async Task<(string ComponentType, NotificationComponentType NotificationType, Dictionary<string, string> Metadata)> DetectAsync(
         string componentName,
@@ -17,7 +17,7 @@ public sealed class DaprComponentDetector(
     {
         // Try to detect component type from Dapr runtime metadata first
         var componentType = await TryResolveComponentTypeFromDaprAsync(componentName, cancellationToken) ?? string.Empty;
-        
+
         NotificationComponentType notificationType = componentType switch
         {
             var t when !string.IsNullOrWhiteSpace(t) && t.StartsWith("pubsub.", StringComparison.OrdinalIgnoreCase)
@@ -82,9 +82,12 @@ public sealed class DaprComponentDetector(
                 }
             }
         }
-        catch
+        catch (Exception ex)
         {
-            throw;
+            logger.LogError(ex,
+                "Failed resolve component type from dapr component");
+
+            return null;
         }
         return null;
     }
@@ -94,7 +97,7 @@ public sealed class DaprComponentDetector(
         foreach (var item in array.EnumerateArray())
         {
             if (item.ValueKind != JsonValueKind.Object) continue;
-            
+
             // Try both lowercase and uppercase property names
             string? name = null;
             if (item.TryGetProperty("name", out var nameEl) && nameEl.ValueKind == JsonValueKind.String)
@@ -122,6 +125,6 @@ public sealed class DaprComponentDetector(
         return null;
     }
 
- 
+
 }
 

--- a/src/BBT.Workflow.Application/Notifications/DaprComponentDetector.cs
+++ b/src/BBT.Workflow.Application/Notifications/DaprComponentDetector.cs
@@ -84,7 +84,7 @@ public sealed class DaprComponentDetector(
         }
         catch
         {
-            return null;
+            throw;
         }
         return null;
     }

--- a/src/BBT.Workflow.Application/Notifications/DaprComponentDetector.cs
+++ b/src/BBT.Workflow.Application/Notifications/DaprComponentDetector.cs
@@ -1,0 +1,127 @@
+using System.Text.Json;
+using Dapr.Client;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace BBT.Workflow.Application.Notifications;
+
+public sealed class DaprComponentDetector(
+    DaprClient daprClient,
+    IConfiguration configuration,
+    ILogger<DaprComponentDetector> _)
+{
+    public async Task<(string ComponentType, NotificationComponentType NotificationType, Dictionary<string, string> Metadata)> DetectAsync(
+        string componentName,
+        Dictionary<string, string> metadata,
+        CancellationToken cancellationToken)
+    {
+        // Try to detect component type from Dapr runtime metadata first
+        var componentType = await TryResolveComponentTypeFromDaprAsync(componentName, cancellationToken) ?? string.Empty;
+        
+        NotificationComponentType notificationType = componentType switch
+        {
+            var t when !string.IsNullOrWhiteSpace(t) && t.StartsWith("pubsub.", StringComparison.OrdinalIgnoreCase)
+                => NotificationComponentType.PubSub,
+            var t when !string.IsNullOrWhiteSpace(t) && t.Equals("bindings.http", StringComparison.OrdinalIgnoreCase)
+                => NotificationComponentType.HttpBinding,
+            var t when !string.IsNullOrWhiteSpace(t) && t.Equals("bindings.mqtt", StringComparison.OrdinalIgnoreCase)
+                => NotificationComponentType.MqttBinding,
+            _ => NotificationComponentType.HttpBinding // Default to HTTP binding
+        };
+
+        // If pubsub or mqtt and topic missing, inject default topic from configuration if present
+        if ((notificationType == NotificationComponentType.PubSub ||
+             notificationType == NotificationComponentType.MqttBinding) &&
+            !metadata.ContainsKey("topic"))
+        {
+            var cfgTopic = configuration[$"DaprComponents:{componentName}:topic"];
+            if (!string.IsNullOrWhiteSpace(cfgTopic))
+            {
+                metadata["topic"] = cfgTopic!;
+            }
+        }
+
+        // Note: method and ForwardingHeaders are read from NotificationTask.Metadata in NotificationTaskExecutor
+        // and already included in the metadata dictionary passed here
+
+        return (componentType, notificationType, metadata);
+    }
+
+    private async Task<string?> TryResolveComponentTypeFromDaprAsync(string componentName, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var md = await daprClient.GetMetadataAsync(cancellationToken);
+            // Serialize to JSON and search for components array fields without relying on SDK property names
+            var json = JsonSerializer.Serialize(md);
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            // Common property names observed: "registeredComponents", "components", "Components"
+            if (root.ValueKind == JsonValueKind.Object)
+            {
+                // Try different property name variations (case-insensitive search)
+                JsonElement? componentArray = null;
+                if (root.TryGetProperty("registeredComponents", out var reg) && reg.ValueKind == JsonValueKind.Array)
+                {
+                    componentArray = reg;
+                }
+                else if (root.TryGetProperty("components", out var comps) && comps.ValueKind == JsonValueKind.Array)
+                {
+                    componentArray = comps;
+                }
+                else if (root.TryGetProperty("Components", out var compsCap) && compsCap.ValueKind == JsonValueKind.Array)
+                {
+                    componentArray = compsCap;
+                }
+
+                if (componentArray.HasValue)
+                {
+                    var type = FindTypeInArray(componentArray.Value, componentName);
+                    if (!string.IsNullOrWhiteSpace(type)) return type;
+                }
+            }
+        }
+        catch
+        {
+            // Ignore and fallback to configuration
+        }
+        return null;
+    }
+
+    private static string? FindTypeInArray(JsonElement array, string componentName)
+    {
+        foreach (var item in array.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.Object) continue;
+            
+            // Try both lowercase and uppercase property names
+            string? name = null;
+            if (item.TryGetProperty("name", out var nameEl) && nameEl.ValueKind == JsonValueKind.String)
+            {
+                name = nameEl.GetString();
+            }
+            else if (item.TryGetProperty("Name", out var nameElCap) && nameElCap.ValueKind == JsonValueKind.String)
+            {
+                name = nameElCap.GetString();
+            }
+
+            if (name != null && string.Equals(name, componentName, StringComparison.OrdinalIgnoreCase))
+            {
+                // Try both lowercase and uppercase property names for type
+                if (item.TryGetProperty("type", out var typeEl) && typeEl.ValueKind == JsonValueKind.String)
+                {
+                    return typeEl.GetString();
+                }
+                if (item.TryGetProperty("Type", out var typeElCap) && typeElCap.ValueKind == JsonValueKind.String)
+                {
+                    return typeElCap.GetString();
+                }
+            }
+        }
+        return null;
+    }
+
+ 
+}
+

--- a/src/BBT.Workflow.Application/Notifications/NotificationComponentType.cs
+++ b/src/BBT.Workflow.Application/Notifications/NotificationComponentType.cs
@@ -1,0 +1,23 @@
+namespace BBT.Workflow.Application.Notifications;
+
+/// <summary>
+/// Notification component types that determine how notifications are sent through Dapr components.
+/// </summary>
+public enum NotificationComponentType
+{
+    /// <summary>
+    /// HTTP binding component for sending notifications via HTTP
+    /// </summary>
+    HttpBinding = 1,
+
+    /// <summary>
+    /// Pub/Sub component (e.g., Kafka) for sending notifications via pub/sub messaging
+    /// </summary>
+    PubSub = 2,
+
+    /// <summary>
+    /// MQTT binding component for sending notifications via MQTT protocol
+    /// </summary>
+    MqttBinding = 3
+}
+

--- a/src/BBT.Workflow.Application/Shared/ScriptCodeInput.cs
+++ b/src/BBT.Workflow.Application/Shared/ScriptCodeInput.cs
@@ -1,11 +1,12 @@
 using System.ComponentModel.DataAnnotations;
+using BBT.Workflow.Definitions;
 
 namespace BBT.Workflow.Shared;
 
 public class ScriptCodeInput
 {
-    [Required]
-    public string Code { get; set; }
-    [Required]
-    public string Location { get; set; }
+
+    public MappingType? Type { get; set; }
+    public string? Code { get; set; }
+    public string? Location { get; set; }
 }

--- a/src/BBT.Workflow.Application/Tasks/Execution/LocalTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Execution/LocalTaskExecutor.cs
@@ -98,7 +98,7 @@ public sealed class LocalTaskExecutor(
             using var activity = WorkflowActivitySource.Instance.StartActivity(
                 TelemetryConstants.SpanNames.TaskExecution,
                 ActivityKind.Internal);
-            
+
             activity?.SetTag(TelemetryConstants.TagNames.TaskKey, task.Key);
             activity?.SetTag(TelemetryConstants.TagNames.TaskType, taskType);
             activity?.SetTag(TelemetryConstants.TagNames.InstanceId, context.Instance.Id.ToString());
@@ -109,9 +109,33 @@ public sealed class LocalTaskExecutor(
 
             try
             {
+                // Determine script code to use based on mapping type
+                string scriptCode;
+                if (onExecuteTask.Mapping.Type.Code == "G" && task is IGlobalTask globalTask)
+                {
+                    // For global tasks, serialize the IMapping instance type name
+                    if (globalTask.Mapping == null)
+                    {
+                        scriptCode = string.Empty;
+                    }
+                    else
+                    {
+                        // Serialize IMapping type name to Base64 string
+                        var mappingTypeName = globalTask.Mapping.GetType().AssemblyQualifiedName ?? globalTask.Mapping.GetType().FullName ?? string.Empty;
+                        var bytes = System.Text.Encoding.UTF8.GetBytes(mappingTypeName);
+                        scriptCode = Convert.ToBase64String(bytes);
+                    }
+
+                }
+                else
+                {
+                    // For local tasks, use the decoded script code from mapping
+                    scriptCode = onExecuteTask.Mapping.DecodedCode;
+                }
+
                 var response = await taskExecutor.ExecuteAsync(
                     task,
-                    onExecuteTask.Mapping.DecodedCode,
+                    scriptCode,
                     context,
                     cancellationToken);
                 if (response != null)
@@ -137,7 +161,7 @@ public sealed class LocalTaskExecutor(
                     new JsonData(JsonSerializer.Serialize(response ?? new { }, JsonSerializerConstants.JsonOptions)));
 
                 sw.Stop();
-                
+
                 // Log task execution completion
                 logger.TaskExecutionCompleted(
                     TelemetryConstants.Prefixes.Execution,
@@ -152,9 +176,9 @@ public sealed class LocalTaskExecutor(
             catch (Exception e)
             {
                 sw.Stop();
-                
+
                 activity?.RecordExceptionWithStatus(e);
-                
+
                 instanceTask.Faulted(e.Message);
 
                 // Log task execution failure
@@ -167,7 +191,7 @@ public sealed class LocalTaskExecutor(
 
                 // Record task failure
                 workflowMetrics.RecordTaskExecution(taskType, "failure");
-                
+
                 throw;
             }
 

--- a/src/BBT.Workflow.Application/Tasks/Executors/DaprBindingTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/DaprBindingTaskExecutor.cs
@@ -63,7 +63,7 @@ public sealed class DaprBindingTaskExecutor(
             workflowMetrics.RecordDaprBindingInvocation(daprTask.BindingName, daprTask.Operation, "failure");
 
             Logger.LogError(ex, "Error occurred during DAPR binding task {TaskKey} execution  - BindingName: {BindingName}, Operation: {Operation}",
-                daprTask.Key,  daprTask.BindingName, daprTask.Operation);
+                daprTask.Key, daprTask.BindingName, daprTask.Operation);
             throw;
         }
     }
@@ -75,7 +75,7 @@ public sealed class DaprBindingTaskExecutor(
         try
         {
             var metadata = daprTask.Metadata.ToDictionary();
-            
+
             // Get operation from metadata (method), override task operation if present
             var operation = metadata.TryGetValue("method", out var method) && !string.IsNullOrWhiteSpace(method)
                 ? method
@@ -92,14 +92,15 @@ public sealed class DaprBindingTaskExecutor(
                     if (string.Equals(fhValue.Trim(), "all", StringComparison.OrdinalIgnoreCase))
                     {
                         // Forward all headers
-                        foreach (var kvp in contextHeaders!)
-                        {
-                            var headerKey = kvp.Key?.ToString() ?? string.Empty;
-                            if (string.IsNullOrEmpty(headerKey)) continue;
-                            var headerValue = kvp.Value?.ToString() ?? string.Empty;
-                            var normalizedKey = NormalizeHeaderName(headerKey);
-                            metadata[normalizedKey] = headerValue;
-                        }
+                        // foreach (var kvp in contextHeaders!)
+                        // {
+                        //     var headerKey = kvp.Key?.ToString() ?? string.Empty;
+                        //     if (string.IsNullOrEmpty(headerKey)) continue;
+                        //     var headerValue = kvp.Value?.ToString() ?? string.Empty;
+                        //     var normalizedKey = NormalizeHeaderName(headerKey);
+                        //     metadata[normalizedKey] = headerValue;
+                        // }
+                        metadata=SetHeaderToMetadata(metadata, forwardingHeaders, contextHeaders);
                     }
                     else
                     {
@@ -109,31 +110,32 @@ public sealed class DaprBindingTaskExecutor(
                         {
                             forwardingHeaders.Add(headerName.Trim());
                         }
+                        metadata=SetHeaderToMetadata(metadata, forwardingHeaders, contextHeaders);
+                        // foreach (var kvp in contextHeaders!)
+                        // {
+                        //     var headerKey = kvp.Key?.ToString() ?? string.Empty;
+                        //     if (string.IsNullOrEmpty(headerKey) || !forwardingHeaders.Contains(headerKey))
+                        //         continue;
 
-                        foreach (var kvp in contextHeaders!)
-                        {
-                            var headerKey = kvp.Key?.ToString() ?? string.Empty;
-                            if (string.IsNullOrEmpty(headerKey) || !forwardingHeaders.Contains(headerKey))
-                                continue;
-                            
-                            var headerValue = kvp.Value?.ToString() ?? string.Empty;
-                            var normalizedKey = NormalizeHeaderName(headerKey);
-                            metadata[normalizedKey] = headerValue;
-                        }
+                        //     var headerValue = kvp.Value?.ToString() ?? string.Empty;
+                        //     var normalizedKey = NormalizeHeaderName(headerKey);
+                        //     metadata[normalizedKey] = headerValue;
+                        // }
                     }
                 }
                 else
                 {
                     // ForwardingHeaders not found or empty - forward all headers by default
                     Logger.LogDebug("ForwardingHeaders not specified for task {TaskKey}, forwarding all context headers", daprTask.Key);
-                    foreach (var kvp in contextHeaders!)
-                    {
-                        var headerKey = kvp.Key?.ToString() ?? string.Empty;
-                        if (string.IsNullOrEmpty(headerKey)) continue;
-                        var headerValue = kvp.Value?.ToString() ?? string.Empty;
-                        var normalizedKey = NormalizeHeaderName(headerKey);
-                        metadata[normalizedKey] = headerValue;
-                    }
+                    metadata=SetHeaderToMetadata(metadata, null, contextHeaders);
+                    // foreach (var kvp in contextHeaders!)
+                    // {
+                    //     var headerKey = kvp.Key?.ToString() ?? string.Empty;
+                    //     if (string.IsNullOrEmpty(headerKey)) continue;
+                    //     var headerValue = kvp.Value?.ToString() ?? string.Empty;
+                    //     var normalizedKey = NormalizeHeaderName(headerKey);
+                    //     metadata[normalizedKey] = headerValue;
+                    // }
                 }
 
             }
@@ -165,8 +167,8 @@ public sealed class DaprBindingTaskExecutor(
                 daprTask.Key, stopwatch.ElapsedMilliseconds);
 
             Logger.LogDebug("Processing output for DAPR binding task {TaskKey}", daprTask.Key);
-            
-            
+
+
         }
         catch (TaskCanceledException ex) when (ex.CancellationToken.IsCancellationRequested)
         {
@@ -191,7 +193,18 @@ public sealed class DaprBindingTaskExecutor(
             throw;
         }
     }
-
+    private static Dictionary<string, string> SetHeaderToMetadata(Dictionary<string, string> metadata, HashSet<string>? forwardingHeaders, dynamic? contextHeaders)
+    {
+        foreach (var kvp in contextHeaders!)
+        {
+            var headerKey = kvp.Key?.ToString() ?? string.Empty;
+            if (string.IsNullOrEmpty(headerKey)|| (forwardingHeaders!=null&&!forwardingHeaders.Contains(headerKey))) continue;
+            var headerValue = kvp.Value?.ToString() ?? string.Empty;
+            var normalizedKey = NormalizeHeaderName(headerKey);
+            metadata[normalizedKey] = headerValue;
+        }
+        return metadata;
+    }
     /// <summary>
     /// Normalizes header name to start with uppercase letter (e.g., x-device-id -> X-device-id)
     /// Dapr HTTP binding requires headers to start with uppercase.

--- a/src/BBT.Workflow.Application/Tasks/Executors/DaprBindingTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/DaprBindingTaskExecutor.cs
@@ -41,66 +41,170 @@ public sealed class DaprBindingTaskExecutor(
         CancellationToken cancellationToken = default)
     {
         var daprTask = (task as DaprBindingTask)!;
-        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
-        
-        Logger.LogInformation("Starting DAPR binding task execution for task {TaskKey} - BindingName: {BindingName}, Operation: {Operation}", 
+
+
+        Logger.LogInformation("Starting DAPR binding task execution for task {TaskKey} - BindingName: {BindingName}, Operation: {Operation}",
             daprTask.Key, daprTask.BindingName, daprTask.Operation);
 
         try
         {
             Logger.LogDebug("Preparing input for DAPR binding task {TaskKey}", daprTask.Key);
             await PrepareInputAsync(daprTask, scriptCode, context, cancellationToken);
+            await CallAsync(daprTask, context, cancellationToken);
+            var outputResponse = await ProcessOutputAsync(scriptCode, context, cancellationToken);
 
+            Logger.LogInformation("DAPR binding task {TaskKey} execution completed, returning processed output", daprTask.Key);
+            return outputResponse;
+
+        }
+        catch (Exception ex)
+        {
+            // Record failed DAPR binding invocation
+            workflowMetrics.RecordDaprBindingInvocation(daprTask.BindingName, daprTask.Operation, "failure");
+
+            Logger.LogError(ex, "Error occurred during DAPR binding task {TaskKey} execution  - BindingName: {BindingName}, Operation: {Operation}",
+                daprTask.Key,  daprTask.BindingName, daprTask.Operation);
+            throw;
+        }
+    }
+    public async Task CallAsync(WorkflowTask task, ScriptContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var daprTask = (task as DaprBindingTask)!;
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        try
+        {
             var metadata = daprTask.Metadata.ToDictionary();
-            Logger.LogDebug("Prepared metadata for DAPR binding task {TaskKey}: {MetadataCount} entries", 
+            
+            // Get operation from metadata (method), override task operation if present
+            var operation = metadata.TryGetValue("method", out var method) && !string.IsNullOrWhiteSpace(method)
+                ? method
+                : daprTask.Operation;
+
+            // Process context headers if available (for HTTP binding ForwardingHeaders support)
+            var contextHeaders = context.Headers;
+            if (contextHeaders != null && contextHeaders!.Count > 0)
+            {
+                // Get ForwardingHeaders list from metadata (set by detector from YAML)
+                var forwardingHeaders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                if (metadata.TryGetValue("ForwardingHeaders", out var fhValue) && !string.IsNullOrWhiteSpace(fhValue))
+                {
+                    if (string.Equals(fhValue.Trim(), "all", StringComparison.OrdinalIgnoreCase))
+                    {
+                        // Forward all headers
+                        foreach (var kvp in contextHeaders!)
+                        {
+                            var headerKey = kvp.Key?.ToString() ?? string.Empty;
+                            if (string.IsNullOrEmpty(headerKey)) continue;
+                            var headerValue = kvp.Value?.ToString() ?? string.Empty;
+                            var normalizedKey = NormalizeHeaderName(headerKey);
+                            metadata[normalizedKey] = headerValue;
+                        }
+                    }
+                    else
+                    {
+                        // Forward only specified headers (comma-separated)
+                        var headerNames = fhValue.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                        foreach (var headerName in headerNames)
+                        {
+                            forwardingHeaders.Add(headerName.Trim());
+                        }
+
+                        foreach (var kvp in contextHeaders!)
+                        {
+                            var headerKey = kvp.Key?.ToString() ?? string.Empty;
+                            if (string.IsNullOrEmpty(headerKey) || !forwardingHeaders.Contains(headerKey))
+                                continue;
+                            
+                            var headerValue = kvp.Value?.ToString() ?? string.Empty;
+                            var normalizedKey = NormalizeHeaderName(headerKey);
+                            metadata[normalizedKey] = headerValue;
+                        }
+                    }
+                }
+                else
+                {
+                    // ForwardingHeaders not found or empty - forward all headers by default
+                    Logger.LogDebug("ForwardingHeaders not specified for task {TaskKey}, forwarding all context headers", daprTask.Key);
+                    foreach (var kvp in contextHeaders!)
+                    {
+                        var headerKey = kvp.Key?.ToString() ?? string.Empty;
+                        if (string.IsNullOrEmpty(headerKey)) continue;
+                        var headerValue = kvp.Value?.ToString() ?? string.Empty;
+                        var normalizedKey = NormalizeHeaderName(headerKey);
+                        metadata[normalizedKey] = headerValue;
+                    }
+                }
+
+            }
+
+            // Remove method and ForwardingHeaders from metadata before sending (they're not HTTP headers)
+            metadata.Remove("method");
+            metadata.Remove("ForwardingHeaders");
+
+            Logger.LogDebug("Prepared metadata for DAPR binding task {TaskKey}: {MetadataCount} entries",
                 daprTask.Key, metadata.Count);
 
-            Logger.LogInformation("Invoking DAPR binding for task {TaskKey}: {BindingName} with operation {Operation}", 
-                daprTask.Key, daprTask.BindingName, daprTask.Operation);
+            Logger.LogInformation("Invoking DAPR binding for task {TaskKey}: {BindingName} with operation {Operation}",
+                daprTask.Key, daprTask.BindingName, operation);
 
             await daprClient.InvokeBindingAsync(
                 daprTask.BindingName,
-                daprTask.Operation,
+                operation,
                 daprTask.Data,
                 metadata,
                 cancellationToken: cancellationToken
             );
 
             stopwatch.Stop();
-            
+
             // Record successful DAPR binding invocation
             workflowMetrics.RecordDaprBindingInvocation(daprTask.BindingName, daprTask.Operation, "success");
-            
-            Logger.LogInformation("DAPR binding task {TaskKey} completed successfully in {Duration}ms", 
+
+            Logger.LogInformation("DAPR binding task {TaskKey} completed successfully in {Duration}ms",
                 daprTask.Key, stopwatch.ElapsedMilliseconds);
 
             Logger.LogDebug("Processing output for DAPR binding task {TaskKey}", daprTask.Key);
-            var outputResponse = await ProcessOutputAsync(scriptCode, context, cancellationToken);
             
-            Logger.LogInformation("DAPR binding task {TaskKey} execution completed, returning processed output", daprTask.Key);
-            return outputResponse;
+            
         }
         catch (TaskCanceledException ex) when (ex.CancellationToken.IsCancellationRequested)
         {
             stopwatch.Stop();
-            
+
             // Record cancelled DAPR binding invocation
             workflowMetrics.RecordDaprBindingInvocation(daprTask.BindingName, daprTask.Operation, "cancelled");
-            
-            Logger.LogWarning("DAPR binding task {TaskKey} was cancelled after {Duration}ms", 
+
+            Logger.LogWarning("DAPR binding task {TaskKey} was cancelled after {Duration}ms",
                 daprTask.Key, stopwatch.ElapsedMilliseconds);
             throw;
         }
         catch (Exception ex)
         {
             stopwatch.Stop();
-            
+
             // Record failed DAPR binding invocation
             workflowMetrics.RecordDaprBindingInvocation(daprTask.BindingName, daprTask.Operation, "failure");
-            
-            Logger.LogError(ex, "Error occurred during DAPR binding task {TaskKey} execution after {Duration}ms - BindingName: {BindingName}, Operation: {Operation}", 
+
+            Logger.LogError(ex, "Error occurred during DAPR binding task {TaskKey} execution after {Duration}ms - BindingName: {BindingName}, Operation: {Operation}",
                 daprTask.Key, stopwatch.ElapsedMilliseconds, daprTask.BindingName, daprTask.Operation);
             throw;
         }
+    }
+
+    /// <summary>
+    /// Normalizes header name to start with uppercase letter (e.g., x-device-id -> X-device-id)
+    /// Dapr HTTP binding requires headers to start with uppercase.
+    /// </summary>
+    private static string NormalizeHeaderName(string headerName)
+    {
+        if (string.IsNullOrWhiteSpace(headerName))
+            return headerName;
+
+        // Only capitalize the first letter of the header name
+        if (headerName.Length == 1)
+            return headerName.ToUpperInvariant();
+
+        return char.ToUpperInvariant(headerName[0]) + headerName.Substring(1);
     }
 }

--- a/src/BBT.Workflow.Application/Tasks/Executors/DaprPubSubTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/DaprPubSubTaskExecutor.cs
@@ -42,10 +42,10 @@ public sealed class DaprPubSubTaskExecutor(
     {
         var daprTask = (task as DaprPubSubTask)!;
         var stopwatch = System.Diagnostics.Stopwatch.StartNew();
-        
-        Logger.LogInformation("Starting DAPR pub/sub task execution for task {TaskKey} - PubSubName: {PubSubName}, Topic: {Topic}", 
+
+        Logger.LogInformation("Starting DAPR pub/sub task execution for task {TaskKey} - PubSubName: {PubSubName}, Topic: {Topic}",
             daprTask.Key, daprTask.PubSubName, daprTask.Topic);
-            
+
         StandardTaskResponse standardResponse;
 
         try
@@ -53,37 +53,14 @@ public sealed class DaprPubSubTaskExecutor(
             Logger.LogDebug("Preparing input for DAPR pub/sub task {TaskKey}", daprTask.Key);
             await PrepareInputAsync(daprTask, scriptCode, context, cancellationToken);
 
-            //Usage
-            var metadata = daprTask.Metadata.ValueKind != JsonValueKind.Null && daprTask.Metadata.ValueKind != JsonValueKind.Undefined 
-                ? daprTask.Metadata.ToDictionary() 
-                : new Dictionary<string, string>();
-            
-            Logger.LogDebug("Prepared metadata for DAPR pub/sub task {TaskKey}: {MetadataCount} entries", 
-                daprTask.Key, metadata.Count);
-            
-            if (metadata.Count > 0)
-            {
-                Logger.LogDebug("DAPR pub/sub metadata for task {TaskKey}: {Metadata}", 
-                    daprTask.Key, string.Join(", ", metadata.Select(kvp => $"{kvp.Key}={kvp.Value}")));
-            }
-
-            Logger.LogInformation("Publishing event to DAPR pub/sub for task {TaskKey}: {PubSubName}/{Topic}", 
-                daprTask.Key, daprTask.PubSubName, daprTask.Topic);
-                
-            await daprClient.PublishEventAsync(
-                daprTask.PubSubName,
-                daprTask.Topic,
-                daprTask.Data,
-                metadata,
-                cancellationToken: cancellationToken
-            );
+            await CallAsync(daprTask, context, cancellationToken);
 
             stopwatch.Stop();
 
             // Record successful DAPR pub/sub message published
             workflowMetrics.RecordDaprPubsubMessagePublished(daprTask.PubSubName, daprTask.Topic, "success");
 
-            Logger.LogInformation("DAPR pub/sub task {TaskKey} completed successfully in {Duration}ms", 
+            Logger.LogInformation("DAPR pub/sub task {TaskKey} completed successfully in {Duration}ms",
                 daprTask.Key, stopwatch.ElapsedMilliseconds);
 
             standardResponse = CreateSuccessResponse(
@@ -99,13 +76,13 @@ public sealed class DaprPubSubTaskExecutor(
         catch (TaskCanceledException ex) when (ex.CancellationToken.IsCancellationRequested)
         {
             stopwatch.Stop();
-            
+
             // Record cancelled DAPR pub/sub message publishing
             workflowMetrics.RecordDaprPubsubMessagePublished(daprTask.PubSubName, daprTask.Topic, "cancelled");
-            
-            Logger.LogWarning("DAPR pub/sub task {TaskKey} was cancelled after {Duration}ms", 
+
+            Logger.LogWarning("DAPR pub/sub task {TaskKey} was cancelled after {Duration}ms",
                 daprTask.Key, stopwatch.ElapsedMilliseconds);
-                
+
             standardResponse = CreateErrorResponse(
                 errorMessage: "DAPR pub/sub operation was cancelled",
                 taskType: nameof(TaskType.DaprPubSub),
@@ -121,13 +98,13 @@ public sealed class DaprPubSubTaskExecutor(
         catch (Exception ex)
         {
             stopwatch.Stop();
-            
+
             // Record failed DAPR pub/sub message publishing
             workflowMetrics.RecordDaprPubsubMessagePublished(daprTask.PubSubName, daprTask.Topic, "failure");
-            
-            Logger.LogError(ex, "Error occurred during DAPR pub/sub task {TaskKey} execution after {Duration}ms - PubSubName: {PubSubName}, Topic: {Topic}", 
+
+            Logger.LogError(ex, "Error occurred during DAPR pub/sub task {TaskKey} execution after {Duration}ms - PubSubName: {PubSubName}, Topic: {Topic}",
                 daprTask.Key, stopwatch.ElapsedMilliseconds, daprTask.PubSubName, daprTask.Topic);
-                
+
             standardResponse = CreateErrorResponse(
                 errorMessage: ex.Message,
                 taskType: nameof(TaskType.DaprPubSub),
@@ -142,11 +119,40 @@ public sealed class DaprPubSubTaskExecutor(
 
         Logger.LogDebug("Setting standard response in context for DAPR pub/sub task {TaskKey}", daprTask.Key);
         context.SetStandardResponse(standardResponse);
-        
+
         Logger.LogDebug("Processing output for DAPR pub/sub task {TaskKey}", daprTask.Key);
         var outputResponse = await ProcessOutputAsync(scriptCode, context, cancellationToken);
-        
+
         Logger.LogInformation("DAPR pub/sub task {TaskKey} execution completed, returning processed output", daprTask.Key);
         return outputResponse;
     }
+    public async Task CallAsync(WorkflowTask task, ScriptContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var daprTask = (task as DaprPubSubTask)!;
+          var metadata = daprTask.Metadata.ValueKind != JsonValueKind.Null && daprTask.Metadata.ValueKind != JsonValueKind.Undefined
+                ? daprTask.Metadata.ToDictionary()
+                : new Dictionary<string, string>();
+
+            Logger.LogDebug("Prepared metadata for DAPR pub/sub task {TaskKey}: {MetadataCount} entries",
+                daprTask.Key, metadata.Count);
+
+            if (metadata.Count > 0)
+            {
+                Logger.LogDebug("DAPR pub/sub metadata for task {TaskKey}: {Metadata}",
+                    daprTask.Key, string.Join(", ", metadata.Select(kvp => $"{kvp.Key}={kvp.Value}")));
+            }
+
+            Logger.LogInformation("Publishing event to DAPR pub/sub for task {TaskKey}: {PubSubName}/{Topic}",
+                daprTask.Key, daprTask.PubSubName, daprTask.Topic);
+
+            await daprClient.PublishEventAsync(
+                daprTask.PubSubName,
+                daprTask.Topic,
+                daprTask.Data,
+                metadata,
+                cancellationToken: cancellationToken
+            );
+    }
+
 }

--- a/src/BBT.Workflow.Application/Tasks/Executors/NotificationTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/NotificationTaskExecutor.cs
@@ -1,0 +1,374 @@
+using System.Text;
+using System.Text.Json;
+using BBT.Workflow.DataSink;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Instances.DTOs;
+using BBT.Workflow.Notifications;
+using BBT.Workflow.Runtime;
+using BBT.Workflow.Scripting;
+using BBT.Workflow.Shared;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using BBT.Workflow.Application.Notifications;
+
+namespace BBT.Workflow.Tasks;
+
+/// <summary>
+/// Executes notification workflow tasks that send instance state updates through notification senders.
+/// This executor sends workflow instance state information through configured notification channels (SignalR, MQTT, etc.).
+/// </summary>
+/// <param name="scriptEngine">The script engine used for compiling input/output mapping scripts.</param>
+/// <param name="configuration">The application configuration to read binding component settings.</param>
+/// <param name="runtimeInfoProvider">The runtime information provider for domain checks.</param>
+/// <param name="instanceCorrelationRepository">The instance correlation repository for retrieving active correlations.</param>
+/// <param name="componentDetector">Detector that resolves Dapr component type and notification type.</param>
+/// <param name="taskExecutorFactory">Factory for creating task executors.</param>
+/// <param name="logger">The logger instance for logging notification task execution details.</param>
+public sealed class NotificationTaskExecutor(
+    IScriptEngine scriptEngine,
+    IConfiguration configuration,
+    IRuntimeInfoProvider runtimeInfoProvider,
+    IInstanceCorrelationRepository instanceCorrelationRepository,
+    DaprComponentDetector componentDetector,
+    ITaskExecutorFactory taskExecutorFactory,
+    ILogger<NotificationTaskExecutor> logger) : TaskExecutor(scriptEngine, logger), ITaskExecutor
+{
+
+    /// <summary>
+    /// Executes a notification task by building the instance state output and sending it through the notification sender.
+    /// </summary>
+    /// <param name="task">The notification workflow task containing configuration details.</param>
+    /// <param name="scriptCode">The script code that handles input preparation and output processing.</param>
+    /// <param name="context">The script context containing instance data and headers.</param>
+    /// <param name="cancellationToken">Token to monitor for cancellation requests during execution.</param>
+    /// <returns>
+    /// A task that represents the asynchronous operation. The task result contains the processed response data
+    /// from the notification sender after output mapping transformation.
+    /// </returns>
+    /// <exception cref="InvalidCastException">Thrown when the task cannot be cast to NotificationTask type.</exception>
+    public async Task<object?> ExecuteAsync(
+        WorkflowTask task,
+        string scriptCode,
+        ScriptContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var notificationTask = (task as NotificationTask)!;
+
+        Logger.LogInformation("Starting notification task execution for task {TaskKey}", notificationTask.Key);
+
+        try
+        {
+
+            // Check runtime domain
+            runtimeInfoProvider.Check(context.Runtime.Domain);
+
+            // Build instance state output
+            var instanceOutput = await BuildInstanceStateOutputAsync(notificationTask, context, cancellationToken);
+
+            // Create notification message
+            var notificationMessage = NotificationMessage.Create(
+                id: context.Instance.Id.ToString(),
+                data: instanceOutput);
+
+            Logger.LogDebug("Detecting DAPR component and sending for task {TaskKey}", notificationTask.Key);
+
+            // Determine component name precedence: task metadata -> configuration
+            var componentName = TryGetFromMetadata(notificationTask, "componentName")
+                ?? configuration["DaprNotification:ComponentName"];
+
+            if (string.IsNullOrWhiteSpace(componentName))
+                throw new InvalidOperationException("ComponentName must be provided in task metadata or configuration.");
+
+            // Prepare metadata (without headers)
+            var metadata = new Dictionary<string, string>();
+
+            // Merge any metadata from task.config.metadata (string pairs)
+            foreach (var kv in GetStringDictionary(notificationTask.Metadata))
+            {
+                if (!metadata.ContainsKey(kv.Key))
+                    metadata[kv.Key] = kv.Value;
+            }
+
+            var (componentType, notificationType, updatedMetadata) = await componentDetector.DetectAsync(componentName!, metadata, cancellationToken);
+
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
+            // Route to appropriate executor based on notification component type
+            if (notificationType == NotificationComponentType.HttpBinding)
+            {
+                // Create DaprBindingTask and call DaprBindingTaskExecutor
+                var daprBindingTask = CreateDaprBindingTask(notificationTask, componentName!, notificationMessage, updatedMetadata);
+                var bindingExecutor = taskExecutorFactory.GetExecutor(TaskType.DaprBinding) as DaprBindingTaskExecutor;
+                
+                if (bindingExecutor == null)
+                    throw new InvalidOperationException("DaprBindingTaskExecutor not found");
+
+                Logger.LogDebug("Preparing input for DAPR binding task {TaskKey}", notificationTask.Key);
+                await PrepareInputAsync(daprBindingTask, scriptCode, context, cancellationToken);
+
+                Logger.LogDebug("Calling DaprBindingTaskExecutor.CallAsync for notification task {TaskKey}", notificationTask.Key);
+                await bindingExecutor.CallAsync(daprBindingTask, context, cancellationToken);
+            }
+            else if (notificationType == NotificationComponentType.PubSub)
+            {
+                // Create DaprPubSubTask and call DaprPubSubTaskExecutor
+                var daprPubSubTask = CreateDaprPubSubTask(notificationTask, componentName!, notificationMessage, updatedMetadata);
+                var pubSubExecutor = taskExecutorFactory.GetExecutor(TaskType.DaprPubSub) as DaprPubSubTaskExecutor;
+                
+                if (pubSubExecutor == null)
+                    throw new InvalidOperationException("DaprPubSubTaskExecutor not found");
+
+                Logger.LogDebug("Preparing input for DAPR pub/sub task {TaskKey}", notificationTask.Key);
+                await PrepareInputAsync(daprPubSubTask, scriptCode, context, cancellationToken);
+
+                Logger.LogDebug("Calling DaprPubSubTaskExecutor.CallAsync for notification task {TaskKey}", notificationTask.Key);
+                await pubSubExecutor.CallAsync(daprPubSubTask, context, cancellationToken);
+            }
+            else if (notificationType == NotificationComponentType.MqttBinding)
+            {
+                // Create DaprBindingTask and call DaprBindingTaskExecutor for MQTT
+                var daprBindingTask = CreateDaprBindingTask(notificationTask, componentName!, notificationMessage, updatedMetadata);
+                var bindingExecutor = taskExecutorFactory.GetExecutor(TaskType.DaprBinding) as DaprBindingTaskExecutor;
+                
+                if (bindingExecutor == null)
+                    throw new InvalidOperationException("DaprBindingTaskExecutor not found");
+
+                Logger.LogDebug("Preparing input for DAPR MQTT binding task {TaskKey}", notificationTask.Key);
+                await PrepareInputAsync(daprBindingTask, scriptCode, context, cancellationToken);
+
+                Logger.LogDebug("Calling DaprBindingTaskExecutor.CallAsync for MQTT notification task {TaskKey}", notificationTask.Key);
+                await bindingExecutor.CallAsync(daprBindingTask, context, cancellationToken);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error occurred during notification task {TaskKey} execution", notificationTask.Key);
+
+            StandardTaskResponse standardResponse = CreateErrorResponse(
+                errorMessage: ex.Message,
+                taskType: nameof(TaskType.Notification),
+                executionDurationMs: 0,
+                exception: ex,
+                metadata: new Dictionary<string, object>
+                {
+                    ["TaskKey"] = notificationTask.Key
+                });
+            context.SetStandardResponse(standardResponse);
+        }
+
+        Logger.LogDebug("Processing output for notification task {TaskKey}", notificationTask.Key);
+        var outputResponse = await ProcessOutputAsync(scriptCode, context, cancellationToken);
+
+        Logger.LogInformation("Notification task {TaskKey} execution completed, returning processed output", notificationTask.Key);
+        return outputResponse;
+    }
+
+    private async Task<object> BuildInstanceStateOutputAsync(
+        NotificationTask notificationTask,
+        ScriptContext context,
+        CancellationToken cancellationToken)
+    {
+        var workflow = context.Workflow;
+        var instance = context.Instance;
+
+        // Build instance transition information
+        var transitionInfo = await BuildInstanceTransitionInfoAsync(instance, cancellationToken);
+
+        // Get available transitions
+        var availableTransitions = GetMainFlowTransitions(instance, workflow, transitionInfo);
+
+        // Build transition items with href links
+        var transitionItems = availableTransitions.Select(transitionKey => new TransitionItem
+        {
+            Name = transitionKey,
+            Href = string.Format(InstanceUrlTemplates.Transition, context.Runtime.Domain, workflow.Key, instance.Id, transitionKey)
+        }).ToList();
+
+        // Build data href
+        var dataHref = new DataHref
+        {
+            Href = string.Format(InstanceUrlTemplates.Data, context.Runtime.Domain, workflow.Key, instance.Id)
+        };
+
+        // Build view href
+        var viewHref = new ViewHref
+        {
+            Href = string.Format(InstanceUrlTemplates.View, context.Runtime.Domain, workflow.Key, instance.Id),
+            LoadData = true
+        };
+
+        // Build active correlations with href links
+        var activeCorrelations = transitionInfo.ActiveCorrelations.Select(correlation => new ActiveCorrelationHref
+        {
+            CorrelationId = correlation.CorrelationId,
+            ParentState = correlation.ParentState,
+            SubFlowInstanceId = correlation.SubFlowInstanceId,
+            SubFlowType = correlation.SubFlowType,
+            SubFlowDomain = correlation.SubFlowDomain,
+            SubFlowName = correlation.SubFlowName,
+            SubFlowVersion = correlation.SubFlowVersion,
+            IsCompleted = correlation.IsCompleted,
+            Href = string.Format(InstanceUrlTemplates.SubFlowData, correlation.SubFlowDomain, correlation.SubFlowName, correlation.SubFlowInstanceId)
+        }).ToList();
+
+        return new GetInstanceStateOutput
+        {
+            Data = dataHref,
+            View = viewHref,
+            State = context.Instance.CurrentState ?? string.Empty,
+            Status = context.Instance.Status,
+            ActiveCorrelations = activeCorrelations,
+            Transitions = transitionItems,
+            ETag = context.Instance.LatestData?.ETag ?? string.Empty
+        };
+    }
+
+    private async Task<(InstanceStatus Status, string? CurrentState, List<InstanceCorrelationInfo> ActiveCorrelations)> BuildInstanceTransitionInfoAsync(Instance instance, CancellationToken cancellationToken)
+    {
+        var correlations = await instanceCorrelationRepository.GetActiveByParentAsync(instance.Id, cancellationToken);
+
+        var activeCorrelations = correlations
+            .Select(c => new InstanceCorrelationInfo
+            {
+                CorrelationId = c.Id,
+                ParentState = c.ParentState,
+                SubFlowInstanceId = c.SubFlowInstanceId,
+                SubFlowType = c.SubFlowType,
+                SubFlowDomain = c.SubFlowDomain,
+                SubFlowName = c.SubFlowName,
+                SubFlowVersion = c.SubFlowVersion,
+                IsCompleted = c.IsCompleted
+            })
+            .ToList();
+
+        return (instance.Status, instance.CurrentState, activeCorrelations);
+    }
+
+    private List<string> GetMainFlowTransitions(
+        Instance instance,
+        BBT.Workflow.Definitions.Workflow currentWorkflow,
+        (InstanceStatus Status, string? CurrentState, List<InstanceCorrelationInfo> ActiveCorrelations) transitionInfo)
+    {
+        var availableTransitions = new List<string>();
+
+        if (instance.Status.Equals(InstanceStatus.Active))
+        {
+            var stateResult = currentWorkflow.GetState(instance.GetCurrentState);
+            if (stateResult.IsSuccess)
+            {
+                availableTransitions = currentWorkflow.GetAvailableUserTransitionKeys(stateResult.Value!);
+            }
+        }
+
+        return availableTransitions;
+    }
+
+    private static string? TryGetFromMetadata(NotificationTask notificationTask, string key)
+    {
+        if (notificationTask.Metadata.HasValue)
+        {
+            var el = notificationTask.Metadata.Value;
+            if (el.ValueKind == JsonValueKind.Object && el.TryGetProperty(key, out var v) && v.ValueKind == JsonValueKind.String)
+            {
+                return v.GetString();
+            }
+        }
+        return null;
+    }
+
+    private static Dictionary<string, string> GetStringDictionary(JsonElement? element)
+    {
+        var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (!element.HasValue)
+            return dict;
+        var el = element.Value;
+        if (el.ValueKind != JsonValueKind.Object)
+            return dict;
+        foreach (var prop in el.EnumerateObject())
+        {
+            if (prop.Value.ValueKind == JsonValueKind.String)
+            {
+                var val = prop.Value.GetString() ?? string.Empty;
+                dict[prop.Name] = val;
+            }
+        }
+        return dict;
+    }
+
+    /// <summary>
+    /// Creates a DaprBindingTask from notification task data for HTTP binding handlers.
+    /// </summary>
+    private DaprBindingTask CreateDaprBindingTask(
+        NotificationTask notificationTask,
+        string componentName,
+        NotificationMessage notificationMessage,
+        Dictionary<string, string> metadata)
+    {
+        // Get operation from metadata (method), default to "create"
+        var operation = metadata.TryGetValue("method", out var method) && !string.IsNullOrWhiteSpace(method)
+            ? method
+            : "create";
+
+        // Prepare metadata dictionary (will be processed in DaprBindingTaskExecutor)
+        // Include ForwardingHeaders and method for processing
+        // Context headers will be read directly from ScriptContext in DaprBindingTaskExecutor
+        var taskMetadata = new Dictionary<string, string>(metadata);
+
+        // Create task config JSON
+        var configBuilder = new Dictionary<string, object>
+        {
+            ["key"] = notificationTask.Key,
+            ["bindingName"] = componentName,
+            ["operation"] = operation,
+            ["metadata"] = taskMetadata,
+            ["data"] = JsonSerializer.SerializeToElement(notificationMessage)
+        };
+
+        // Copy base properties from notificationTask if available
+        var configJson = JsonSerializer.Serialize(configBuilder);
+        var configElement = JsonDocument.Parse(configJson).RootElement;
+
+        var daprBindingTask = DaprBindingTask.Create(configElement);
+        
+        // Copy base properties from notificationTask
+        notificationTask.CopyBaseToInternal(daprBindingTask);
+
+        return daprBindingTask;
+    }
+
+    /// <summary>
+    /// Creates a DaprPubSubTask from notification task data for Kafka/pubsub handlers.
+    /// </summary>
+    private DaprPubSubTask CreateDaprPubSubTask(
+        NotificationTask notificationTask,
+        string componentName,
+        NotificationMessage notificationMessage,
+        Dictionary<string, string> metadata)
+    {
+        // Get topic from metadata, default to "notifications"
+        var topic = metadata.TryGetValue("topic", out var t) && !string.IsNullOrWhiteSpace(t)
+            ? t
+            : "notifications";
+
+        // Create task config JSON
+        var configBuilder = new Dictionary<string, object>
+        {
+            ["key"] = notificationTask.Key,
+            ["pubSubName"] = componentName,
+            ["topic"] = topic,
+            ["metadata"] = metadata,
+            ["data"] = JsonSerializer.SerializeToElement(notificationMessage)
+        };
+
+        var configJson = JsonSerializer.Serialize(configBuilder);
+        var configElement = JsonDocument.Parse(configJson).RootElement;
+
+        var daprPubSubTask = DaprPubSubTask.Create(configElement);
+        
+        // Copy base properties from notificationTask
+        notificationTask.CopyBaseToInternal(daprPubSubTask);
+
+        return daprPubSubTask;
+    }
+}

--- a/src/BBT.Workflow.Application/Tasks/Executors/NotificationTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/NotificationTaskExecutor.cs
@@ -105,7 +105,7 @@ public sealed class NotificationTaskExecutor(
                     throw new InvalidOperationException("DaprBindingTaskExecutor not found");
 
                 Logger.LogDebug("Preparing input for DAPR binding task {TaskKey}", notificationTask.Key);
-                await PrepareInputAsync(daprBindingTask, scriptCode, context, cancellationToken);
+               
 
                 Logger.LogDebug("Calling DaprBindingTaskExecutor.CallAsync for notification task {TaskKey}", notificationTask.Key);
                 await bindingExecutor.CallAsync(daprBindingTask, context, cancellationToken);
@@ -120,8 +120,7 @@ public sealed class NotificationTaskExecutor(
                     throw new InvalidOperationException("DaprPubSubTaskExecutor not found");
 
                 Logger.LogDebug("Preparing input for DAPR pub/sub task {TaskKey}", notificationTask.Key);
-                await PrepareInputAsync(daprPubSubTask, scriptCode, context, cancellationToken);
-
+               
                 Logger.LogDebug("Calling DaprPubSubTaskExecutor.CallAsync for notification task {TaskKey}", notificationTask.Key);
                 await pubSubExecutor.CallAsync(daprPubSubTask, context, cancellationToken);
             }
@@ -135,7 +134,7 @@ public sealed class NotificationTaskExecutor(
                     throw new InvalidOperationException("DaprBindingTaskExecutor not found");
 
                 Logger.LogDebug("Preparing input for DAPR MQTT binding task {TaskKey}", notificationTask.Key);
-                await PrepareInputAsync(daprBindingTask, scriptCode, context, cancellationToken);
+              
 
                 Logger.LogDebug("Calling DaprBindingTaskExecutor.CallAsync for MQTT notification task {TaskKey}", notificationTask.Key);
                 await bindingExecutor.CallAsync(daprBindingTask, context, cancellationToken);
@@ -157,11 +156,14 @@ public sealed class NotificationTaskExecutor(
             context.SetStandardResponse(standardResponse);
         }
 
-        Logger.LogDebug("Processing output for notification task {TaskKey}", notificationTask.Key);
-        var outputResponse = await ProcessOutputAsync(scriptCode, context, cancellationToken);
+
 
         Logger.LogInformation("Notification task {TaskKey} execution completed, returning processed output", notificationTask.Key);
-        return outputResponse;
+        return new ScriptResponse()
+        {
+            Headers=context.Headers,
+            Data = context.Body
+        };
     }
 
     private async Task<object> BuildInstanceStateOutputAsync(

--- a/src/BBT.Workflow.Application/Tasks/Executors/NotificationTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/NotificationTaskExecutor.cs
@@ -92,7 +92,6 @@ public sealed class NotificationTaskExecutor(
 
             var (componentType, notificationType, updatedMetadata) = await componentDetector.DetectAsync(componentName!, metadata, cancellationToken);
 
-            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
 
             // Route to appropriate executor based on notification component type
             if (notificationType == NotificationComponentType.HttpBinding)

--- a/src/BBT.Workflow.Application/Tasks/Executors/TaskExecutorFactory.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/TaskExecutorFactory.cs
@@ -54,6 +54,8 @@ public sealed class TaskExecutorFactory(IServiceProvider serviceProvider) : ITas
                 return serviceProvider.GetRequiredService<ConditionTaskExecutor>();
             case TaskType.Timer:
                 return serviceProvider.GetRequiredService<TimerTaskExecutor>();
+            case TaskType.Notification:
+                return serviceProvider.GetRequiredService<NotificationTaskExecutor>();
             default:
                 throw new ArgumentOutOfRangeException(nameof(type), type, null);
         }

--- a/src/BBT.Workflow.Application/Tasks/Factory/PooledTaskFactory.cs
+++ b/src/BBT.Workflow.Application/Tasks/Factory/PooledTaskFactory.cs
@@ -230,10 +230,14 @@ public static class PoolableTaskRegistry
         RegisterPoolableTask<DaprHttpEndpointTask>(
             DaprHttpEndpointTask.CreateEmpty,
             (source, target) => ((DaprHttpEndpointTask)target).CopyFromInternal((DaprHttpEndpointTask)source));
-            
+
         RegisterPoolableTask<HumanTask>(
             HumanTask.CreateEmpty,
             (source, target) => ((HumanTask)target).CopyFromInternal((HumanTask)source));
+        RegisterPoolableTask<NotificationTask>(
+            NotificationTask.CreateEmpty,
+            (source, target) => ((NotificationTask)target).CopyFromInternal((NotificationTask)source));
+            
     }
 
     public static void RegisterPoolableTask<T>(

--- a/src/BBT.Workflow.Application/Tasks/TaskCommandAppService.cs
+++ b/src/BBT.Workflow.Application/Tasks/TaskCommandAppService.cs
@@ -36,7 +36,7 @@ public sealed class TaskCommandAppService(
             var onExecuteTask = OnExecuteTask.Create(
                 input.OnExecuteTask.Order,
                 input.OnExecuteTask.Task,
-                new ScriptCode(input.OnExecuteTask.Mapping.Location, input.OnExecuteTask.Mapping.Code)
+                new ScriptCode(input.OnExecuteTask.Mapping.Location, input.OnExecuteTask.Mapping.Code,input.OnExecuteTask.Mapping.Type)
             );
 
             // 3. Create script context with all necessary mappings

--- a/src/BBT.Workflow.Domain/Definitions/MappingType.cs
+++ b/src/BBT.Workflow.Domain/Definitions/MappingType.cs
@@ -1,0 +1,57 @@
+using System.Text.Json.Serialization;
+
+namespace BBT.Workflow.Definitions;
+
+/// <summary>
+/// Mapping type for script code execution (Global or Local)
+/// </summary>
+[JsonConverter(typeof(IEquatableJsonConverter<MappingType>))]
+public class MappingType : IEquatable<MappingType>
+{
+    public static readonly MappingType Global = new MappingType("G", "Global");
+    public static readonly MappingType Local = new MappingType("L", "Local");
+
+    public string Code { get; }
+    public string Description { get; }
+
+    private MappingType()
+    {
+    }
+
+    private MappingType(string code, string description)
+    {
+        Code = code ?? throw new ArgumentNullException(nameof(code));
+        Description = description ?? throw new ArgumentNullException(nameof(description));
+    }
+
+    public static MappingType FromCode(string code)
+    {
+        return code switch
+        {
+            "G" => Global,
+            "L" => Local,
+            _ => throw new ArgumentException($"Unknown mapping type code: {code}")
+        };
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is MappingType other && Equals(other);
+    }
+
+    public bool Equals(MappingType? other)
+    {
+        return Code == other?.Code;
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Code);
+    }
+
+    public override string ToString()
+    {
+        return $"{Description} ({Code})";
+    }
+}
+

--- a/src/BBT.Workflow.Domain/Definitions/ScriptCode.cs
+++ b/src/BBT.Workflow.Domain/Definitions/ScriptCode.cs
@@ -7,16 +7,18 @@ public sealed class ScriptCode : ValueObject
 {
     public string Location { get; private set; }
     public string Code { get; private set; }
+    public MappingType Type { get; private set; }
 
     private ScriptCode()
     {
     }
 
     [JsonConstructor]
-    public ScriptCode(string location, string code)
+    public ScriptCode(string location, string code, MappingType? type = null)
     {
         Location = location;
         Code = code;
+        Type = type ?? MappingType.Local;
     }
 
     public string DecodedCode
@@ -25,8 +27,12 @@ public sealed class ScriptCode : ValueObject
         {
             try
             {
-                var bytes = Convert.FromBase64String(Code);
-                return System.Text.Encoding.UTF8.GetString(bytes);
+                if (Type != MappingType.Global)
+                {
+                    var bytes = Convert.FromBase64String(Code);
+                    return System.Text.Encoding.UTF8.GetString(bytes);
+                }
+                return string.Empty;
             }
             catch
             {
@@ -39,5 +45,6 @@ public sealed class ScriptCode : ValueObject
     {
         yield return Location;
         yield return Code;
+        yield return Type;
     }
 }

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/IGlobalTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/IGlobalTask.cs
@@ -1,0 +1,16 @@
+using BBT.Workflow.Scripting;
+
+namespace BBT.Workflow.Definitions;
+
+/// <summary>
+/// Interface for tasks that support global mapping configuration.
+/// Global tasks can have an IMapping instance that is used instead of script code.
+/// </summary>
+public interface IGlobalTask
+{
+    /// <summary>
+    /// Gets the mapping instance for this task. Can be null if no global mapping is configured.
+    /// </summary>
+    IMapping? Mapping { get; }
+}
+

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/NotificationTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/NotificationTask.cs
@@ -1,12 +1,13 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using BBT.Workflow.Scripting;
 
 namespace BBT.Workflow.Definitions;
 
 /// <summary>
 /// SignalR Task Definition
 /// </summary>
-public sealed class NotificationTask : WorkflowTask
+public sealed class NotificationTask : WorkflowTask, IGlobalTask
 {
     private NotificationTask()
     {
@@ -19,7 +20,10 @@ public sealed class NotificationTask : WorkflowTask
          Type = ((int)TaskType.Notification).ToString();
     }
 
-
+    /// <summary>
+    /// Gets the mapping instance for this task. Returns null as NotificationTask uses script-based mapping.
+    /// </summary>
+    public IMapping? Mapping => null;
 
     /// <summary>
     /// Additional metadata for notification sending (e.g., componentName, topic, headers)

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/NotificationTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/NotificationTask.cs
@@ -1,0 +1,98 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace BBT.Workflow.Definitions;
+
+/// <summary>
+/// SignalR Task Definition
+/// </summary>
+public sealed class NotificationTask : WorkflowTask
+{
+    private NotificationTask()
+    {
+    }
+
+    [JsonConstructor]
+    private NotificationTask(
+        JsonElement config) : base(config)
+    {
+         Type = ((int)TaskType.Notification).ToString();
+    }
+
+
+
+    /// <summary>
+    /// Additional metadata for notification sending (e.g., componentName, topic, headers)
+    /// </summary>
+    public JsonElement? Metadata { get; private set; }
+
+    /// <summary>
+    /// Internal property setters for object pooling
+    /// </summary>
+    internal void SetMetadataInternal(JsonElement? metadata) => Metadata = metadata;
+
+    protected override void Configure(JsonElement config)
+    {
+        base.Configure(config);
+
+        if (config.TryGetProperty("metadata", out var metadataElement))
+        {
+            var metadataRaw = metadataElement.GetRawText();
+            Metadata = string.IsNullOrWhiteSpace(metadataRaw) ? null : metadataElement;
+        }
+    }
+
+    public static NotificationTask Create(
+        JsonElement config)
+    {
+        return new NotificationTask(config);
+    }
+
+    /// <summary>
+    /// Creates a deep copy of the current SignalRTask instance.
+    /// </summary>
+    public override WorkflowTask Clone()
+    {
+        return CloneTyped();
+    }
+
+    /// <summary>
+    /// Creates a typed deep copy of the current SignalRTask instance.
+    /// </summary>
+    public NotificationTask CloneTyped()
+    {
+        var cloned = new NotificationTask();
+        CopyBaseTo(cloned);
+
+        cloned.Metadata = Metadata;
+
+        return cloned;
+    }
+
+    /// <summary>
+    /// Internal method for object pooling - copies all properties efficiently
+    /// </summary>
+    /// <param name="source">Source task to copy from</param>
+    public void CopyFromInternal(NotificationTask source)
+    {
+        source.CopyBaseToInternal(this);
+        SetMetadataInternal(source.Metadata);
+    }
+
+    /// <summary>
+    /// Resets the task instance to a clean state for object pooling
+    /// </summary>
+    public override void Reset()
+    {
+        base.Reset();
+        Metadata = null;
+    }
+
+    /// <summary>
+    /// Creates a new instance for object pooling - internal use only
+    /// </summary>
+    public static NotificationTask CreateEmpty()
+    {
+        return new NotificationTask();
+    }
+}

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/TaskEnums.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/TaskEnums.cs
@@ -16,7 +16,8 @@ public enum TaskType
     Http = 6,
     Script = 7,
     Condition = 8,
-    Timer = 9
+    Timer = 9,
+    Notification = 10
 }
 
 /// <summary>

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/WorkflowTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/WorkflowTask.cs
@@ -16,6 +16,7 @@ namespace BBT.Workflow.Definitions;
 [JsonDerivedType(typeof(HumanTask), typeDiscriminator: "5")]
 [JsonDerivedType(typeof(HttpTask), typeDiscriminator: "6")]
 [JsonDerivedType(typeof(ScriptTask), typeDiscriminator: "7")]
+[JsonDerivedType(typeof(NotificationTask), typeDiscriminator: "10")]
 public abstract class WorkflowTask : IDomainEntity, ITaskReference, IReferenceSetter, ITaskClonable
 {
     protected WorkflowTask()

--- a/src/BBT.Workflow.Domain/Notifications/NotificationMessage.cs
+++ b/src/BBT.Workflow.Domain/Notifications/NotificationMessage.cs
@@ -1,0 +1,60 @@
+using System.Text.Json.Serialization;
+
+namespace BBT.Workflow.Notifications;
+
+/// <summary>
+/// Represents a notification message to be sent through notification channels (SignalR, MQTT, etc.)
+/// </summary>
+public class NotificationMessage
+{
+    /// <summary>
+    /// Gets or sets the unique identifier of the message
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+
+    /// <summary>
+    /// Gets or sets the source of the message
+    /// </summary>
+    [JsonPropertyName("source")]
+    public required string Source { get; set; }
+
+    /// <summary>
+    /// Gets or sets the type of the message
+    /// </summary>
+    [JsonPropertyName("type")]
+    public required string Type { get; set; }
+
+    /// <summary>
+    /// Gets or sets the subject of the message
+    /// </summary>
+    [JsonPropertyName("subject")]
+    public required string Subject { get; set; }
+
+    /// <summary>
+    /// Gets or sets the data payload of the message
+    /// </summary>
+    [JsonPropertyName("data")]
+    public required object Data { get; set; }
+
+    /// <summary>
+    /// Creates a new notification message with the specified identifier and data.
+    /// The source, type, and subject are set to default values: "vnext", "vnext.workflow", and "workflow-completed" respectively.
+    /// </summary>
+    /// <param name="id">The unique identifier of the message.</param>
+    /// <param name="data">The data payload of the message.</param>
+    /// <returns>A new instance of NotificationMessage.</returns>
+    public static NotificationMessage Create(string id, object data)
+    {
+        return new NotificationMessage
+        {
+            Id = id,
+            Source = "vnext",
+            Type = "vnext.workflow",
+            Subject = "workflow-completed",
+            Data = data
+        };
+    }
+}
+


### PR DESCRIPTION
## Summary by Sourcery

Add support for NotificationTask in the workflow engine: define the new task type, executor, and component detector; register them in DI and factory; refactor existing Dapr binding and pub/sub executors for reusable CallAsync logic with header forwarding and consistent logging/metrics.

New Features:
- Introduce NotificationTask domain model and JSON-derived type for workflow tasks.
- Implement NotificationTaskExecutor to build and send instance state via Dapr components (HTTP binding, Pub/Sub, MQTT) based on detected component type.
- Add DaprComponentDetector to resolve Dapr component types and inject default topics from configuration.
- Register NotificationTaskExecutor and DaprComponentDetector in dependency injection and extend TaskExecutorFactory to handle Notification task type.

Enhancements:
- Refactor DaprBindingTaskExecutor and DaprPubSubTaskExecutor to extract CallAsync methods and unify invocation logic.
- Enhance DaprBindingTaskExecutor to forward context headers based on ForwardingHeaders metadata and normalize header names for HTTP bindings.
- Unify logging and metric recording in Dapr executors for success, failure, and cancellation cases.

Deployment:
- Add sample Dapr component YAML for HTTP notification binding.

Chores:
- Add DaprNotification configuration section in appsettings.json.
- Register NotificationTask in the pooled task registry and update TaskEnums with Notification type.