### PR TITLE
Enabling the getInstanceData task to run for other flows

### DIFF
--- a/docs/trigger-transition-strategy-pattern.md
+++ b/docs/trigger-transition-strategy-pattern.md
@@ -95,16 +95,30 @@ public interface ITriggerTransitionStrategyFactory
 #### ITriggerTransitionHttpTaskFactory
 Location: `src/BBT.Workflow.Domain/Execution/TriggerTransition/Factory/ITriggerTransitionHttpTaskFactory.cs`
 
-Factory interface for creating HTTP tasks used in trigger transitions.
+Factory interface for creating HTTP tasks and resolving instance IDs for trigger transitions.
 
 ```csharp
 public interface ITriggerTransitionHttpTaskFactory
 {
+    /// <summary>
+    /// Creates an HTTP task for trigger transition execution.
+    /// </summary>
     HttpTask CreateHttpTask(
         TriggerTransitionTask triggerTask,
         ScriptContext context,
         string path,
         string method);
+    
+    /// <summary>
+    /// Resolves the target instance ID using a priority-based mechanism:
+    /// 1. Use TriggerInstanceId if provided
+    /// 2. Query instance by TriggerKey if provided
+    /// 3. Use current instance ID as default
+    /// </summary>
+    Task<string> ResolveInstanceIdAsync(
+        TriggerTransitionTask task,
+        ScriptContext context,
+        CancellationToken cancellationToken);
 }
 ```
 
@@ -122,12 +136,25 @@ Handles the Start trigger type by creating a new workflow instance.
 #### DirectTriggerStrategy
 Location: `src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/DirectTriggerStrategy.cs`
 
-Handles the Trigger (Direct) trigger type by executing a transition on the current instance.
+Handles the Trigger (Direct) trigger type by executing a transition on a target instance.
 
-- Creates path using `InstanceUrlTemplates.Transition`
+**Key Features:**
+- Validates that TransitionName is provided (required field)
+- Resolves target instance ID using `ITriggerTransitionHttpTaskFactory.ResolveInstanceIdAsync`
+- Creates path using `InstanceUrlTemplates.Transition` format: `/{domain}/workflows/{flow}/instances/{instanceId}/transitions/{transitionName}`
 - Uses HTTP PATCH method
-- Validates that TransitionName is provided
 - Delegates to HttpTaskExecutor for execution
+
+**Instance Resolution:**
+```csharp
+// Resolve instance ID using the factory's ResolveInstanceIdAsync method
+var instanceId = await _httpTaskFactory.ResolveInstanceIdAsync(task, context, cancellationToken);
+```
+
+This allows the strategy to target:
+- A specific instance (if TriggerInstanceId is set)
+- An instance by key (if TriggerKey is set)
+- The current instance (default behavior)
 
 #### SubProcessTriggerStrategy
 Location: `src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/SubProcessTriggerStrategy.cs`
@@ -142,17 +169,28 @@ Location: `src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/GetIns
 
 Handles the GetInstanceData trigger type by retrieving instance data from a workflow instance.
 
-- Creates path using `InstanceUrlTemplates.Data` or `InstanceUrlTemplates.DataWithExtensions`
-- Uses HTTP GET method (unlike other strategies that use POST/PATCH)
-- Supports optional `extensions` query parameter for data enrichment
-- Supports `If-None-Match` header for ETag-based conditional requests
-- Delegates to HttpTaskExecutor for execution
-
 **Key Features:**
 - **Read Operation**: This is a query operation, not a mutation
 - **No Body**: GET requests don't send body data
 - **Extensions Support**: Can request specific extensions to enrich the instance data
 - **ETag Support**: Supports conditional requests for efficient caching
+- Uses HTTP GET method (unlike other strategies that use POST/PATCH)
+- Resolves target instance ID using `ITriggerTransitionHttpTaskFactory.ResolveInstanceIdAsync`
+- Creates path using `InstanceUrlTemplates.Data` or `InstanceUrlTemplates.DataWithExtensions`
+- Delegates to HttpTaskExecutor for execution
+
+**Instance Resolution:**
+```csharp
+// Resolve instance ID using the factory's ResolveInstanceIdAsync method
+var instanceId = await _httpTaskFactory.ResolveInstanceIdAsync(task, context, cancellationToken);
+```
+
+This allows the strategy to retrieve data from:
+- A specific instance (if TriggerInstanceId is set)
+- An instance by key (if TriggerKey is set - used directly without querying)
+- The current instance (default behavior)
+
+**Note:** For GetInstanceData type, when TriggerKey is provided, it's used directly as the instance identifier without an additional query.
 
 **Example Configuration:**
 ```json
@@ -195,12 +233,77 @@ public ITriggerTransitionStrategy Get(TriggerTransitionType type)
 #### TriggerTransitionHttpTaskFactory
 Location: `src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/TriggerTransitionHttpTaskFactory.cs`
 
-Factory that creates HTTP tasks for trigger transitions.
+Factory that creates HTTP tasks for trigger transitions and resolves instance IDs.
 
+**Key Responsibilities:**
 - Reads configuration from `vNextApi:BaseUrl` and `vNextApi:ApiVersion`
 - Builds full URL with API version
 - Prepares headers and body from context
 - Creates HttpTask with proper configuration
+- Resolves instance IDs using a priority-based mechanism
+
+**Instance ID Resolution (ResolveInstanceIdAsync):**
+
+The factory provides a `ResolveInstanceIdAsync` method that determines the target instance ID using a three-tier priority system:
+
+1. **Priority 1: Use TriggerInstanceId if provided**
+   ```csharp
+   if (!string.IsNullOrWhiteSpace(task.TriggerInstanceId))
+       return task.TriggerInstanceId;
+   ```
+
+2. **Priority 2: Query instance by TriggerKey if provided**
+   ```csharp
+   if (!string.IsNullOrWhiteSpace(task.TriggerKey))
+   {
+       // For GetInstanceData, use the key directly
+       if (task.TriggerType == TriggerTransitionType.GetInstanceData)
+           return task.TriggerKey;
+       
+       // For other types, query the instance and extract the ID
+       return await ResolveInstanceIdByKeyAsync(task, context, cancellationToken);
+   }
+   ```
+
+3. **Priority 3: Use current instance ID as default**
+   ```csharp
+   return context.Instance.Id.ToString();
+   ```
+
+**ResolveInstanceIdByKeyAsync Implementation:**
+
+When TriggerKey is provided but TriggerInstanceId is not, the factory:
+1. Creates an HTTP GET request to `/{domain}/workflows/{flow}/instances/{key}`
+2. Calls the HttpTaskExecutor to retrieve the instance data
+3. Extracts the instance ID from the response
+4. Restores the original context body
+5. Returns the resolved instance ID
+
+This mechanism allows flexible instance targeting without requiring the exact instance ID upfront.
+
+**Instance Resolution Summary by Strategy:**
+
+| Strategy | Uses ResolveInstanceIdAsync | Behavior |
+|----------|---------------------------|----------|
+| **StartTriggerStrategy** | ❌ No | Creates new instance - no resolution needed |
+| **DirectTriggerStrategy** | ✅ Yes | Resolves target instance using priority mechanism |
+| **GetInstanceDataTriggerStrategy** | ✅ Yes | Resolves target instance; TriggerKey used directly for GetInstanceData type |
+| **SubProcessTriggerStrategy** | 🚧 TBD | Not yet implemented |
+
+**Priority Resolution Flow:**
+
+```
+ResolveInstanceIdAsync()
+    │
+    ├─→ TriggerInstanceId set? ──Yes──→ Use TriggerInstanceId
+    │                           └─No
+    │
+    ├─→ TriggerKey set? ──Yes──→ GetInstanceData type? ──Yes──→ Use TriggerKey directly
+    │                    │                              └─No──→ Query instance by key, extract ID
+    │                    └─No
+    │
+    └─→ Use context.Instance.Id (current instance)
+```
 
 ### 3. Refactored Executor
 
@@ -243,6 +346,172 @@ public async Task<object?> ExecuteAsync(...)
     return outputResponse;
 }
 ```
+
+## Script Mapping Examples
+
+The `TriggerTransitionTask` class provides several setter methods that allow dynamic configuration of task properties during script execution (input mapping). This is particularly useful when you need to determine target instances or parameters at runtime.
+
+### Available Setter Methods
+
+#### SetInstance
+Sets the target instance ID for the trigger transition.
+
+**Signature:**
+```csharp
+public void SetInstance(string instanceId)
+```
+
+**Example - Using data from current instance:**
+```csharp
+// Set target instance ID from instance data
+triggerTask.SetInstance(context.Instance.Data.getDataInstanceId);
+```
+
+**Example - Using response from previous task:**
+```csharp
+// Set instance ID from a previous HTTP call response
+triggerTask.SetInstance(context.Body.data.instanceId);
+```
+
+#### SetKey
+Sets the target instance key for the trigger transition. The key will be used to resolve the instance ID automatically.
+
+**Signature:**
+```csharp
+public void SetKey(string key)
+```
+
+**Example - Using data from current instance:**
+```csharp
+// Set target instance key from instance data
+triggerTask.SetKey(context.Instance.Data.getDataInstanceKey);
+```
+
+**Example - Building a composite key:**
+```csharp
+// Build a key from multiple data points
+var orderKey = $"{context.Instance.Data.customerId}-{context.Instance.Data.orderId}";
+triggerTask.SetKey(orderKey);
+```
+
+#### SetBody
+Sets the body data to send with the trigger transition request.
+
+**Signature:**
+```csharp
+public void SetBody(dynamic body)
+```
+
+**Example - Passing instance data:**
+```csharp
+// Pass specific data from current instance to target workflow
+triggerTask.SetBody(new {
+    customerId = context.Instance.Data.customerId,
+    orderAmount = context.Instance.Data.totalAmount,
+    source = "parent-workflow"
+});
+```
+
+**Example - Forwarding response from previous task:**
+```csharp
+// Forward the response from a previous HTTP task
+triggerTask.SetBody(context.Body.data);
+```
+
+#### SetDomain
+Sets the target workflow domain.
+
+**Signature:**
+```csharp
+public void SetDomain(string domain)
+```
+
+**Example:**
+```csharp
+// Set domain dynamically based on instance data
+triggerTask.SetDomain(context.Instance.Data.targetDomain);
+```
+
+#### SetFlow
+Sets the target workflow name.
+
+**Signature:**
+```csharp
+public void SetFlow(string flow)
+```
+
+**Example:**
+```csharp
+// Set flow name dynamically
+triggerTask.SetFlow(context.Instance.Data.subFlowName);
+```
+
+#### SetTriggerType
+Sets the trigger type (Start, Trigger, SubProcess, or GetInstanceData).
+
+**Signature:**
+```csharp
+public void SetTriggerType(string type)
+```
+
+**Example:**
+```csharp
+// Conditionally set trigger type
+var triggerType = context.Instance.Data.isNewFlow ? "Start" : "Trigger";
+triggerTask.SetTriggerType(triggerType);
+```
+
+### Complete Mapping Example
+
+Here's a complete example showing how to configure a trigger transition task dynamically:
+
+```csharp
+// Input mapping script for a DirectTriggerStrategy
+// Determine target instance from stored correlation data
+if (context.Instance.Data.correlatedInstanceId != null)
+{
+    // Target a specific instance
+    triggerTask.SetInstance(context.Instance.Data.correlatedInstanceId);
+}
+else if (context.Instance.Data.correlatedInstanceKey != null)
+{
+    // Let the system resolve the instance by key
+    triggerTask.SetKey(context.Instance.Data.correlatedInstanceKey);
+}
+
+// Set the target domain and flow
+triggerTask.SetDomain(context.Instance.Data.targetDomain ?? "default");
+triggerTask.SetFlow(context.Instance.Data.targetFlow ?? "main-flow");
+
+// Prepare the body with relevant data
+triggerTask.SetBody(new {
+    initiatedBy = context.Instance.Key,
+    timestamp = DateTime.UtcNow,
+    payload = context.Instance.Data.transferData
+});
+```
+
+### Task Configuration Properties
+
+The `TriggerTransitionTask` class supports the following configuration properties:
+
+| Property | Type | Description | Required | Used By |
+|----------|------|-------------|----------|---------|
+| `domain` | string | Target workflow domain | ✅ Yes | All strategies |
+| `flow` | string | Target workflow name | ✅ Yes | All strategies |
+| `type` | enum | Trigger type: Start, Trigger, SubProcess, GetInstanceData | ✅ Yes | All strategies |
+| `transitionName` | string | Transition to execute | ⚠️ For Trigger type | DirectTriggerStrategy |
+| `key` | string | Target instance key | ❌ Optional | DirectTriggerStrategy, GetInstanceDataTriggerStrategy |
+| `instanceId` | string | Target instance ID | ❌ Optional | DirectTriggerStrategy, GetInstanceDataTriggerStrategy |
+| `body` | object | Request body data | ❌ Optional | StartTriggerStrategy, DirectTriggerStrategy |
+| `version` | string | SubFlow version | ❌ Optional | SubProcessTriggerStrategy |
+| `extensions` | string[] | Data extensions to include | ❌ Optional | GetInstanceDataTriggerStrategy |
+
+**Notes:**
+- Either `key` or `instanceId` can be provided, with `instanceId` taking priority
+- If neither is provided, the current instance ID is used
+- The `body` can be set in configuration or dynamically via input mapping
+- For `GetInstanceData` type, when `key` is provided, it's used directly without additional querying
 
 ## Dependency Injection Registration
 

--- a/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/DirectTriggerStrategy.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/DirectTriggerStrategy.cs
@@ -1,7 +1,5 @@
-using System.Text.Json;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Execution.TriggerTransition;
-using BBT.Workflow.Instances;
 using BBT.Workflow.Scripting;
 using Microsoft.Extensions.Logging;
 
@@ -45,8 +43,8 @@ public sealed class DirectTriggerStrategy : ITriggerTransitionStrategy
         _logger.LogInformation("Handling Direct trigger for task {TaskKey} - InstanceId: {InstanceId}, Transition: {Transition}",
             task.Key, context.Instance.Id, task.TransitionName);
 
-        // Resolve instance ID
-        var instanceId = await GetInstanceIdAsync(task, context, cancellationToken);
+        // Resolve instance ID using the factory's ResolveInstanceIdAsync method
+        var instanceId = await _httpTaskFactory.ResolveInstanceIdAsync(task, context, cancellationToken);
 
         // Create path using InstanceUrlTemplates.Transition format
         var path = string.Format(InstanceUrlTemplates.Transition,
@@ -64,117 +62,6 @@ public sealed class DirectTriggerStrategy : ITriggerTransitionStrategy
 
         _logger.LogDebug("Calling HttpTaskExecutor.CallAsync for Direct trigger task {TaskKey}", task.Key);
         await httpExecutor.CallAsync(httpTask, context, cancellationToken);
-    }
-
-    /// <summary>
-    /// Resolves the instance ID for the transition based on task configuration.
-    /// </summary>
-    /// <param name="task">The trigger transition task.</param>
-    /// <param name="context">The script context.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The resolved instance ID.</returns>
-    private async Task<string> GetInstanceIdAsync(
-        TriggerTransitionTask task,
-        ScriptContext context,
-        CancellationToken cancellationToken)
-    {
-        // If TriggerInstanceId is provided, use it
-        if (!string.IsNullOrWhiteSpace(task.TriggerInstanceId))
-        {
-            _logger.LogDebug("Using provided TriggerInstanceId: {InstanceId}", task.TriggerInstanceId);
-            return task.TriggerInstanceId;
-        }
-
-        // If TriggerKey is provided but TriggerInstanceId is not, query the instance
-        if (!string.IsNullOrWhiteSpace(task.TriggerKey))
-        {
-            _logger.LogInformation("TriggerInstanceId not provided but TriggerKey exists: {Key}. Querying instance by key.", 
-                task.TriggerKey);
-
-            var path = string.Format(InstanceUrlTemplates.Instance,
-                task.TriggerDomain,
-                task.TriggerFlow,
-                task.TriggerKey);
-
-            var httpTask = _httpTaskFactory.CreateHttpTask(task, context, path, "GET");
-
-            var httpExecutor = _taskExecutorFactory.GetExecutor(TaskType.Http) as HttpTaskExecutor;
-            if (httpExecutor == null)
-                throw new InvalidOperationException("HttpTaskExecutor not found");
-
-            _logger.LogDebug("Calling HttpTaskExecutor.CallAsync to get instance by key {Key}", task.TriggerKey);
-            
-            // Store original body to restore after the call
-            object? originalBody = context.Body;
-            
-            await httpExecutor.CallAsync(httpTask, context, cancellationToken);
-
-            // Parse the response and extract the Id
-            // After CallAsync, context.Body contains StandardTaskResponse merged data
-            // The actual response data is in context.Body.data property (camelCase)
-            if (context.Body != null)
-            {
-                try
-                {
-                    // Access the 'data' property from StandardTaskResponse
-                    dynamic bodyData = context.Body;
-                    var responseData = bodyData.data;
-                    
-                    if (responseData != null)
-                    {
-                        var jsonElement = JsonSerializer.SerializeToElement(responseData);
-                        
-                        // Use case-insensitive deserialization to match camelCase JSON properties to PascalCase C# properties
-                        var options = new JsonSerializerOptions
-                        {
-                            PropertyNameCaseInsensitive = true
-                        };
-                        
-                        var instanceOutput = JsonSerializer.Deserialize<GetInstanceOutput>(jsonElement, options);
-
-                        if (instanceOutput != null)
-                        {
-
-                            string idValue = instanceOutput.Id?.ToString() ?? "null";
-                            Guid resolvedGuid = Guid.TryParse(idValue, out var instanceId)?instanceId:Guid.Empty;
-                            
-                            if (resolvedGuid != Guid.Empty)
-                            {
-                                string resolvedId = resolvedGuid.ToString();
-                                string? TriggerKey = task.TriggerKey;
-                                _logger.LogInformation("Resolved instance ID from key {Key}: {InstanceId}", 
-                                    TriggerKey, resolvedId);
-                                
-                                // Restore original body
-                                context.SetBody(originalBody);
-                                
-                                return resolvedId;
-                            }
-                        }
-
-                        throw new InvalidOperationException($"Instance with key '{task.TriggerKey}' returned no valid Id");
-                    }
-
-                    throw new InvalidOperationException($"Response data is null when querying instance by key '{task.TriggerKey}'");
-                }
-                catch (JsonException ex)
-                {
-                    _logger.LogError(ex, "Failed to deserialize GetInstanceOutput for key {Key}", task.TriggerKey);
-                    throw new InvalidOperationException($"Failed to parse instance response for key '{task.TriggerKey}'", ex);
-                }
-                catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException ex)
-                {
-                    _logger.LogError(ex, "Failed to access response data property for key {Key}", task.TriggerKey);
-                    throw new InvalidOperationException($"Invalid response structure when querying instance by key '{task.TriggerKey}'", ex);
-                }
-            }
-
-            throw new InvalidOperationException($"No response received when querying instance by key '{task.TriggerKey}'");
-        }
-
-        // Default to current instance ID
-        _logger.LogDebug("Using current instance ID: {InstanceId}", context.Instance.Id);
-        return context.Instance.Id.ToString();
     }
 }
 

--- a/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/DirectTriggerStrategy.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/DirectTriggerStrategy.cs
@@ -1,4 +1,5 @@
 using BBT.Workflow.Definitions;
+using BBT.Workflow.Domain;
 using BBT.Workflow.Execution.TriggerTransition;
 using BBT.Workflow.Scripting;
 using Microsoft.Extensions.Logging;
@@ -32,36 +33,60 @@ public sealed class DirectTriggerStrategy : ITriggerTransitionStrategy
     }
 
     /// <inheritdoc />
-    public async Task ExecuteAsync(
+    public async Task<Result> ExecuteAsync(
         TriggerTransitionTask task,
         ScriptContext context,
         CancellationToken cancellationToken)
     {
-        if (string.IsNullOrWhiteSpace(task.TransitionName))
-            throw new InvalidOperationException("TransitionName is required for Trigger (Direct) trigger type");
+        return await ResultExtensions.TryAsync(
+            async ct =>
+            {
+                // Validate TransitionName
+                if (string.IsNullOrWhiteSpace(task.TransitionName))
+                {
+                    throw new InvalidOperationException("TransitionName is required for Trigger (Direct) trigger type");
+                }
 
-        _logger.LogInformation("Handling Direct trigger for task {TaskKey} - InstanceId: {InstanceId}, Transition: {Transition}",
-            task.Key, context.Instance.Id, task.TransitionName);
+                _logger.LogInformation("Handling Direct trigger for task {TaskKey} - InstanceId: {InstanceId}, Transition: {Transition}",
+                    task.Key, context.Instance.Id, task.TransitionName);
 
-        // Resolve instance ID using the factory's ResolveInstanceIdAsync method
-        var instanceId = await _httpTaskFactory.ResolveInstanceIdAsync(task, context, cancellationToken);
+                // Resolve instance ID using the factory's ResolveInstanceIdAsync method
+                var instanceIdResult = await _httpTaskFactory.ResolveInstanceIdAsync(task, context, ct);
+                if (!instanceIdResult.IsSuccess)
+                {
+                    _logger.LogError("Failed to resolve instance ID for Direct trigger: {Error}", instanceIdResult.Error.Code);
+                    throw new InvalidOperationException($"Failed to resolve instance ID: {instanceIdResult.Error.Message}");
+                }
 
-        // Create path using InstanceUrlTemplates.Transition format
-        var path = string.Format(InstanceUrlTemplates.Transition,
-            task.TriggerDomain,
-            task.TriggerFlow,
-            instanceId,
-            task.TransitionName);
+                var instanceId = instanceIdResult.Value!;
 
-        var httpTask = _httpTaskFactory.CreateHttpTask(task, context, path, "PATCH");
+                // Create path using InstanceUrlTemplates.Transition format
+                var path = string.Format(InstanceUrlTemplates.Transition,
+                    task.TriggerDomain,
+                    task.TriggerFlow,
+                    instanceId,
+                    task.TransitionName);
 
-        var httpExecutor = _taskExecutorFactory.GetExecutor(TaskType.Http) as HttpTaskExecutor;
+                var httpTaskResult = _httpTaskFactory.CreateHttpTask(task, context, path, "PATCH");
+                if (!httpTaskResult.IsSuccess)
+                {
+                    _logger.LogError("Failed to create HTTP task for Direct trigger: {Error}", httpTaskResult.Error.Code);
+                    throw new InvalidOperationException($"Failed to create HTTP task: {httpTaskResult.Error.Message}");
+                }
 
-        if (httpExecutor == null)
-            throw new InvalidOperationException("HttpTaskExecutor not found");
+                var httpTask = httpTaskResult.Value!;
 
-        _logger.LogDebug("Calling HttpTaskExecutor.CallAsync for Direct trigger task {TaskKey}", task.Key);
-        await httpExecutor.CallAsync(httpTask, context, cancellationToken);
+                var httpExecutor = _taskExecutorFactory.GetExecutor(TaskType.Http) as HttpTaskExecutor;
+
+                if (httpExecutor == null)
+                    throw new InvalidOperationException("HttpTaskExecutor not found");
+
+                _logger.LogDebug("Calling HttpTaskExecutor.CallAsync for Direct trigger task {TaskKey}", task.Key);
+                await httpExecutor.CallAsync(httpTask, context, ct);
+            },
+            cancellationToken,
+            ex => Error.Failure(WorkflowErrorCodes.TriggerDirectExecutionFailed, 
+                $"Failed to execute Direct trigger for task '{task.Key}': {ex.Message}"));
     }
 }
 

--- a/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/GetInstanceDataTriggerStrategy.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/GetInstanceDataTriggerStrategy.cs
@@ -1,4 +1,5 @@
 using BBT.Workflow.Definitions;
+using BBT.Workflow.Domain;
 using BBT.Workflow.Execution.TriggerTransition;
 using BBT.Workflow.Scripting;
 using Microsoft.Extensions.Logging;
@@ -32,44 +33,65 @@ public sealed class GetInstanceDataTriggerStrategy : ITriggerTransitionStrategy
     }
 
     /// <inheritdoc />
-    public async Task ExecuteAsync(
+    public async Task<Result> ExecuteAsync(
         TriggerTransitionTask task,
         ScriptContext context,
         CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Handling GetInstanceData trigger for task {TaskKey} - Domain: {Domain}, Flow: {Flow}, InstanceId: {InstanceId}",
-            task.Key, task.TriggerDomain, task.TriggerFlow, context.Instance.Id);
+        return await ResultExtensions.TryAsync(
+            async ct =>
+            {
+                _logger.LogInformation("Handling GetInstanceData trigger for task {TaskKey} - Domain: {Domain}, Flow: {Flow}, InstanceId: {InstanceId}",
+                    task.Key, task.TriggerDomain, task.TriggerFlow, context.Instance.Id);
 
-        // Resolve instance ID using the factory's ResolveInstanceIdAsync method
-        var instanceId = await _httpTaskFactory.ResolveInstanceIdAsync(task, context, cancellationToken);
+                // Resolve instance ID using the factory's ResolveInstanceIdAsync method
+                var instanceIdResult = await _httpTaskFactory.ResolveInstanceIdAsync(task, context, ct);
+                if (!instanceIdResult.IsSuccess)
+                {
+                    _logger.LogError("Failed to resolve instance ID for GetInstanceData trigger: {Error}", instanceIdResult.Error.Code);
+                    throw new InvalidOperationException($"Failed to resolve instance ID: {instanceIdResult.Error.Message}");
+                }
 
-        // Build path with or without extensions
-        string path;
-        if (task.Extensions?.Length > 0)
-        {
-            var extensionsParam = string.Join(",", task.Extensions);
-            path = string.Format(InstanceUrlTemplates.DataWithExtensions,
-                task.TriggerDomain,
-                task.TriggerFlow,
-                instanceId,
-                extensionsParam);
-        }
-        else
-        {
-            path = string.Format(InstanceUrlTemplates.Data,
-                task.TriggerDomain,
-                task.TriggerFlow,
-                instanceId);
-        }
+                var instanceId = instanceIdResult.Value!;
 
-        var httpTask = _httpTaskFactory.CreateHttpTask(task, context, path, "GET");
+                // Build path with or without extensions
+                string path;
+                if (task.Extensions?.Length > 0)
+                {
+                    var extensionsParam = string.Join(",", task.Extensions);
+                    path = string.Format(InstanceUrlTemplates.DataWithExtensions,
+                        task.TriggerDomain,
+                        task.TriggerFlow,
+                        instanceId,
+                        extensionsParam);
+                }
+                else
+                {
+                    path = string.Format(InstanceUrlTemplates.Data,
+                        task.TriggerDomain,
+                        task.TriggerFlow,
+                        instanceId);
+                }
 
-        var httpExecutor = _taskExecutorFactory.GetExecutor(TaskType.Http) as HttpTaskExecutor;
+                var httpTaskResult = _httpTaskFactory.CreateHttpTask(task, context, path, "GET");
+                if (!httpTaskResult.IsSuccess)
+                {
+                    _logger.LogError("Failed to create HTTP task for GetInstanceData trigger: {Error}", httpTaskResult.Error.Code);
+                    throw new InvalidOperationException($"Failed to create HTTP task: {httpTaskResult.Error.Message}");
+                }
 
-        if (httpExecutor == null)
-            throw new InvalidOperationException("HttpTaskExecutor not found");
+                var httpTask = httpTaskResult.Value!;
 
-        _logger.LogDebug("Calling HttpTaskExecutor.CallAsync for GetInstanceData trigger task {TaskKey}", task.Key);
-        await httpExecutor.CallAsync(httpTask, context, cancellationToken);
+                var httpExecutor = _taskExecutorFactory.GetExecutor(TaskType.Http) as HttpTaskExecutor;
+
+                if (httpExecutor == null)
+                    throw new InvalidOperationException("HttpTaskExecutor not found");
+
+                _logger.LogDebug("Calling HttpTaskExecutor.CallAsync for GetInstanceData trigger task {TaskKey}", task.Key);
+                await httpExecutor.CallAsync(httpTask, context, ct);
+            },
+            cancellationToken,
+            ex => Error.Failure(WorkflowErrorCodes.TriggerGetInstanceDataFailed, 
+                $"Failed to execute GetInstanceData trigger for task '{task.Key}': {ex.Message}"));
     }
 }

--- a/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/GetInstanceDataTriggerStrategy.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/GetInstanceDataTriggerStrategy.cs
@@ -40,6 +40,9 @@ public sealed class GetInstanceDataTriggerStrategy : ITriggerTransitionStrategy
         _logger.LogInformation("Handling GetInstanceData trigger for task {TaskKey} - Domain: {Domain}, Flow: {Flow}, InstanceId: {InstanceId}",
             task.Key, task.TriggerDomain, task.TriggerFlow, context.Instance.Id);
 
+        // Resolve instance ID using the factory's ResolveInstanceIdAsync method
+        var instanceId = await _httpTaskFactory.ResolveInstanceIdAsync(task, context, cancellationToken);
+
         // Build path with or without extensions
         string path;
         if (task.Extensions?.Length > 0)
@@ -48,7 +51,7 @@ public sealed class GetInstanceDataTriggerStrategy : ITriggerTransitionStrategy
             path = string.Format(InstanceUrlTemplates.DataWithExtensions,
                 task.TriggerDomain,
                 task.TriggerFlow,
-                context.Instance.Id,
+                instanceId,
                 extensionsParam);
         }
         else
@@ -56,7 +59,7 @@ public sealed class GetInstanceDataTriggerStrategy : ITriggerTransitionStrategy
             path = string.Format(InstanceUrlTemplates.Data,
                 task.TriggerDomain,
                 task.TriggerFlow,
-                context.Instance.Id);
+                instanceId);
         }
 
         var httpTask = _httpTaskFactory.CreateHttpTask(task, context, path, "GET");

--- a/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/StartTriggerStrategy.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/StartTriggerStrategy.cs
@@ -1,4 +1,5 @@
 using BBT.Workflow.Definitions;
+using BBT.Workflow.Domain;
 using BBT.Workflow.Execution.TriggerTransition;
 using BBT.Workflow.Scripting;
 using Microsoft.Extensions.Logging;
@@ -32,28 +33,42 @@ public sealed class StartTriggerStrategy : ITriggerTransitionStrategy
     }
 
     /// <inheritdoc />
-    public async Task ExecuteAsync(
+    public async Task<Result> ExecuteAsync(
         TriggerTransitionTask task,
         ScriptContext context,
         CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Handling Start trigger for task {TaskKey} - Domain: {Domain}, Flow: {Flow}",
-            task.Key, task.TriggerDomain, task.TriggerFlow);
+        return await ResultExtensions.TryAsync(
+            async ct =>
+            {
+                _logger.LogInformation("Handling Start trigger for task {TaskKey} - Domain: {Domain}, Flow: {Flow}",
+                    task.Key, task.TriggerDomain, task.TriggerFlow);
 
-        // Create path using InstanceUrlTemplates.Start format
-        var path = string.Format(InstanceUrlTemplates.Start,
-            task.TriggerDomain,
-            task.TriggerFlow);
-        
-        var httpTask = _httpTaskFactory.CreateHttpTask(task, context, path, "POST");
+                // Create path using InstanceUrlTemplates.Start format
+                var path = string.Format(InstanceUrlTemplates.Start,
+                    task.TriggerDomain,
+                    task.TriggerFlow);
+                
+                var httpTaskResult = _httpTaskFactory.CreateHttpTask(task, context, path, "POST");
+                if (!httpTaskResult.IsSuccess)
+                {
+                    _logger.LogError("Failed to create HTTP task for Start trigger: {Error}", httpTaskResult.Error.Code);
+                    throw new InvalidOperationException($"Failed to create HTTP task: {httpTaskResult.Error.Message}");
+                }
 
-        var httpExecutor = _taskExecutorFactory.GetExecutor(TaskType.Http) as HttpTaskExecutor;
+                var httpTask = httpTaskResult.Value!;
 
-        if (httpExecutor == null)
-            throw new InvalidOperationException("HttpTaskExecutor not found");
+                var httpExecutor = _taskExecutorFactory.GetExecutor(TaskType.Http) as HttpTaskExecutor;
 
-        _logger.LogDebug("Calling HttpTaskExecutor.CallAsync for Start trigger task {TaskKey}", task.Key);
-        await httpExecutor.CallAsync(httpTask, context, cancellationToken);
+                if (httpExecutor == null)
+                    throw new InvalidOperationException("HttpTaskExecutor not found");
+
+                _logger.LogDebug("Calling HttpTaskExecutor.CallAsync for Start trigger task {TaskKey}", task.Key);
+                await httpExecutor.CallAsync(httpTask, context, ct);
+            },
+            cancellationToken,
+            ex => Error.Failure(WorkflowErrorCodes.TriggerStartExecutionFailed, 
+                $"Failed to execute Start trigger for task '{task.Key}': {ex.Message}"));
     }
 }
 

--- a/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/SubProcessTriggerStrategy.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/SubProcessTriggerStrategy.cs
@@ -1,5 +1,6 @@
 using BBT.Aether.Guids;
 using BBT.Workflow.Definitions;
+using BBT.Workflow.Domain;
 using BBT.Workflow.Execution.TriggerTransition;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Runtime;
@@ -37,47 +38,54 @@ public sealed class SubProcessTriggerStrategy : ITriggerTransitionStrategy
     }
 
     /// <inheritdoc />
-    public async Task ExecuteAsync(
+    public async Task<Result> ExecuteAsync(
         TriggerTransitionTask task,
         ScriptContext context,
         CancellationToken cancellationToken)
     {
-        _logger.LogInformation(
-            "Executing SubProcess trigger for task {TaskKey} - Domain: {Domain}, Key: {Key}, Version: {Version}",
-            task.Key, task.TriggerDomain, task.TriggerKey, task.TriggerVersion);
+        return await ResultExtensions.TryAsync(
+            async ct =>
+            {
+                _logger.LogInformation(
+                    "Executing SubProcess trigger for task {TaskKey} - Domain: {Domain}, Key: {Key}, Version: {Version}",
+                    task.Key, task.TriggerDomain, task.TriggerKey, task.TriggerVersion);
 
-        // Create correlation for SubProcess
-        var correlation = InstanceCorrelation.Create(
-            _guidGenerator.Create(),
-            context.Instance.Id,
-            context.Instance.GetCurrentState,
-            _guidGenerator.Create(),
-            SubFlowType.SubProcess.Code,
-            task.TriggerDomain,
-            task.TriggerKey!,
-            task.TriggerVersion);
-        context.Instance.AddCorrelation(correlation);
+                // Create correlation for SubProcess
+                var correlation = InstanceCorrelation.Create(
+                    _guidGenerator.Create(),
+                    context.Instance.Id,
+                    context.Instance.GetCurrentState,
+                    _guidGenerator.Create(),
+                    SubFlowType.SubProcess.Code,
+                    task.TriggerDomain,
+                    task.TriggerKey!,
+                    task.TriggerVersion);
+                context.Instance.AddCorrelation(correlation);
 
-        // Create a SubFlow reference for the subprocess
-        var subFlowReference = new Reference(
-            task.TriggerKey!,
-            task.TriggerDomain,
-            RuntimeSysSchemaInfo.Flows,
-            task.TriggerVersion ?? string.Empty);
+                // Create a SubFlow reference for the subprocess
+                var subFlowReference = new Reference(
+                    task.TriggerKey!,
+                    task.TriggerDomain,
+                    RuntimeSysSchemaInfo.Flows,
+                    task.TriggerVersion ?? string.Empty);
 
-        // Start the SubProcess using simplified SubStartAsync method
-        await _subflowStarter.SubStartAsync(
-            context.Workflow,
-            context.Instance,
-            subFlowReference,
-            context.Transition!,
-            correlation,
-            SubFlowType.SubProcess.Code,
-            cancellationToken);
+                // Start the SubProcess using simplified SubStartAsync method
+                await _subflowStarter.SubStartAsync(
+                    context.Workflow,
+                    context.Instance,
+                    subFlowReference,
+                    context.Transition!,
+                    correlation,
+                    SubFlowType.SubProcess.Code,
+                    ct);
 
-        _logger.LogInformation(
-            "SubProcess trigger completed for task {TaskKey} with correlation {CorrelationId}",
-            task.Key, correlation.Id);
+                _logger.LogInformation(
+                    "SubProcess trigger completed for task {TaskKey} with correlation {CorrelationId}",
+                    task.Key, correlation.Id);
+            },
+            cancellationToken,
+            ex => Error.Failure(WorkflowErrorCodes.TriggerSubProcessExecutionFailed, 
+                $"Failed to execute SubProcess trigger for task '{task.Key}': {ex.Message}"));
     }
 }
 

--- a/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/TriggerTransitionHttpTaskFactory.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/TriggerTransitionHttpTaskFactory.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Execution.TriggerTransition;
+using BBT.Workflow.Instances;
 using BBT.Workflow.Scripting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -9,22 +10,27 @@ namespace BBT.Workflow.Tasks.TriggerTransition;
 
 /// <summary>
 /// Factory implementation for creating HTTP tasks used in trigger transition strategies.
+/// Also provides utilities for resolving instance IDs.
 /// </summary>
 public sealed class TriggerTransitionHttpTaskFactory : ITriggerTransitionHttpTaskFactory
 {
     private readonly IConfiguration _configuration;
+    private readonly ITaskExecutorFactory _taskExecutorFactory;
     private readonly ILogger<TriggerTransitionHttpTaskFactory> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TriggerTransitionHttpTaskFactory"/> class.
     /// </summary>
     /// <param name="configuration">The configuration instance for reading vNextApi settings.</param>
+    /// <param name="taskExecutorFactory">Factory for creating task executors.</param>
     /// <param name="logger">The logger instance.</param>
     public TriggerTransitionHttpTaskFactory(
         IConfiguration configuration,
+        ITaskExecutorFactory taskExecutorFactory,
         ILogger<TriggerTransitionHttpTaskFactory> logger)
     {
         _configuration = configuration;
+        _taskExecutorFactory = taskExecutorFactory;
         _logger = logger;
     }
 
@@ -96,6 +102,150 @@ public sealed class TriggerTransitionHttpTaskFactory : ITriggerTransitionHttpTas
         triggerTask.CopyBaseToInternal(httpTask);
 
         return httpTask;
+    }
+
+    /// <inheritdoc />
+    public async Task<string> ResolveInstanceIdAsync(
+        TriggerTransitionTask task,
+        ScriptContext context,
+        CancellationToken cancellationToken)
+    {
+        // Priority 1: If TriggerInstanceId is provided, use it
+        if (!string.IsNullOrWhiteSpace(task.TriggerInstanceId))
+        {
+            _logger.LogDebug("Using provided TriggerInstanceId: {InstanceId}", task.TriggerInstanceId);
+            return task.TriggerInstanceId;
+        }
+
+        // Priority 2: If TriggerKey is provided but TriggerInstanceId is not, query the instance
+        if (!string.IsNullOrWhiteSpace(task.TriggerKey))
+        {
+            _logger.LogInformation("TriggerInstanceId not provided but TriggerKey exists: {Key}. Querying instance by key.",
+                task.TriggerKey);
+            if(task.TriggerType==TriggerTransitionType.GetInstanceData)
+            {
+                return task.TriggerKey;
+            }
+            return await ResolveInstanceIdByKeyAsync(task, context, cancellationToken);
+        }
+
+        // Priority 3: Default to current instance ID
+        _logger.LogDebug("Using current instance ID: {InstanceId}", context.Instance.Id);
+        return context.Instance.Id.ToString();
+    }
+
+    /// <summary>
+    /// Resolves the instance ID by querying the instance using the TriggerKey.
+    /// </summary>
+    /// <param name="task">The trigger transition task.</param>
+    /// <param name="context">The script context.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The resolved instance ID.</returns>
+    private async Task<string> ResolveInstanceIdByKeyAsync(
+        TriggerTransitionTask task,
+        ScriptContext context,
+        CancellationToken cancellationToken)
+    {
+        var path = string.Format(InstanceUrlTemplates.Instance,
+            task.TriggerDomain,
+            task.TriggerFlow,
+            task.TriggerKey);
+
+        var httpTask = CreateHttpTask(task, context, path, "GET");
+
+        var httpExecutor = _taskExecutorFactory.GetExecutor(TaskType.Http) as HttpTaskExecutor;
+        if (httpExecutor == null)
+            throw new InvalidOperationException("HttpTaskExecutor not found");
+
+        _logger.LogDebug("Calling HttpTaskExecutor.CallAsync to get instance by key {Key}", task.TriggerKey);
+
+        // Store original body to restore after the call
+        object? originalBody = context.Body;
+
+        await httpExecutor.CallAsync(httpTask, context, cancellationToken);
+
+        try
+        {
+            // Parse the response and extract the Id
+            // After CallAsync, context.Body contains StandardTaskResponse merged data
+            // The actual response data is in context.Body.data property (camelCase)
+            if (context.Body == null)
+            {
+                throw new InvalidOperationException($"No response received when querying instance by key '{task.TriggerKey}'");
+            }
+
+            string instanceId = ExtractInstanceIdFromResponse(context.Body, task.TriggerKey!);
+
+            // Restore original body
+            context.SetBody(originalBody);
+
+            string key = task.TriggerKey!;
+            _logger.LogInformation("Resolved instance ID from key {Key}: {InstanceId}",
+                key, instanceId);
+
+            return instanceId;
+        }
+        catch (Exception ex) when (ex is not InvalidOperationException)
+        {
+            _logger.LogError(ex, "Failed to resolve instance ID for key {Key}", task.TriggerKey);
+            throw new InvalidOperationException($"Failed to resolve instance ID for key '{task.TriggerKey}'", ex);
+        }
+    }
+
+    /// <summary>
+    /// Extracts the instance ID from the HTTP response body.
+    /// </summary>
+    /// <param name="responseBody">The response body containing the instance data.</param>
+    /// <param name="triggerKey">The trigger key used for error messages.</param>
+    /// <returns>The extracted instance ID.</returns>
+    private string ExtractInstanceIdFromResponse(object responseBody, string triggerKey)
+    {
+        try
+        {
+            // Access the 'data' property from StandardTaskResponse
+            dynamic bodyData = responseBody;
+            var responseData = bodyData.data;
+
+            if (responseData == null)
+            {
+                throw new InvalidOperationException($"Response data is null when querying instance by key '{triggerKey}'");
+            }
+
+            var jsonElement = JsonSerializer.SerializeToElement(responseData);
+
+            // Use case-insensitive deserialization to match camelCase JSON properties to PascalCase C# properties
+            var options = new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            };
+
+            var instanceOutput = JsonSerializer.Deserialize<GetInstanceOutput>(jsonElement, options);
+
+            if (instanceOutput == null)
+            {
+                throw new InvalidOperationException($"Failed to deserialize instance response for key '{triggerKey}'");
+            }
+
+            string idValue = instanceOutput.Id?.ToString() ?? "null";
+            Guid resolvedGuid = Guid.TryParse(idValue, out var instanceId) ? instanceId : Guid.Empty;
+
+            if (resolvedGuid == Guid.Empty)
+            {
+                throw new InvalidOperationException($"Instance with key '{triggerKey}' returned no valid Id");
+            }
+
+            return resolvedGuid.ToString();
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogError(ex, "Failed to deserialize GetInstanceOutput for key {Key}", triggerKey);
+            throw new InvalidOperationException($"Failed to parse instance response for key '{triggerKey}'", ex);
+        }
+        catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException ex)
+        {
+            _logger.LogError(ex, "Failed to access response data property for key {Key}", triggerKey);
+            throw new InvalidOperationException($"Invalid response structure when querying instance by key '{triggerKey}'", ex);
+        }
     }
 }
 

--- a/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/TriggerTransitionHttpTaskFactory.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransition/TriggerTransitionHttpTaskFactory.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using BBT.Workflow.Definitions;
+using BBT.Workflow.Domain;
 using BBT.Workflow.Execution.TriggerTransition;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Scripting;
@@ -35,77 +36,81 @@ public sealed class TriggerTransitionHttpTaskFactory : ITriggerTransitionHttpTas
     }
 
     /// <inheritdoc />
-    public HttpTask CreateHttpTask(
+    public Result<HttpTask> CreateHttpTask(
         TriggerTransitionTask triggerTask,
         ScriptContext context,
         string path,
         string method)
     {
-        // Build full URL using configuration
-        var baseUrl = _configuration["vNextApi:BaseUrl"]?.TrimEnd('/') ?? string.Empty;
-        var apiVersion = _configuration["vNextApi:ApiVersion"] ?? "1";
-        var fullUrl = $"{baseUrl}/api/v{apiVersion}{path}";
-
-        _logger.LogDebug("Creating HttpTask with URL: {Url}", fullUrl);
-
-        // Prepare body from triggerTask.Body or context.Body
-        JsonElement? body = triggerTask.Body;
-        if (!body.HasValue && context.Body != null)
+        return ResultExtensions.Try(() =>
         {
-            body = JsonSerializer.SerializeToElement(context.Body);
-        }
+            // Build full URL using configuration
+            var baseUrl = _configuration["vNextApi:BaseUrl"]?.TrimEnd('/') ?? string.Empty;
+            var apiVersion = _configuration["vNextApi:ApiVersion"] ?? "1";
+            var fullUrl = $"{baseUrl}/api/v{apiVersion}{path}";
 
-        // Prepare headers from context.Headers
-        var headersDict = new Dictionary<string, string>();
-        if (context.Headers != null)
-        {
-            foreach (var header in context.Headers)
+            _logger.LogDebug("Creating HttpTask with URL: {Url}", fullUrl);
+
+            // Prepare body from triggerTask.Body or context.Body
+            JsonElement? body = triggerTask.Body;
+            if (!body.HasValue && context.Body != null)
             {
-                var key = header.Key?.ToString() ?? string.Empty;
-                var value = header.Value?.ToString() ?? string.Empty;
-                if (!string.IsNullOrWhiteSpace(key))
+                body = JsonSerializer.SerializeToElement(context.Body);
+            }
+
+            // Prepare headers from context.Headers
+            var headersDict = new Dictionary<string, string>();
+            if (context.Headers != null)
+            {
+                foreach (var header in context.Headers)
                 {
-                    headersDict[key] = value;
+                    var key = header.Key?.ToString() ?? string.Empty;
+                    var value = header.Value?.ToString() ?? string.Empty;
+                    if (!string.IsNullOrWhiteSpace(key))
+                    {
+                        headersDict[key] = value;
+                    }
                 }
             }
-        }
 
-        // Get timeout from configuration
-        var timeoutSeconds = _configuration.GetValue<int>("vNextApi:TimeoutSeconds", 30);
+            // Get timeout from configuration
+            var timeoutSeconds = _configuration.GetValue<int>("vNextApi:TimeoutSeconds", 30);
 
-        // Create task config JSON
-        var configBuilder = new Dictionary<string, object>
-        {
-            ["key"] = triggerTask.Key,
-            ["url"] = fullUrl,
-            ["method"] = method,
-            ["timeoutSeconds"] = timeoutSeconds,
-            ["validateSSL"] = true
-        };
+            // Create task config JSON
+            var configBuilder = new Dictionary<string, object>
+            {
+                ["key"] = triggerTask.Key,
+                ["url"] = fullUrl,
+                ["method"] = method,
+                ["timeoutSeconds"] = timeoutSeconds,
+                ["validateSSL"] = true
+            };
 
-        if (headersDict.Count > 0)
-        {
-            configBuilder["headers"] = headersDict;
-        }
+            if (headersDict.Count > 0)
+            {
+                configBuilder["headers"] = headersDict;
+            }
 
-        if (body.HasValue)
-        {
-            configBuilder["body"] = body.Value;
-        }
+            if (body.HasValue)
+            {
+                configBuilder["body"] = body.Value;
+            }
 
-        var configJson = JsonSerializer.Serialize(configBuilder);
-        var configElement = JsonDocument.Parse(configJson).RootElement;
+            var configJson = JsonSerializer.Serialize(configBuilder);
+            var configElement = JsonDocument.Parse(configJson).RootElement;
 
-        var httpTask = HttpTask.Create(configElement);
+            var httpTask = HttpTask.Create(configElement);
 
-        // Copy base properties from triggerTask
-        triggerTask.CopyBaseToInternal(httpTask);
+            // Copy base properties from triggerTask
+            triggerTask.CopyBaseToInternal(httpTask);
 
-        return httpTask;
+            return httpTask;
+        },
+        ex => Error.Failure(WorkflowErrorCodes.TriggerCreateHttpTaskFailed, $"Failed to create HTTP task: {ex.Message}"));
     }
 
     /// <inheritdoc />
-    public async Task<string> ResolveInstanceIdAsync(
+    public async Task<Result<string>> ResolveInstanceIdAsync(
         TriggerTransitionTask task,
         ScriptContext context,
         CancellationToken cancellationToken)
@@ -114,7 +119,7 @@ public sealed class TriggerTransitionHttpTaskFactory : ITriggerTransitionHttpTas
         if (!string.IsNullOrWhiteSpace(task.TriggerInstanceId))
         {
             _logger.LogDebug("Using provided TriggerInstanceId: {InstanceId}", task.TriggerInstanceId);
-            return task.TriggerInstanceId;
+            return Result<string>.Ok(task.TriggerInstanceId);
         }
 
         // Priority 2: If TriggerKey is provided but TriggerInstanceId is not, query the instance
@@ -124,14 +129,14 @@ public sealed class TriggerTransitionHttpTaskFactory : ITriggerTransitionHttpTas
                 task.TriggerKey);
             if(task.TriggerType==TriggerTransitionType.GetInstanceData)
             {
-                return task.TriggerKey;
+                return Result<string>.Ok(task.TriggerKey);
             }
             return await ResolveInstanceIdByKeyAsync(task, context, cancellationToken);
         }
 
         // Priority 3: Default to current instance ID
         _logger.LogDebug("Using current instance ID: {InstanceId}", context.Instance.Id);
-        return context.Instance.Id.ToString();
+        return Result<string>.Ok(context.Instance.Id.ToString());
     }
 
     /// <summary>
@@ -140,56 +145,68 @@ public sealed class TriggerTransitionHttpTaskFactory : ITriggerTransitionHttpTas
     /// <param name="task">The trigger transition task.</param>
     /// <param name="context">The script context.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The resolved instance ID.</returns>
-    private async Task<string> ResolveInstanceIdByKeyAsync(
+    /// <returns>A Result containing the resolved instance ID or an error.</returns>
+    private async Task<Result<string>> ResolveInstanceIdByKeyAsync(
         TriggerTransitionTask task,
         ScriptContext context,
         CancellationToken cancellationToken)
     {
-        var path = string.Format(InstanceUrlTemplates.Instance,
-            task.TriggerDomain,
-            task.TriggerFlow,
-            task.TriggerKey);
-
-        var httpTask = CreateHttpTask(task, context, path, "GET");
-
-        var httpExecutor = _taskExecutorFactory.GetExecutor(TaskType.Http) as HttpTaskExecutor;
-        if (httpExecutor == null)
-            throw new InvalidOperationException("HttpTaskExecutor not found");
-
-        _logger.LogDebug("Calling HttpTaskExecutor.CallAsync to get instance by key {Key}", task.TriggerKey);
-
-        // Store original body to restore after the call
-        object? originalBody = context.Body;
-
-        await httpExecutor.CallAsync(httpTask, context, cancellationToken);
-
-        try
-        {
-            // Parse the response and extract the Id
-            // After CallAsync, context.Body contains StandardTaskResponse merged data
-            // The actual response data is in context.Body.data property (camelCase)
-            if (context.Body == null)
+        return await ResultExtensions.TryAsync(
+            async ct =>
             {
-                throw new InvalidOperationException($"No response received when querying instance by key '{task.TriggerKey}'");
-            }
+                var path = string.Format(InstanceUrlTemplates.Instance,
+                    task.TriggerDomain,
+                    task.TriggerFlow,
+                    task.TriggerKey);
 
-            string instanceId = ExtractInstanceIdFromResponse(context.Body, task.TriggerKey!);
+                var httpTaskResult = CreateHttpTask(task, context, path, "GET");
+                if (!httpTaskResult.IsSuccess)
+                {
+                    _logger.LogError("Failed to create HTTP task for key resolution: {Error}", httpTaskResult.Error.Code);
+                    throw new InvalidOperationException($"Failed to create HTTP task: {httpTaskResult.Error.Message}");
+                }
 
-            // Restore original body
-            context.SetBody(originalBody);
+                var httpTask = httpTaskResult.Value!;
 
-            string key = task.TriggerKey!;
-            _logger.LogInformation("Resolved instance ID from key {Key}: {InstanceId}",
-                key, instanceId);
+                var httpExecutor = _taskExecutorFactory.GetExecutor(TaskType.Http) as HttpTaskExecutor;
+                if (httpExecutor == null)
+                    throw new InvalidOperationException("HttpTaskExecutor not found");
 
-            return instanceId;
-        }
-        catch (Exception ex) when (ex is not InvalidOperationException)
-        {
-            _logger.LogError(ex, "Failed to resolve instance ID for key {Key}", task.TriggerKey);
-            throw new InvalidOperationException($"Failed to resolve instance ID for key '{task.TriggerKey}'", ex);
-        }
+                _logger.LogDebug("Calling HttpTaskExecutor.CallAsync to get instance by key {Key}", task.TriggerKey);
+
+                // Store original body to restore after the call
+                object? originalBody = context.Body;
+
+                await httpExecutor.CallAsync(httpTask, context, ct);
+
+                // Parse the response and extract the Id
+                // After CallAsync, context.Body contains StandardTaskResponse merged data
+                // The actual response data is in context.Body.data property (camelCase)
+                if (context.Body == null)
+                {
+                    throw new InvalidOperationException($"No response received when querying instance by key '{task.TriggerKey}'");
+                }
+
+                var instanceIdResult = ExtractInstanceIdFromResponse(context.Body, task.TriggerKey!);
+                if (!instanceIdResult.IsSuccess)
+                {
+                    throw new InvalidOperationException(instanceIdResult.Error.Message ?? "Failed to extract instance ID");
+                }
+
+                string instanceId = instanceIdResult.Value!;
+
+                // Restore original body
+                context.SetBody(originalBody);
+
+                string key = task.TriggerKey!;
+                _logger.LogInformation("Resolved instance ID from key {Key}: {InstanceId}",
+                    key, instanceId);
+
+                return instanceId;
+            },
+            cancellationToken,
+            ex => Error.Dependency(WorkflowErrorCodes.TriggerResolveInstanceFailed, 
+                $"Failed to resolve instance ID for key '{task.TriggerKey}': {ex.Message}"));
     }
 
     /// <summary>
@@ -197,10 +214,10 @@ public sealed class TriggerTransitionHttpTaskFactory : ITriggerTransitionHttpTas
     /// </summary>
     /// <param name="responseBody">The response body containing the instance data.</param>
     /// <param name="triggerKey">The trigger key used for error messages.</param>
-    /// <returns>The extracted instance ID.</returns>
-    private string ExtractInstanceIdFromResponse(object responseBody, string triggerKey)
+    /// <returns>A Result containing the extracted instance ID or an error.</returns>
+    private Result<string> ExtractInstanceIdFromResponse(object responseBody, string triggerKey)
     {
-        try
+        return ResultExtensions.Try(() =>
         {
             // Access the 'data' property from StandardTaskResponse
             dynamic bodyData = responseBody;
@@ -235,17 +252,16 @@ public sealed class TriggerTransitionHttpTaskFactory : ITriggerTransitionHttpTas
             }
 
             return resolvedGuid.ToString();
-        }
-        catch (JsonException ex)
+        },
+        ex => ex switch
         {
-            _logger.LogError(ex, "Failed to deserialize GetInstanceOutput for key {Key}", triggerKey);
-            throw new InvalidOperationException($"Failed to parse instance response for key '{triggerKey}'", ex);
-        }
-        catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException ex)
-        {
-            _logger.LogError(ex, "Failed to access response data property for key {Key}", triggerKey);
-            throw new InvalidOperationException($"Invalid response structure when querying instance by key '{triggerKey}'", ex);
-        }
+            JsonException jsonEx => Error.Validation(WorkflowErrorCodes.TriggerInvalidResponseFormat, 
+                $"Failed to parse instance response for key '{triggerKey}': {jsonEx.Message}"),
+            Microsoft.CSharp.RuntimeBinder.RuntimeBinderException binderEx => Error.Validation(WorkflowErrorCodes.TriggerInvalidResponseStructure,
+                $"Invalid response structure when querying instance by key '{triggerKey}': {binderEx.Message}"),
+            _ => Error.Failure(WorkflowErrorCodes.TriggerExtractInstanceIdFailed, 
+                $"Failed to extract instance ID for key '{triggerKey}': {ex.Message}")
+        });
     }
 }
 

--- a/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransitionTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/TriggerTransitionTaskExecutor.cs
@@ -1,4 +1,5 @@
 using BBT.Workflow.Definitions;
+using BBT.Workflow.Domain;
 using BBT.Workflow.Execution.TriggerTransition;
 using BBT.Workflow.Runtime;
 using BBT.Workflow.Scripting;
@@ -54,7 +55,15 @@ public sealed class TriggerTransitionTaskExecutor(
 
             // Get appropriate strategy and execute
             var strategy = strategyFactory.Get(triggerTask.TriggerType);
-            await strategy.ExecuteAsync(triggerTask, context, cancellationToken);
+            var executionResult = await strategy.ExecuteAsync(triggerTask, context, cancellationToken);
+            
+            // If strategy execution failed, throw exception to maintain existing error handling behavior
+            if (!executionResult.IsSuccess)
+            {
+                Logger.LogError("Strategy execution failed for task {TaskKey}: {ErrorCode} - {ErrorMessage}",
+                    triggerTask.Key, executionResult.Error.Code, executionResult.Error.Message);
+                throw new InvalidOperationException($"Strategy execution failed: {executionResult.Error.Message}");
+            }
 
             Logger.LogDebug("Processing output for trigger transition task {TaskKey}", triggerTask.Key);
             var outputResponse = await ProcessOutputAsync(scriptCode, context, cancellationToken);

--- a/src/BBT.Workflow.Domain/Execution/TriggerTransition/Factory/ITriggerTransitionHttpTaskFactory.cs
+++ b/src/BBT.Workflow.Domain/Execution/TriggerTransition/Factory/ITriggerTransitionHttpTaskFactory.cs
@@ -1,4 +1,5 @@
 using BBT.Workflow.Definitions;
+using BBT.Workflow.Domain;
 using BBT.Workflow.Scripting;
 
 namespace BBT.Workflow.Execution.TriggerTransition;
@@ -16,8 +17,8 @@ public interface ITriggerTransitionHttpTaskFactory
     /// <param name="context">The script context containing headers and body data.</param>
     /// <param name="path">The API endpoint path to call (without base URL and version).</param>
     /// <param name="method">The HTTP method (POST, PATCH, etc.).</param>
-    /// <returns>A configured HttpTask ready to execute.</returns>
-    HttpTask CreateHttpTask(
+    /// <returns>A Result containing a configured HttpTask or an error.</returns>
+    Result<HttpTask> CreateHttpTask(
         TriggerTransitionTask triggerTask,
         ScriptContext context,
         string path,
@@ -29,14 +30,14 @@ public interface ITriggerTransitionHttpTaskFactory
     /// <param name="task">The trigger transition task.</param>
     /// <param name="context">The script context.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The resolved instance ID as a string.</returns>
+    /// <returns>A Result containing the resolved instance ID as a string or an error.</returns>
     /// <remarks>
     /// Resolution priority:
     /// 1. If TriggerInstanceId is provided, uses it directly
     /// 2. If TriggerKey is provided, queries the instance by key to get the ID
     /// 3. Otherwise, uses the current instance ID from context
     /// </remarks>
-    Task<string> ResolveInstanceIdAsync(
+    Task<Result<string>> ResolveInstanceIdAsync(
         TriggerTransitionTask task,
         ScriptContext context,
         CancellationToken cancellationToken);

--- a/src/BBT.Workflow.Domain/Execution/TriggerTransition/Factory/ITriggerTransitionHttpTaskFactory.cs
+++ b/src/BBT.Workflow.Domain/Execution/TriggerTransition/Factory/ITriggerTransitionHttpTaskFactory.cs
@@ -5,6 +5,7 @@ namespace BBT.Workflow.Execution.TriggerTransition;
 
 /// <summary>
 /// Factory for creating HTTP tasks used in trigger transition strategies.
+/// Also provides utilities for resolving instance IDs.
 /// </summary>
 public interface ITriggerTransitionHttpTaskFactory
 {
@@ -21,5 +22,23 @@ public interface ITriggerTransitionHttpTaskFactory
         ScriptContext context,
         string path,
         string method);
+
+    /// <summary>
+    /// Resolves the instance ID for a trigger task based on its configuration.
+    /// </summary>
+    /// <param name="task">The trigger transition task.</param>
+    /// <param name="context">The script context.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The resolved instance ID as a string.</returns>
+    /// <remarks>
+    /// Resolution priority:
+    /// 1. If TriggerInstanceId is provided, uses it directly
+    /// 2. If TriggerKey is provided, queries the instance by key to get the ID
+    /// 3. Otherwise, uses the current instance ID from context
+    /// </remarks>
+    Task<string> ResolveInstanceIdAsync(
+        TriggerTransitionTask task,
+        ScriptContext context,
+        CancellationToken cancellationToken);
 }
 

--- a/src/BBT.Workflow.Domain/Execution/TriggerTransition/ITriggerTransitionStrategy.cs
+++ b/src/BBT.Workflow.Domain/Execution/TriggerTransition/ITriggerTransitionStrategy.cs
@@ -1,4 +1,5 @@
 using BBT.Workflow.Definitions;
+using BBT.Workflow.Domain;
 using BBT.Workflow.Scripting;
 
 namespace BBT.Workflow.Execution.TriggerTransition;
@@ -15,8 +16,8 @@ public interface ITriggerTransitionStrategy
     /// <param name="task">The trigger transition task containing configuration.</param>
     /// <param name="context">The script context containing instance data and headers.</param>
     /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
-    /// <returns>A task representing the asynchronous operation.</returns>
-    Task ExecuteAsync(
+    /// <returns>A Result representing success or failure of the operation.</returns>
+    Task<Result> ExecuteAsync(
         TriggerTransitionTask task,
         ScriptContext context,
         CancellationToken cancellationToken);

--- a/src/BBT.Workflow.Domain/WorkflowErrorCodes.cs
+++ b/src/BBT.Workflow.Domain/WorkflowErrorCodes.cs
@@ -52,4 +52,18 @@ public static class WorkflowErrorCodes
     public const string TaskExecution = "Task:400002";
     
     #endregion
+    
+    #region Trigger Errors (500xxx)
+    
+    public const string TriggerCreateHttpTaskFailed = "Trigger:500001";
+    public const string TriggerResolveInstanceFailed = "Trigger:500002";
+    public const string TriggerExtractInstanceIdFailed = "Trigger:500003";
+    public const string TriggerDirectExecutionFailed = "Trigger:500004";
+    public const string TriggerGetInstanceDataFailed = "Trigger:500005";
+    public const string TriggerStartExecutionFailed = "Trigger:500006";
+    public const string TriggerSubProcessExecutionFailed = "Trigger:500007";
+    public const string TriggerInvalidResponseFormat = "Trigger:500008";
+    public const string TriggerInvalidResponseStructure = "Trigger:500009";
+    
+    #endregion
 }


### PR DESCRIPTION
refactor(trigger-transition): consolidate instance ID resolution into factory and Enabling the getInstanceData task to run for other flows
Consolidated instance ID resolution logic into ITriggerTransitionHttpTaskFactory 
to simplify architecture and reduce dependencies. 

- Added ResolveInstanceIdAsync to ITriggerTransitionHttpTaskFactory
- Added special case for GetInstanceData to use TriggerKey directly
- Updated DirectTriggerStrategy and GetInstanceDataTriggerStrategy

## Summary by Sourcery

Consolidate instance ID resolution into the HTTP task factory and update trigger strategies to leverage it, enabling consistent instance targeting across flows and supporting getInstanceData with keys.

Enhancements:
- Centralize instance ID resolution into ITriggerTransitionHttpTaskFactory via ResolveInstanceIdAsync.
- Update DirectTriggerStrategy and GetInstanceDataTriggerStrategy to use the unified instance resolution for consistent targeting.
- Introduce special handling so GetInstanceData uses TriggerKey directly without lookup.
- Implement a three-tier priority system for instance targeting: explicit ID, key lookup, or default to current instance ID.

Documentation:
- Extend documentation with instance resolution details, usage examples, and script mapping for trigger transition strategies.