### PR TITLE
Fix response and null data handling in workflow

### DIFF
--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs
@@ -93,7 +93,7 @@ public sealed class FunctionController(
                 }
 
                 // Return only the content as requested, without Type and Target
-                return Ok(responseView.Value!.Content);
+                return Ok(responseView.Value!);
             case Definitions.Functions.FunctionTypeConst.Data:
                 var inputData = new GetInstanceDataInput
                 {

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/CreateTransitionRecordStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/CreateTransitionRecordStep.cs
@@ -46,11 +46,14 @@ public sealed class CreateTransitionRecordStep(
 
                 var transition = context.Workflow.FindTransition(transitionKey);
 
-                context.Instance.AddData(
-                    guidGenerator.Create(),
-                    new JsonData(context.Data),
-                    transition?.VersionStrategy
-                );
+                if (context.Data != null)
+                {
+                    context.Instance.AddData(
+                        guidGenerator.Create(),
+                        new JsonData(context.Data),
+                        transition?.VersionStrategy
+                    );
+                }
 
                 await instanceRepository.UpdateAsync(context.Instance, true, ct);
 


### PR DESCRIPTION
FunctionController now returns the full responseView.Value instead of just its Content. CreateTransitionRecordStep adds data only if context.Data is not null, preventing unnecessary data creation.

## Summary by Sourcery

Fix response handling in FunctionController and prevent creation of empty data entries in workflow transitions

Bug Fixes:
- Return the full response object in FunctionController instead of only its content
- Add transition record data only when context.Data is not null to avoid unnecessary data creation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced function details response to return complete data structures for view functions instead of partial content
  * Improved robustness in workflow transition handling to safely manage null data scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->