### PR TITLE
Sprint23/101 transition trigger task

### DIFF
--- a/docs/trigger-transition-strategy-pattern.md
+++ b/docs/trigger-transition-strategy-pattern.md
@@ -23,7 +23,8 @@ We implemented the Strategy Pattern to separate different trigger transition beh
 ITriggerTransitionStrategy (Domain)
 ├── StartTriggerStrategy (Application) - Creates new workflow instances
 ├── DirectTriggerStrategy (Application) - Triggers transition on current instance
-└── SubProcessTriggerStrategy (Application) - Triggers transition on correlated SubFlow (placeholder)
+├── SubProcessTriggerStrategy (Application) - Triggers transition on correlated SubFlow (placeholder)
+└── GetInstanceDataTriggerStrategy (Application) - Retrieves instance data from workflow instances
 ```
 
 ### Factory Pattern
@@ -53,7 +54,7 @@ TriggerTransitionTaskExecutor
     ↓
 ITriggerTransitionStrategyFactory (resolves strategy based on TriggerTransitionType enum)
     ↓
-ITriggerTransitionStrategy (StartTriggerStrategy, DirectTriggerStrategy, or SubProcessTriggerStrategy)
+ITriggerTransitionStrategy (StartTriggerStrategy, DirectTriggerStrategy, SubProcessTriggerStrategy, or GetInstanceDataTriggerStrategy)
     ↓
 ITriggerTransitionHttpTaskFactory (creates HttpTask)
     ↓
@@ -136,6 +137,37 @@ Placeholder for future implementation of SubProcess trigger type.
 - Currently throws `NotImplementedException`
 - Reserved for future correlation-based SubFlow triggering
 
+#### GetInstanceDataTriggerStrategy
+Location: `src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/GetInstanceDataTriggerStrategy.cs`
+
+Handles the GetInstanceData trigger type by retrieving instance data from a workflow instance.
+
+- Creates path using `InstanceUrlTemplates.Data` or `InstanceUrlTemplates.DataWithExtensions`
+- Uses HTTP GET method (unlike other strategies that use POST/PATCH)
+- Supports optional `extensions` query parameter for data enrichment
+- Supports `If-None-Match` header for ETag-based conditional requests
+- Delegates to HttpTaskExecutor for execution
+
+**Key Features:**
+- **Read Operation**: This is a query operation, not a mutation
+- **No Body**: GET requests don't send body data
+- **Extensions Support**: Can request specific extensions to enrich the instance data
+- **ETag Support**: Supports conditional requests for efficient caching
+
+**Example Configuration:**
+```json
+{
+  "key": "getSubFlowData",
+  "type": "TriggerTransition",
+  "config": {
+    "domain": "sales",
+    "flow": "order-processing",
+    "type": "GetInstanceData",
+    "extensions": ["pricing", "inventory"]
+  }
+}
+```
+
 #### TriggerTransitionStrategyFactory
 Location: `src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/TriggerTransitionStrategyFactory.cs`
 
@@ -149,6 +181,7 @@ public ITriggerTransitionStrategy Get(TriggerTransitionType type)
         TriggerTransitionType.Start => _serviceProvider.GetService<StartTriggerStrategy>(),
         TriggerTransitionType.Trigger => _serviceProvider.GetService<DirectTriggerStrategy>(),
         TriggerTransitionType.SubProcess => _serviceProvider.GetService<SubProcessTriggerStrategy>(),
+        TriggerTransitionType.GetInstanceData => _serviceProvider.GetService<GetInstanceDataTriggerStrategy>(),
         _ => null
     };
     
@@ -224,6 +257,7 @@ services.AddScoped<ITriggerTransitionHttpTaskFactory, TriggerTransitionHttpTaskF
 services.AddScoped<StartTriggerStrategy>();
 services.AddScoped<DirectTriggerStrategy>();
 services.AddScoped<SubProcessTriggerStrategy>();
+services.AddScoped<GetInstanceDataTriggerStrategy>();
 ```
 
 ## Benefits

--- a/docs/trigger-transition-strategy-pattern.md
+++ b/docs/trigger-transition-strategy-pattern.md
@@ -1,0 +1,308 @@
+# Trigger Transition Strategy Pattern Implementation
+
+## Overview
+
+This document describes the refactoring of `TriggerTransitionTaskExecutor` to use the Strategy Pattern, improving code maintainability, extensibility, and adherence to SOLID principles.
+
+## Problem Statement
+
+The original `TriggerTransitionTaskExecutor` had the following issues:
+
+1. **Switch Statement**: Used a switch statement to handle different trigger types, making it difficult to extend
+2. **Large Executor Class**: Multiple private methods handling different trigger types made the class bloated
+3. **Violation of Open/Closed Principle**: Adding new trigger types required modifying the executor class
+4. **Mixed Responsibilities**: HTTP task creation logic was embedded in the executor
+
+## Solution Architecture
+
+### Strategy Pattern Implementation
+
+We implemented the Strategy Pattern to separate different trigger transition behaviors:
+
+```
+ITriggerTransitionStrategy (Domain)
+├── StartTriggerStrategy (Application) - Creates new workflow instances
+├── DirectTriggerStrategy (Application) - Triggers transition on current instance
+└── SubProcessTriggerStrategy (Application) - Triggers transition on correlated SubFlow (placeholder)
+```
+
+### Factory Pattern
+
+A factory is used to resolve the appropriate strategy based on the trigger type:
+
+```
+ITriggerTransitionStrategyFactory (Domain)
+└── TriggerTransitionStrategyFactory (Application)
+```
+
+### HTTP Task Factory
+
+HTTP task creation logic was extracted into a dedicated factory:
+
+```
+ITriggerTransitionHttpTaskFactory (Domain)
+└── TriggerTransitionHttpTaskFactory (Application)
+```
+
+## Architecture Flow
+
+The execution flow follows this pattern:
+
+```
+TriggerTransitionTaskExecutor
+    ↓
+ITriggerTransitionStrategyFactory (resolves strategy based on TriggerTransitionType enum)
+    ↓
+ITriggerTransitionStrategy (StartTriggerStrategy, DirectTriggerStrategy, or SubProcessTriggerStrategy)
+    ↓
+ITriggerTransitionHttpTaskFactory (creates HttpTask)
+    ↓
+HttpTaskExecutor (executes HTTP request)
+```
+
+## Key Components
+
+### 1. Domain Layer Interfaces
+
+#### ITriggerTransitionStrategy
+Location: `src/BBT.Workflow.Domain/Execution/TriggerTransition/ITriggerTransitionStrategy.cs`
+
+Defines the contract for trigger transition execution strategies.
+
+```csharp
+public interface ITriggerTransitionStrategy
+{
+    Task ExecuteAsync(
+        TriggerTransitionTask task,
+        ScriptContext context,
+        CancellationToken cancellationToken);
+}
+```
+
+#### ITriggerTransitionStrategyFactory
+Location: `src/BBT.Workflow.Domain/Execution/TriggerTransition/Factory/ITriggerTransitionStrategyFactory.cs`
+
+Factory interface for creating appropriate strategies based on trigger type.
+
+```csharp
+public interface ITriggerTransitionStrategyFactory
+{
+    ITriggerTransitionStrategy Get(TriggerTransitionType type);
+}
+```
+
+#### ITriggerTransitionHttpTaskFactory
+Location: `src/BBT.Workflow.Domain/Execution/TriggerTransition/Factory/ITriggerTransitionHttpTaskFactory.cs`
+
+Factory interface for creating HTTP tasks used in trigger transitions.
+
+```csharp
+public interface ITriggerTransitionHttpTaskFactory
+{
+    HttpTask CreateHttpTask(
+        TriggerTransitionTask triggerTask,
+        ScriptContext context,
+        string path,
+        string method);
+}
+```
+
+### 2. Application Layer Implementations
+
+#### StartTriggerStrategy
+Location: `src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/StartTriggerStrategy.cs`
+
+Handles the Start trigger type by creating a new workflow instance.
+
+- Creates path: `/{domain}/workflows/{workflow}/instances/start`
+- Uses HTTP POST method
+- Delegates to HttpTaskExecutor for execution
+
+#### DirectTriggerStrategy
+Location: `src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/DirectTriggerStrategy.cs`
+
+Handles the Trigger (Direct) trigger type by executing a transition on the current instance.
+
+- Creates path using `InstanceUrlTemplates.Transition`
+- Uses HTTP PATCH method
+- Validates that TransitionName is provided
+- Delegates to HttpTaskExecutor for execution
+
+#### SubProcessTriggerStrategy
+Location: `src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/SubProcessTriggerStrategy.cs`
+
+Placeholder for future implementation of SubProcess trigger type.
+
+- Currently throws `NotImplementedException`
+- Reserved for future correlation-based SubFlow triggering
+
+#### TriggerTransitionStrategyFactory
+Location: `src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/TriggerTransitionStrategyFactory.cs`
+
+Factory implementation that resolves strategies from the DI container.
+
+```csharp
+public ITriggerTransitionStrategy Get(TriggerTransitionType type)
+{
+    ITriggerTransitionStrategy? strategy = type switch
+    {
+        TriggerTransitionType.Start => _serviceProvider.GetService<StartTriggerStrategy>(),
+        TriggerTransitionType.Trigger => _serviceProvider.GetService<DirectTriggerStrategy>(),
+        TriggerTransitionType.SubProcess => _serviceProvider.GetService<SubProcessTriggerStrategy>(),
+        _ => null
+    };
+    
+    if (strategy == null)
+        throw new NotSupportedException($"No trigger transition strategy found for type {type}");
+    
+    return strategy;
+}
+```
+
+#### TriggerTransitionHttpTaskFactory
+Location: `src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/TriggerTransitionHttpTaskFactory.cs`
+
+Factory that creates HTTP tasks for trigger transitions.
+
+- Reads configuration from `vNextApi:BaseUrl` and `vNextApi:ApiVersion`
+- Builds full URL with API version
+- Prepares headers and body from context
+- Creates HttpTask with proper configuration
+
+### 3. Refactored Executor
+
+#### TriggerTransitionTaskExecutor
+Location: `src/BBT.Workflow.Application/Tasks/Executors/TriggerTransitionTaskExecutor.cs`
+
+Simplified executor that delegates to strategies:
+
+**Before:**
+- Had switch statement with multiple cases
+- Contained private methods: `HandleCreateNewAsync`, `HandleDirectAsync`, `HandleCorrelationAsync`
+- Contained `CreateHttpTask` method
+- Injected multiple dependencies
+
+**After:**
+- Delegates to strategy factory
+- No switch statement
+- No private handler methods
+- Cleaner constructor with fewer dependencies
+- Single responsibility: orchestrate script execution and strategy delegation
+
+```csharp
+public async Task<object?> ExecuteAsync(...)
+{
+    var triggerTask = (task as TriggerTransitionTask)!;
+    
+    // Check runtime domain
+    runtimeInfoProvider.Check(context.Runtime.Domain);
+    
+    // Prepare input
+    await PrepareInputAsync(triggerTask, scriptCode, context, cancellationToken);
+    
+    // Get appropriate strategy and execute
+    var strategy = strategyFactory.Get(triggerTask.TriggerType);
+    await strategy.ExecuteAsync(triggerTask, context, cancellationToken);
+    
+    // Process output
+    var outputResponse = await ProcessOutputAsync(scriptCode, context, cancellationToken);
+    
+    return outputResponse;
+}
+```
+
+## Dependency Injection Registration
+
+All strategies and factories are registered in the DI container:
+
+Location: `src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs`
+
+```csharp
+// Trigger Transition Strategies
+services.AddScoped<ITriggerTransitionStrategyFactory, TriggerTransitionStrategyFactory>();
+services.AddScoped<ITriggerTransitionHttpTaskFactory, TriggerTransitionHttpTaskFactory>();
+services.AddScoped<StartTriggerStrategy>();
+services.AddScoped<DirectTriggerStrategy>();
+services.AddScoped<SubProcessTriggerStrategy>();
+```
+
+## Benefits
+
+### 1. Open/Closed Principle
+- New trigger types can be added by creating new strategy classes
+- No need to modify existing executor or strategy classes
+
+### 2. Single Responsibility Principle
+- Each strategy handles one specific trigger type
+- HTTP task creation is separated into its own factory
+- Executor focuses on orchestration
+
+### 3. Dependency Inversion Principle
+- Executor depends on abstractions (interfaces) not concrete implementations
+- Strategies are resolved through DI container
+
+### 4. Improved Testability
+- Each strategy can be unit tested independently
+- Easier to mock dependencies
+- Clearer test scenarios
+
+### 5. Better Maintainability
+- Clear separation of concerns
+- Easier to understand and modify individual strategies
+- Reduced code duplication
+
+### 6. Consistency
+- Follows existing codebase patterns (similar to `ITransitionStrategy`, `ExecutionStrategyFactory`)
+- Uses the same factory pattern approach
+- Maintains architectural consistency
+
+## Future Extensions
+
+To add a new trigger type:
+
+1. Create a new strategy class implementing `ITriggerTransitionStrategy`
+2. Add the new enum value to `TriggerTransitionType`
+3. Update `TriggerTransitionStrategyFactory` to resolve the new strategy
+4. Register the new strategy in the DI container
+
+Example:
+
+```csharp
+// 1. Create new strategy
+public sealed class CustomTriggerStrategy : ITriggerTransitionStrategy
+{
+    public async Task ExecuteAsync(...)
+    {
+        // Custom implementation
+    }
+}
+
+// 2. Add enum value
+public enum TriggerTransitionType
+{
+    Start = 1,
+    Trigger = 2,
+    SubProcess = 3,
+    Custom = 4  // New type
+}
+
+// 3. Update factory
+TriggerTransitionType.Custom => _serviceProvider.GetService<CustomTriggerStrategy>(),
+
+// 4. Register in DI
+services.AddScoped<CustomTriggerStrategy>();
+```
+
+## Migration Notes
+
+- No breaking changes to public APIs
+- Existing workflow definitions continue to work without modification
+- The refactoring is internal to the execution layer
+- All existing trigger types (Start, Trigger) maintain the same behavior
+
+## Related Documentation
+
+- [Strategy Pattern Implementation](strategy-pattern-implementation.md) - General strategy pattern usage in the codebase
+- [Task Executors](task-executors.md) - Overview of task execution architecture
+- [Architecture Overview](architecture-overview.md) - Overall system architecture
+

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -560,7 +560,7 @@ public sealed class InstanceQueryAppService(
                             SubFlowName = correlation.SubFlowName,
                             SubFlowVersion = correlation.SubFlowVersion,
                             IsCompleted = correlation.IsCompleted,
-                            Href = string.Format(InstanceUrlTemplates.SubFlowData, correlation.SubFlowDomain,
+                            Href = string.Format(InstanceUrlTemplates.Data, correlation.SubFlowDomain,
                                 correlation.SubFlowName, correlation.SubFlowInstanceId)
                         }).ToList();
 

--- a/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
@@ -26,6 +26,8 @@ using BBT.Workflow.Execution.Transitions.Factory;
 using BBT.Workflow.Execution.Transitions.Services;
 using BBT.Workflow.Execution.Validation;
 using BBT.Workflow.Application.Notifications;
+using BBT.Workflow.Execution.TriggerTransition;
+using BBT.Workflow.Tasks.TriggerTransition;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -181,6 +183,14 @@ public static class WorkflowApplicationModuleServiceCollectionExtensions
         services.AddScoped<ConditionTaskExecutor>();
         services.AddScoped<TimerTaskExecutor>();
         services.AddScoped<NotificationTaskExecutor>();
+        services.AddScoped<TriggerTransitionTaskExecutor>();
+
+        // Trigger Transition Strategies
+        services.AddScoped<ITriggerTransitionStrategyFactory, TriggerTransitionStrategyFactory>();
+        services.AddScoped<ITriggerTransitionHttpTaskFactory, TriggerTransitionHttpTaskFactory>();
+        services.AddScoped<StartTriggerStrategy>();
+        services.AddScoped<DirectTriggerStrategy>();
+        services.AddScoped<SubProcessTriggerStrategy>();
         
         // Scripting service
         services.AddScoped<IScriptContextFactory, ScriptContextFactory>();

--- a/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
@@ -191,6 +191,7 @@ public static class WorkflowApplicationModuleServiceCollectionExtensions
         services.AddScoped<StartTriggerStrategy>();
         services.AddScoped<DirectTriggerStrategy>();
         services.AddScoped<SubProcessTriggerStrategy>();
+        services.AddScoped<GetInstanceDataTriggerStrategy>();
         
         // Scripting service
         services.AddScoped<IScriptContextFactory, ScriptContextFactory>();

--- a/src/BBT.Workflow.Application/SubFlow/Contracts/ISubflowStarter.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Contracts/ISubflowStarter.cs
@@ -43,4 +43,25 @@ public interface ISubflowStarter
         InstanceCorrelation correlation,
         ScriptContext context,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Starts a SubProcess workflow without requiring a target state or mapping.
+    /// Used for triggering SubProcess workflows from tasks.
+    /// </summary>
+    /// <param name="workflow">The parent workflow.</param>
+    /// <param name="parentInstance">The parent instance.</param>
+    /// <param name="subFlowReference">Reference to the SubFlow/SubProcess to start.</param>
+    /// <param name="transition">The transition triggering the SubProcess.</param>
+    /// <param name="correlation">Correlation information for tracking.</param>
+    /// <param name="subFlowType">Type code of the SubFlow ("S" or "P").</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous sub-flow initiation operation.</returns>
+    Task SubStartAsync(
+        Definitions.Workflow workflow,
+        Instance parentInstance,
+        Reference subFlowReference,
+        Transition transition,
+        InstanceCorrelation correlation,
+        string subFlowType,
+        CancellationToken cancellationToken = default);
 }

--- a/src/BBT.Workflow.Application/SubFlow/Services/SubflowStarter.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubflowStarter.cs
@@ -37,6 +37,72 @@ public sealed class SubflowStarter(
         CancellationToken cancellationToken = default)
     {
         var subFlowConfig = targetState.SubFlow!;
+        
+        // Handle input mapping if mapping is configured
+        ScriptResponse? inputMappingResult = null;
+        if (subFlowConfig.Mapping != null)
+        {
+            inputMappingResult = await HandleInputMappingAsync(subFlowConfig, context, cancellationToken);
+        }
+
+        await StartSubFlowInternalAsync(
+            workflow,
+            parentInstance,
+            subFlowConfig.Process,
+            targetState.Key,
+            transition.Key,
+            correlation,
+            subFlowConfig.Type.Code,
+            inputMappingResult,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Starts a SubProcess workflow without requiring a target state or mapping.
+    /// Used for triggering SubProcess workflows from tasks.
+    /// </summary>
+    /// <param name="workflow">The parent workflow.</param>
+    /// <param name="parentInstance">The parent instance.</param>
+    /// <param name="subFlowReference">Reference to the SubFlow/SubProcess to start.</param>
+    /// <param name="transition">The transition triggering the SubProcess.</param>
+    /// <param name="correlation">Correlation information for tracking.</param>
+    /// <param name="subFlowType">Type code of the SubFlow ("S" or "P").</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task SubStartAsync(
+        Definitions.Workflow workflow,
+        Instance parentInstance,
+        Reference subFlowReference,
+        Transition transition,
+        InstanceCorrelation correlation,
+        string subFlowType,
+        CancellationToken cancellationToken = default)
+    {
+        await StartSubFlowInternalAsync(
+            workflow,
+            parentInstance,
+            subFlowReference,
+            parentInstance.GetCurrentState,
+            transition.Key,
+            correlation,
+            subFlowType,
+            inputMappingResult: null,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Internal method that contains the common logic for starting SubFlow/SubProcess workflows.
+    /// </summary>
+    private async Task StartSubFlowInternalAsync(
+        Definitions.Workflow workflow,
+        Instance parentInstance,
+        Reference subFlowReference,
+        string stateKey,
+        string transitionKey,
+        InstanceCorrelation correlation,
+        string subFlowTypeCode,
+        ScriptResponse? inputMappingResult,
+        CancellationToken cancellationToken)
+    {
         var sw = Stopwatch.StartNew();
 
         // Enrich logs with parent workflow context for SubFlow start
@@ -45,12 +111,12 @@ public sealed class SubflowStarter(
             parentFlow: workflow.Key,
             parentFlowVersion: workflow.Version,
             parentInstanceId: parentInstance.Id,
-            transitionKey: transition.Key))
+            transitionKey: transitionKey))
         {
             // Log SubFlow start
             logger.SubFlowStarted(
                 TelemetryConstants.Prefixes.Execution,
-                subFlowConfig.Process.Key,
+                subFlowReference.Key,
                 correlation.SubFlowInstanceId,
                 parentInstance.Id);
 
@@ -59,107 +125,100 @@ public sealed class SubflowStarter(
                 TelemetryConstants.SpanNames.SubFlowStart,
                 ActivityKind.Internal);
             
-            activity?.SetTag(TelemetryConstants.TagNames.SubFlowKey, subFlowConfig.Process.Key);
-            activity?.SetTag(TelemetryConstants.TagNames.Domain, subFlowConfig.Process.Domain);
+            activity?.SetTag(TelemetryConstants.TagNames.SubFlowKey, subFlowReference.Key);
+            activity?.SetTag(TelemetryConstants.TagNames.Domain, subFlowReference.Domain);
             activity?.SetTag(TelemetryConstants.TagNames.InstanceId, parentInstance.Id.ToString());
-            activity?.SetDisplayName($"SubFlow Start: {subFlowConfig.Process.Key}");
+            activity?.SetDisplayName($"SubFlow Start: {subFlowReference.Key}");
 
             try
             {
-            // Handle input mapping if mapping is configured
-            ScriptResponse? inputMappingResult = null;
-            if (subFlowConfig.Mapping != null)
-            {
-                inputMappingResult = await HandleInputMappingAsync(subFlowConfig, context, cancellationToken);
-            }
-
-            // Prepare instance creation input
-            var createInstanceInput = new CreateInstanceInput
-            {
-                Id = correlation.SubFlowInstanceId,
-                Callback = configuration["DAPR_APP_ID"],
-                Key = parentInstance.Key ?? string.Empty,
-                Attributes = inputMappingResult?.Data != null
-                    ? JsonSerializer.SerializeToElement(inputMappingResult.Data)
-                    : null,
-                Tags =
-                [
-                    $"parent.key:{parentInstance.Key}",
-                    $"parent.domain:{workflow.Domain}",
-                    $"parent.flow:{workflow.Key}"
-                ],
-                MetaData = new ObjectDictionary
+                // Prepare instance creation input
+                var createInstanceInput = new CreateInstanceInput
                 {
-                    [DomainConsts.MetaDataKeys.Id] = parentInstance.Id,
-                    [DomainConsts.MetaDataKeys.Key] = parentInstance.Key ?? string.Empty,
-                    [DomainConsts.MetaDataKeys.Domain] = workflow.Domain,
-                    [DomainConsts.MetaDataKeys.Flow] = workflow.Key,
-                    [DomainConsts.MetaDataKeys.Version] = workflow.Version,
-                    [DomainConsts.MetaDataKeys.State] = targetState.Key,
-                    [DomainConsts.MetaDataKeys.Transition] = transition.Key,
-                    [DomainConsts.MetaDataKeys.FlowType] = subFlowConfig.Type.Code
-                }
-            };
+                    Id = correlation.SubFlowInstanceId,
+                    Callback = configuration["DAPR_APP_ID"],
+                    Key = parentInstance.Key ?? string.Empty,
+                    Attributes = inputMappingResult?.Data != null
+                        ? JsonSerializer.SerializeToElement(inputMappingResult.Data)
+                        : null,
+                    Tags =
+                    [
+                        $"parent.key:{parentInstance.Key}",
+                        $"parent.domain:{workflow.Domain}",
+                        $"parent.flow:{workflow.Key}"
+                    ],
+                    MetaData = new ObjectDictionary
+                    {
+                        [DomainConsts.MetaDataKeys.Id] = parentInstance.Id,
+                        [DomainConsts.MetaDataKeys.Key] = parentInstance.Key ?? string.Empty,
+                        [DomainConsts.MetaDataKeys.Domain] = workflow.Domain,
+                        [DomainConsts.MetaDataKeys.Flow] = workflow.Key,
+                        [DomainConsts.MetaDataKeys.Version] = workflow.Version,
+                        [DomainConsts.MetaDataKeys.State] = stateKey,
+                        [DomainConsts.MetaDataKeys.Transition] = transitionKey,
+                        [DomainConsts.MetaDataKeys.FlowType] = subFlowTypeCode
+                    }
+                };
 
-            // Apply additional properties from input mapping if available
-            if (inputMappingResult != null)
-            {
-                if (!inputMappingResult.Key.IsNullOrEmpty())
+                // Apply additional properties from input mapping if available
+                if (inputMappingResult != null)
                 {
-                    createInstanceInput.Key = inputMappingResult.Key;
+                    if (!inputMappingResult.Key.IsNullOrEmpty())
+                    {
+                        createInstanceInput.Key = inputMappingResult.Key;
+                    }
+
+                    if (!inputMappingResult.Tags.IsNullOrEmpty())
+                    {
+                        var existingTags = createInstanceInput.Tags?.ToList() ?? new List<string>();
+                        existingTags.AddRange(inputMappingResult.Tags);
+                        createInstanceInput.Tags = existingTags.ToArray();
+                    }
                 }
 
-                if (!inputMappingResult.Tags.IsNullOrEmpty())
+                var subFlowStartInput = new StartInstanceInput(
+                    subFlowReference.Domain,
+                    subFlowReference.Key,
+                    subFlowReference.Version,
+                    sync: true
+                )
                 {
-                    var existingTags = createInstanceInput.Tags?.ToList() ?? new List<string>();
-                    existingTags.AddRange(inputMappingResult.Tags);
-                    createInstanceInput.Tags = existingTags.ToArray();
+                    Instance = createInstanceInput,
+                    Headers = inputMappingResult?.Headers ?? new Dictionary<string, string?>(),
+                    RouteValues = inputMappingResult?.RouteValues ?? new Dictionary<string, string?>()
+                };
+
+                var startResult = await remoteInstanceCommandAppService.StartSubAsync(subFlowStartInput, cancellationToken);
+                
+                if (!startResult.IsSuccess)
+                {
+                    sw.Stop();
+                    var error = startResult.Error;
+                    
+                    logger.LogError(
+                        "{Prefix} SubFlow {SubFlowKey} start failed for instance {InstanceId}: {ErrorCode} - {ErrorMessage}",
+                        TelemetryConstants.Prefixes.Execution,
+                        subFlowReference.Key,
+                        parentInstance.Id,
+                        error.Code,
+                        error.Message);
+                    
+                    activity?.SetStatus(ActivityStatusCode.Error, error.Message);
+                    activity?.SetTag("error.code", error.Code);
+                    
+                    throw new InvalidOperationException(
+                        $"Failed to start SubFlow {subFlowReference.Key}: {error.Message}", 
+                        new Exception(error.Code));
                 }
-            }
-
-            var subFlowStartInput = new StartInstanceInput(
-                subFlowConfig.Process.Domain,
-                subFlowConfig.Process.Key,
-                subFlowConfig.Process.Version,
-                sync: true
-            )
-            {
-                Instance = createInstanceInput,
-                Headers = inputMappingResult?.Headers ?? new Dictionary<string, string?>(),
-                RouteValues = inputMappingResult?.RouteValues ?? new Dictionary<string, string?>()
-            };
-
-            var startResult = await remoteInstanceCommandAppService.StartSubAsync(subFlowStartInput, cancellationToken);
-            
-            if (!startResult.IsSuccess)
-            {
+                
                 sw.Stop();
-                var error = startResult.Error;
                 
-                logger.LogError(
-                    "{Prefix} SubFlow {SubFlowKey} start failed for instance {InstanceId}: {ErrorCode} - {ErrorMessage}",
+                logger.LogInformation(
+                    "{Prefix} SubFlow {SubFlowKey} started successfully for instance {InstanceId} in {ElapsedMs}ms",
                     TelemetryConstants.Prefixes.Execution,
-                    subFlowConfig.Process.Key,
+                    subFlowReference.Key,
                     parentInstance.Id,
-                    error.Code,
-                    error.Message);
-                
-                activity?.SetStatus(ActivityStatusCode.Error, error.Message);
-                activity?.SetTag("error.code", error.Code);
-                
-                throw new InvalidOperationException(
-                    $"Failed to start SubFlow {subFlowConfig.Process.Key}: {error.Message}", 
-                    new Exception(error.Code));
-            }
-            
-            sw.Stop();
-            
-            logger.LogInformation(
-                "{Prefix} SubFlow {SubFlowKey} started successfully for instance {InstanceId} in {ElapsedMs}ms",
-                TelemetryConstants.Prefixes.Execution,
-                subFlowConfig.Process.Key,
-                parentInstance.Id,
-                sw.ElapsedMilliseconds);
+                    sw.ElapsedMilliseconds);
             }
             catch (Exception ex)
             {
@@ -170,7 +229,7 @@ public sealed class SubflowStarter(
                 logger.LogError(ex,
                     "{Prefix} SubFlow {SubFlowKey} start failed for instance {InstanceId}",
                     TelemetryConstants.Prefixes.Execution,
-                    subFlowConfig.Process.Key,
+                    subFlowReference.Key,
                     parentInstance.Id);
                 
                 throw;

--- a/src/BBT.Workflow.Application/Tasks/Executors/HttpTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/HttpTaskExecutor.cs
@@ -48,18 +48,53 @@ public sealed class HttpTaskExecutor(
         CancellationToken cancellationToken = default)
     {
         var httpTask = (task as HttpTask)!;
-        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
         
         Logger.LogInformation("Starting HTTP task execution for task {TaskKey} - URL: {Url}, Method: {Method}", 
             httpTask.Key, httpTask.Url, httpTask.Method);
-            
-        StandardTaskResponse standardResponse;
 
         try
         {
             Logger.LogDebug("Preparing input for HTTP task {TaskKey}", httpTask.Key);
             await PrepareInputAsync(httpTask, scriptCode, context, cancellationToken);
             
+            await CallAsync(httpTask, context, cancellationToken);
+            
+            Logger.LogDebug("Processing output for HTTP task {TaskKey}", httpTask.Key);
+            var outputResponse = await ProcessOutputAsync(scriptCode, context, cancellationToken);
+            
+            Logger.LogInformation("HTTP task {TaskKey} execution completed, returning processed output", httpTask.Key);
+            return outputResponse;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error occurred during HTTP task {TaskKey} execution", httpTask.Key);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Executes an HTTP call without script processing. Used for internal workflow operations.
+    /// This method makes the HTTP request and sets the response in the context.
+    /// </summary>
+    /// <param name="task">The HTTP workflow task to execute.</param>
+    /// <param name="context">The script context for storing the response.</param>
+    /// <param name="cancellationToken">Token to monitor for cancellation requests during execution.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    public async Task CallAsync(
+        WorkflowTask task,
+        ScriptContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var httpTask = (task as HttpTask)!;
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        
+        Logger.LogInformation("Calling HTTP endpoint for task {TaskKey} - URL: {Url}, Method: {Method}", 
+            httpTask.Key, httpTask.Url, httpTask.Method);
+            
+        StandardTaskResponse standardResponse;
+
+        try
+        {
             var httpClient = CreateHttpClient(httpTask);
             
             var request = new HttpRequestMessage(new HttpMethod(httpTask.Method), httpTask.Url);
@@ -164,6 +199,12 @@ public sealed class HttpTaskExecutor(
                         ["ResponseContent"] = content
                     });
             }
+            
+            Logger.LogDebug("Setting standard response in context for HTTP task {TaskKey}", httpTask.Key);
+            context.SetStandardResponse(standardResponse);
+            
+            Logger.LogDebug("Setting response body in context for HTTP task {TaskKey}", httpTask.Key);
+            context.SetBody(responseData);
         }
         catch (TaskCanceledException ex) when (ex.CancellationToken.IsCancellationRequested)
         {
@@ -182,6 +223,9 @@ public sealed class HttpTaskExecutor(
                     ["Method"] = httpTask.Method,
                     ["Cancelled"] = true
                 });
+            
+            context.SetStandardResponse(standardResponse);
+            throw;
         }
         catch (HttpRequestException ex)
         {
@@ -199,6 +243,9 @@ public sealed class HttpTaskExecutor(
                     ["Url"] = httpTask.Url,
                     ["Method"] = httpTask.Method
                 });
+            
+            context.SetStandardResponse(standardResponse);
+            throw;
         }
         catch (Exception ex)
         {
@@ -216,16 +263,10 @@ public sealed class HttpTaskExecutor(
                     ["Url"] = httpTask.Url,
                     ["Method"] = httpTask.Method
                 });
+            
+            context.SetStandardResponse(standardResponse);
+            throw;
         }
-
-        Logger.LogDebug("Setting standard response in context for HTTP task {TaskKey}", httpTask.Key);
-        context.SetStandardResponse(standardResponse);
-        
-        Logger.LogDebug("Processing output for HTTP task {TaskKey}", httpTask.Key);
-        var outputResponse = await ProcessOutputAsync(scriptCode, context, cancellationToken);
-        
-        Logger.LogInformation("HTTP task {TaskKey} execution completed, returning processed output", httpTask.Key);
-        return outputResponse;
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Application/Tasks/Executors/NotificationTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/NotificationTaskExecutor.cs
@@ -210,7 +210,7 @@ public sealed class NotificationTaskExecutor(
             SubFlowName = correlation.SubFlowName,
             SubFlowVersion = correlation.SubFlowVersion,
             IsCompleted = correlation.IsCompleted,
-            Href = string.Format(InstanceUrlTemplates.SubFlowData, correlation.SubFlowDomain, correlation.SubFlowName, correlation.SubFlowInstanceId)
+            Href = string.Format(InstanceUrlTemplates.Data, correlation.SubFlowDomain, correlation.SubFlowName, correlation.SubFlowInstanceId)
         }).ToList();
 
         return new GetInstanceStateOutput

--- a/src/BBT.Workflow.Application/Tasks/Executors/TaskExecutorFactory.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/TaskExecutorFactory.cs
@@ -56,6 +56,8 @@ public sealed class TaskExecutorFactory(IServiceProvider serviceProvider) : ITas
                 return serviceProvider.GetRequiredService<TimerTaskExecutor>();
             case TaskType.Notification:
                 return serviceProvider.GetRequiredService<NotificationTaskExecutor>();
+            case TaskType.TriggerTransition:
+                return serviceProvider.GetRequiredService<TriggerTransitionTaskExecutor>();
             default:
                 throw new ArgumentOutOfRangeException(nameof(type), type, null);
         }

--- a/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/DirectTriggerStrategy.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/DirectTriggerStrategy.cs
@@ -1,5 +1,7 @@
+using System.Text.Json;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Execution.TriggerTransition;
+using BBT.Workflow.Instances;
 using BBT.Workflow.Scripting;
 using Microsoft.Extensions.Logging;
 
@@ -43,11 +45,14 @@ public sealed class DirectTriggerStrategy : ITriggerTransitionStrategy
         _logger.LogInformation("Handling Direct trigger for task {TaskKey} - InstanceId: {InstanceId}, Transition: {Transition}",
             task.Key, context.Instance.Id, task.TransitionName);
 
+        // Resolve instance ID
+        var instanceId = await GetInstanceIdAsync(task, context, cancellationToken);
+
         // Create path using InstanceUrlTemplates.Transition format
         var path = string.Format(InstanceUrlTemplates.Transition,
-            task.TransitionDomain,
-            task.TransitionFlow,
-            context.Instance.Id,
+            task.TriggerDomain,
+            task.TriggerFlow,
+            instanceId,
             task.TransitionName);
 
         var httpTask = _httpTaskFactory.CreateHttpTask(task, context, path, "PATCH");
@@ -59,6 +64,118 @@ public sealed class DirectTriggerStrategy : ITriggerTransitionStrategy
 
         _logger.LogDebug("Calling HttpTaskExecutor.CallAsync for Direct trigger task {TaskKey}", task.Key);
         await httpExecutor.CallAsync(httpTask, context, cancellationToken);
+    }
+
+    /// <summary>
+    /// Resolves the instance ID for the transition based on task configuration.
+    /// </summary>
+    /// <param name="task">The trigger transition task.</param>
+    /// <param name="context">The script context.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The resolved instance ID.</returns>
+    private async Task<string> GetInstanceIdAsync(
+        TriggerTransitionTask task,
+        ScriptContext context,
+        CancellationToken cancellationToken)
+    {
+        // If TriggerInstanceId is provided, use it
+        if (!string.IsNullOrWhiteSpace(task.TriggerInstanceId))
+        {
+            _logger.LogDebug("Using provided TriggerInstanceId: {InstanceId}", task.TriggerInstanceId);
+            return task.TriggerInstanceId;
+        }
+
+        // If TriggerKey is provided but TriggerInstanceId is not, query the instance
+        if (!string.IsNullOrWhiteSpace(task.TriggerKey))
+        {
+            _logger.LogInformation("TriggerInstanceId not provided but TriggerKey exists: {Key}. Querying instance by key.", 
+                task.TriggerKey);
+
+            var path = string.Format(InstanceUrlTemplates.Instance,
+                task.TriggerDomain,
+                task.TriggerFlow,
+                task.TriggerKey);
+
+            var httpTask = _httpTaskFactory.CreateHttpTask(task, context, path, "GET");
+
+            var httpExecutor = _taskExecutorFactory.GetExecutor(TaskType.Http) as HttpTaskExecutor;
+            if (httpExecutor == null)
+                throw new InvalidOperationException("HttpTaskExecutor not found");
+
+            _logger.LogDebug("Calling HttpTaskExecutor.CallAsync to get instance by key {Key}", task.TriggerKey);
+            
+            // Store original body to restore after the call
+            object? originalBody = context.Body;
+            
+            await httpExecutor.CallAsync(httpTask, context, cancellationToken);
+
+            // Parse the response and extract the Id
+            // After CallAsync, context.Body contains StandardTaskResponse merged data
+            // The actual response data is in context.Body.data property (camelCase)
+            if (context.Body != null)
+            {
+                try
+                {
+                    // Access the 'data' property from StandardTaskResponse
+                    dynamic bodyData = context.Body;
+                    var responseData = bodyData.data;
+                    
+                    if (responseData != null)
+                    {
+                        var jsonElement = JsonSerializer.SerializeToElement(responseData);
+                        
+                        // Use case-insensitive deserialization to match camelCase JSON properties to PascalCase C# properties
+                        var options = new JsonSerializerOptions
+                        {
+                            PropertyNameCaseInsensitive = true
+                        };
+                        
+                        var instanceOutput = JsonSerializer.Deserialize<GetInstanceOutput>(jsonElement, options);
+
+                        if (instanceOutput != null)
+                        {
+
+                            string idValue = instanceOutput.Id?.ToString() ?? "null";
+                            // Use GetValueOrDefault() to safely access Nullable<Guid>
+                            Guid resolvedGuid = Guid.TryParse(idValue, out var instanceId)?instanceId:Guid.Empty;
+                            
+                            if (resolvedGuid != Guid.Empty)
+                            {
+                                string resolvedId = resolvedGuid.ToString();
+                                string? TriggerKey = task.TriggerKey;
+                                _logger.LogInformation("Resolved instance ID from key {Key}: {InstanceId}", 
+                                    TriggerKey, resolvedId);
+                                
+                                // Restore original body
+                                context.SetBody(originalBody);
+                                
+                                return resolvedId;
+                            }
+                        }
+
+                        throw new InvalidOperationException($"Instance with key '{task.TriggerKey}' returned no valid Id");
+                    }
+
+                    throw new InvalidOperationException($"Response data is null when querying instance by key '{task.TriggerKey}'");
+                }
+                catch (JsonException ex)
+                {
+                    _logger.LogError(ex, "Failed to deserialize GetInstanceOutput for key {Key}", task.TriggerKey);
+                    throw new InvalidOperationException($"Failed to parse instance response for key '{task.TriggerKey}'", ex);
+                }
+                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException ex)
+                {
+                    _logger.LogError(ex, "Failed to access response data property for key {Key}", task.TriggerKey);
+                    throw new InvalidOperationException($"Invalid response structure when querying instance by key '{task.TriggerKey}'", ex);
+                }
+            }
+
+            throw new InvalidOperationException($"No response received when querying instance by key '{task.TriggerKey}'");
+        }
+
+        // Default to current instance ID
+        _logger.LogDebug("Using current instance ID: {InstanceId}", context.Instance.Id);
+        return context.Instance.Id.ToString();
     }
 }
 

--- a/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/DirectTriggerStrategy.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/DirectTriggerStrategy.cs
@@ -136,7 +136,6 @@ public sealed class DirectTriggerStrategy : ITriggerTransitionStrategy
                         {
 
                             string idValue = instanceOutput.Id?.ToString() ?? "null";
-                            // Use GetValueOrDefault() to safely access Nullable<Guid>
                             Guid resolvedGuid = Guid.TryParse(idValue, out var instanceId)?instanceId:Guid.Empty;
                             
                             if (resolvedGuid != Guid.Empty)

--- a/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/DirectTriggerStrategy.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/DirectTriggerStrategy.cs
@@ -1,0 +1,64 @@
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Execution.TriggerTransition;
+using BBT.Workflow.Scripting;
+using Microsoft.Extensions.Logging;
+
+namespace BBT.Workflow.Tasks.TriggerTransition;
+
+/// <summary>
+/// Strategy for handling Trigger (Direct) trigger type.
+/// Executes a transition on the current workflow instance using HttpTask to call the transition endpoint.
+/// </summary>
+public sealed class DirectTriggerStrategy : ITriggerTransitionStrategy
+{
+    private readonly ITaskExecutorFactory _taskExecutorFactory;
+    private readonly ITriggerTransitionHttpTaskFactory _httpTaskFactory;
+    private readonly ILogger<DirectTriggerStrategy> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DirectTriggerStrategy"/> class.
+    /// </summary>
+    /// <param name="taskExecutorFactory">Factory for creating task executors.</param>
+    /// <param name="httpTaskFactory">Factory for creating HTTP tasks for trigger transitions.</param>
+    /// <param name="logger">The logger instance.</param>
+    public DirectTriggerStrategy(
+        ITaskExecutorFactory taskExecutorFactory,
+        ITriggerTransitionHttpTaskFactory httpTaskFactory,
+        ILogger<DirectTriggerStrategy> logger)
+    {
+        _taskExecutorFactory = taskExecutorFactory;
+        _httpTaskFactory = httpTaskFactory;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task ExecuteAsync(
+        TriggerTransitionTask task,
+        ScriptContext context,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(task.TransitionName))
+            throw new InvalidOperationException("TransitionName is required for Trigger (Direct) trigger type");
+
+        _logger.LogInformation("Handling Direct trigger for task {TaskKey} - InstanceId: {InstanceId}, Transition: {Transition}",
+            task.Key, context.Instance.Id, task.TransitionName);
+
+        // Create path using InstanceUrlTemplates.Transition format
+        var path = string.Format(InstanceUrlTemplates.Transition,
+            task.TransitionDomain,
+            task.TransitionFlow,
+            context.Instance.Id,
+            task.TransitionName);
+
+        var httpTask = _httpTaskFactory.CreateHttpTask(task, context, path, "PATCH");
+
+        var httpExecutor = _taskExecutorFactory.GetExecutor(TaskType.Http) as HttpTaskExecutor;
+
+        if (httpExecutor == null)
+            throw new InvalidOperationException("HttpTaskExecutor not found");
+
+        _logger.LogDebug("Calling HttpTaskExecutor.CallAsync for Direct trigger task {TaskKey}", task.Key);
+        await httpExecutor.CallAsync(httpTask, context, cancellationToken);
+    }
+}
+

--- a/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/GetInstanceDataTriggerStrategy.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/GetInstanceDataTriggerStrategy.cs
@@ -42,7 +42,7 @@ public sealed class GetInstanceDataTriggerStrategy : ITriggerTransitionStrategy
 
         // Build path with or without extensions
         string path;
-        if (task.Extensions != null && task.Extensions.Length > 0)
+        if (task.Extensions?.Length > 0)
         {
             var extensionsParam = string.Join(",", task.Extensions);
             path = string.Format(InstanceUrlTemplates.DataWithExtensions,

--- a/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/GetInstanceDataTriggerStrategy.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/GetInstanceDataTriggerStrategy.cs
@@ -1,0 +1,72 @@
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Execution.TriggerTransition;
+using BBT.Workflow.Scripting;
+using Microsoft.Extensions.Logging;
+
+namespace BBT.Workflow.Tasks.TriggerTransition;
+
+/// <summary>
+/// Strategy for handling GetInstanceData trigger type.
+/// Retrieves instance data from a workflow instance using the data function endpoint.
+/// </summary>
+public sealed class GetInstanceDataTriggerStrategy : ITriggerTransitionStrategy
+{
+    private readonly ITaskExecutorFactory _taskExecutorFactory;
+    private readonly ITriggerTransitionHttpTaskFactory _httpTaskFactory;
+    private readonly ILogger<GetInstanceDataTriggerStrategy> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GetInstanceDataTriggerStrategy"/> class.
+    /// </summary>
+    /// <param name="taskExecutorFactory">Factory for creating task executors.</param>
+    /// <param name="httpTaskFactory">Factory for creating HTTP tasks for trigger transitions.</param>
+    /// <param name="logger">The logger instance.</param>
+    public GetInstanceDataTriggerStrategy(
+        ITaskExecutorFactory taskExecutorFactory,
+        ITriggerTransitionHttpTaskFactory httpTaskFactory,
+        ILogger<GetInstanceDataTriggerStrategy> logger)
+    {
+        _taskExecutorFactory = taskExecutorFactory;
+        _httpTaskFactory = httpTaskFactory;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task ExecuteAsync(
+        TriggerTransitionTask task,
+        ScriptContext context,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Handling GetInstanceData trigger for task {TaskKey} - Domain: {Domain}, Flow: {Flow}, InstanceId: {InstanceId}",
+            task.Key, task.TransitionDomain, task.TransitionFlow, context.Instance.Id);
+
+        // Build path with or without extensions
+        string path;
+        if (task.Extensions != null && task.Extensions.Length > 0)
+        {
+            var extensionsParam = string.Join(",", task.Extensions);
+            path = string.Format(InstanceUrlTemplates.DataWithExtensions,
+                task.TransitionDomain,
+                task.TransitionFlow,
+                context.Instance.Id,
+                extensionsParam);
+        }
+        else
+        {
+            path = string.Format(InstanceUrlTemplates.Data,
+                task.TransitionDomain,
+                task.TransitionFlow,
+                context.Instance.Id);
+        }
+
+        var httpTask = _httpTaskFactory.CreateHttpTask(task, context, path, "GET");
+
+        var httpExecutor = _taskExecutorFactory.GetExecutor(TaskType.Http) as HttpTaskExecutor;
+
+        if (httpExecutor == null)
+            throw new InvalidOperationException("HttpTaskExecutor not found");
+
+        _logger.LogDebug("Calling HttpTaskExecutor.CallAsync for GetInstanceData trigger task {TaskKey}", task.Key);
+        await httpExecutor.CallAsync(httpTask, context, cancellationToken);
+    }
+}

--- a/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/GetInstanceDataTriggerStrategy.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/GetInstanceDataTriggerStrategy.cs
@@ -38,7 +38,7 @@ public sealed class GetInstanceDataTriggerStrategy : ITriggerTransitionStrategy
         CancellationToken cancellationToken)
     {
         _logger.LogInformation("Handling GetInstanceData trigger for task {TaskKey} - Domain: {Domain}, Flow: {Flow}, InstanceId: {InstanceId}",
-            task.Key, task.TransitionDomain, task.TransitionFlow, context.Instance.Id);
+            task.Key, task.TriggerDomain, task.TriggerFlow, context.Instance.Id);
 
         // Build path with or without extensions
         string path;
@@ -46,16 +46,16 @@ public sealed class GetInstanceDataTriggerStrategy : ITriggerTransitionStrategy
         {
             var extensionsParam = string.Join(",", task.Extensions);
             path = string.Format(InstanceUrlTemplates.DataWithExtensions,
-                task.TransitionDomain,
-                task.TransitionFlow,
+                task.TriggerDomain,
+                task.TriggerFlow,
                 context.Instance.Id,
                 extensionsParam);
         }
         else
         {
             path = string.Format(InstanceUrlTemplates.Data,
-                task.TransitionDomain,
-                task.TransitionFlow,
+                task.TriggerDomain,
+                task.TriggerFlow,
                 context.Instance.Id);
         }
 

--- a/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/StartTriggerStrategy.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/StartTriggerStrategy.cs
@@ -38,13 +38,13 @@ public sealed class StartTriggerStrategy : ITriggerTransitionStrategy
         CancellationToken cancellationToken)
     {
         _logger.LogInformation("Handling Start trigger for task {TaskKey} - Domain: {Domain}, Flow: {Flow}",
-            task.Key, task.TransitionDomain, task.TransitionFlow);
+            task.Key, task.TriggerDomain, task.TriggerFlow);
 
         // Create path using format: /{domain}/workflows/{workflow}/instances/start
         var path = string.Format("/{0}/workflows/{1}/instances/start",
-            task.TransitionDomain,
-            task.TransitionFlow);
-
+            task.TriggerDomain,
+            task.TriggerFlow);
+        
         var httpTask = _httpTaskFactory.CreateHttpTask(task, context, path, "POST");
 
         var httpExecutor = _taskExecutorFactory.GetExecutor(TaskType.Http) as HttpTaskExecutor;

--- a/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/StartTriggerStrategy.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/StartTriggerStrategy.cs
@@ -40,8 +40,8 @@ public sealed class StartTriggerStrategy : ITriggerTransitionStrategy
         _logger.LogInformation("Handling Start trigger for task {TaskKey} - Domain: {Domain}, Flow: {Flow}",
             task.Key, task.TriggerDomain, task.TriggerFlow);
 
-        // Create path using format: /{domain}/workflows/{workflow}/instances/start
-        var path = string.Format("/{0}/workflows/{1}/instances/start",
+        // Create path using InstanceUrlTemplates.Start format
+        var path = string.Format(InstanceUrlTemplates.Start,
             task.TriggerDomain,
             task.TriggerFlow);
         

--- a/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/StartTriggerStrategy.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/StartTriggerStrategy.cs
@@ -1,0 +1,59 @@
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Execution.TriggerTransition;
+using BBT.Workflow.Scripting;
+using Microsoft.Extensions.Logging;
+
+namespace BBT.Workflow.Tasks.TriggerTransition;
+
+/// <summary>
+/// Strategy for handling Start trigger type.
+/// Creates a new workflow instance using HttpTask to call the workflow start endpoint.
+/// </summary>
+public sealed class StartTriggerStrategy : ITriggerTransitionStrategy
+{
+    private readonly ITaskExecutorFactory _taskExecutorFactory;
+    private readonly ITriggerTransitionHttpTaskFactory _httpTaskFactory;
+    private readonly ILogger<StartTriggerStrategy> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StartTriggerStrategy"/> class.
+    /// </summary>
+    /// <param name="taskExecutorFactory">Factory for creating task executors.</param>
+    /// <param name="httpTaskFactory">Factory for creating HTTP tasks for trigger transitions.</param>
+    /// <param name="logger">The logger instance.</param>
+    public StartTriggerStrategy(
+        ITaskExecutorFactory taskExecutorFactory,
+        ITriggerTransitionHttpTaskFactory httpTaskFactory,
+        ILogger<StartTriggerStrategy> logger)
+    {
+        _taskExecutorFactory = taskExecutorFactory;
+        _httpTaskFactory = httpTaskFactory;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task ExecuteAsync(
+        TriggerTransitionTask task,
+        ScriptContext context,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Handling Start trigger for task {TaskKey} - Domain: {Domain}, Flow: {Flow}",
+            task.Key, task.TransitionDomain, task.TransitionFlow);
+
+        // Create path using format: /{domain}/workflows/{workflow}/instances/start
+        var path = string.Format("/{0}/workflows/{1}/instances/start",
+            task.TransitionDomain,
+            task.TransitionFlow);
+
+        var httpTask = _httpTaskFactory.CreateHttpTask(task, context, path, "POST");
+
+        var httpExecutor = _taskExecutorFactory.GetExecutor(TaskType.Http) as HttpTaskExecutor;
+
+        if (httpExecutor == null)
+            throw new InvalidOperationException("HttpTaskExecutor not found");
+
+        _logger.LogDebug("Calling HttpTaskExecutor.CallAsync for Start trigger task {TaskKey}", task.Key);
+        await httpExecutor.CallAsync(httpTask, context, cancellationToken);
+    }
+}
+

--- a/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/SubProcessTriggerStrategy.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/SubProcessTriggerStrategy.cs
@@ -1,0 +1,36 @@
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Execution.TriggerTransition;
+using BBT.Workflow.Scripting;
+using Microsoft.Extensions.Logging;
+
+namespace BBT.Workflow.Tasks.TriggerTransition;
+
+/// <summary>
+/// Strategy for handling SubProcess trigger type.
+/// This is a placeholder for future implementation that will trigger transitions on correlated SubFlow instances.
+/// </summary>
+public sealed class SubProcessTriggerStrategy : ITriggerTransitionStrategy
+{
+    private readonly ILogger<SubProcessTriggerStrategy> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SubProcessTriggerStrategy"/> class.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    public SubProcessTriggerStrategy(ILogger<SubProcessTriggerStrategy> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task ExecuteAsync(
+        TriggerTransitionTask task,
+        ScriptContext context,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogError("SubProcess trigger type is not yet implemented for task {TaskKey}", task.Key);
+        throw new NotImplementedException(
+            $"SubProcess trigger type is not yet implemented. Task: {task.Key}");
+    }
+}
+

--- a/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/SubProcessTriggerStrategy.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/SubProcessTriggerStrategy.cs
@@ -1,36 +1,83 @@
+using BBT.Aether.Guids;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Execution.TriggerTransition;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Runtime;
 using BBT.Workflow.Scripting;
+using BBT.Workflow.SubFlow;
 using Microsoft.Extensions.Logging;
 
 namespace BBT.Workflow.Tasks.TriggerTransition;
 
 /// <summary>
 /// Strategy for handling SubProcess trigger type.
-/// This is a placeholder for future implementation that will trigger transitions on correlated SubFlow instances.
+/// Triggers transitions on correlated SubFlow instances by starting a subprocess workflow.
 /// </summary>
 public sealed class SubProcessTriggerStrategy : ITriggerTransitionStrategy
 {
+    private readonly ISubflowStarter _subflowStarter;
+    private readonly IGuidGenerator _guidGenerator;
     private readonly ILogger<SubProcessTriggerStrategy> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SubProcessTriggerStrategy"/> class.
     /// </summary>
+    /// <param name="subflowStarter">Service for starting SubFlow workflows.</param>
+    /// <param name="guidGenerator">Generator for creating unique identifiers.</param>
     /// <param name="logger">The logger instance.</param>
-    public SubProcessTriggerStrategy(ILogger<SubProcessTriggerStrategy> logger)
+    public SubProcessTriggerStrategy(
+        ISubflowStarter subflowStarter,
+        IGuidGenerator guidGenerator,
+        ILogger<SubProcessTriggerStrategy> logger
+        )
     {
+        _subflowStarter = subflowStarter;
+        _guidGenerator = guidGenerator;
         _logger = logger;
     }
 
     /// <inheritdoc />
-    public Task ExecuteAsync(
+    public async Task ExecuteAsync(
         TriggerTransitionTask task,
         ScriptContext context,
         CancellationToken cancellationToken)
     {
-        _logger.LogError("SubProcess trigger type is not yet implemented for task {TaskKey}", task.Key);
-        throw new NotImplementedException(
-            $"SubProcess trigger type is not yet implemented. Task: {task.Key}");
+        _logger.LogInformation(
+            "Executing SubProcess trigger for task {TaskKey} - Domain: {Domain}, Key: {Key}, Version: {Version}",
+            task.Key, task.TriggerDomain, task.TriggerKey, task.TriggerVersion);
+
+        // Create correlation for SubProcess
+        var correlation = InstanceCorrelation.Create(
+            _guidGenerator.Create(),
+            context.Instance.Id,
+            context.Instance.GetCurrentState,
+            _guidGenerator.Create(),
+            SubFlowType.SubProcess.Code,
+            task.TriggerDomain,
+            task.TriggerKey!,
+            task.TriggerVersion);
+        context.Instance.AddCorrelation(correlation);
+
+        // Create a SubFlow reference for the subprocess
+        var subFlowReference = new Reference(
+            task.TriggerKey!,
+            task.TriggerDomain,
+            RuntimeSysSchemaInfo.Flows,
+            task.TriggerVersion ?? string.Empty);
+
+        // Start the SubProcess using simplified SubStartAsync method
+        await _subflowStarter.SubStartAsync(
+            context.Workflow,
+            context.Instance,
+            subFlowReference,
+            context.Transition!,
+            correlation,
+            SubFlowType.SubProcess.Code,
+            cancellationToken);
+
+        _logger.LogInformation(
+            "SubProcess trigger completed for task {TaskKey} with correlation {CorrelationId}",
+            task.Key, correlation.Id);
     }
 }
 

--- a/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/TriggerTransitionHttpTaskFactory.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/TriggerTransitionHttpTaskFactory.cs
@@ -1,0 +1,101 @@
+using System.Text.Json;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Execution.TriggerTransition;
+using BBT.Workflow.Scripting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace BBT.Workflow.Tasks.TriggerTransition;
+
+/// <summary>
+/// Factory implementation for creating HTTP tasks used in trigger transition strategies.
+/// </summary>
+public sealed class TriggerTransitionHttpTaskFactory : ITriggerTransitionHttpTaskFactory
+{
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<TriggerTransitionHttpTaskFactory> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TriggerTransitionHttpTaskFactory"/> class.
+    /// </summary>
+    /// <param name="configuration">The configuration instance for reading vNextApi settings.</param>
+    /// <param name="logger">The logger instance.</param>
+    public TriggerTransitionHttpTaskFactory(
+        IConfiguration configuration,
+        ILogger<TriggerTransitionHttpTaskFactory> logger)
+    {
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public HttpTask CreateHttpTask(
+        TriggerTransitionTask triggerTask,
+        ScriptContext context,
+        string path,
+        string method)
+    {
+        // Build full URL using configuration
+        var baseUrl = _configuration["vNextApi:BaseUrl"]?.TrimEnd('/') ?? string.Empty;
+        var apiVersion = _configuration["vNextApi:ApiVersion"] ?? "1";
+        var fullUrl = $"{baseUrl}/api/v{apiVersion}{path}";
+
+        _logger.LogDebug("Creating HttpTask with URL: {Url}", fullUrl);
+
+        // Prepare body from triggerTask.Body or context.Body
+        JsonElement? body = triggerTask.Body;
+        if (!body.HasValue && context.Body != null)
+        {
+            body = JsonSerializer.SerializeToElement(context.Body);
+        }
+
+        // Prepare headers from context.Headers
+        var headersDict = new Dictionary<string, string>();
+        if (context.Headers != null)
+        {
+            foreach (var header in context.Headers)
+            {
+                var key = header.Key?.ToString() ?? string.Empty;
+                var value = header.Value?.ToString() ?? string.Empty;
+                if (!string.IsNullOrWhiteSpace(key))
+                {
+                    headersDict[key] = value;
+                }
+            }
+        }
+
+        // Get timeout from configuration
+        var timeoutSeconds = _configuration.GetValue<int>("vNextApi:TimeoutSeconds", 30);
+
+        // Create task config JSON
+        var configBuilder = new Dictionary<string, object>
+        {
+            ["key"] = triggerTask.Key,
+            ["url"] = fullUrl,
+            ["method"] = method,
+            ["timeoutSeconds"] = timeoutSeconds,
+            ["validateSSL"] = true
+        };
+
+        if (headersDict.Count > 0)
+        {
+            configBuilder["headers"] = headersDict;
+        }
+
+        if (body.HasValue)
+        {
+            configBuilder["body"] = body.Value;
+        }
+
+        var configJson = JsonSerializer.Serialize(configBuilder);
+        var configElement = JsonDocument.Parse(configJson).RootElement;
+
+        var httpTask = HttpTask.Create(configElement);
+
+        // Copy base properties from triggerTask
+        triggerTask.CopyBaseToInternal(httpTask);
+
+        return httpTask;
+    }
+}
+

--- a/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/TriggerTransitionStrategyFactory.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/TriggerTransitionStrategyFactory.cs
@@ -1,0 +1,55 @@
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Execution.TriggerTransition;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace BBT.Workflow.Tasks.TriggerTransition;
+
+/// <summary>
+/// Factory implementation for creating appropriate trigger transition strategies based on trigger type.
+/// Uses dependency injection to resolve strategies.
+/// </summary>
+public sealed class TriggerTransitionStrategyFactory : ITriggerTransitionStrategyFactory
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<TriggerTransitionStrategyFactory> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TriggerTransitionStrategyFactory"/> class.
+    /// </summary>
+    /// <param name="serviceProvider">The service provider used to resolve strategy instances.</param>
+    /// <param name="logger">The logger instance.</param>
+    public TriggerTransitionStrategyFactory(
+        IServiceProvider serviceProvider,
+        ILogger<TriggerTransitionStrategyFactory> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public ITriggerTransitionStrategy Get(TriggerTransitionType type)
+    {
+        _logger.LogDebug("Resolving trigger transition strategy for type {TriggerType}", type);
+
+        ITriggerTransitionStrategy? strategy = type switch
+        {
+            TriggerTransitionType.Start => _serviceProvider.GetService<StartTriggerStrategy>(),
+            TriggerTransitionType.Trigger => _serviceProvider.GetService<DirectTriggerStrategy>(),
+            TriggerTransitionType.SubProcess => _serviceProvider.GetService<SubProcessTriggerStrategy>(),
+            _ => null
+        };
+
+        if (strategy == null)
+        {
+            _logger.LogError("No trigger transition strategy found for type {TriggerType}", type);
+            throw new NotSupportedException($"No trigger transition strategy found for type {type}");
+        }
+
+        _logger.LogDebug("Resolved trigger transition strategy {StrategyType} for type {TriggerType}",
+            strategy.GetType().Name, type);
+
+        return strategy;
+    }
+}
+

--- a/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/TriggerTransitionStrategyFactory.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/TriggerTransitionStrategyFactory.cs
@@ -37,6 +37,7 @@ public sealed class TriggerTransitionStrategyFactory : ITriggerTransitionStrateg
             TriggerTransitionType.Start => _serviceProvider.GetService<StartTriggerStrategy>(),
             TriggerTransitionType.Trigger => _serviceProvider.GetService<DirectTriggerStrategy>(),
             TriggerTransitionType.SubProcess => _serviceProvider.GetService<SubProcessTriggerStrategy>(),
+            TriggerTransitionType.GetInstanceData => _serviceProvider.GetService<GetInstanceDataTriggerStrategy>(),
             _ => null
         };
 

--- a/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransitionTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransitionTaskExecutor.cs
@@ -1,34 +1,28 @@
-using System.Text.Json;
 using BBT.Workflow.Definitions;
-using BBT.Workflow.Instances;
+using BBT.Workflow.Execution.TriggerTransition;
 using BBT.Workflow.Runtime;
 using BBT.Workflow.Scripting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace BBT.Workflow.Tasks;
 
 /// <summary>
 /// Executes trigger transition workflow tasks that trigger transitions on workflow instances.
-/// This executor can create new instances, trigger direct transitions, or trigger transitions on correlated SubFlow instances.
+/// This executor delegates to appropriate strategies based on trigger type (Start, Trigger, SubProcess).
 /// </summary>
 /// <param name="scriptEngine">The script engine used for compiling input/output mapping scripts.</param>
-/// <param name="instanceCorrelationRepository">The instance correlation repository for retrieving active correlations.</param>
 /// <param name="runtimeInfoProvider">The runtime information provider for domain checks.</param>
-/// <param name="taskExecutorFactory">Factory for creating task executors.</param>
-/// <param name="configuration">The configuration instance for reading vNextApi settings.</param>
+/// <param name="strategyFactory">Factory for creating trigger transition strategies.</param>
 /// <param name="logger">The logger instance for logging trigger transition task execution details.</param>
 public sealed class TriggerTransitionTaskExecutor(
     IScriptEngine scriptEngine,
-    IInstanceCorrelationRepository instanceCorrelationRepository,
     IRuntimeInfoProvider runtimeInfoProvider,
-    ITaskExecutorFactory taskExecutorFactory,
-    IConfiguration configuration,
+    ITriggerTransitionStrategyFactory strategyFactory,
     ILogger<TriggerTransitionTaskExecutor> logger) : TaskExecutor(scriptEngine, logger), ITaskExecutor
 {
     /// <summary>
-    /// Executes a trigger transition task by preparing the request through script mapping, triggering the appropriate transition,
-    /// and processing the response through output mapping.
+    /// Executes a trigger transition task by preparing the request through script mapping, 
+    /// delegating to the appropriate strategy, and processing the response through output mapping.
     /// </summary>
     /// <param name="task">The trigger transition workflow task containing transition configuration.</param>
     /// <param name="scriptCode">The script code that handles input preparation and output processing.</param>
@@ -58,20 +52,9 @@ public sealed class TriggerTransitionTaskExecutor(
             Logger.LogDebug("Preparing input for trigger transition task {TaskKey}", triggerTask.Key);
             await PrepareInputAsync(triggerTask, scriptCode, context, cancellationToken);
 
-            // Route to appropriate handler based on trigger type
-            switch (triggerTask.TriggerType)
-            {
-                case TriggerTransitionType.Start:
-                    await HandleCreateNewAsync(triggerTask, context, cancellationToken);
-                    break;
-
-                case TriggerTransitionType.Trigger:
-                    await HandleDirectAsync(triggerTask, context, cancellationToken);
-                    break;
-
-                default:
-                    throw new InvalidOperationException($"Unsupported trigger type: {triggerTask.TriggerType}");
-            }
+            // Get appropriate strategy and execute
+            var strategy = strategyFactory.Get(triggerTask.TriggerType);
+            await strategy.ExecuteAsync(triggerTask, context, cancellationToken);
 
             Logger.LogDebug("Processing output for trigger transition task {TaskKey}", triggerTask.Key);
             var outputResponse = await ProcessOutputAsync(scriptCode, context, cancellationToken);
@@ -101,209 +84,5 @@ public sealed class TriggerTransitionTaskExecutor(
         }
     }
 
-    /// <summary>
-    /// Handles CreateNew trigger type by creating a new workflow instance using HttpTask.
-    /// </summary>
-    private async Task HandleCreateNewAsync(
-        TriggerTransitionTask triggerTask,
-        ScriptContext context,
-        CancellationToken cancellationToken)
-    {
-        Logger.LogInformation("Handling CreateNew trigger for task {TaskKey} - Domain: {Domain}, Flow: {Flow}",
-            triggerTask.Key, triggerTask.TransitionDomain, triggerTask.TransitionFlow);
-
-        // Create path using format: /{domain}/workflows/{workflow}/instances/start
-        var path = string.Format("/{0}/workflows/{1}/instances/start",
-            triggerTask.TransitionDomain,
-            triggerTask.TransitionFlow);
-
-        var httpTask = CreateHttpTask(triggerTask, context, path, "POST");
-
-        var httpExecutor = taskExecutorFactory.GetExecutor(TaskType.Http) as HttpTaskExecutor;
-
-        if (httpExecutor == null)
-            throw new InvalidOperationException("HttpTaskExecutor not found");
-
-        Logger.LogDebug("Calling HttpTaskExecutor.CallAsync for CreateNew trigger task {TaskKey}", triggerTask.Key);
-        await httpExecutor.CallAsync(httpTask, context, cancellationToken);
-    }
-
-    /// <summary>
-    /// Handles Direct trigger type by executing a transition on the current instance using HttpTask.
-    /// </summary>
-    private async Task HandleDirectAsync(
-        TriggerTransitionTask triggerTask,
-        ScriptContext context,
-        CancellationToken cancellationToken)
-    {
-        if (string.IsNullOrWhiteSpace(triggerTask.TransitionName))
-            throw new InvalidOperationException("TransitionName is required for Direct trigger type");
-
-        Logger.LogInformation("Handling Direct trigger for task {TaskKey} - InstanceId: {InstanceId}, Transition: {Transition}",
-            triggerTask.Key, context.Instance.Id, triggerTask.TransitionName);
-
-        // Create path using InstanceUrlTemplates.Transition format
-        var path = string.Format(InstanceUrlTemplates.Transition,
-            triggerTask.TransitionDomain,
-            triggerTask.TransitionFlow,
-            context.Instance.Id,
-            triggerTask.TransitionName);
-
-        var httpTask = CreateHttpTask(triggerTask, context, path, "PATCH");
-
-        var httpExecutor = taskExecutorFactory.GetExecutor(TaskType.Http) as HttpTaskExecutor;
-
-        if (httpExecutor == null)
-            throw new InvalidOperationException("HttpTaskExecutor not found");
-
-        Logger.LogDebug("Calling HttpTaskExecutor.CallAsync for Direct trigger task {TaskKey}", triggerTask.Key);
-        await httpExecutor.CallAsync(httpTask, context, cancellationToken);
-    }
-
-    /// <summary>
-    /// Handles Correlation trigger type by finding the appropriate SubFlow instance and executing a transition using HttpTask.
-    /// </summary>
-    private async Task HandleCorrelationAsync(
-        TriggerTransitionTask triggerTask,
-        ScriptContext context,
-        CancellationToken cancellationToken)
-    {
-        if (string.IsNullOrWhiteSpace(triggerTask.TransitionName))
-            throw new InvalidOperationException("TransitionName is required for Correlation trigger type");
-
-        Logger.LogInformation("Handling Correlation trigger for task {TaskKey} - ParentInstanceId: {InstanceId}, SubFlowName: {SubFlowName}",
-            triggerTask.Key, context.Instance.Id, triggerTask.SubFlowName);
-
-        // Get active correlations for the parent instance
-        var activeCorrelations = await instanceCorrelationRepository.GetActiveByParentAsync(
-            context.Instance.Id,
-            cancellationToken);
-
-        if (activeCorrelations == null || activeCorrelations.Count == 0)
-            throw new InvalidOperationException($"No active correlations found for parent instance {context.Instance.Id}");
-
-        // Find matching SubFlow instance
-        Guid subFlowInstanceId;
-        if (!string.IsNullOrWhiteSpace(triggerTask.SubFlowName))
-        {
-            // Try to find correlation matching SubFlowName
-            var matchingCorrelation = activeCorrelations.FirstOrDefault(c =>
-                string.Equals(c.SubFlowName, triggerTask.SubFlowName, StringComparison.OrdinalIgnoreCase));
-
-            if (matchingCorrelation != null)
-            {
-                subFlowInstanceId = matchingCorrelation.SubFlowInstanceId;
-                Logger.LogDebug("Found matching SubFlow correlation for SubFlowName: {SubFlowName}, InstanceId: {InstanceId}",
-                    triggerTask.SubFlowName, subFlowInstanceId);
-            }
-            else
-            {
-                // Use first active correlation if no match found
-                subFlowInstanceId = activeCorrelations[0].SubFlowInstanceId;
-                Logger.LogWarning("No matching SubFlow found for SubFlowName: {SubFlowName}, using first active correlation InstanceId: {InstanceId}",
-                    triggerTask.SubFlowName, subFlowInstanceId);
-            }
-        }
-        else
-        {
-            // Use first active correlation if SubFlowName not specified
-            subFlowInstanceId = activeCorrelations[0].SubFlowInstanceId;
-            Logger.LogDebug("SubFlowName not specified, using first active correlation InstanceId: {InstanceId}", subFlowInstanceId);
-        }
-
-        // Create path using InstanceUrlTemplates.Transition format
-        var path = string.Format(InstanceUrlTemplates.Transition,
-            triggerTask.TransitionDomain,
-            triggerTask.TransitionFlow,
-            subFlowInstanceId,
-            triggerTask.TransitionName);
-
-        var httpTask = CreateHttpTask(triggerTask, context, path, "PATCH");
-
-        var httpExecutor = taskExecutorFactory.GetExecutor(TaskType.Http) as HttpTaskExecutor;
-
-        if (httpExecutor == null)
-            throw new InvalidOperationException("HttpTaskExecutor not found");
-
-        Logger.LogDebug("Calling HttpTaskExecutor.CallAsync for Correlation trigger task {TaskKey}", triggerTask.Key);
-        await httpExecutor.CallAsync(httpTask, context, cancellationToken);
-    }
-
-    /// <summary>
-    /// Creates an HttpTask for calling workflow instance endpoints.
-    /// </summary>
-    /// <param name="triggerTask">The trigger transition task containing configuration.</param>
-    /// <param name="context">The script context containing headers and body data.</param>
-    /// <param name="path">The API endpoint path to call (without base URL and version).</param>
-    /// <param name="method">The HTTP method (POST, PATCH, etc.).</param>
-    /// <returns>A configured HttpTask ready to execute.</returns>
-    private HttpTask CreateHttpTask(
-        TriggerTransitionTask triggerTask,
-        ScriptContext context,
-        string path,
-        string method)
-    {
-        // Build full URL using configuration
-        var baseUrl = configuration["vNextApi:BaseUrl"]?.TrimEnd('/') ?? string.Empty;
-        var apiVersion = configuration["vNextApi:ApiVersion"] ?? "1";
-        var fullUrl = $"{baseUrl}/api/v{apiVersion}{path}";
-
-        Logger.LogDebug("Creating HttpTask with URL: {Url}", fullUrl);
-
-        // Prepare body from triggerTask.Body or context.Body
-        JsonElement? body = triggerTask.Body;
-        if (!body.HasValue && context.Body != null)
-        {
-            body = JsonSerializer.SerializeToElement(context.Body);
-        }
-
-        // Prepare headers from context.Headers
-        var headersDict = new Dictionary<string, string>();
-        if (context.Headers != null)
-        {
-            foreach (var header in context.Headers)
-            {
-                var key = header.Key?.ToString() ?? string.Empty;
-                var value = header.Value?.ToString() ?? string.Empty;
-                if (!string.IsNullOrWhiteSpace(key))
-                {
-                    headersDict[key] = value;
-                }
-            }
-        }
-
-        // Get timeout from configuration
-        var timeoutSeconds = configuration.GetValue<int>("vNextApi:TimeoutSeconds", 30);
-
-        // Create task config JSON
-        var configBuilder = new Dictionary<string, object>
-        {
-            ["key"] = triggerTask.Key,
-            ["url"] = fullUrl,
-            ["method"] = method,
-            ["timeoutSeconds"] = timeoutSeconds,
-            ["validateSSL"] = true
-        };
-
-        if (headersDict.Count > 0)
-        {
-            configBuilder["headers"] = headersDict;
-        }
-
-        if (body.HasValue)
-        {
-            configBuilder["body"] = body.Value;
-        }
-
-        var configJson = JsonSerializer.Serialize(configBuilder);
-        var configElement = JsonDocument.Parse(configJson).RootElement;
-
-        var httpTask = HttpTask.Create(configElement);
-
-        // Copy base properties from triggerTask
-        triggerTask.CopyBaseToInternal(httpTask);
-
-        return httpTask;
-    }
 }
 

--- a/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransitionTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransitionTaskExecutor.cs
@@ -42,7 +42,7 @@ public sealed class TriggerTransitionTaskExecutor(
         var triggerTask = (task as TriggerTransitionTask)!;
 
         Logger.LogInformation("Starting trigger transition task execution for task {TaskKey} - TriggerType: {TriggerType}, Domain: {Domain}, Flow: {Flow}",
-            triggerTask.Key, triggerTask.TriggerType, triggerTask.TransitionDomain, triggerTask.TransitionFlow);
+            triggerTask.Key, triggerTask.TriggerType, triggerTask.TriggerDomain, triggerTask.TriggerKey);
 
         try
         {
@@ -65,7 +65,7 @@ public sealed class TriggerTransitionTaskExecutor(
         catch (Exception ex)
         {
             Logger.LogError(ex, "Error occurred during trigger transition task {TaskKey} execution - TriggerType: {TriggerType}, Domain: {Domain}, Flow: {Flow}",
-                triggerTask.Key, triggerTask.TriggerType, triggerTask.TransitionDomain, triggerTask.TransitionFlow);
+                triggerTask.Key, triggerTask.TriggerType, triggerTask.TriggerDomain, triggerTask.TriggerFlow);
 
             StandardTaskResponse standardResponse = CreateErrorResponse(
                 errorMessage: ex.Message,
@@ -76,8 +76,8 @@ public sealed class TriggerTransitionTaskExecutor(
                 {
                     ["TaskKey"] = triggerTask.Key,
                     ["TriggerType"] = triggerTask.TriggerType.ToString(),
-                    ["Domain"] = triggerTask.TransitionDomain,
-                    ["Flow"] = triggerTask.TransitionFlow
+                    ["Domain"] = triggerTask.TriggerDomain,
+                    ["Flow"] = triggerTask.TriggerFlow
                 });
             context.SetStandardResponse(standardResponse);
             throw;

--- a/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransitionTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransitionTaskExecutor.cs
@@ -1,0 +1,309 @@
+using System.Text.Json;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Runtime;
+using BBT.Workflow.Scripting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace BBT.Workflow.Tasks;
+
+/// <summary>
+/// Executes trigger transition workflow tasks that trigger transitions on workflow instances.
+/// This executor can create new instances, trigger direct transitions, or trigger transitions on correlated SubFlow instances.
+/// </summary>
+/// <param name="scriptEngine">The script engine used for compiling input/output mapping scripts.</param>
+/// <param name="instanceCorrelationRepository">The instance correlation repository for retrieving active correlations.</param>
+/// <param name="runtimeInfoProvider">The runtime information provider for domain checks.</param>
+/// <param name="taskExecutorFactory">Factory for creating task executors.</param>
+/// <param name="configuration">The configuration instance for reading vNextApi settings.</param>
+/// <param name="logger">The logger instance for logging trigger transition task execution details.</param>
+public sealed class TriggerTransitionTaskExecutor(
+    IScriptEngine scriptEngine,
+    IInstanceCorrelationRepository instanceCorrelationRepository,
+    IRuntimeInfoProvider runtimeInfoProvider,
+    ITaskExecutorFactory taskExecutorFactory,
+    IConfiguration configuration,
+    ILogger<TriggerTransitionTaskExecutor> logger) : TaskExecutor(scriptEngine, logger), ITaskExecutor
+{
+    /// <summary>
+    /// Executes a trigger transition task by preparing the request through script mapping, triggering the appropriate transition,
+    /// and processing the response through output mapping.
+    /// </summary>
+    /// <param name="task">The trigger transition workflow task containing transition configuration.</param>
+    /// <param name="scriptCode">The script code that handles input preparation and output processing.</param>
+    /// <param name="context">The script context containing instance data and headers.</param>
+    /// <param name="cancellationToken">Token to monitor for cancellation requests during execution.</param>
+    /// <returns>
+    /// A task that represents the asynchronous operation. The task result contains the processed response data
+    /// from the transition execution after output mapping transformation.
+    /// </returns>
+    /// <exception cref="InvalidCastException">Thrown when the task cannot be cast to TriggerTransitionTask type.</exception>
+    public async Task<object?> ExecuteAsync(
+        WorkflowTask task,
+        string scriptCode,
+        ScriptContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var triggerTask = (task as TriggerTransitionTask)!;
+
+        Logger.LogInformation("Starting trigger transition task execution for task {TaskKey} - TriggerType: {TriggerType}, Domain: {Domain}, Flow: {Flow}",
+            triggerTask.Key, triggerTask.TriggerType, triggerTask.TransitionDomain, triggerTask.TransitionFlow);
+
+        try
+        {
+            // Check runtime domain
+            runtimeInfoProvider.Check(context.Runtime.Domain);
+
+            Logger.LogDebug("Preparing input for trigger transition task {TaskKey}", triggerTask.Key);
+            await PrepareInputAsync(triggerTask, scriptCode, context, cancellationToken);
+
+            // Route to appropriate handler based on trigger type
+            switch (triggerTask.TriggerType)
+            {
+                case TriggerTransitionType.Start:
+                    await HandleCreateNewAsync(triggerTask, context, cancellationToken);
+                    break;
+
+                case TriggerTransitionType.Trigger:
+                    await HandleDirectAsync(triggerTask, context, cancellationToken);
+                    break;
+
+                default:
+                    throw new InvalidOperationException($"Unsupported trigger type: {triggerTask.TriggerType}");
+            }
+
+            Logger.LogDebug("Processing output for trigger transition task {TaskKey}", triggerTask.Key);
+            var outputResponse = await ProcessOutputAsync(scriptCode, context, cancellationToken);
+
+            Logger.LogInformation("Trigger transition task {TaskKey} execution completed, returning processed output", triggerTask.Key);
+            return outputResponse;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error occurred during trigger transition task {TaskKey} execution - TriggerType: {TriggerType}, Domain: {Domain}, Flow: {Flow}",
+                triggerTask.Key, triggerTask.TriggerType, triggerTask.TransitionDomain, triggerTask.TransitionFlow);
+
+            StandardTaskResponse standardResponse = CreateErrorResponse(
+                errorMessage: ex.Message,
+                taskType: nameof(TaskType.TriggerTransition),
+                executionDurationMs: 0,
+                exception: ex,
+                metadata: new Dictionary<string, object>
+                {
+                    ["TaskKey"] = triggerTask.Key,
+                    ["TriggerType"] = triggerTask.TriggerType.ToString(),
+                    ["Domain"] = triggerTask.TransitionDomain,
+                    ["Flow"] = triggerTask.TransitionFlow
+                });
+            context.SetStandardResponse(standardResponse);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Handles CreateNew trigger type by creating a new workflow instance using HttpTask.
+    /// </summary>
+    private async Task HandleCreateNewAsync(
+        TriggerTransitionTask triggerTask,
+        ScriptContext context,
+        CancellationToken cancellationToken)
+    {
+        Logger.LogInformation("Handling CreateNew trigger for task {TaskKey} - Domain: {Domain}, Flow: {Flow}",
+            triggerTask.Key, triggerTask.TransitionDomain, triggerTask.TransitionFlow);
+
+        // Create path using format: /{domain}/workflows/{workflow}/instances/start
+        var path = string.Format("/{0}/workflows/{1}/instances/start",
+            triggerTask.TransitionDomain,
+            triggerTask.TransitionFlow);
+
+        var httpTask = CreateHttpTask(triggerTask, context, path, "POST");
+
+        var httpExecutor = taskExecutorFactory.GetExecutor(TaskType.Http) as HttpTaskExecutor;
+
+        if (httpExecutor == null)
+            throw new InvalidOperationException("HttpTaskExecutor not found");
+
+        Logger.LogDebug("Calling HttpTaskExecutor.CallAsync for CreateNew trigger task {TaskKey}", triggerTask.Key);
+        await httpExecutor.CallAsync(httpTask, context, cancellationToken);
+    }
+
+    /// <summary>
+    /// Handles Direct trigger type by executing a transition on the current instance using HttpTask.
+    /// </summary>
+    private async Task HandleDirectAsync(
+        TriggerTransitionTask triggerTask,
+        ScriptContext context,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(triggerTask.TransitionName))
+            throw new InvalidOperationException("TransitionName is required for Direct trigger type");
+
+        Logger.LogInformation("Handling Direct trigger for task {TaskKey} - InstanceId: {InstanceId}, Transition: {Transition}",
+            triggerTask.Key, context.Instance.Id, triggerTask.TransitionName);
+
+        // Create path using InstanceUrlTemplates.Transition format
+        var path = string.Format(InstanceUrlTemplates.Transition,
+            triggerTask.TransitionDomain,
+            triggerTask.TransitionFlow,
+            context.Instance.Id,
+            triggerTask.TransitionName);
+
+        var httpTask = CreateHttpTask(triggerTask, context, path, "PATCH");
+
+        var httpExecutor = taskExecutorFactory.GetExecutor(TaskType.Http) as HttpTaskExecutor;
+
+        if (httpExecutor == null)
+            throw new InvalidOperationException("HttpTaskExecutor not found");
+
+        Logger.LogDebug("Calling HttpTaskExecutor.CallAsync for Direct trigger task {TaskKey}", triggerTask.Key);
+        await httpExecutor.CallAsync(httpTask, context, cancellationToken);
+    }
+
+    /// <summary>
+    /// Handles Correlation trigger type by finding the appropriate SubFlow instance and executing a transition using HttpTask.
+    /// </summary>
+    private async Task HandleCorrelationAsync(
+        TriggerTransitionTask triggerTask,
+        ScriptContext context,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(triggerTask.TransitionName))
+            throw new InvalidOperationException("TransitionName is required for Correlation trigger type");
+
+        Logger.LogInformation("Handling Correlation trigger for task {TaskKey} - ParentInstanceId: {InstanceId}, SubFlowName: {SubFlowName}",
+            triggerTask.Key, context.Instance.Id, triggerTask.SubFlowName);
+
+        // Get active correlations for the parent instance
+        var activeCorrelations = await instanceCorrelationRepository.GetActiveByParentAsync(
+            context.Instance.Id,
+            cancellationToken);
+
+        if (activeCorrelations == null || activeCorrelations.Count == 0)
+            throw new InvalidOperationException($"No active correlations found for parent instance {context.Instance.Id}");
+
+        // Find matching SubFlow instance
+        Guid subFlowInstanceId;
+        if (!string.IsNullOrWhiteSpace(triggerTask.SubFlowName))
+        {
+            // Try to find correlation matching SubFlowName
+            var matchingCorrelation = activeCorrelations.FirstOrDefault(c =>
+                string.Equals(c.SubFlowName, triggerTask.SubFlowName, StringComparison.OrdinalIgnoreCase));
+
+            if (matchingCorrelation != null)
+            {
+                subFlowInstanceId = matchingCorrelation.SubFlowInstanceId;
+                Logger.LogDebug("Found matching SubFlow correlation for SubFlowName: {SubFlowName}, InstanceId: {InstanceId}",
+                    triggerTask.SubFlowName, subFlowInstanceId);
+            }
+            else
+            {
+                // Use first active correlation if no match found
+                subFlowInstanceId = activeCorrelations[0].SubFlowInstanceId;
+                Logger.LogWarning("No matching SubFlow found for SubFlowName: {SubFlowName}, using first active correlation InstanceId: {InstanceId}",
+                    triggerTask.SubFlowName, subFlowInstanceId);
+            }
+        }
+        else
+        {
+            // Use first active correlation if SubFlowName not specified
+            subFlowInstanceId = activeCorrelations[0].SubFlowInstanceId;
+            Logger.LogDebug("SubFlowName not specified, using first active correlation InstanceId: {InstanceId}", subFlowInstanceId);
+        }
+
+        // Create path using InstanceUrlTemplates.Transition format
+        var path = string.Format(InstanceUrlTemplates.Transition,
+            triggerTask.TransitionDomain,
+            triggerTask.TransitionFlow,
+            subFlowInstanceId,
+            triggerTask.TransitionName);
+
+        var httpTask = CreateHttpTask(triggerTask, context, path, "PATCH");
+
+        var httpExecutor = taskExecutorFactory.GetExecutor(TaskType.Http) as HttpTaskExecutor;
+
+        if (httpExecutor == null)
+            throw new InvalidOperationException("HttpTaskExecutor not found");
+
+        Logger.LogDebug("Calling HttpTaskExecutor.CallAsync for Correlation trigger task {TaskKey}", triggerTask.Key);
+        await httpExecutor.CallAsync(httpTask, context, cancellationToken);
+    }
+
+    /// <summary>
+    /// Creates an HttpTask for calling workflow instance endpoints.
+    /// </summary>
+    /// <param name="triggerTask">The trigger transition task containing configuration.</param>
+    /// <param name="context">The script context containing headers and body data.</param>
+    /// <param name="path">The API endpoint path to call (without base URL and version).</param>
+    /// <param name="method">The HTTP method (POST, PATCH, etc.).</param>
+    /// <returns>A configured HttpTask ready to execute.</returns>
+    private HttpTask CreateHttpTask(
+        TriggerTransitionTask triggerTask,
+        ScriptContext context,
+        string path,
+        string method)
+    {
+        // Build full URL using configuration
+        var baseUrl = configuration["vNextApi:BaseUrl"]?.TrimEnd('/') ?? string.Empty;
+        var apiVersion = configuration["vNextApi:ApiVersion"] ?? "1";
+        var fullUrl = $"{baseUrl}/api/v{apiVersion}{path}";
+
+        Logger.LogDebug("Creating HttpTask with URL: {Url}", fullUrl);
+
+        // Prepare body from triggerTask.Body or context.Body
+        JsonElement? body = triggerTask.Body;
+        if (!body.HasValue && context.Body != null)
+        {
+            body = JsonSerializer.SerializeToElement(context.Body);
+        }
+
+        // Prepare headers from context.Headers
+        var headersDict = new Dictionary<string, string>();
+        if (context.Headers != null)
+        {
+            foreach (var header in context.Headers)
+            {
+                var key = header.Key?.ToString() ?? string.Empty;
+                var value = header.Value?.ToString() ?? string.Empty;
+                if (!string.IsNullOrWhiteSpace(key))
+                {
+                    headersDict[key] = value;
+                }
+            }
+        }
+
+        // Get timeout from configuration
+        var timeoutSeconds = configuration.GetValue<int>("vNextApi:TimeoutSeconds", 30);
+
+        // Create task config JSON
+        var configBuilder = new Dictionary<string, object>
+        {
+            ["key"] = triggerTask.Key,
+            ["url"] = fullUrl,
+            ["method"] = method,
+            ["timeoutSeconds"] = timeoutSeconds,
+            ["validateSSL"] = true
+        };
+
+        if (headersDict.Count > 0)
+        {
+            configBuilder["headers"] = headersDict;
+        }
+
+        if (body.HasValue)
+        {
+            configBuilder["body"] = body.Value;
+        }
+
+        var configJson = JsonSerializer.Serialize(configBuilder);
+        var configElement = JsonDocument.Parse(configJson).RootElement;
+
+        var httpTask = HttpTask.Create(configElement);
+
+        // Copy base properties from triggerTask
+        triggerTask.CopyBaseToInternal(httpTask);
+
+        return httpTask;
+    }
+}
+

--- a/src/BBT.Workflow.Application/Tasks/Factory/PooledTaskFactory.cs
+++ b/src/BBT.Workflow.Application/Tasks/Factory/PooledTaskFactory.cs
@@ -28,7 +28,7 @@ public sealed class PooledTaskFactory(
     /// Uses object pooling for better performance in high-throughput scenarios.
     /// </summary>
     public async Task<WorkflowTask> CreateExecutionTaskAsync(
-        IReference taskReference, 
+        IReference taskReference,
         CancellationToken cancellationToken = default)
     {
         try
@@ -56,25 +56,25 @@ public sealed class PooledTaskFactory(
         try
         {
             var taskType = cachedTask.GetType();
-            
+
             // Use configuration to determine strategy
             if (ShouldUsePoolingFromConfig(taskType))
             {
                 // Use real object pooling with the new CopyFromInternal methods
                 return CreateFromPool(cachedTask);
             }
-            
+
             // Fall back to direct cloning for non-pooled types
             var directClonedTask = cachedTask.Clone();
-            
-            logger.LogDebug("Successfully cloned task {TaskKey} of type {TaskType}", 
+
+            logger.LogDebug("Successfully cloned task {TaskKey} of type {TaskType}",
                 cachedTask.Key, taskType.Name);
-            
+
             return directClonedTask;
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to clone task {TaskKey} of type {TaskType}", 
+            logger.LogError(ex, "Failed to clone task {TaskKey} of type {TaskType}",
                 cachedTask.Key, cachedTask.GetType().Name);
             throw;
         }
@@ -85,21 +85,21 @@ public sealed class PooledTaskFactory(
         var taskType = template.GetType();
         var taskTypeName = taskType.Name;
         var pool = _pools.GetOrAdd(taskType, _ => CreatePoolForType(taskType));
-        
+
         // Record pool rental metric
         workflowMetrics.RecordTaskFactoryPoolRental(taskTypeName);
-        
+
         var pooledTask = pool.Get();
-        
+
         // Update pool state metrics (approximate tracking)
         // Note: These are estimates since DefaultObjectPool doesn't expose exact counts
         UpdatePoolStateMetrics(taskTypeName, isRenting: true);
-        
+
         // Copy properties from template to pooled instance using efficient internal methods
         CopyTaskProperties(template, pooledTask);
-        
+
         logger.LogDebug("Retrieved and configured task from pool for type {TaskType}", taskType.Name);
-        
+
         return pooledTask;
     }
 
@@ -111,14 +111,14 @@ public sealed class PooledTaskFactory(
     {
         // Since DefaultObjectPool doesn't expose internal counts, we use estimated values
         // This is a best-effort tracking mechanism for monitoring purposes
-        
+
         if (isRenting)
         {
             // When renting, we assume available decreases and in-use increases
             // These are estimates for monitoring trends
             logger.LogTrace("Object rented from pool for task type {TaskType}", taskTypeName);
         }
-        
+
         // For more accurate metrics, consider implementing a custom object pool
         // that tracks exact counts or using a third-party pool with metrics support
     }
@@ -133,7 +133,7 @@ public sealed class PooledTaskFactory(
         {
             return;
         }
-        
+
         // Fallback to base copy for unsupported types
         source.CopyBaseToInternal(target);
     }
@@ -143,12 +143,12 @@ public sealed class PooledTaskFactory(
         // Pool creation logic kept for future use
         var policy = new TaskPooledObjectPolicy(taskType, workflowMetrics);
         var pool = new DefaultObjectPool<WorkflowTask>(policy, _options.MaxPoolSize);
-        
+
         // Initialize pool size metric
         workflowMetrics.SetTaskFactoryPoolSize(taskType.Name, _options.MaxPoolSize);
         workflowMetrics.SetTaskFactoryPoolAvailable(taskType.Name, _options.MaxPoolSize);
         workflowMetrics.SetTaskFactoryPoolInUse(taskType.Name, 0);
-        
+
         return pool;
     }
 
@@ -169,14 +169,14 @@ internal sealed class TaskPooledObjectPolicy(Type taskType, IWorkflowMetrics wor
     {
         // Record object creation metric
         workflowMetrics.RecordTaskFactoryPoolCreate(_taskTypeName);
-        
+
         // Try registry-based creation first
         var task = PoolableTaskRegistry.TryCreateEmpty(taskType);
         if (task != null)
         {
             return task;
         }
-        
+
         // Fallback to reflection for non-registered types
         return (WorkflowTask)Activator.CreateInstance(taskType, true)!;
     }
@@ -185,7 +185,7 @@ internal sealed class TaskPooledObjectPolicy(Type taskType, IWorkflowMetrics wor
     {
         // Record object return metric
         workflowMetrics.RecordTaskFactoryPoolReturn(_taskTypeName);
-        
+
         // Reset the object state before returning to pool
         obj.Reset();
         return true;
@@ -206,27 +206,27 @@ public static class PoolableTaskRegistry
         RegisterPoolableTask<DaprServiceTask>(
             DaprServiceTask.CreateEmpty,
             (source, target) => ((DaprServiceTask)target).CopyFromInternal((DaprServiceTask)source));
-            
+
         RegisterPoolableTask<HttpTask>(
             HttpTask.CreateEmpty,
             (source, target) => ((HttpTask)target).CopyFromInternal((HttpTask)source));
-            
+
         RegisterPoolableTask<ScriptTask>(
             ScriptTask.CreateEmpty,
             (source, target) => ((ScriptTask)target).CopyFromInternal((ScriptTask)source));
-            
+
         RegisterPoolableTask<ConditionTask>(
             ConditionTask.CreateEmpty,
             (source, target) => ((ConditionTask)target).CopyFromInternal((ConditionTask)source));
-            
+
         RegisterPoolableTask<DaprBindingTask>(
             DaprBindingTask.CreateEmpty,
             (source, target) => ((DaprBindingTask)target).CopyFromInternal((DaprBindingTask)source));
-            
+
         RegisterPoolableTask<DaprPubSubTask>(
             DaprPubSubTask.CreateEmpty,
             (source, target) => ((DaprPubSubTask)target).CopyFromInternal((DaprPubSubTask)source));
-            
+
         RegisterPoolableTask<DaprHttpEndpointTask>(
             DaprHttpEndpointTask.CreateEmpty,
             (source, target) => ((DaprHttpEndpointTask)target).CopyFromInternal((DaprHttpEndpointTask)source));
@@ -237,7 +237,10 @@ public static class PoolableTaskRegistry
         RegisterPoolableTask<NotificationTask>(
             NotificationTask.CreateEmpty,
             (source, target) => ((NotificationTask)target).CopyFromInternal((NotificationTask)source));
-            
+        RegisterPoolableTask<TriggerTransitionTask>(
+        TriggerTransitionTask.CreateEmpty,
+        (source, target) => ((TriggerTransitionTask)target).CopyFromInternal((TriggerTransitionTask)source));
+
     }
 
     public static void RegisterPoolableTask<T>(
@@ -264,4 +267,4 @@ public static class PoolableTaskRegistry
         }
         return false;
     }
-} 
+}

--- a/src/BBT.Workflow.Domain/Definitions/InstanceUrlTemplates.cs
+++ b/src/BBT.Workflow.Domain/Definitions/InstanceUrlTemplates.cs
@@ -8,10 +8,34 @@ namespace BBT.Workflow.Definitions;
 public static class InstanceUrlTemplates
 {
     /// <summary>
+    /// URL template for instance endpoints.
+    /// Format: /{domain}/workflows/{workflow}/instances/{instance}
+    /// </summary>
+    public const string Instance = "/{0}/workflows/{1}/instances/{2}";
+
+    /// <summary>
+    /// URL template for instance list endpoints.
+    /// Format: /{domain}/workflows/{workflow}/instances/{instance}
+    /// </summary>
+    public const string InstanceList = "/{0}/workflows/{1}/instances";
+
+    /// <summary>
+    /// URL template for instance history endpoints.
+    /// Format: /{domain}/workflows/{workflow}/instances/{instance}
+    /// </summary>
+    public const string InstanceHistory = "/{0}/workflows/{1}/instances/{2}/transitions";
+
+    /// <summary>
     /// URL template for instance transition endpoints.
     /// Format: /{domain}/workflows/{workflow}/instances/{instanceId}/transitions/{transitionKey}
     /// </summary>
     public const string Transition = "/{0}/workflows/{1}/instances/{2}/transitions/{3}";
+
+    /// <summary>
+    /// URL template for instance state endpoints.
+    /// Format: /{domain}/workflows/{workflow}/instances/{instanceId}/functions/state
+    /// </summary>
+    public const string State = "/{0}/workflows/{1}/instances/{2}/functions/state";
 
     /// <summary>
     /// URL template for instance data endpoints.
@@ -32,8 +56,14 @@ public static class InstanceUrlTemplates
     public const string View = "/{0}/workflows/{1}/instances/{2}/functions/view";
 
     /// <summary>
-    /// URL template for SubFlow instance data endpoints.
-    /// Format: /{domain}/workflows/{workflow}/instances/{instanceId}/functions/data
+    /// URL template for start instance endpoints.
+    /// Format: /{domain}/workflows/{workflow}/instances/{instanceId}/start
     /// </summary>
-    public const string SubFlowData = "/{0}/workflows/{1}/instances/{2}/functions/data";
+    public const string Start = "/{0}/workflows/{1}/instances/start";
+
+    /// <summary>
+    /// URL template for start sub instance endpoints.
+    /// Format: /{domain}/workflows/{workflow}/sub/instances/start
+    /// </summary>
+    public const string StartSub = "/{0}/workflows/{1}/sub/instances/start";
 }

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/TaskEnums.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/TaskEnums.cs
@@ -17,7 +17,8 @@ public enum TaskType
     Script = 7,
     Condition = 8,
     Timer = 9,
-    Notification = 10
+    Notification = 10,
+    TriggerTransition = 11
 }
 
 /// <summary>

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/TriggerTransitionTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/TriggerTransitionTask.cs
@@ -46,7 +46,7 @@ public sealed class TriggerTransitionTask : WorkflowTask, IGlobalTask
     public string TransitionFlow { get; private set; } = string.Empty;
 
     /// <summary>
-    /// Trigger type: Direct, Correlation, or CreateNew
+    /// Trigger type
     /// </summary>
     public TriggerTransitionType TriggerType { get; private set; }
 
@@ -54,6 +54,12 @@ public sealed class TriggerTransitionTask : WorkflowTask, IGlobalTask
     /// SubFlow name for Correlation trigger type (optional)
     /// </summary>
     public string? SubFlowName { get; private set; }
+
+    /// <summary>
+    /// Extensions to request for GetInstanceData trigger type (optional)
+    /// </summary>
+    public string[]? Extensions { get; private set; }
+
     public void SetBody(dynamic body)
     {
         Body = JsonSerializer.SerializeToElement(body);
@@ -68,6 +74,7 @@ public sealed class TriggerTransitionTask : WorkflowTask, IGlobalTask
     internal void SetTransitionFlowInternal(string transitionFlow) => TransitionFlow = transitionFlow;
     internal void SetTriggerTypeInternal(TriggerTransitionType triggerType) => TriggerType = triggerType;
     internal void SetSubFlowNameInternal(string? subFlowName) => SubFlowName = subFlowName;
+    internal void SetExtensionsInternal(string[]? extensions) => Extensions = extensions;
 
     protected override void Configure(JsonElement config)
     {
@@ -99,6 +106,21 @@ public sealed class TriggerTransitionTask : WorkflowTask, IGlobalTask
 
         if (config.TryGetProperty("subFlowName", out var subFlowNameElement))
             SubFlowName = subFlowNameElement.GetString();
+
+        if (config.TryGetProperty("extensions", out var extensionsElement))
+        {
+            if (extensionsElement.ValueKind == JsonValueKind.Array)
+            {
+                var extensionsList = new List<string>();
+                foreach (var item in extensionsElement.EnumerateArray())
+                {
+                    var ext = item.GetString();
+                    if (!string.IsNullOrWhiteSpace(ext))
+                        extensionsList.Add(ext);
+                }
+                Extensions = extensionsList.Count > 0 ? extensionsList.ToArray() : null;
+            }
+        }
     }
 
     public static TriggerTransitionTask Create(
@@ -129,6 +151,7 @@ public sealed class TriggerTransitionTask : WorkflowTask, IGlobalTask
         cloned.TransitionFlow = TransitionFlow;
         cloned.TriggerType = TriggerType;
         cloned.SubFlowName = SubFlowName;
+        cloned.Extensions = Extensions;
 
         return cloned;
     }
@@ -146,6 +169,7 @@ public sealed class TriggerTransitionTask : WorkflowTask, IGlobalTask
         SetTransitionFlowInternal(source.TransitionFlow);
         SetTriggerTypeInternal(source.TriggerType);
         SetSubFlowNameInternal(source.SubFlowName);
+        SetExtensionsInternal(source.Extensions);
     }
 
     /// <summary>
@@ -160,6 +184,7 @@ public sealed class TriggerTransitionTask : WorkflowTask, IGlobalTask
         TransitionFlow = string.Empty;
         TriggerType = TriggerTransitionType.Trigger;
         SubFlowName = null;
+        Extensions = null;
     }
 
     /// <summary>
@@ -180,14 +205,21 @@ public enum TriggerTransitionType
     /// <summary>
     /// Create a new workflow instance
     /// </summary>
-       Start = 1,
+    Start = 1,
 
     /// <summary>
     /// Direct transition on the current instance
     /// </summary>
-
     Trigger = 2,
 
-    SubProcess=3
+    /// <summary>
+    /// Subprocess trigger
+    /// </summary>
+    SubProcess = 3,
+    
+    /// <summary>
+    /// GetInstanceData trigger
+    /// </summary>
+    GetInstanceData = 4
 }
 

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/TriggerTransitionTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/TriggerTransitionTask.cs
@@ -118,11 +118,17 @@ public sealed class TriggerTransitionTask : WorkflowTask
             Body = string.IsNullOrWhiteSpace(body) ? null : bodyElement;
         }
 
-        if (config.TryGetProperty("domain", out var TriggerDomainElement))
-            TriggerDomain = TriggerDomainElement.GetString() ?? throw new ArgumentNullException(nameof(TriggerDomainElement));
+        if (config.TryGetProperty("domain", out var triggerDomainElement))
+            TriggerDomain = triggerDomainElement.GetString() ?? string.Empty;
 
-        if (config.TryGetProperty("flow", out var TriggerFlowElement))
-            TriggerFlow = TriggerFlowElement.GetString() ?? throw new ArgumentNullException(nameof(TriggerFlowElement));
+        if (string.IsNullOrWhiteSpace(TriggerDomain))
+            throw new ArgumentException("Property 'domain' is required for TriggerTransitionTask.", nameof(config));
+
+        if (config.TryGetProperty("flow", out var triggerFlowElement))
+            TriggerFlow = triggerFlowElement.GetString() ?? string.Empty;
+
+        if (string.IsNullOrWhiteSpace(TriggerFlow))
+            throw new ArgumentException("Property 'flow' is required for TriggerTransitionTask.", nameof(config));
 
         if (config.TryGetProperty("type", out var triggerTypeElement))
         {

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/TriggerTransitionTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/TriggerTransitionTask.cs
@@ -7,7 +7,7 @@ namespace BBT.Workflow.Definitions;
 /// <summary>
 /// Trigger Transition Task Definition
 /// </summary>
-public sealed class TriggerTransitionTask : WorkflowTask, IGlobalTask
+public sealed class TriggerTransitionTask : WorkflowTask
 {
     private TriggerTransitionTask()
     {
@@ -19,11 +19,6 @@ public sealed class TriggerTransitionTask : WorkflowTask, IGlobalTask
     {
         Type = ((int)TaskType.TriggerTransition).ToString();
     }
-
-    /// <summary>
-    /// Gets the mapping instance for this task. Returns null as TriggerTransitionTask uses script-based mapping.
-    /// </summary>
-    public IMapping? Mapping => null;
 
     /// <summary>
     /// Transition name to execute (required for Direct and Correlation trigger types)
@@ -38,22 +33,31 @@ public sealed class TriggerTransitionTask : WorkflowTask, IGlobalTask
     /// <summary>
     /// Domain of the target workflow
     /// </summary>
-    public string TransitionDomain { get; private set; } = string.Empty;
+    public string TriggerDomain { get; private set; } = string.Empty;
 
     /// <summary>
     /// Flow name of the target workflow
     /// </summary>
-    public string TransitionFlow { get; private set; } = string.Empty;
+    public string TriggerFlow { get; private set; } = string.Empty;
+    /// <summary>
+    /// Flow key of the target workflow
+    /// </summary>
+    public string? TriggerKey { get; private set; } = string.Empty;
+    /// <summary>
+    /// InstanceId of the target workflow
+    /// </summary>
+    public string? TriggerInstanceId { get; private set; } = string.Empty;
 
     /// <summary>
     /// Trigger type
     /// </summary>
     public TriggerTransitionType TriggerType { get; private set; }
 
+
     /// <summary>
-    /// SubFlow name for Correlation trigger type (optional)
+    /// SubFlow version for SubProcess trigger type (optional)
     /// </summary>
-    public string? SubFlowName { get; private set; }
+    public string? TriggerVersion { get; private set; }
 
     /// <summary>
     /// Extensions to request for GetInstanceData trigger type (optional)
@@ -64,16 +68,41 @@ public sealed class TriggerTransitionTask : WorkflowTask, IGlobalTask
     {
         Body = JsonSerializer.SerializeToElement(body);
     }
+    public void SetInstance(string instanceId)
+    {
+        TriggerInstanceId = instanceId;
+    }
+    public void SetKey(string key)
+    {
+        TriggerKey = key;
+    }
+    public void SetDomain(string domain)
+    {
+        TriggerDomain = domain;
+    }
+    public void SetFlow(string flow)
+    {
+        TriggerFlow = flow;
+    }
+    public void SetTriggerType(string type)
+    {
+        if (!string.IsNullOrWhiteSpace(type))
+        {
+            TriggerType = Enum.Parse<TriggerTransitionType>(type, ignoreCase: true);
+        }
+    }
 
     /// <summary>
     /// Internal property setters for object pooling
     /// </summary>
     internal void SetTransitionNameInternal(string? transitionName) => TransitionName = transitionName;
     internal void SetBodyInternal(JsonElement? body) => Body = body;
-    internal void SetTransitionDomainInternal(string transitionDomain) => TransitionDomain = transitionDomain;
-    internal void SetTransitionFlowInternal(string transitionFlow) => TransitionFlow = transitionFlow;
+    internal void SetTriggerDomainInternal(string triggerDomain) => TriggerDomain = triggerDomain;
+    internal void SetTriggerFlowInternal(string triggerFlow) => TriggerFlow = triggerFlow;
+    internal void SetTriggerKeyInternal(string? triggerKey) => TriggerKey = triggerKey;
+    internal void SetTriggerInstanceIdInternal(string? triggerInstanceId) => TriggerInstanceId = triggerInstanceId;
     internal void SetTriggerTypeInternal(TriggerTransitionType triggerType) => TriggerType = triggerType;
-    internal void SetSubFlowNameInternal(string? subFlowName) => SubFlowName = subFlowName;
+    internal void SetTriggerVersionInternal(string? triggerVersion) => TriggerVersion = triggerVersion;
     internal void SetExtensionsInternal(string[]? extensions) => Extensions = extensions;
 
     protected override void Configure(JsonElement config)
@@ -89,11 +118,11 @@ public sealed class TriggerTransitionTask : WorkflowTask, IGlobalTask
             Body = string.IsNullOrWhiteSpace(body) ? null : bodyElement;
         }
 
-        if (config.TryGetProperty("domain", out var transitionDomainElement))
-            TransitionDomain = transitionDomainElement.GetString() ?? throw new ArgumentNullException(nameof(transitionDomainElement));
+        if (config.TryGetProperty("domain", out var TriggerDomainElement))
+            TriggerDomain = TriggerDomainElement.GetString() ?? throw new ArgumentNullException(nameof(TriggerDomainElement));
 
-        if (config.TryGetProperty("flow", out var transitionFlowElement))
-            TransitionFlow = transitionFlowElement.GetString() ?? throw new ArgumentNullException(nameof(transitionFlowElement));
+        if (config.TryGetProperty("flow", out var TriggerFlowElement))
+            TriggerFlow = TriggerFlowElement.GetString() ?? throw new ArgumentNullException(nameof(TriggerFlowElement));
 
         if (config.TryGetProperty("type", out var triggerTypeElement))
         {
@@ -104,8 +133,16 @@ public sealed class TriggerTransitionTask : WorkflowTask, IGlobalTask
             }
         }
 
-        if (config.TryGetProperty("subFlowName", out var subFlowNameElement))
-            SubFlowName = subFlowNameElement.GetString();
+
+
+        if (config.TryGetProperty("version", out var TriggerVersionElement))
+            TriggerVersion = TriggerVersionElement.GetString();
+
+        if (config.TryGetProperty("key", out var keyElement))
+            TriggerKey = keyElement.GetString();
+
+        if (config.TryGetProperty("instanceId", out var instanceIdElement))
+            TriggerInstanceId = instanceIdElement.GetString();
 
         if (config.TryGetProperty("extensions", out var extensionsElement))
         {
@@ -147,10 +184,12 @@ public sealed class TriggerTransitionTask : WorkflowTask, IGlobalTask
 
         cloned.TransitionName = TransitionName;
         cloned.Body = Body;
-        cloned.TransitionDomain = TransitionDomain;
-        cloned.TransitionFlow = TransitionFlow;
+        cloned.TriggerDomain = TriggerDomain;
+        cloned.TriggerFlow = TriggerFlow;
+        cloned.TriggerKey = TriggerKey;
+        cloned.TriggerInstanceId = TriggerInstanceId;
         cloned.TriggerType = TriggerType;
-        cloned.SubFlowName = SubFlowName;
+        cloned.TriggerVersion = TriggerVersion;
         cloned.Extensions = Extensions;
 
         return cloned;
@@ -165,10 +204,12 @@ public sealed class TriggerTransitionTask : WorkflowTask, IGlobalTask
         source.CopyBaseToInternal(this);
         SetTransitionNameInternal(source.TransitionName);
         SetBodyInternal(source.Body);
-        SetTransitionDomainInternal(source.TransitionDomain);
-        SetTransitionFlowInternal(source.TransitionFlow);
+        SetTriggerDomainInternal(source.TriggerDomain);
+        SetTriggerFlowInternal(source.TriggerFlow);
+        SetTriggerKeyInternal(source.TriggerKey);
+        SetTriggerInstanceIdInternal(source.TriggerInstanceId);
         SetTriggerTypeInternal(source.TriggerType);
-        SetSubFlowNameInternal(source.SubFlowName);
+        SetTriggerVersionInternal(source.TriggerVersion);
         SetExtensionsInternal(source.Extensions);
     }
 
@@ -180,10 +221,12 @@ public sealed class TriggerTransitionTask : WorkflowTask, IGlobalTask
         base.Reset();
         TransitionName = null;
         Body = null;
-        TransitionDomain = string.Empty;
-        TransitionFlow = string.Empty;
+        TriggerDomain = string.Empty;
+        TriggerFlow = string.Empty;
+        TriggerKey = null;
+        TriggerInstanceId = null;
         TriggerType = TriggerTransitionType.Trigger;
-        SubFlowName = null;
+        TriggerVersion = null;
         Extensions = null;
     }
 
@@ -216,7 +259,7 @@ public enum TriggerTransitionType
     /// Subprocess trigger
     /// </summary>
     SubProcess = 3,
-    
+
     /// <summary>
     /// GetInstanceData trigger
     /// </summary>

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/TriggerTransitionTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/TriggerTransitionTask.cs
@@ -1,0 +1,193 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using BBT.Workflow.Scripting;
+
+namespace BBT.Workflow.Definitions;
+
+/// <summary>
+/// Trigger Transition Task Definition
+/// </summary>
+public sealed class TriggerTransitionTask : WorkflowTask, IGlobalTask
+{
+    private TriggerTransitionTask()
+    {
+    }
+
+    [JsonConstructor]
+    private TriggerTransitionTask(
+        JsonElement config) : base(config)
+    {
+        Type = ((int)TaskType.TriggerTransition).ToString();
+    }
+
+    /// <summary>
+    /// Gets the mapping instance for this task. Returns null as TriggerTransitionTask uses script-based mapping.
+    /// </summary>
+    public IMapping? Mapping => null;
+
+    /// <summary>
+    /// Transition name to execute (required for Direct and Correlation trigger types)
+    /// </summary>
+    public string? TransitionName { get; private set; }
+
+    /// <summary>
+    /// Body data to send with the transition request
+    /// </summary>
+    public JsonElement? Body { get; private set; }
+
+    /// <summary>
+    /// Domain of the target workflow
+    /// </summary>
+    public string TransitionDomain { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Flow name of the target workflow
+    /// </summary>
+    public string TransitionFlow { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Trigger type: Direct, Correlation, or CreateNew
+    /// </summary>
+    public TriggerTransitionType TriggerType { get; private set; }
+
+    /// <summary>
+    /// SubFlow name for Correlation trigger type (optional)
+    /// </summary>
+    public string? SubFlowName { get; private set; }
+    public void SetBody(dynamic body)
+    {
+        Body = JsonSerializer.SerializeToElement(body);
+    }
+
+    /// <summary>
+    /// Internal property setters for object pooling
+    /// </summary>
+    internal void SetTransitionNameInternal(string? transitionName) => TransitionName = transitionName;
+    internal void SetBodyInternal(JsonElement? body) => Body = body;
+    internal void SetTransitionDomainInternal(string transitionDomain) => TransitionDomain = transitionDomain;
+    internal void SetTransitionFlowInternal(string transitionFlow) => TransitionFlow = transitionFlow;
+    internal void SetTriggerTypeInternal(TriggerTransitionType triggerType) => TriggerType = triggerType;
+    internal void SetSubFlowNameInternal(string? subFlowName) => SubFlowName = subFlowName;
+
+    protected override void Configure(JsonElement config)
+    {
+        base.Configure(config);
+
+        if (config.TryGetProperty("transitionName", out var transitionNameElement))
+            TransitionName = transitionNameElement.GetString();
+
+        if (config.TryGetProperty("body", out var bodyElement))
+        {
+            var body = bodyElement.GetRawText();
+            Body = string.IsNullOrWhiteSpace(body) ? null : bodyElement;
+        }
+
+        if (config.TryGetProperty("domain", out var transitionDomainElement))
+            TransitionDomain = transitionDomainElement.GetString() ?? throw new ArgumentNullException(nameof(transitionDomainElement));
+
+        if (config.TryGetProperty("flow", out var transitionFlowElement))
+            TransitionFlow = transitionFlowElement.GetString() ?? throw new ArgumentNullException(nameof(transitionFlowElement));
+
+        if (config.TryGetProperty("type", out var triggerTypeElement))
+        {
+            var triggerTypeStr = triggerTypeElement.GetString();
+            if (!string.IsNullOrWhiteSpace(triggerTypeStr))
+            {
+                TriggerType = Enum.Parse<TriggerTransitionType>(triggerTypeStr, ignoreCase: true);
+            }
+        }
+
+        if (config.TryGetProperty("subFlowName", out var subFlowNameElement))
+            SubFlowName = subFlowNameElement.GetString();
+    }
+
+    public static TriggerTransitionTask Create(
+        JsonElement config)
+    {
+        return new TriggerTransitionTask(config);
+    }
+
+    /// <summary>
+    /// Creates a deep copy of the current TriggerTransitionTask instance.
+    /// </summary>
+    public override WorkflowTask Clone()
+    {
+        return CloneTyped();
+    }
+
+    /// <summary>
+    /// Creates a typed deep copy of the current TriggerTransitionTask instance.
+    /// </summary>
+    public TriggerTransitionTask CloneTyped()
+    {
+        var cloned = new TriggerTransitionTask();
+        CopyBaseTo(cloned);
+
+        cloned.TransitionName = TransitionName;
+        cloned.Body = Body;
+        cloned.TransitionDomain = TransitionDomain;
+        cloned.TransitionFlow = TransitionFlow;
+        cloned.TriggerType = TriggerType;
+        cloned.SubFlowName = SubFlowName;
+
+        return cloned;
+    }
+
+    /// <summary>
+    /// Internal method for object pooling - copies all properties efficiently
+    /// </summary>
+    /// <param name="source">Source task to copy from</param>
+    public void CopyFromInternal(TriggerTransitionTask source)
+    {
+        source.CopyBaseToInternal(this);
+        SetTransitionNameInternal(source.TransitionName);
+        SetBodyInternal(source.Body);
+        SetTransitionDomainInternal(source.TransitionDomain);
+        SetTransitionFlowInternal(source.TransitionFlow);
+        SetTriggerTypeInternal(source.TriggerType);
+        SetSubFlowNameInternal(source.SubFlowName);
+    }
+
+    /// <summary>
+    /// Resets the task instance to a clean state for object pooling
+    /// </summary>
+    public override void Reset()
+    {
+        base.Reset();
+        TransitionName = null;
+        Body = null;
+        TransitionDomain = string.Empty;
+        TransitionFlow = string.Empty;
+        TriggerType = TriggerTransitionType.Trigger;
+        SubFlowName = null;
+    }
+
+    /// <summary>
+    /// Creates a new instance for object pooling - internal use only
+    /// </summary>
+    public static TriggerTransitionTask CreateEmpty()
+    {
+        return new TriggerTransitionTask();
+    }
+}
+
+/// <summary>
+/// Trigger transition type enumeration
+/// </summary>
+public enum TriggerTransitionType
+{
+
+    /// <summary>
+    /// Create a new workflow instance
+    /// </summary>
+       Start = 1,
+
+    /// <summary>
+    /// Direct transition on the current instance
+    /// </summary>
+
+    Trigger = 2,
+
+    SubProcess=3
+}
+

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/WorkflowTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/WorkflowTask.cs
@@ -17,6 +17,7 @@ namespace BBT.Workflow.Definitions;
 [JsonDerivedType(typeof(HttpTask), typeDiscriminator: "6")]
 [JsonDerivedType(typeof(ScriptTask), typeDiscriminator: "7")]
 [JsonDerivedType(typeof(NotificationTask), typeDiscriminator: "10")]
+[JsonDerivedType(typeof(TriggerTransitionTask), typeDiscriminator: "11")]
 public abstract class WorkflowTask : IDomainEntity, ITaskReference, IReferenceSetter, ITaskClonable
 {
     protected WorkflowTask()

--- a/src/BBT.Workflow.Domain/Execution/TriggerTransition/Factory/ITriggerTransitionHttpTaskFactory.cs
+++ b/src/BBT.Workflow.Domain/Execution/TriggerTransition/Factory/ITriggerTransitionHttpTaskFactory.cs
@@ -1,0 +1,25 @@
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Scripting;
+
+namespace BBT.Workflow.Execution.TriggerTransition;
+
+/// <summary>
+/// Factory for creating HTTP tasks used in trigger transition strategies.
+/// </summary>
+public interface ITriggerTransitionHttpTaskFactory
+{
+    /// <summary>
+    /// Creates an HttpTask for calling workflow instance endpoints.
+    /// </summary>
+    /// <param name="triggerTask">The trigger transition task containing configuration.</param>
+    /// <param name="context">The script context containing headers and body data.</param>
+    /// <param name="path">The API endpoint path to call (without base URL and version).</param>
+    /// <param name="method">The HTTP method (POST, PATCH, etc.).</param>
+    /// <returns>A configured HttpTask ready to execute.</returns>
+    HttpTask CreateHttpTask(
+        TriggerTransitionTask triggerTask,
+        ScriptContext context,
+        string path,
+        string method);
+}
+

--- a/src/BBT.Workflow.Domain/Execution/TriggerTransition/Factory/ITriggerTransitionStrategyFactory.cs
+++ b/src/BBT.Workflow.Domain/Execution/TriggerTransition/Factory/ITriggerTransitionStrategyFactory.cs
@@ -1,0 +1,18 @@
+using BBT.Workflow.Definitions;
+
+namespace BBT.Workflow.Execution.TriggerTransition;
+
+/// <summary>
+/// Factory for creating appropriate trigger transition strategies based on trigger type.
+/// </summary>
+public interface ITriggerTransitionStrategyFactory
+{
+    /// <summary>
+    /// Gets the appropriate trigger transition strategy for the specified trigger type.
+    /// </summary>
+    /// <param name="type">The trigger transition type (Start, Trigger, SubProcess).</param>
+    /// <returns>The strategy capable of handling the specified trigger type.</returns>
+    /// <exception cref="NotSupportedException">Thrown when no strategy is found for the trigger type.</exception>
+    ITriggerTransitionStrategy Get(TriggerTransitionType type);
+}
+

--- a/src/BBT.Workflow.Domain/Execution/TriggerTransition/ITriggerTransitionStrategy.cs
+++ b/src/BBT.Workflow.Domain/Execution/TriggerTransition/ITriggerTransitionStrategy.cs
@@ -1,0 +1,24 @@
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Scripting;
+
+namespace BBT.Workflow.Execution.TriggerTransition;
+
+/// <summary>
+/// Defines the contract for trigger transition execution strategies.
+/// Implements the Strategy Pattern to handle different trigger transition types (Start, Trigger, SubProcess).
+/// </summary>
+public interface ITriggerTransitionStrategy
+{
+    /// <summary>
+    /// Executes the trigger transition using the strategy's specific implementation.
+    /// </summary>
+    /// <param name="task">The trigger transition task containing configuration.</param>
+    /// <param name="context">The script context containing instance data and headers.</param>
+    /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task ExecuteAsync(
+        TriggerTransitionTask task,
+        ScriptContext context,
+        CancellationToken cancellationToken);
+}
+

--- a/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceCommandAppService.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceCommandAppService.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.Json;
 using BBT.Aether.Http;
+using BBT.Workflow.Definitions;
 using BBT.Workflow.Domain;
 using BBT.Workflow.ExceptionHandling;
 using BBT.Workflow.Remote.Configuration;
@@ -35,7 +36,7 @@ public sealed class RemoteInstanceCommandAppService(
         return await ResultExtensions.TryAsync(
             async ct =>
             {
-                var url = $"api/v{_options.ApiVersion}/{input.Domain}/workflows/{input.Workflow}/instances/start";
+                var url = $"api/v{_options.ApiVersion}" + string.Format(InstanceUrlTemplates.Start, input.Domain, input.Workflow);
 
                 var queryParams = new List<string>();
                 if (!string.IsNullOrEmpty(input.Version))
@@ -99,7 +100,7 @@ public sealed class RemoteInstanceCommandAppService(
         return await ResultExtensions.TryAsync(
             async ct =>
             {
-                var url = $"api/v{_options.ApiVersion}/{input.Domain}/workflows/{input.Workflow}/sub/instances/start";
+                var url = $"api/v{_options.ApiVersion}" + string.Format(InstanceUrlTemplates.StartSub, input.Domain, input.Workflow);
 
                 var queryParams = new List<string>();
                 if (!string.IsNullOrEmpty(input.Version))
@@ -168,8 +169,7 @@ public sealed class RemoteInstanceCommandAppService(
         return await ResultExtensions.TryAsync(
             async ct =>
             {
-                var url =
-                    $"api/v{_options.ApiVersion}/{input.Domain}/workflows/{input.Workflow}/instances/{instanceId}/transitions/{transitionKey}";
+                var url = $"api/v{_options.ApiVersion}" + string.Format(InstanceUrlTemplates.Transition, input.Domain, input.Workflow, instanceId, transitionKey);
 
                 var queryParams = new List<string>();
                 if (!string.IsNullOrEmpty(input.Version))

--- a/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceQueryAppService.cs
@@ -35,7 +35,7 @@ public sealed class RemoteInstanceQueryAppService(
     {
         try
         {
-            var url = $"/api/v{_options.ApiVersion}/{input.Domain}/workflows/{input.Workflow}/instances/{input.Instance}";
+            var url = $"api/v{_options.ApiVersion}" + string.Format(InstanceUrlTemplates.Instance, input.Domain, input.Workflow, input.Instance);
 
             var queryParams = new List<string>();
             if (input.Extension?.Length > 0)
@@ -95,7 +95,7 @@ public sealed class RemoteInstanceQueryAppService(
         return await ResultExtensions.TryAsync(
             async ct =>
             {
-                var url = $"/api/v{_options.ApiVersion}/{input.Domain}/workflows/{input.Workflow}/instances";
+                var url = $"api/v{_options.ApiVersion}" + string.Format(InstanceUrlTemplates.InstanceList, input.Domain, input.Workflow);
 
                 var queryParams = new List<string>
                 {
@@ -142,8 +142,7 @@ public sealed class RemoteInstanceQueryAppService(
         return await ResultExtensions.TryAsync(
             async ct =>
             {
-                var url =
-                    $"/api/v{_options.ApiVersion}/{input.Domain}/workflows/{input.Workflow}/instances/{input.Instance}/transitions";
+                 var url = $"api/v{_options.ApiVersion}" + string.Format(InstanceUrlTemplates.InstanceHistory, input.Domain, input.Workflow, input.Instance);
 
                 var queryParams = new List<string>();
                 if (input.Extension?.Length > 0)
@@ -186,8 +185,7 @@ public sealed class RemoteInstanceQueryAppService(
         return await ResultExtensions.TryAsync(
             async ct =>
             {
-                var url =
-                    $"/api/v{_options.ApiVersion}/{input.Domain}/workflows/{input.Workflow}/instances/{input.Instance}/functions/{input.Function}";
+                var url = $"api/v{_options.ApiVersion}" + string.Format(InstanceUrlTemplates.State, input.Domain, input.Workflow, input.Instance);
 
                 var queryParams = new List<string>();
                 if (!string.IsNullOrEmpty(input.Version))
@@ -237,8 +235,7 @@ public sealed class RemoteInstanceQueryAppService(
         return await ResultExtensions.TryAsync(
             async ct =>
             {
-                var url =
-                    $"/api/v{_options.ApiVersion}/{input.Domain}/workflows/{input.Workflow}/instances/{input.Instance}/functions/view";
+                var url = $"api/v{_options.ApiVersion}" + string.Format(InstanceUrlTemplates.View, input.Domain, input.Workflow, input.Instance);
 
                 var queryParams = new List<string>();
                 if (!string.IsNullOrEmpty(input.Version))


### PR DESCRIPTION
## Summary by Sourcery

Add full support for a new TriggerTransition workflow task by implementing strategy pattern for diverse trigger types, enhance subflow start mechanics, standardize URL generation, and refine HTTP execution and task pooling for improved maintainability and extensibility.

New Features:
- Introduce TriggerTransition task type with strategy-based executor supporting Start, Direct, SubProcess, and GetInstanceData operations
- Enable triggering SubProcess workflows from tasks via new SubStartAsync method in subflow starter service
- Add new URL templates for instances and subflows in InstanceUrlTemplates and apply them in remote query/command services

Enhancements:
- Refactor SubflowStarter to consolidate start logic in StartSubFlowInternalAsync and enrich metadata, logging, and input mapping
- Split HttpTaskExecutor into CallAsync and output processing phases for clearer separation of concerns
- Extend object pooling in PooledTaskFactory to include TriggerTransitionTask and update task cloning metrics
- Register TriggerTransition strategies, factories, and executor in DI for cleaner composition