### PR TITLE
Data Overwritten After Manual Transition - Duplicate Version Records

### DIFF
--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/CreateTransitionRecordStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/CreateTransitionRecordStep.cs
@@ -79,6 +79,12 @@ public sealed class CreateTransitionRecordStep(
             new JsonData(JsonSerializer.Serialize(context.Headers)));
 
         var transition = context.Workflow.FindTransition(transitionKey);
+        if(transition==null)
+        {
+            var state =context.Workflow.GetState(context.Instance.GetCurrentState).Value!;
+            transition = context.Workflow.ResolveTransition(transitionKey,  state);
+        }
+        
 
         return (instanceTransition, transition);
     }


### PR DESCRIPTION
Data is being overwritten after a manual transition operation, resulting in duplicate records being created with the same version number.

## Summary by Sourcery

Bug Fixes:
- Fallback to resolving the workflow transition from the instance's current state when the direct transition lookup returns null, avoiding incorrect or duplicate transition records.