### PR TITLE
Add Resume execution mode for SubFlow completion

### DIFF
--- a/src/BBT.Workflow.Application/Execution/Transitions/Factory/ExecutionStrategyFactory.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Factory/ExecutionStrategyFactory.cs
@@ -21,6 +21,7 @@ public sealed class ExecutionStrategyFactory(
         {
             ExecMode.Sync => serviceProvider.GetService<SyncTransitionStrategy>(),
             ExecMode.Async => serviceProvider.GetService<AsyncTransitionStrategy>(),
+            ExecMode.Resume => serviceProvider.GetService<SyncTransitionStrategy>(), // Resume mode uses Sync strategy
             _ => null
         };
 

--- a/src/BBT.Workflow.Application/Execution/Transitions/Factory/TransitionContextFactory.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Factory/TransitionContextFactory.cs
@@ -66,7 +66,11 @@ public sealed class TransitionContextFactory(
                 Result<(Definitions.Workflow, Instance, State, Transition?)>.Fail(currentStateResult.Error));
 
         var currentState = currentStateResult.Value!;
-        var transition = ResolveTransition(data.Workflow, currentState, input.TransitionKey);
+        
+        // In Resume mode, transition is optional (e.g., SubFlow completion scenarios)
+        var transition = input.Mode == ExecMode.Resume 
+            ? null 
+            : ResolveTransition(data.Workflow, currentState, input.TransitionKey);
 
         return Task.FromResult(
             Result<(Definitions.Workflow, Instance, State, Transition?)>.Ok(

--- a/src/BBT.Workflow.Application/Execution/Transitions/Handlers/TransitionHandlerBase.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Handlers/TransitionHandlerBase.cs
@@ -35,6 +35,13 @@ public abstract class TransitionHandlerBase : ITransitionHandler
     /// <inheritdoc />
     public async Task PreHandleAsync(TransitionExecutionContext context, CancellationToken cancellationToken)
     {
+        // Skip all PreHandle operations for Resume mode - validations already done
+        if (context.Directives.IsSubFlowResume)
+        {
+            Logger.LogDebug("Skipping PreHandle for Resume mode on instance {InstanceId}", context.InstanceId);
+            return;
+        }
+        
         var sw = Stopwatch.StartNew();
         var handlerName = GetType().Name;
         

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ChangeStateStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ChangeStateStep.cs
@@ -22,8 +22,16 @@ public sealed class ChangeStateStep(
     /// <inheritdoc />
     public async Task<Result<StepOutcome>> ExecuteAsync(TransitionExecutionContext context, CancellationToken cancellationToken)
     {
+        // Skip for SubFlow resume - state already changed
+        if (context.Directives.IsSubFlowResume || context.Transition == null)
+        {
+            logger.LogDebug("Skipping state change for SubFlow resume on instance {InstanceId}",
+                context.InstanceId);
+            return Result<StepOutcome>.Ok(StepOutcome.Continue());
+        }
+        
         var fromState = context.Instance.GetCurrentState;
-        var toState = context.Transition!.Target;
+        var toState = context.Transition.Target;
         
         logger.LogDebug("Changing state from {FromState} to {ToState} for instance {InstanceId}",
             fromState, toState, context.InstanceId);

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/CreateTransitionRecordStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/CreateTransitionRecordStep.cs
@@ -28,6 +28,14 @@ public sealed class CreateTransitionRecordStep(
     public async Task<Result<StepOutcome>> ExecuteAsync(TransitionExecutionContext context,
         CancellationToken cancellationToken)
     {
+        // Skip for SubFlow resume - transition record already exists
+        if (context.Directives.IsSubFlowResume)
+        {
+            logger.LogDebug("Skipping transition record creation for SubFlow resume on instance {InstanceId}",
+                context.InstanceId);
+            return Result<StepOutcome>.Ok(StepOutcome.Continue());
+        }
+        
         logger.LogDebug("Creating transition record for {TransitionKey} on instance {InstanceId}",
             context.TransitionKey, context.InstanceId);
 

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/HandleSubFlowStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/HandleSubFlowStep.cs
@@ -47,9 +47,10 @@ public sealed class HandleSubFlowStep(
     /// </summary>
     private bool IsApplicable(TransitionExecutionContext context)
     {
-        if (context.Target == null)
+        if (context.Target == null || context.Transition == null)
         {
-            logger.LogWarning("Target state is null for instance {InstanceId}", context.InstanceId);
+            logger.LogTrace("Target state or transition is null for instance {InstanceId}, skipping SubFlow handling", 
+                context.InstanceId);
             return false;
         }
 

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/RunOnEntryTasksStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/RunOnEntryTasksStep.cs
@@ -72,13 +72,16 @@ public sealed class RunOnEntryTasksStep(
     /// </summary>
     private ScriptContext CreateScriptContext(TransitionExecutionContext context)
     {
-        return scriptContextFactory.NewBuilder()
+        var builder = scriptContextFactory.NewBuilder()
             .WithWorkflow(context.Workflow)
             .WithInstance(context.Instance)
-            .WithTransition(context.Transition)
             .WithBody(context.Data)
-            .WithHeaders(context.Headers.ToDictionary(kvp => kvp.Key, kvp => (string?)kvp.Value))
-            .BuildAsync(CancellationToken.None)
+            .WithHeaders(context.Headers.ToDictionary(kvp => kvp.Key, kvp => (string?)kvp.Value));
+        
+        if (context.Transition != null)
+            builder.WithTransition(context.Transition);
+        
+        return builder.BuildAsync(CancellationToken.None)
             .GetAwaiter()
             .GetResult();
     }

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/RunOnExecuteTasksStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/RunOnExecuteTasksStep.cs
@@ -26,7 +26,8 @@ public sealed class RunOnExecuteTasksStep(
     /// <inheritdoc />
     public async Task<Result<StepOutcome>> ExecuteAsync(TransitionExecutionContext context, CancellationToken cancellationToken)
     {
-        if (!context.Transition!.OnExecutionTasks.Any())
+        // Skip if no transition or no OnExecute tasks
+        if (context.Transition == null || !context.Transition.OnExecutionTasks.Any())
         {
             logger.LogTrace("No OnExecute tasks for transition {TransitionKey}", context.TransitionKey);
             return Result<StepOutcome>.Ok(StepOutcome.Continue());

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/RunOnExitTasksStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/RunOnExitTasksStep.cs
@@ -71,13 +71,16 @@ public sealed class RunOnExitTasksStep(
     /// </summary>
     private ScriptContext CreateScriptContext(TransitionExecutionContext context)
     {
-        return scriptContextFactory.NewBuilder()
+        var builder = scriptContextFactory.NewBuilder()
             .WithWorkflow(context.Workflow)
             .WithInstance(context.Instance)
-            .WithTransition(context.Transition)
             .WithBody(context.Data)
-            .WithHeaders(context.Headers.ToDictionary(kvp => kvp.Key, kvp => (string?)kvp.Value))
-            .BuildAsync(CancellationToken.None)
+            .WithHeaders(context.Headers.ToDictionary(kvp => kvp.Key, kvp => (string?)kvp.Value));
+        
+        if (context.Transition != null)
+            builder.WithTransition(context.Transition);
+        
+        return builder.BuildAsync(CancellationToken.None)
             .GetAwaiter()
             .GetResult();
     }

--- a/src/BBT.Workflow.Application/Execution/Transitions/Validation/TransitionValidationService.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Validation/TransitionValidationService.cs
@@ -68,6 +68,13 @@ public class TransitionValidationService(
     {
         logger.LogTrace("Validating transition policy for {TransitionKey}", context.TransitionKey);
         
+        // Skip validation for SubFlow resume scenarios or when transition is null
+        if (context.Directives.IsSubFlowResume || context.Transition == null)
+        {
+            logger.LogTrace("Skipping transition policy validation - SubFlow resume or no transition");
+            return Task.FromResult(Result.Ok());
+        }
+        
         if (context.Instance.HasActiveSubFlow)
         {
             logger.LogTrace("Skipping transition policy validation for {TransitionKey} - instance has active subflow", 
@@ -76,7 +83,7 @@ public class TransitionValidationService(
         }
 
         var result = context.Instance.CanExecuteTransition(
-            context.Transition!, 
+            context.Transition, 
             context.Current, 
             stateTransitionPolicy, 
             executionActor);

--- a/src/BBT.Workflow.Application/SubFlow/Services/SubflowCompletionService.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubflowCompletionService.cs
@@ -341,8 +341,9 @@ public sealed class SubflowCompletionService(
                 WorkflowKey = parentWorkflow.Key,
                 WorkflowVersion = parentWorkflow.Version,
                 InstanceId = parentInstance.Id,
-                TransitionKey = transition.Key,
+                TransitionKey = transition.Key, // For logging purposes only
                 TriggerType = transition.TriggerType,
+                Mode = ExecMode.Resume, // Use Resume mode for SubFlow completion
                 Headers = new Dictionary<string, string?>(),
                 Actor = ExecutionActor.System,
                 RequestedAt = DateTimeOffset.UtcNow,

--- a/src/BBT.Workflow.Domain/Execution/Transitions/Context/ContextEnums.cs
+++ b/src/BBT.Workflow.Domain/Execution/Transitions/Context/ContextEnums.cs
@@ -9,7 +9,10 @@ public enum ExecMode
     Sync = 0,
     
     /// <summary>Asynchronous execution via background jobs.</summary>
-    Async = 1
+    Async = 1,
+    
+    /// <summary>Resume execution from a specific pipeline step (e.g., SubFlow completion).</summary>
+    Resume = 2
 }
 
 /// <summary>


### PR DESCRIPTION
Introduces a new ExecMode.Resume to support resuming workflow execution from specific pipeline steps, particularly for SubFlow completion scenarios. Updates factories, pipeline steps, handlers, and validation logic to handle Resume mode by skipping unnecessary operations when resuming. Ensures transition and state changes are only performed when appropriate, improving robustness and clarity in SubFlow handling.

## Summary by Sourcery

Introduce a Resume execution mode to enable workflows to resume at specific pipeline steps (such as SubFlow completion) and adjust factories, strategies, and pipeline steps to bypass unnecessary operations when resuming

New Features:
- Add ExecMode.Resume to support resuming workflow execution from specific pipeline steps
- Use Resume mode in SubFlowCompletionService when restarting the parent workflow

Enhancements:
- Make transition resolution optional in resume mode and map Resume to the SyncTransitionStrategy
- Skip validations, PreHandle, state changes, transition record creation, subflow handling, and task executions in pipeline steps when in resume mode or transition is null