### PR TITLE
extensions param added

### DIFF
--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs
@@ -70,7 +70,7 @@ public sealed class FunctionController(
                     Workflow = workflow,
                     Instance = instance,
                     Version = parameters.Version,
-                    Extension = parameters.Extension
+                    Extensions = parameters.Extensions
                 };
                 var response = await queryAppService.GetInstanceStateAsync(inputLongpooling, cancellationToken);
                 return response.ToActionResult();
@@ -100,7 +100,8 @@ public sealed class FunctionController(
                     Domain = domain,
                     Workflow = workflow,
                     Instance = instance,
-                    IfNoneMatch = ifNoneMatch
+                    IfNoneMatch = ifNoneMatch,
+                    Extension = parameters.Extensions
                 };
                 var responseData = await queryAppService.GetInstanceDataAsync(inputData, cancellationToken);
                 

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs
@@ -101,7 +101,7 @@ public sealed class FunctionController(
                     Workflow = workflow,
                     Instance = instance,
                     IfNoneMatch = ifNoneMatch,
-                    Extension = parameters.Extensions
+                    Extensions = parameters.Extensions
                 };
                 var responseData = await queryAppService.GetInstanceDataAsync(inputData, cancellationToken);
                 

--- a/src/BBT.Workflow.Application/Instances/DTOs/FunctionQueryParemeters.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/FunctionQueryParemeters.cs
@@ -10,8 +10,8 @@ public class FunctionQueryParemeters
     [JsonPropertyName("version")]
     public string? Version { get; set; } = null;
     
-    [JsonPropertyName("extension")]
-    public string[]? Extension { get; set; } = null;
+    [JsonPropertyName("extensions")]
+    public string[]? Extensions { get; set; } = null;
     
     [JsonPropertyName("transitionKey")]
     public string? TransitionKey { get; set; } = null;

--- a/src/BBT.Workflow.Application/Instances/DTOs/GetInstanceInput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/GetInstanceInput.cs
@@ -121,5 +121,5 @@ public sealed class GetInstanceDataInput : IHasDomain
     /// <summary>
     /// Extensions requested for data enrichment
     /// </summary>
-    public string[]? Extension { get; set; }
+    public string[]? Extensions { get; set; }
 } 

--- a/src/BBT.Workflow.Application/Instances/DTOs/GetInstanceStateInput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/GetInstanceStateInput.cs
@@ -27,5 +27,5 @@ public sealed class GetInstanceStateInput : IHasDomain
     /// <summary>
     /// Extensions to be appended to the data href URL
     /// </summary>
-    public string[]? Extension { get; set; }
+    public string[]? Extensions { get; set; }
 }

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -405,7 +405,7 @@ public sealed class InstanceQueryAppService(
                         .BuildAsync(ct);
 
                     result.Extensions = await instanceExtensionService.ProcessExtensionsAsync(
-                        input.Extension,
+                        input.Extensions,
                         scriptContext,
                         flow,
                         ExtensionScope.GetInstance,

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -531,7 +531,7 @@ public sealed class InstanceQueryAppService(
                         currentStateResult.Value);
 
                     // Build data href with extensions
-                    var allExtensions = (input.Extension ?? []).Concat(viewDefinition?.Extensions ?? []).ToArray();
+                    var allExtensions = (input.Extensions ?? []).Concat(viewDefinition?.Extensions ?? []).ToArray();
                     var dataHref = new DataHref
                     {
                         Href = allExtensions.Length > 0


### PR DESCRIPTION
## Summary by Sourcery

Standardize the extensions parameter to use plural 'Extensions' across the HTTP API, application DTOs, and service logic

Enhancements:
- Rename the function query parameter and JSON property from "extension" to "extensions"
- Update the FunctionController to pass the new Extensions field when querying instance state and data
- Adjust the instance query service to use input.Extensions when concatenating view definition extensions for the data href