### PR TITLE
Support instance id and key for endpoints

### DIFF
--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
@@ -101,7 +101,7 @@ public sealed class InstanceController(
     /// <response code="404">Instance, workflow, or transition not found</response>
     /// <response code="409">Transition already in progress (locked) or SubFlow blocking</response>
     /// <response code="503">Service temporarily unavailable</response>
-    [HttpPatch("{domain}/workflows/{workflow}/instances/{instanceId}/transitions/{transitionKey}")]
+    [HttpPatch("{domain}/workflows/{workflow}/instances/{instance}/transitions/{transitionKey}")]
     [ProducesResponseType(typeof(TransitionOutput), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
@@ -111,7 +111,7 @@ public sealed class InstanceController(
     public async Task<IActionResult> TransitionAsync(
         [FromRoute] string domain,
         [FromRoute] string workflow,
-        [FromRoute] Guid instanceId,
+        [FromRoute] string instance,
         [FromRoute] string transitionKey,
         [FromBody] JsonElement? attributes,
         [FromQuery] string? version = null,
@@ -134,7 +134,7 @@ public sealed class InstanceController(
         }
 
         var result = await commandAppService.TransitionAsync(
-            instanceId,
+            instance,
             transitionKey,
             input,
             cancellationToken);

--- a/src/BBT.Workflow.Application/Instances/IInstanceCommandAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/IInstanceCommandAppService.cs
@@ -10,7 +10,7 @@ public interface IInstanceCommandAppService : IApplicationService
         CancellationToken cancellationToken = default);
 
     Task<Result<TransitionOutput>> TransitionAsync(
-        Guid instanceId,
+        string instance,
         string transitionKey,
         TransitionInput input,
         CancellationToken cancellationToken = default);

--- a/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
@@ -1,4 +1,5 @@
 using BBT.Aether.Application.Services;
+using BBT.Aether.Domain.Entities;
 using BBT.Aether.Guids;
 using BBT.Workflow.Caching;
 using BBT.Workflow.Domain;
@@ -188,15 +189,33 @@ public sealed class InstanceCommandAppService(
 
     /// <inheritdoc />
     public async Task<Result<TransitionOutput>> TransitionAsync(
-        Guid instanceId,
+        string instance,
         string transitionKey,
         TransitionInput input,
         CancellationToken cancellationToken = default)
     {
         // Validate domain first
         runtimeInfoProvider.Check(input.Domain);
-        return await ExecuteTransitionAsync(instanceId, transitionKey, input, cancellationToken)
-            .OnSuccess(output => AddTransitionHeader(output, input));
+        
+        // If already a Guid, use it directly without repository lookup
+        if (Guid.TryParse(instance, out var instanceId))
+        {
+            return await ExecuteTransitionAsync(instanceId, transitionKey, input, cancellationToken)
+                .OnSuccess(output => AddTransitionHeader(output, input));
+        }
+        
+        // If it's a Key, we need to lookup the instance ID
+        using (currentSchema.Change(input.Workflow))
+        {
+            var instanceResult = await GetInstanceIdByKeyAsync(instance, cancellationToken);
+            if (!instanceResult.IsSuccess)
+            {
+                return Result<TransitionOutput>.Fail(instanceResult.Error);
+            }
+
+            return await ExecuteTransitionAsync(instanceResult.Value, transitionKey, input, cancellationToken)
+                .OnSuccess(output => AddTransitionHeader(output, input));
+        }
     }
 
     /// <summary>
@@ -223,6 +242,32 @@ public sealed class InstanceCommandAppService(
         );
     }
 
+
+    /// <summary>
+    /// Gets instance ID by Key.
+    /// </summary>
+    /// <param name="instanceKey">Instance Key</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Instance ID if found, or error result</returns>
+    private async Task<Result<Guid>> GetInstanceIdByKeyAsync(
+        string instanceKey,
+        CancellationToken cancellationToken)
+    {
+        return await ResultExtensions.TryAsync(
+            async ct =>
+            {
+                var instance = await instanceRepository.FindByKeyAsReadOnlyAsync(instanceKey, ct);
+
+                if (instance == null)
+                {
+                    throw new EntityNotFoundException(typeof(Instance), instanceKey);
+                }
+
+                return instance.Id;
+            },
+            cancellationToken,
+            _ => WorkflowErrors.InstanceNotFound(instanceKey));
+    }
 
     /// <summary>
     /// Creates and prepares a new instance with the provided parameters.


### PR DESCRIPTION
## Summary by Sourcery

Allow workflow transitions to target instances by either GUID or business key instead of only GUID.

New Features:
- Support executing transitions using an instance key that is resolved to an instance ID at runtime.

Enhancements:
- Expose the instance identifier in the transition API route as a generic string to accept both GUIDs and keys.
- Add lookup logic to resolve instance keys to IDs with proper not-found handling when performing transitions.