### PR TITLE
Function Allow Header And Paremeter

### DIFF
--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs
@@ -38,8 +38,16 @@ public sealed class FunctionController(IFunctionAppService functionAppService,
         [FromQuery] bool? async = false,
         CancellationToken cancellationToken = default)
     {
-            var response = await functionAppService.GetFunctionByFunctionKey(function, RuntimeSysSchemaInfo.Functions,
-            domain, cancellationToken);
+            var headers = HttpContext.Request.Headers.ToDictionary(h => h.Key, h => (string?)h.Value.ToString());
+            var queryParams = HttpContext.Request.Query.ToDictionary(q => q.Key, q => (string?)q.Value.ToString());
+            
+            var response = await functionAppService.GetFunctionByFunctionKey(
+                function, 
+                RuntimeSysSchemaInfo.Functions,
+                domain, 
+                headers, 
+                queryParams, 
+                cancellationToken);
         return Ok(response);
     }
 
@@ -94,6 +102,9 @@ public sealed class FunctionController(IFunctionAppService functionAppService,
         [FromHeader(Name = "If-None-Match")] string? ifNoneMatch,
         CancellationToken cancellationToken = default)
     {
+        var headers = HttpContext.Request.Headers.ToDictionary(h => h.Key, h => (string?)h.Value.ToString());
+        var queryParams = HttpContext.Request.Query.ToDictionary(q => q.Key, q => (string?)q.Value.ToString());
+        
         return function.ToLowerInvariant() switch
         {
             Definitions.Functions.FunctionTypeConst.Longpooling =>
@@ -103,7 +114,7 @@ public sealed class FunctionController(IFunctionAppService functionAppService,
             Definitions.Functions.FunctionTypeConst.Data =>
                 await ProcessDataFunction(domain, workflow, instance, ifNoneMatch, parameters.Extensions, cancellationToken),
             _ =>
-                Ok(await functionAppService.GetFunctionByInstance(function, workflow, domain, instance, cancellationToken))
+                Ok(await functionAppService.GetFunctionByInstance(function, workflow, domain, instance, headers, queryParams, cancellationToken))
         };
     }
 
@@ -289,6 +300,9 @@ public sealed class FunctionController(IFunctionAppService functionAppService,
         PaginationResult<GetInstanceOutput> instanceListResult,
         CancellationToken cancellationToken)
     {
+        var headers = HttpContext.Request.Headers.ToDictionary(h => h.Key, h => (string?)h.Value.ToString());
+        var queryParams = HttpContext.Request.Query.ToDictionary(q => q.Key, q => (string?)q.Value.ToString());
+        
         var outputs = new PaginationResult<Dictionary<string, dynamic?>>
         {
             Pagination = instanceListResult.Pagination,
@@ -298,7 +312,7 @@ public sealed class FunctionController(IFunctionAppService functionAppService,
         foreach (var instance in instanceListResult.Data)
         {
             outputs.Data.Add(
-                await functionAppService.GetFunctionByInstance(function, workflow, domain, instance.Key!.ToString(), cancellationToken)
+                await functionAppService.GetFunctionByInstance(function, workflow, domain, instance.Key!.ToString(), headers, queryParams, cancellationToken)
             );
         }
 
@@ -307,3 +321,4 @@ public sealed class FunctionController(IFunctionAppService functionAppService,
 
     #endregion
 }
+

--- a/src/BBT.Workflow.Application/Functions/FunctionAppService.cs
+++ b/src/BBT.Workflow.Application/Functions/FunctionAppService.cs
@@ -24,13 +24,15 @@ public sealed class FunctionAppService(IServiceProvider serviceProvider,
      string key,
      string flow,
      string domain,
+     Dictionary<string, string?>? headers = null,
+     Dictionary<string, string?>? queryParameters = null,
      CancellationToken cancellationToken = default)
     {
         runtimeInfoProvider.Check(domain);
         using (currentSchema.Change(flow))
         {
             Instance? instance = await instanceRepository.FindByKeyAsync(key, cancellationToken);
-            return await BuildFunctionResponse(instance, key, flow, domain, cancellationToken);
+            return await BuildFunctionResponse(instance, key, flow, domain, headers, queryParameters, cancellationToken);
         }
 
     }
@@ -39,6 +41,8 @@ public sealed class FunctionAppService(IServiceProvider serviceProvider,
        string flow,
        string domain,
        string instanceKey,
+       Dictionary<string, string?>? headers = null,
+       Dictionary<string, string?>? queryParameters = null,
        CancellationToken cancellationToken = default)
     {
         runtimeInfoProvider.Check(domain);
@@ -48,7 +52,7 @@ public sealed class FunctionAppService(IServiceProvider serviceProvider,
             Instance? instance = Guid.TryParse(instanceKey, out var instanceId)
             ? await instanceRepository.FindAsync(instanceId, true, cancellationToken)
             : await instanceRepository.FindByKeyAsync(instanceKey, cancellationToken);
-            return await BuildFunctionResponse(instance, key, flow, domain, cancellationToken);
+            return await BuildFunctionResponse(instance, key, flow, domain, headers, queryParameters, cancellationToken);
         }
     }
     public async Task<List<InstanceAndDataModel>> GetDomainFunctions(
@@ -64,7 +68,10 @@ public sealed class FunctionAppService(IServiceProvider serviceProvider,
     }
     private async Task<dynamic> BuildFunctionResponse(Instance? instance, string key,
        string flow,
-       string domain, CancellationToken cancellationToken = default)
+       string domain,
+       Dictionary<string, string?>? headers = null,
+       Dictionary<string, string?>? queryParameters = null,
+       CancellationToken cancellationToken = default)
     {
         Dictionary<string, object> response = new Dictionary<string, object>();
         using (currentSchema.Change(flow))
@@ -85,6 +92,8 @@ public sealed class FunctionAppService(IServiceProvider serviceProvider,
 .WithInstance(instance)
 .WithRuntime(runtimeInfoProvider)
 .WithBody(instance?.LatestData?.Data ?? new JsonData("{}"))
+.WithHeaders(headers)
+.WithQueryParameters(queryParameters)
 .BuildAsync(cancellationToken);
             await taskExecutionService.ExecuteAsync(
                     function.GetExecuteTasks(),

--- a/src/BBT.Workflow.Application/Functions/IFunctionAppService.cs
+++ b/src/BBT.Workflow.Application/Functions/IFunctionAppService.cs
@@ -8,6 +8,8 @@ public interface IFunctionAppService : IApplicationService
         string key,
         string flow,
         string domain,
+        Dictionary<string, string?>? headers = null,
+        Dictionary<string, string?>? queryParameters = null,
         CancellationToken cancellationToken = default);
         Task<List<Instances.InstanceAndDataModel>> GetDomainFunctions(
         string domain,
@@ -17,5 +19,7 @@ public interface IFunctionAppService : IApplicationService
         string flow,
         string domain,
         string instance,
+        Dictionary<string, string?>? headers = null,
+        Dictionary<string, string?>? queryParameters = null,
         CancellationToken cancellationToken = default);
 }

--- a/src/BBT.Workflow.Domain/Scripting/Factory/Contracts/IScriptContextBuilder.cs
+++ b/src/BBT.Workflow.Domain/Scripting/Factory/Contracts/IScriptContextBuilder.cs
@@ -76,6 +76,16 @@ public interface IScriptContextBuilder
     IScriptContextBuilder WithRouteValues(Dictionary<string, string?>? routeValues);
     
     /// <summary>
+    /// Sets the query parameters for the ScriptContext.
+    /// </summary>
+    IScriptContextBuilder WithQueryParameters(Dictionary<string, object?>? queryParameters);
+    
+    /// <summary>
+    /// Sets the query parameters for the ScriptContext.
+    /// </summary>
+    IScriptContextBuilder WithQueryParameters(Dictionary<string, string?>? queryParameters);
+    
+    /// <summary>
     /// Sets the task response data for the ScriptContext.
     /// </summary>
     IScriptContextBuilder WithTaskResponse(Dictionary<string, object?> taskResponse);

--- a/src/BBT.Workflow.Domain/Scripting/Factory/Services/ScriptContextBuilder.cs
+++ b/src/BBT.Workflow.Domain/Scripting/Factory/Services/ScriptContextBuilder.cs
@@ -23,6 +23,7 @@ internal sealed class ScriptContextBuilder(
     private object? _body;
     private Dictionary<string, string?>? _headers;
     private Dictionary<string, object?>? _routeValues;
+    private Dictionary<string, object?>? _queryParameters;
     private Dictionary<string, object?> _taskResponse = new();
     private Dictionary<string, object> _metadata = new();
     private Dictionary<string, object> _definitions = new();
@@ -139,6 +140,18 @@ internal sealed class ScriptContextBuilder(
         return this;
     }
 
+    public IScriptContextBuilder WithQueryParameters(Dictionary<string, object?>? queryParameters)
+    {
+        _queryParameters = queryParameters;
+        return this;
+    }
+
+    public IScriptContextBuilder WithQueryParameters(Dictionary<string, string?>? queryParameters)
+    {
+        _queryParameters = queryParameters?.ToDictionary(kvp => kvp.Key, kvp => (object?)kvp.Value);
+        return this;
+    }
+
     public IScriptContextBuilder WithTaskResponse(Dictionary<string, object?> taskResponse)
     {
         _taskResponse = taskResponse;
@@ -177,6 +190,7 @@ internal sealed class ScriptContextBuilder(
             .SetBody(_body)
             .SetHeaders(_headers)
             .SetRouteValues(_routeValues)
+            .SetQueryParameters(_queryParameters)
             .SetTaskResponse(_taskResponse)
             .SetMetadata(_metadata)
             .SetDefinitions(_definitions)

--- a/src/BBT.Workflow.Domain/Scripting/Models.cs
+++ b/src/BBT.Workflow.Domain/Scripting/Models.cs
@@ -229,6 +229,21 @@ public class ScriptContext(ILogger<ScriptContext> logger) : IDisposable
     public dynamic? RouteValues { get; private set; }
     
     /// <summary>
+    /// Contains query string parameters extracted from the HTTP request.
+    /// These values are derived from URL query string parameters.
+    /// </summary>
+    /// <value>
+    /// A dynamic object containing query parameter key-value pairs:
+    /// - Query string parameters (e.g., ?filter=value&sort=asc)
+    /// - Can be null if no query parameters are available
+    /// </value>
+    /// <remarks>
+    /// Query parameters provide a way to pass filtering, sorting, pagination,
+    /// and other request-specific data through the URL query string.
+    /// </remarks>
+    public dynamic? QueryParameters { get; private set; }
+    
+    /// <summary>
     /// The active workflow instance that is currently being processed or executed.
     /// This represents the live instance with its current state, data, and execution history.
     /// </summary>
@@ -449,6 +464,12 @@ public class ScriptContext(ILogger<ScriptContext> logger) : IDisposable
         public Builder SetRouteValues(object? routeValues)
         {
             _context.RouteValues = routeValues;
+            return this;
+        }
+
+        public Builder SetQueryParameters(object? queryParameters)
+        {
+            _context.QueryParameters = queryParameters;
             return this;
         }
 


### PR DESCRIPTION
Header and query parameter values ​​could not be used in function operations. They can now be used.