### PR TITLE
if transition target is a reserved key, instance state should not change

### DIFF
--- a/src/BBT.Workflow.Domain/Definitions/WorkflowConstants.cs
+++ b/src/BBT.Workflow.Domain/Definitions/WorkflowConstants.cs
@@ -36,6 +36,7 @@ public class StateConstants
 {
     public const int MaxKeyLength = WorkflowConstants.MaxKeyLength;
     public const int MaxDescriptionLength = 500;
+    public static readonly string[] ReservedTargetKeys = ["$self"];
 }
 
 public class TransitionConstants

--- a/src/BBT.Workflow.Domain/Instances/Instance.cs
+++ b/src/BBT.Workflow.Domain/Instances/Instance.cs
@@ -282,6 +282,10 @@ public sealed class Instance : AggregateRoot<Guid>, IHasCreatedAt, IHasModifyTim
 
     public void ChangeState(Transition transition)
     {
+        if (StateConstants.ReservedTargetKeys.Contains(transition.Target))
+        {
+            return;
+        }
         SetState(transition.Target);
     }
 


### PR DESCRIPTION
## Summary by Sourcery

Prevent the instance state from changing when a transition’s target matches a reserved key

Enhancements:
- Define ReservedTargetKeys constant to hold reserved state identifiers
- Update ChangeState(Transition) to skip state changes when transition.Target is in ReservedTargetKeys