### PR TITLE
Add schema function support to instance queries

### DIFF
--- a/docs/auto-transition-evaluation.md
+++ b/docs/auto-transition-evaluation.md
@@ -76,19 +76,98 @@ Concrete implementation that:
 - Uses `IScriptContextFactory` to build script contexts
 - Returns structured evaluation results using the Result pattern
 - Logs evaluation outcomes and errors
-- Caches ScriptContext in the TransitionExecutionContext
+- Caches ScriptContext in the TransitionExecutionContext using `GetOrBuildScriptContextAsync`
 
 **Location**: `src/BBT.Workflow.Application/Execution/Transitions/Evaluation/`
+
+```csharp
+public sealed class AutoConditionEvaluator(
+    ITaskConditionService taskConditionService,
+    IScriptContextFactory scriptContextFactory,
+    IInstanceRepository instanceRepository,
+    ILogger<AutoConditionEvaluator> logger,
+    IRuntimeInfoProvider runtimeInfoProvider) : IAutoConditionEvaluator
+{
+    /// <summary>
+    /// Evaluates the automatic transition condition.
+    /// Railway chain: Validate Rule → Execute Script → Map to Evaluation
+    /// </summary>
+    public Task<Result<AutoConditionEvaluation>> EvaluateAsync(
+        Transition transition,
+        TransitionExecutionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        return ValidateTransitionRule(transition)
+            .BindAsync(_ => ExecuteConditionSafelyAsync(transition, context, cancellationToken));
+    }
+}
+```
+
+**Key Features**:
+- **Railway Pattern**: Uses `BindAsync` for clean error chaining
+- **TryAsync**: Wraps script execution safely with `ResultExtensions.TryAsync`
+- **ScriptContext Caching**: Uses `context.GetOrBuildScriptContextAsync` to avoid rebuilding
+- **Structured Error Handling**: Creates detailed errors with `ExecutionErrors.TransitionRuleEvaluationFailed`
 
 #### RunAutomaticTransitionsStep
 
 Updated pipeline step that:
 1. Evaluates all automatic transitions for the target state
 2. Finds the first satisfied transition
-3. Validates that at least one transition is satisfied
-4. Enqueues the winning transition for inline execution
+3. Enqueues the winning transition for inline execution via `PipelineDirectives.EnqueueInlineAuto`
 
 **Location**: `src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/`
+
+```csharp
+public sealed class RunAutomaticTransitionsStep(
+    IAutoConditionEvaluator autoConditionEvaluator,
+    ILogger<RunAutomaticTransitionsStep> logger) : ITransitionStep
+{
+    public int Order => LifecycleOrder.Auto; // 90
+
+    [Trace]
+    public async Task<Result<StepOutcome>> ExecuteAsync(
+        TransitionExecutionContext context, 
+        CancellationToken cancellationToken)
+    {
+        Activity.Current?.SetDisplayName($"[{Order}] {nameof(RunAutomaticTransitionsStep)}");
+
+        // Check if target state has any automatic transitions
+        if (context.Target?.AutoTransitions == null || !context.Target.AutoTransitions.Any())
+        {
+            return Result<StepOutcome>.Ok(StepOutcome.Continue());
+        }
+
+        // Railway chain: Evaluate all transitions -> Process winner (if exists)
+        return await EvaluateAllTransitionsAsync(context, cancellationToken)
+            .Map(evaluations => ProcessEvaluationResults(context, evaluations));
+    }
+}
+```
+
+## Inline Auto Chain Execution
+
+When an automatic transition is satisfied, it is **not** executed immediately. Instead:
+
+1. **Enqueue**: The winning transition is enqueued to `PipelineDirectives.InlineAutoQueue`
+2. **Snapshot**: After pipeline completion, `DirectivesSnapshot` captures the queue
+3. **Post-Commit**: `TransitionRunner` processes the queue after UoW commit
+
+```csharp
+private static void EnqueueWinningTransition(TransitionExecutionContext context, AutoConditionEvaluation winner)
+{
+    var command = ReentryCommand.ForAutomatic(
+        context.InstanceId,
+        context.Domain,
+        context.WorkflowKey,
+        winner.TransitionKey,
+        context.ExecutionChainId,
+        context.ChainDepth,
+        context.Headers);
+
+    context.Directives.EnqueueInlineAuto(command);
+}
+```
 
 ## Behavior
 
@@ -110,11 +189,85 @@ The system distinguishes three scenarios:
 
 | Scenario | Status | Result | Behavior |
 |----------|--------|--------|----------|
-| Condition is true | Satisfied | First winner enqueued | Transition executes inline |
+| Condition is true | Satisfied | First winner enqueued | Transition executes via TransitionRunner inline chain |
 | All conditions false | NotSatisfied | Pipeline continues | Instance stays in current state |
 | Script error, missing rule | Failed | Pipeline fails | Error propagated to caller |
 
 **Key Point**: When no automatic transition is satisfied, this is **not an error**. The instance remains in its current state, and the workflow can continue via other triggers (manual, timer, event).
+
+## TransitionRunner Integration
+
+The `TransitionRunner` orchestrates the entire transition chain with isolated DI scope and UoW per hop:
+
+```csharp
+public sealed class TransitionRunner(
+    IServiceScopeFactory scopeFactory,
+    IOptions<ReentryOptions> options,
+    ILogger<TransitionRunner> logger) : ITransitionRunner
+{
+    /// <summary>
+    /// Runs transitions in a loop, each in its own DI scope + RequiresNew UoW.
+    /// Post-commit: enqueues inline auto chain transitions from DirectivesSnapshot.
+    /// </summary>
+    [Trace]
+    public async Task<Result<TransitionOutput>> RunAsync(
+        WorkflowExecutionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var queue = new Queue<WorkflowExecutionContext>();
+        queue.Enqueue(context);
+
+        var hop = 0;
+        TransitionOutput? lastOutput = null;
+
+        while (queue.TryDequeue(out var current))
+        {
+            hop++;
+
+            // Guard: prevent infinite loops
+            if (hop > _options.MaxAutoHops)
+            {
+                logger.MaxAutoHopsExceeded(_options.MaxAutoHops, instanceGuid, current.Execution?.ExecutionChainId);
+                return Result<TransitionOutput>.Fail(
+                    Error.Validation("auto.chain.maxhops", $"Auto chain exceeded max hops: {_options.MaxAutoHops}"));
+            }
+
+            // Execute in isolated scope + UoW
+            var hopResult = await ExecuteHopAsync(current, cancellationToken);
+            if (!hopResult.IsSuccess)
+                return Result<TransitionOutput>.Fail(hopResult.Error);
+
+            var coreOutput = hopResult.Value!;
+            lastOutput = coreOutput.Output;
+
+            // POST-COMMIT: enqueue inline auto chain transitions
+            if (coreOutput.DirectivesSnapshot.HasQueuedTransitions)
+            {
+                foreach (var cmd in coreOutput.DirectivesSnapshot.InlineAutoQueue)
+                {
+                    var nextCmd = cmd with { ChainDepth = cmd.ChainDepth + 1 };
+                    
+                    if (nextCmd.ChainDepth <= _options.MaxAutoHops)
+                    {
+                        queue.Enqueue(WorkflowExecutionContext.From(nextCmd));
+                    }
+                }
+            }
+        }
+
+        return lastOutput is null
+            ? Result<TransitionOutput>.Fail(Error.Failure("transition.output.missing", "Transition output missing"))
+            : Result<TransitionOutput>.Ok(lastOutput);
+    }
+}
+```
+
+### Key Design Decisions
+
+1. **Isolated DI Scope per Hop**: Each transition runs in a new DI scope with `RequiresNew` UoW
+2. **Post-Commit Processing**: Inline auto chain is processed AFTER UoW commit
+3. **DirectivesSnapshot**: Captures queue state for cross-UoW boundary transfer
+4. **MaxAutoHops Guard**: Prevents infinite loops with configurable limit
 
 ## Key Benefits
 
@@ -126,59 +279,17 @@ The system distinguishes three scenarios:
 6. **Proper separation**: Business logic (which transition) vs technical concerns (how to evaluate)
 7. **Testability**: Easier to unit test without catching exceptions
 8. **Aether SDK integration**: Uses `[Trace]` aspect for automatic span creation
-
-## Usage Example
-
-```csharp
-// In RunAutomaticTransitionsStep
-[Trace]
-public async Task<Result<StepOutcome>> ExecuteAsync(
-    TransitionExecutionContext context, 
-    CancellationToken cancellationToken)
-{
-    // Check if target state has any automatic transitions
-    if (context.Target?.AutoTransitions == null || !context.Target.AutoTransitions.Any())
-    {
-        return Result<StepOutcome>.Ok(StepOutcome.Continue());
-    }
-
-    // Railway chain: Evaluate all transitions -> Process winner (if exists)
-    return await EvaluateAllTransitionsAsync(context, cancellationToken)
-        .Map(evaluations => ProcessEvaluationResults(context, evaluations));
-}
-
-private StepOutcome ProcessEvaluationResults(
-    TransitionExecutionContext context,
-    List<AutoConditionEvaluation> evaluations)
-{
-    var winner = evaluations.FirstOrDefault(e => e.Status == AutoConditionStatus.Satisfied);
-
-    if (winner.TransitionKey is null)
-    {
-        // No winner found - SOFT-FAIL: continue pipeline, stay in current state
-        logger.AutoTransitionConditionNotSatisfied(
-            context.Target!.Key,
-            context.InstanceId,
-            string.Join(", ", evaluations.Select(e => e.TransitionKey)));
-
-        return StepOutcome.Continue(); // NOT a failure
-    }
-
-    // Winner found - enqueue for inline execution
-    logger.AutoTransitionSelected(winner.TransitionKey, context.Target!.Key, context.InstanceId);
-    EnqueueWinningTransition(context, winner);
-
-    return StepOutcome.Continue();
-}
-```
+9. **Post-commit safety**: Auto chain runs after UoW commit for data consistency
 
 ## Dependency Injection
 
-The `IAutoConditionEvaluator` service is registered in the Application module:
+The services are registered in the Application module:
 
 ```csharp
 // In WorkflowApplicationModuleServiceCollectionExtensions.AddTransitionPipeline()
 services.AddScoped<IAutoConditionEvaluator, AutoConditionEvaluator>();
+services.AddScoped<ITransitionRunner, TransitionRunner>();
+services.AddScoped<IWorkflowExecutionCore, WorkflowExecutionService>();
 ```
 
 ## Testing Considerations
@@ -190,7 +301,8 @@ When testing automatic transitions:
 3. **Test all NotSatisfied**: Ensure pipeline continues (soft-fail) and instance stays in current state
 4. **Test technical errors**: Script compilation errors, missing rules should fail the pipeline
 5. **Verify logging**: Check that `WorkflowLogs.AutoTransitionConditionNotSatisfied` is called when no winner
-6. **Test inline execution chain**: Verify `ProcessInlineAutoChainStep` correctly processes enqueued transitions
+6. **Test inline execution chain**: Verify `TransitionRunner` correctly processes enqueued transitions
+7. **Test MaxAutoHops**: Verify chain depth limits are enforced
 
 ## Migration Notes
 
@@ -213,13 +325,13 @@ This is a **non-breaking change** for most workflows:
 
 Expected performance improvements:
 - **No exceptions**: Eliminates exception construction and stack unwinding for false conditions
-- **Cached ScriptContext**: ScriptContext is created once and reused
+- **Cached ScriptContext**: ScriptContext is created once and reused via `GetOrBuildScriptContextAsync`
 - **Structured logging**: Better performance than exception-based logging
+- **Inline execution**: No background job overhead for auto chains (post-commit inline processing)
 
 ## Related Documentation
 
 - [Transition Pipeline Architecture](transition-pipeline-architecture.md)
-- [Result Pattern](../aether/Results/result-pattern/README.md)
+- [Result Pattern](result-pattern-railway.md)
 - [Scripting Engine](scripting-engine.md)
 - [Task Executors](task-executors.md)
-

--- a/docs/transition-pipeline-architecture.md
+++ b/docs/transition-pipeline-architecture.md
@@ -1,10 +1,10 @@
 # Transition Pipeline Architecture
 
-This documentation describes the new **Transition Pipeline Architecture** refactoring implemented in the BBT.Workflow project.
+This documentation describes the **Transition Pipeline Architecture** implemented in the BBT.Workflow project.
 
 ## Overview
 
-The new architecture is designed to make transition execution **readable, testable, and extensible**. It reduces complexity on the `StateMachineExecutor` and defines Auto/Schedule **re-entry** scenarios as first-class citizens.
+The architecture is designed to make transition execution **readable, testable, and extensible**. It reduces complexity on the `StateMachineExecutor` and defines Auto/Schedule **re-entry** scenarios as first-class citizens.
 
 ## Core Principles
 
@@ -13,6 +13,7 @@ The new architecture is designed to make transition execution **readable, testab
 - **Context Rehydration:** Context is not carried over in Auto/Schedule re-entry; it is rebuilt in a new DI scope
 - **No Service Locator:** Services are not in Context but injected into steps/handlers via DI
 - **Idempotency & Lock:** Instance-based locking and idempotency is a core feature
+- **Post-Commit Processing:** Inline auto chain runs after UoW commit for data consistency
 
 ## Architecture Components
 
@@ -77,25 +78,191 @@ public interface ITransitionHandler
 }
 ```
 
-### 2. Pipeline Steps (Lifecycle Order)
+### 2. TransitionRunner (New)
+
+The `TransitionRunner` orchestrates transition chaining with isolated DI scope and UoW per hop. This is the entry point for transition execution.
+
+#### ITransitionRunner Interface
+```csharp
+public interface ITransitionRunner
+{
+    /// <summary>
+    /// Runs a transition and any subsequent inline auto chain transitions.
+    /// Each hop is executed in a new DI scope with RequiresNew UoW for complete isolation.
+    /// </summary>
+    Task<Result<TransitionOutput>> RunAsync(
+        WorkflowExecutionContext context,
+        CancellationToken cancellationToken = default);
+}
+```
+
+#### TransitionRunner Implementation
+```csharp
+public sealed class TransitionRunner(
+    IServiceScopeFactory scopeFactory,
+    IOptions<ReentryOptions> options,
+    ILogger<TransitionRunner> logger) : ITransitionRunner
+{
+    private readonly ReentryOptions _options = options.Value;
+
+    [Trace]
+    public async Task<Result<TransitionOutput>> RunAsync(
+        WorkflowExecutionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var queue = new Queue<WorkflowExecutionContext>();
+        queue.Enqueue(context);
+
+        var hop = 0;
+        TransitionOutput? lastOutput = null;
+
+        while (queue.TryDequeue(out var current))
+        {
+            hop++;
+
+            // Guard: prevent infinite loops
+            if (hop > _options.MaxAutoHops)
+            {
+                return Result<TransitionOutput>.Fail(
+                    Error.Validation("auto.chain.maxhops", $"Auto chain exceeded max hops: {_options.MaxAutoHops}"));
+            }
+
+            // Execute in isolated scope + UoW
+            var hopResult = await ExecuteHopAsync(current, cancellationToken);
+            if (!hopResult.IsSuccess)
+                return Result<TransitionOutput>.Fail(hopResult.Error);
+
+            var coreOutput = hopResult.Value!;
+            lastOutput = coreOutput.Output;
+
+            // POST-COMMIT: enqueue inline auto chain transitions
+            if (coreOutput.DirectivesSnapshot.HasQueuedTransitions)
+            {
+                foreach (var cmd in coreOutput.DirectivesSnapshot.InlineAutoQueue)
+                {
+                    var nextCmd = cmd with { ChainDepth = cmd.ChainDepth + 1 };
+                    
+                    if (nextCmd.ChainDepth <= _options.MaxAutoHops)
+                    {
+                        queue.Enqueue(WorkflowExecutionContext.From(nextCmd));
+                    }
+                }
+            }
+        }
+
+        return lastOutput is null
+            ? Result<TransitionOutput>.Fail(Error.Failure("transition.output.missing", "Transition output missing"))
+            : Result<TransitionOutput>.Ok(lastOutput);
+    }
+
+    /// <summary>
+    /// Executes a single transition hop in a new DI scope with RequiresNew UoW.
+    /// </summary>
+    private async Task<Result<TransitionCoreOutput>> ExecuteHopAsync(
+        WorkflowExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        await using var scope = scopeFactory.CreateAsyncScope();
+        var sp = scope.ServiceProvider;
+
+        var uowManager = sp.GetRequiredService<IUnitOfWorkManager>();
+        var core = sp.GetRequiredService<IWorkflowExecutionCore>();
+
+        await using var uow = await uowManager.BeginAsync(
+            new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew },
+            cancellationToken);
+
+        var coreResult = await core.ExecuteTransitionCoreAsync(context, cancellationToken);
+        if (!coreResult.IsSuccess)
+            return Result<TransitionCoreOutput>.Fail(coreResult.Error);
+
+        // Commit is THE boundary - post-commit processing happens after this
+        await uow.CommitAsync(cancellationToken);
+
+        return coreResult;
+    }
+}
+```
+
+**Key Design Decisions:**
+- **Isolated DI Scope per Hop**: Each transition runs in a new DI scope
+- **RequiresNew UoW**: Complete isolation from any ambient UoW
+- **Post-Commit Processing**: Inline auto chain is processed AFTER UoW commit
+- **DirectivesSnapshot**: Captures queue state for cross-UoW boundary transfer
+- **MaxAutoHops Guard**: Prevents infinite loops with configurable limit
+
+### 3. IWorkflowExecutionCore
+
+Core transition execution contract without UoW management:
+
+```csharp
+public interface IWorkflowExecutionCore
+{
+    /// <summary>
+    /// Executes a single transition's core logic without managing UoW.
+    /// Returns both the transition output and directives snapshot for post-commit processing.
+    /// </summary>
+    Task<Result<TransitionCoreOutput>> ExecuteTransitionCoreAsync(
+        WorkflowExecutionContext context,
+        CancellationToken cancellationToken = default);
+}
+```
+
+#### TransitionCoreOutput
+```csharp
+/// <summary>
+/// Output from core transition execution containing both the transition output
+/// and the directives snapshot for post-commit inline auto chain processing.
+/// </summary>
+public sealed record TransitionCoreOutput(TransitionOutput Output, DirectivesSnapshot DirectivesSnapshot);
+```
+
+### 4. Pipeline Steps (Lifecycle Order)
 
 All steps implement `ITransitionStep` and return `Result<StepOutcome>`:
 
-1. **ForwardToActiveSubflowStep** (Order: 5) - Forwards transition to active subflow if exists
-2. **CreateTransitionRecordStep** (Order: 10) - Creates the transition record
-3. **RunOnExecuteTasksStep** (Order: 20) - Executes the transition's OnExecute tasks
-4. **RunOnExitTasksStep** (Order: 30) - Executes the current state's OnExit tasks
-5. **ChangeStateStep** (Order: 40) - Performs the state change
-6. **RunOnEntryTasksStep** (Order: 50) - Executes the target state's OnEntry tasks
-7. **HandleSubFlowStep** (Order: 60) - Manages SubFlow operations
-8. **ClearBusyOnResumeStep** (Order: 69) - Clears BUSY status on resume
-9. **ScheduleTransitionsStep** (Order: 70) - Schedules timed transitions
-10. **RunAutomaticTransitionsStep** (Order: 80) - Enqueues automatic transitions for execution
-11. **HandleFinishStep** (Order: 90) - Handles workflow completion
-12. **FinalizeTransitionStep** (Order: 100) - Finalizes the transition and performs cleanup
-13. **ProcessInlineAutoChainStep** (Order: 101) - Processes inline automatic transition chain
+| Order | Step | Description |
+|-------|------|-------------|
+| 5 | ForwardToActiveSubflowStep | Forwards transition to active subflow if exists (Preflight) |
+| 10 | HandleCancelPreflightStep | Handles cancel preflight operations |
+| 20 | CreateTransitionRecordStep | Creates the transition record |
+| 30 | RunOnExecuteTasksStep | Executes the transition's OnExecute tasks |
+| 40 | RunOnExitTasksStep | Executes the current state's OnExit tasks |
+| 50 | ChangeStateStep | Performs the state change |
+| 60 | RunOnEntryTasksStep | Executes the target state's OnEntry tasks |
+| 70 | HandleSubFlowStep | Manages SubFlow operations |
+| 79 | ClearBusyOnResumeStep | Clears BUSY status on resume |
+| 80 | ScheduleTransitionsStep | Schedules timed transitions |
+| 90 | RunAutomaticTransitionsStep | Evaluates and enqueues automatic transitions |
+| 100 | HandleFinishStep | Handles workflow completion |
+| 110 | FinalizeTransitionStep | Finalizes the transition and performs cleanup |
+| 111 | AfterEpilogueRefresh | Post-epilogue operations |
 
-### 3. Trigger Handlers
+### 5. LifecycleOrder
+
+Constants defining the standard execution order for transition lifecycle steps:
+
+```csharp
+public static class LifecycleOrder
+{
+    public const int Preflight = 5;               // Subflow preflight check
+    public const int ForwardToActiveSubflow = 10; // Forward to active subflow
+    public const int CreateTransition = 20;       // Create transition record
+    public const int OnExecute = 30;              // Execute transition's OnExecute tasks
+    public const int OnExit = 40;                 // Execute current state's OnExit tasks
+    public const int ChangeState = 50;            // Change the instance state
+    public const int OnEntry = 60;                // Execute target state's OnEntry tasks
+    public const int SubFlow = 70;                // Handle SubFlow operations
+    public const int ClearBusyOnResumeStep = Schedule - 1; // Clear BUSY status (79)
+    public const int Schedule = 80;               // Schedule future transitions
+    public const int Auto = 90;                   // Evaluate automatic transitions
+    public const int Finish = 100;                // Handle workflow finishing
+    public const int Finalize = 110;              // Finalize transition and cleanup
+    public const int AfterEpilogueRefresh = Finalize + 1; // Post-epilogue (111)
+}
+```
+
+### 6. Trigger Handlers
 
 #### ManualTransitionHandler
 - Policy/HMAC/Auth/Schema validation
@@ -103,9 +270,25 @@ All steps implement `ITransitionStep` and return `Result<StepOutcome>`:
 - Audit logging
 
 #### AutomaticTransitionHandler
-- Condition re-validation
 - Chain depth control
 - Execution metrics
+- System state validation
+
+```csharp
+public sealed class AutomaticTransitionHandler(
+    ITransitionValidationService validationService,
+    ILogger<AutomaticTransitionHandler> logger) : TransitionHandlerBase(logger, validationService)
+{
+    public override bool CanHandle(TriggerType triggerType) => triggerType == TriggerType.Automatic;
+
+    protected override async Task PreValidateAsync(TransitionExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        await ValidateSystemStateAsync(context);
+        await base.PreValidateAsync(context, cancellationToken);
+    }
+}
+```
 
 #### ScheduledTransitionHandler
 - Timing validation
@@ -117,7 +300,7 @@ All steps implement `ITransitionStep` and return `Result<StepOutcome>`:
 - Event correlation
 - Payload validation
 
-### 4. Re-entry System
+### 7. Re-entry System
 
 #### ReentryCommand
 ```csharp
@@ -138,7 +321,7 @@ public sealed record ReentryCommand(
 - `DispatchAutoAsync`: Manages automatic transitions (inline or background job)
 - `DispatchScheduledAsync`: Queues scheduled transitions as background jobs
 
-### 5. TransitionPipeline
+### 8. TransitionPipeline
 
 The pipeline orchestrates the execution of transition lifecycle steps in a deterministic order.
 
@@ -149,27 +332,74 @@ The pipeline orchestrates the execution of transition lifecycle steps in a deter
 - Provides structured logging and distributed tracing for each step
 - Returns `Result` to indicate success or failure without throwing exceptions
 
-#### Execution Plan Building
-The pipeline dynamically builds execution plans using the `BuildExecutionPlan` method:
+#### Implementation
 
+```csharp
+public class TransitionPipeline
+{
+    private readonly IReadOnlyList<ITransitionStep> _steps;
+
+    public TransitionPipeline(IEnumerable<ITransitionStep> steps)
+    {
+        _steps = steps.OrderBy(s => s.Order).ToList();
+    }
+
+    [Trace]
+    public async Task<Result> RunAsync(TransitionExecutionContext context, CancellationToken cancellationToken)
+    {
+        var state = CreateInitialState(context);
+
+        while (state.HasMoreSteps())
+        {
+            // Guard: Skip immediate execution requested
+            if (context.SkipImmediateExecution)
+                return Result.Ok();
+
+            // Execute current step
+            var stepResult = await ExecuteStepAsync(state.CurrentStep, context, cancellationToken);
+            if (!stepResult.IsSuccess)
+                return Result.Fail(stepResult.Error);
+
+            // Determine flow control based on step outcome
+            var flowControl = DetermineFlowControl(stepResult.Value!, state.CurrentStep, context, state);
+
+            // Apply flow control decision
+            if (flowControl.ShouldStop)
+                break;
+
+            if (flowControl.ShouldReplan)
+            {
+                state = CreateInitialState(context);
+                continue;
+            }
+
+            state = state.MoveNext();
+        }
+
+        return Result.Ok();
+    }
+}
+```
+
+#### Execution Plan Building
 ```csharp
 private IReadOnlyList<ITransitionStep> BuildExecutionPlan(TransitionExecutionContext context)
 {
-    var ordered = _steps.ToList(); // Already ordered in constructor
+    var ordered = _steps.ToList();
 
-    // 1) ResumeFrom: Start from a specific step
+    // 1) ResumeFrom start
     var startOrder = context.Directives.ConsumeResumeFrom();
     if (startOrder.HasValue)
         ordered = ordered.Where(s => s.Order >= startOrder.Value).ToList();
 
-    // 2) Terminal State: Short-circuit to Finalize
+    // 2) Subflow terminal short circuit (until Finalize)
     if (context.Directives.TerminalReached)
     {
         var maxOrder = LifecycleOrder.Finalize;
         ordered = ordered.Where(s => s.Order <= maxOrder).ToList();
     }
 
-    // 3) Epilogue Mode: Skip or run Schedule/Auto steps
+    // 3) Epilogue policy
     if (context.Directives.Epilogue == EpilogueMode.Skip)
     {
         ordered = ordered
@@ -182,56 +412,89 @@ private IReadOnlyList<ITransitionStep> BuildExecutionPlan(TransitionExecutionCon
 }
 ```
 
-#### Planning Strategies
-- **ResumeFrom**: Start from a specific step (subflow completion, re-planning)
-- **Terminal State**: Run only up to Finalize in terminal state
-- **Epilogue Mode**: Skip or run Schedule/Auto steps based on directives
-- **Dynamic Re-planning**: Rebuild plan when directives change mid-execution
-
-### 6. LifecycleOrder
-
-Constants defining the standard execution order for transition lifecycle steps:
-
+#### Pipeline State Management
 ```csharp
-public static class LifecycleOrder
+/// <summary>
+/// Represents the current execution state of the pipeline.
+/// Immutable record struct for functional state management.
+/// </summary>
+private readonly record struct PipelineState(IReadOnlyList<ITransitionStep> Plan, int Index)
 {
-    public const int Preflight = 5;           // Subflow preflight check
-    public const int CreateTransition = 10;   // Create transition record
-    public const int OnExecute = 20;          // Execute transition's OnExecute tasks
-    public const int OnExit = 30;             // Execute current state's OnExit tasks
-    public const int ChangeState = 40;        // Change the instance state
-    public const int OnEntry = 50;            // Execute target state's OnEntry tasks
-    public const int SubFlow = 60;            // Handle SubFlow operations
-    public const int ClearBusyOnResumeStep = Schedule - 1; // Clear BUSY status
-    public const int Schedule = 70;           // Schedule future transitions
-    public const int Auto = 80;               // Execute automatic transitions
-    public const int Finish = 90;             // Handle workflow finishing
-    public const int Finalize = 100;          // Finalize transition and cleanup
-    public const int AfterEpilogueRefresh = Finalize + 1; // Process inline auto chain
+    public ITransitionStep CurrentStep => Plan[Index];
+    public bool HasMoreSteps() => Index < Plan.Count;
+    public PipelineState MoveNext() => this with { Index = Index + 1 };
+}
+
+/// <summary>
+/// Represents flow control decision after step execution.
+/// Factory methods provide clear intent.
+/// </summary>
+private readonly record struct FlowControl(bool ShouldStop, bool ShouldReplan)
+{
+    public static FlowControl Stop() => new(ShouldStop: true, ShouldReplan: false);
+    public static FlowControl Replan() => new(ShouldStop: false, ShouldReplan: true);
+    public static FlowControl Continue() => new(ShouldStop: false, ShouldReplan: false);
 }
 ```
 
-### 7. PipelineDirectives
+### 9. PipelineDirectives
 
 Directive system controlling pipeline behavior:
 
 ```csharp
 public sealed class PipelineDirectives
 {
-    // Which step to resume from
+    /// <summary>
+    /// Gets the order number from which to resume pipeline execution.
+    /// </summary>
     public int? ResumeFromOrder { get; private set; }
     
-    // Behavior of epilogue (Schedule/Auto) steps
-    public EpilogueMode Epilogue { get; private set; }
+    /// <summary>
+    /// Gets the epilogue execution mode.
+    /// </summary>
+    public EpilogueMode Epilogue { get; private set; } = EpilogueMode.Run;
     
-    // Inline automatic transition queue
-    public Queue<ReentryCommand> InlineAutoQueue { get; }
+    /// <summary>
+    /// Gets the queue of re-entry commands for inline automatic transition chain execution.
+    /// </summary>
+    public Queue<ReentryCommand> InlineAutoQueue { get; } = new();
     
-    // Terminal state flag
+    /// <summary>
+    /// Gets a value indicating whether the pipeline has reached a terminal state.
+    /// </summary>
     public bool TerminalReached { get; private set; }
     
-    // SubFlow resume scenario
+    /// <summary>
+    /// Gets a value indicating whether this execution is resuming from a subflow.
+    /// </summary>
     public bool IsSubFlowResume { get; private set; }
+    
+    // Methods
+    public void RequestResumeFrom(int order);
+    public int? ConsumeResumeFrom();
+    public void RequestEpilogue(EpilogueMode mode);
+    public void MarkTerminal();
+    public void EnqueueInlineAuto(ReentryCommand command);
+    public void MarkAsSubFlowResume();
+    public DirectivesSnapshot CreateSnapshot();
+}
+```
+
+#### DirectivesSnapshot
+
+Immutable snapshot for post-commit processing:
+
+```csharp
+/// <summary>
+/// Immutable snapshot of pipeline directives for post-commit processing.
+/// Used to transfer inline auto queue state across UoW boundaries.
+/// </summary>
+public sealed record DirectivesSnapshot(ReentryCommand[] InlineAutoQueue)
+{
+    /// <summary>
+    /// Gets a value indicating whether there are any queued inline auto transitions.
+    /// </summary>
+    public bool HasQueuedTransitions => InlineAutoQueue.Length > 0;
 }
 ```
 
@@ -245,9 +508,9 @@ public enum EpilogueMode
 }
 ```
 
-### 8. StepOutcome
+### 10. StepOutcome
 
-Pipeline step result reporting and flow control. Steps return `Result<StepOutcome>` using the Result pattern:
+Pipeline step result reporting and flow control:
 
 ```csharp
 public sealed class StepOutcome
@@ -273,7 +536,7 @@ return Result<StepOutcome>.Ok(StepOutcome.Continue());
 // Stop the pipeline
 return Result<StepOutcome>.Ok(StepOutcome.Stop());
 
-// Skip to a specific step (e.g., return to CreateTransition after inline auto)
+// Skip to a specific step
 return Result<StepOutcome>.Ok(StepOutcome.SkipTo(LifecycleOrder.CreateTransition));
 
 // Mutate directives
@@ -283,88 +546,7 @@ return Result<StepOutcome>.Ok(StepOutcome.With(d => d.RequestEpilogue(EpilogueMo
 return Result<StepOutcome>.Fail(Error.Validation("step.failed", "Validation failed"));
 ```
 
-### 9. Dynamic Re-planning
-
-The pipeline detects directive changes during execution and rebuilds the plan dynamically:
-
-**Re-planning Scenarios:**
-1. **SubFlow Initiation**: Switch to epilogue SKIP mode
-2. **Inline Auto Chain**: Restart from CreateTransition
-3. **SubFlow Completion**: Resume from Schedule step
-4. **Terminal State**: Execute only up to Finalize
-
-**Pipeline Re-planning Flow:**
-```csharp
-public async Task<Result> RunAsync(TransitionExecutionContext context, CancellationToken cancellationToken)
-{
-    // Build initial execution plan
-    var plan = BuildExecutionPlan(context);
-    var i = 0;
-    
-    while (i < plan.Count)
-    {
-        if (context.SkipImmediateExecution) break;
-
-        var step = plan[i];
-        
-        // Execute step and handle Result
-        var outcomeResult = await step.ExecuteAsync(context, cancellationToken);
-        if (!outcomeResult.IsSuccess)
-            return Result.Fail(outcomeResult.Error);
-        
-        var outcome = outcomeResult.Value!;
-        
-        // Apply directive mutations
-        outcome.MutateDirectives?.Invoke(context.Directives);
-
-        // 1) Stop pipeline?
-        if (outcome.StopPipeline) break;
-
-        // 2) SkipTo? (e.g., restart from CreateTransition after inline auto)
-        if (outcome.SkipToOrder is { } skipTo)
-        {
-            context.Directives.RequestResumeFrom(skipTo);
-            plan = BuildExecutionPlan(context); // Rebuild plan
-            i = 0;
-            continue;
-        }
-
-        // 3) If directives changed, update the plan
-        if (NeedsReplan(plan, context.Directives))
-        {
-            context.Directives.RequestResumeFrom(step.Order + 1);
-            plan = BuildExecutionPlan(context); // Rebuild plan
-            i = 0;
-            continue;
-        }
-
-        i++; // Move to next step
-    }
-    
-    return Result.Ok();
-}
-```
-
-**Re-planning Logic:**
-```csharp
-private static bool NeedsReplan(IReadOnlyList<ITransitionStep> currentPlan, PipelineDirectives d)
-{
-    // Replan if terminal state is reached
-    if (d.TerminalReached) return true;
-    
-    // Replan if epilogue mode changed to SKIP and Schedule/Auto steps are in plan
-    if (d.Epilogue == EpilogueMode.Skip &&
-        currentPlan.Any(s => s.Order == LifecycleOrder.Schedule || s.Order == LifecycleOrder.Auto))
-        return true;
-    
-    // Replan if resume-from is requested
-    if (d.ResumeFromOrder is not null) return true;
-    
-    return false;
-}
-```
-
-### 10. TransitionExecutionContext
+### 11. TransitionExecutionContext
 
 Minimal, service-free context structure that carries only essential data and state:
 
@@ -418,7 +600,9 @@ public sealed class TransitionExecutionContext
     public ClientResponse? ClientResponse { get; set; }
     
     // Helper methods
-    public ScriptContext GetOrBuildScriptContext(Func<ScriptContext> factory);
+    public Task<ScriptContext> GetOrBuildScriptContextAsync(
+        Func<CancellationToken, Task<ScriptContext>> factory,
+        CancellationToken cancellationToken);
     public void ApplyScriptContextChanges(ScriptContext scriptContext);
     public void ClearCacheForFinalize();
 }
@@ -431,6 +615,104 @@ public sealed class TransitionExecutionContext
 - **Items vs Cache**: 
   - `Items`: Temporary storage shared between steps (cleared after execution)
   - `Cache`: Performance cache (ScriptContext, etc.) that can be cleared at finalize
+
+## Execution Flow
+
+### Complete Transition Flow
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         WorkflowExecutionService                            │
+│                    ExecuteTransitionAsync(context)                          │
+└─────────────────────────────┬───────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                           TransitionRunner                                   │
+│  ┌───────────────────────────────────────────────────────────────────────┐  │
+│  │ while (queue.TryDequeue)                                              │  │
+│  │   1. Guard: MaxAutoHops check                                         │  │
+│  │   2. ExecuteHopAsync (isolated DI scope + RequiresNew UoW)            │  │
+│  │   3. UoW Commit                                                       │  │
+│  │   4. POST-COMMIT: Enqueue inline auto transitions from snapshot       │  │
+│  └───────────────────────────────────────────────────────────────────────┘  │
+└─────────────────────────────┬───────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                      IWorkflowExecutionCore                                  │
+│                  ExecuteTransitionCoreAsync(context)                         │
+│  ┌───────────────────────────────────────────────────────────────────────┐  │
+│  │ 1. GetExecutionStrategy(mode)                                         │  │
+│  │ 2. ExecuteStrategyAsync(strategy, context)                            │  │
+│  │ 3. BuildCoreOutputAsync (creates DirectivesSnapshot)                  │  │
+│  └───────────────────────────────────────────────────────────────────────┘  │
+└─────────────────────────────┬───────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                       TransitionPipeline                                     │
+│  ┌───────────────────────────────────────────────────────────────────────┐  │
+│  │ Pipeline Steps (Order):                                               │  │
+│  │   5  → ForwardToActiveSubflowStep                                     │  │
+│  │   10 → HandleCancelPreflightStep                                      │  │
+│  │   20 → CreateTransitionRecordStep                                     │  │
+│  │   30 → RunOnExecuteTasksStep                                          │  │
+│  │   40 → RunOnExitTasksStep                                             │  │
+│  │   50 → ChangeStateStep                                                │  │
+│  │   60 → RunOnEntryTasksStep                                            │  │
+│  │   70 → HandleSubFlowStep                                              │  │
+│  │   79 → ClearBusyOnResumeStep                                          │  │
+│  │   80 → ScheduleTransitionsStep                                        │  │
+│  │   90 → RunAutomaticTransitionsStep (enqueues to InlineAutoQueue)      │  │
+│  │  100 → HandleFinishStep                                               │  │
+│  │  110 → FinalizeTransitionStep                                         │  │
+│  └───────────────────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Inline Auto Chain Flow
+
+```
+Transition A completes
+       │
+       ▼
+RunAutomaticTransitionsStep
+       │
+       ├── Evaluate all auto transitions
+       │
+       └── Winner found? 
+            │
+            ├── Yes → EnqueueInlineAuto(ReentryCommand)
+            │          │
+            └── No  → Continue (soft-fail)
+                       │
+                       ▼
+                 FinalizeTransitionStep
+                       │
+                       ▼
+              DirectivesSnapshot.CreateSnapshot()
+                       │
+                       ▼
+                  UoW.CommitAsync()
+                       │
+                       ▼
+          ┌────────────────────────────────┐
+          │ POST-COMMIT (TransitionRunner) │
+          │ DirectivesSnapshot.HasQueued?  │
+          │    │                           │
+          │    ├── Yes → queue.Enqueue(B)  │
+          │    │          │                │
+          │    └── No  → return lastOutput │
+          └────────────────────────────────┘
+                       │
+                       ▼
+              Next loop iteration
+                       │
+                       ▼
+              Execute Transition B
+                  (new scope + UoW)
+```
 
 ## Usage
 
@@ -472,10 +754,10 @@ var result = await workflowExecutionService.ExecuteTransitionAsync(executionCont
 // Handle result
 if (result.IsSuccess)
 {
-    var context = result.Value!;
+    var output = result.Value!;
     // Transition executed successfully
-    // Access instance state: context.Instance
-    // Access client response: context.ClientResponse
+    // Access instance ID: output.Id
+    // Access status: output.Status
 }
 else
 {
@@ -501,12 +783,15 @@ public sealed class CustomValidationStep : ITransitionStep
         _logger = logger;
     }
     
-    public int Order => 15; // Between CreateTransition (10) and OnExecute (20)
+    public int Order => 25; // Between CreateTransition (20) and OnExecute (30)
     
+    [Trace]
     public async Task<Result<StepOutcome>> ExecuteAsync(
         TransitionExecutionContext context, 
         CancellationToken cancellationToken)
     {
+        Activity.Current?.SetDisplayName($"[{Order}] {nameof(CustomValidationStep)}");
+        
         _logger.LogDebug("Validating business rules for transition {TransitionKey}", 
             context.TransitionKey);
         
@@ -522,13 +807,6 @@ public sealed class CustomValidationStep : ITransitionStep
         
         // Normal continuation
         return Result<StepOutcome>.Ok(StepOutcome.Continue());
-        
-        // Or conditionally stop the pipeline
-        // if (shouldStop)
-        //     return Result<StepOutcome>.Ok(StepOutcome.Stop());
-        
-        // Or skip to a specific step
-        // return Result<StepOutcome>.Ok(StepOutcome.SkipTo(LifecycleOrder.Finalize));
     }
 }
 
@@ -561,6 +839,7 @@ services.AddScoped<ITransitionHandler, WebhookTransitionHandler>();
 - Trigger handlers only manage their own trigger types
 - Execution strategies only handle sync/async differences
 - TransitionPipeline focuses only on orchestration and execution order
+- TransitionRunner manages UoW lifecycle and inline chain processing
 
 ### 2. Dynamic Flow Control
 - Step-level flow control with StepOutcome
@@ -576,64 +855,42 @@ services.AddScoped<ITransitionHandler, WebhookTransitionHandler>();
 - Better error tracking and debugging
 - Consistent error handling across all steps
 
-### 4. Testability
+### 4. Post-Commit Safety
+- Inline auto chain runs AFTER UoW commit
+- DirectivesSnapshot captures queue state
+- Cross-UoW boundary state transfer
+- Data consistency guaranteed
+
+### 5. Testability
 - Each component can be tested independently
 - Easy mocking with dependency injection
 - Pipeline execution can be tested with different directive scenarios
 - Different flow scenarios can be tested with StepOutcome
 - Clear boundaries between components
 
-### 5. Extensibility
+### 6. Extensibility
 - New pipeline steps can be easily added without modifying existing code
 - New trigger handlers can be added for custom trigger types
 - Custom flow control with StepOutcome factory methods
 - Directive-based behavior customization
 - Order-based step insertion at any point in lifecycle
 
-### 6. Performance
+### 7. Performance
 - Re-entry system optimization with inline execution
 - Distributed locking at service level
 - Idempotency control with concurrency tokens
 - Inline automatic transition chaining (prevents unnecessary I/O and background jobs)
 - Dynamic step skipping based on directives (prevents unnecessary operations)
 - Efficient plan building with minimal allocations
+- Isolated DI scope prevents memory leaks
 
-### 7. Observability
+### 8. Observability
 - Structured logging with correlation IDs
-- OpenTelemetry distributed tracing
+- OpenTelemetry distributed tracing with `[Trace]` aspect
 - Detailed telemetry for each step with timing
 - Re-planning events tracking
 - Step-level spans for detailed trace analysis
 - Comprehensive error logging with context
-
-## Key Architecture Changes
-
-### Removed Components
-1. **IPipelinePlanner & DefaultPlanner**: Planning logic moved into `TransitionPipeline.BuildExecutionPlan()`
-2. **Service Locator Pattern**: Services now injected into steps/handlers, not stored in context
-3. **Exception-based Flow Control**: Replaced with Result pattern
-
-### Current Implementation
-1. **Integrated Planning**: Pipeline builds execution plan dynamically based on directives
-2. **Result Pattern**: All operations return `Result<T>` for exception-free error handling
-3. **Simplified Architecture**: Fewer abstractions, clearer responsibilities
-4. **Performance Optimized**: Inline planning eliminates overhead of separate planner service
-
-## Migration Guide
-
-### From Old Architecture
-1. Update step implementations to return `Result<StepOutcome>` instead of `StepOutcome`
-2. Replace exception throwing with `Result.Fail()` calls
-3. Use `TransitionPipeline` directly instead of through planner abstraction
-4. Inject services into steps/handlers instead of retrieving from context
-5. Update tests to verify Result pattern behavior
-
-### Adding New Features
-1. Implement `ITransitionStep` with Result pattern
-2. Set appropriate `Order` constant from `LifecycleOrder`
-3. Register in DI container via `AddTransitionPipeline()`
-4. Use `PipelineDirectives` for flow control
-5. Return `Result<StepOutcome>` for success/failure
 
 ## Best Practices
 
@@ -664,9 +921,11 @@ services.AddScoped<ITransitionHandler, WebhookTransitionHandler>();
 - Use `context.Items` for step-to-step data sharing
 - Clear cache in finalize step if needed
 - Minimize database round-trips
+- Use `GetOrBuildScriptContextAsync` for ScriptContext caching
 
 ## Related Documentation
 
+- [Auto Transition Evaluation](./auto-transition-evaluation.md) - Automatic transition condition evaluation
 - [Aether SDK Aspects](./aether-sdk-aspects.md) - Cross-cutting concerns with `[Trace]`, `[UnitOfWork]`, `[Log]`
 - [Result Pattern & Railway Programming](./result-pattern-railway.md) - Error handling with Result pattern
 - [Strategy Pattern Implementation](./strategy-pattern-implementation.md) - Execution strategy details

--- a/init/VNext.Init.Host/Dockerfile
+++ b/init/VNext.Init.Host/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 
 # Tools + permissions
 RUN apk update && apk upgrade && apk add --no-cache bash curl jq \
-    && mkdir -p /app/.npm-cache /app/custom-components \
+    && mkdir -p /app/.npm-cache \
     && chown -R node:node /app && chmod -R 777 /app
 
 # API server copy

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs
@@ -2,7 +2,6 @@ using BBT.Aether;
 using BBT.Aether.Application.Dtos;
 using BBT.Aether.AspNetCore.Controllers;
 using BBT.Aether.AspNetCore.Pagination;
-using BBT.Aether.Domain.Repositories;
 using BBT.Aether.Results;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Domain.Shared;
@@ -105,6 +104,12 @@ public sealed class FunctionController(
                 cancellationToken));
         }
 
+        if (functionType == Definitions.Functions.FunctionTypeConst.Schema)
+        {
+            return FromResult(await ProcessSchemaFunctionListAsync(domain, workflow, instanceListResult.Value!,
+                cancellationToken));
+        }
+
         return FromResult(await ProcessCustomFunctionListAsync(function, workflow, domain, instanceListResult.Value!,
             cancellationToken));
     }
@@ -147,6 +152,12 @@ public sealed class FunctionController(
             }
 
             return FromResult(dataResult.Result);
+        }
+        
+        if (functionType == Definitions.Functions.FunctionTypeConst.Schema)
+        {
+            return FromResult(await ProcessSchemaFunctionAsync(domain, workflow, instance, parameters.Version,
+                parameters.TransitionKey, cancellationToken));
         }
 
         return FromResult(await functionAppService.GetFunctionByInstanceAsync(function, workflow, domain, instance,
@@ -229,6 +240,58 @@ public sealed class FunctionController(
             platform ?? string.Empty,
             transitionKey ?? string.Empty,
             cancellationToken);
+    }
+
+    private async Task<Result<GetSchemaOutput>> ProcessSchemaFunctionAsync(
+        string domain,
+        string workflow,
+        string instance,
+        string? version,
+        string? transitionKey,
+        CancellationToken cancellationToken)
+    {
+        var input = new GetSchemaInput
+        {
+            Domain = domain,
+            Workflow = workflow,
+            Instance = instance,
+            Version = version
+        };
+
+        return await queryAppService.GetSchemaAsync(input, transitionKey, cancellationToken);
+    }
+
+    private async Task<Result<HateoasPagedResultDto<GetSchemaOutput>>> ProcessSchemaFunctionListAsync(
+        string domain,
+        string workflow,
+        HateoasPagedList<GetInstanceOutput> instanceListResult,
+        CancellationToken cancellationToken)
+    {
+        var list = new List<GetSchemaOutput>();
+
+        foreach (var instance in instanceListResult.Items)
+        {
+            var result = await ProcessSchemaFunctionAsync(
+                domain,
+                workflow,
+                instance.Key!,
+                instance.FlowVersion,
+                string.Empty,
+                cancellationToken);
+
+            if (!result.IsSuccess)
+            {
+                continue;
+            }
+
+            list.Add(result.Value!);
+        }
+
+        var route = InstanceUrlTemplates.FunctionList(domain, workflow,
+            Definitions.Functions.FunctionTypeConst.Schema, InstanceUrlTemplates.GetApiVersionPrefix("1"));
+        var output = linkGenerator.CreateHateoasResult(instanceListResult, list, route);
+
+        return Result<HateoasPagedResultDto<GetSchemaOutput>>.Ok(output);
     }
 
     private async Task<Result<HateoasPagedResultDto<GetViewOutput>>> ProcessViewFunctionListAsync(

--- a/src/BBT.Workflow.Application/Instances/DTOs/GetSchemaInput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/GetSchemaInput.cs
@@ -1,0 +1,41 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
+using BBT.Workflow.Definitions;
+
+namespace BBT.Workflow.Instances.DTOs;
+
+/// <summary>
+/// Input for retrieving instance schema
+/// </summary>
+public sealed class GetSchemaInput: IHasDomain
+{
+    [Required]
+    [StringLength(WorkflowConstants.MaxDomainLength)]
+    public string Domain { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(WorkflowConstants.MaxFlowLength)]
+    public string Workflow { get; set; } = string.Empty;
+
+    [StringLength(WorkflowConstants.MaxVersionLength)]
+    public string? Version { get; set; } = string.Empty;
+
+    [Required] 
+    public string Instance { get; set; } = string.Empty;
+}
+
+public sealed class GetSchemaOutput
+{
+    /// <summary>
+    /// The schema key
+    /// </summary>
+    public string Key { get; set; }
+
+    /// <summary>
+    /// The schema type
+    /// </summary>
+    public string Type { get; set; }
+
+    public JsonElement Schema { get; set; }
+}
+

--- a/src/BBT.Workflow.Application/Instances/IInstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/IInstanceQueryAppService.cs
@@ -2,6 +2,7 @@ using BBT.Aether;
 using BBT.Aether.Application;
 using BBT.Aether.Domain.Repositories;
 using BBT.Aether.Results;
+using BBT.Workflow.Instances.DTOs;
 
 namespace BBT.Workflow.Instances;
 
@@ -48,6 +49,14 @@ public interface IInstanceQueryAppService : IApplicationService
     Task<Result<GetViewOutput>> GetPlatformSpecificViewAsync(
         GetViewInput input,
         string? platform,
+        string? transitionKey,
+        CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// Retrieves schema for an instance
+    /// </summary>
+    Task<Result<GetSchemaOutput>> GetSchemaAsync(
+        GetSchemaInput input,
         string? transitionKey,
         CancellationToken cancellationToken = default);
 }

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -1,12 +1,12 @@
 using BBT.Aether;
 using BBT.Aether.Application.Services;
 using BBT.Aether.Domain.Entities;
-using BBT.Aether.Domain.Repositories;
 using BBT.Aether.Results;
 using BBT.Workflow.Caching;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Logging;
 using BBT.Workflow.Extentions;
+using BBT.Workflow.Instances.DTOs;
 using BBT.Workflow.Instances.Remote;
 using BBT.Workflow.Runtime;
 using BBT.Workflow.Scripting;
@@ -88,8 +88,9 @@ public sealed class InstanceQueryAppService(
 
                     list.Add(instanceOutput);
                 }
-                
-                return new HateoasPagedList<GetInstanceOutput>(list, pagedList.CurrentPage, pagedList.PageSize, pagedList.HasNext);
+
+                return new HateoasPagedList<GetInstanceOutput>(list, pagedList.CurrentPage, pagedList.PageSize,
+                    pagedList.HasNext);
             },
             cancellationToken);
     }
@@ -276,7 +277,7 @@ public sealed class InstanceQueryAppService(
         CancellationToken cancellationToken)
     {
         var flowResult = await componentCacheStore.GetFlowAsync(domain, workflow, null, cancellationToken);
-        
+
         var flow = flowResult.IsSuccess ? flowResult.Value! : null;
 
         var response = new GetInstanceOutput
@@ -471,7 +472,8 @@ public sealed class InstanceQueryAppService(
                 var dataHref = new DataHref
                 {
                     Href = allExtensions.Length > 0
-                        ? InstanceUrlTemplates.DataWithExtensions(input.Domain, input.Workflow, instance.Id.ToString(), string.Join(",", allExtensions))
+                        ? InstanceUrlTemplates.DataWithExtensions(input.Domain, input.Workflow, instance.Id.ToString(),
+                            string.Join(",", allExtensions))
                         : InstanceUrlTemplates.Data(input.Domain, input.Workflow, instance.Id.ToString())
                 };
 
@@ -494,7 +496,8 @@ public sealed class InstanceQueryAppService(
                         SubFlowName = correlation.SubFlowName,
                         SubFlowVersion = correlation.SubFlowVersion,
                         IsCompleted = correlation.IsCompleted,
-                        Href = InstanceUrlTemplates.Data(correlation.SubFlowDomain, correlation.SubFlowName, correlation.SubFlowInstanceId.ToString())
+                        Href = InstanceUrlTemplates.Data(correlation.SubFlowDomain, correlation.SubFlowName,
+                            correlation.SubFlowInstanceId.ToString())
                     }).ToList();
 
                 return new GetInstanceStateOutput
@@ -523,7 +526,81 @@ public sealed class InstanceQueryAppService(
             .BindAsync(instance =>
                 componentCacheStore.GetFlowAsync(input.Domain, input.Workflow, input.Version, cancellationToken)
                     .MapAsync(workflow => (instance, workflow)))
-            .ThenAsync(data => ResolveViewAsync(data.instance, data.workflow, input, platform, transitionKey, cancellationToken));
+            .ThenAsync(data =>
+                ResolveViewAsync(data.instance, data.workflow, input, platform, transitionKey, cancellationToken));
+    }
+
+    /// <summary>
+    /// Gets the schema definition for a specific transition in the workflow instance.
+    /// </summary>
+    /// <param name="input">The schema request input containing domain, workflow, and instance information</param>
+    /// <param name="transitionKey">Optional transition key to get schema for</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Result containing the schema output or error information</returns>
+    public async Task<Result<GetSchemaOutput>> GetSchemaAsync(
+        GetSchemaInput input,
+        string? transitionKey,
+        CancellationToken cancellationToken = default)
+    {
+        runtimeInfoProvider.Check(input.Domain);
+
+        // Railway chain: Get Instance → Get Workflow → Build Schema Output
+        return await GetInstanceByIdOrKeyAsync(input.Instance, cancellationToken)
+            .BindAsync(instance =>
+                componentCacheStore.GetFlowAsync(input.Domain, input.Workflow, input.Version, cancellationToken)
+                    .MapAsync(workflow => (instance, workflow)))
+            .ThenAsync(data =>
+                BuildSchemaOutputAsync(data.instance, data.workflow, input, transitionKey, cancellationToken));
+    }
+
+    /// <summary>
+    /// Builds the schema output for a specific transition.
+    /// Handles state resolution and schema lookup using Railway pattern.
+    /// </summary>
+    private async Task<Result<GetSchemaOutput>> BuildSchemaOutputAsync(
+        Instance instance,
+        Definitions.Workflow currentWorkflow,
+        GetSchemaInput input,
+        string? transitionKey,
+        CancellationToken cancellationToken)
+    {
+        // Get current state using Railway pattern
+        var currentStateResult = currentWorkflow.GetState(instance.GetCurrentState);
+        if (!currentStateResult.IsSuccess || currentStateResult.Value == null)
+        {
+            return Result<GetSchemaOutput>.Fail(
+                Error.NotFound("notfound", $"State {instance.CurrentState} not found in workflow {input.Workflow}"));
+        }
+
+        var currentState = currentStateResult.Value;
+
+        if (string.IsNullOrEmpty(transitionKey))
+        {
+            return Result<GetSchemaOutput>.Fail(
+                Error.Validation("validation", "Transition key is required to get schema"));
+        }
+
+        var transition = currentWorkflow.ResolveTransition(transitionKey, currentState);
+
+        if (transition?.Schema == null)
+        {
+            return Result<GetSchemaOutput>.Fail(
+                Error.NotFound("notfound",
+                    $"Schema not found for transition {transitionKey} in state {instance.CurrentState}"));
+        }
+
+        // Fetch and return the schema using Railway pattern
+        return await componentCacheStore.GetSchemaAsync(
+                transition.Schema.Domain,
+                transition.Schema.Key,
+                transition.Schema.Version,
+                cancellationToken)
+            .MapAsync(schema => new GetSchemaOutput
+            {
+                Key = schema.Key,
+                Type = schema.Type,
+                Schema = schema.Schema
+            });
     }
 
     /// <summary>
@@ -570,7 +647,8 @@ public sealed class InstanceQueryAppService(
         if (viewDefinition?.View == null)
         {
             return Result<GetViewOutput>.Fail(
-                Error.NotFound("notfound", $"View not found for state {instance.CurrentState} in workflow {currentWorkflow.Key}"));
+                Error.NotFound("notfound",
+                    $"View not found for state {instance.CurrentState} in workflow {currentWorkflow.Key}"));
         }
 
         // Fetch and return the view

--- a/src/BBT.Workflow.Domain/Definitions/Functions/FunctionTypeConst.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Functions/FunctionTypeConst.cs
@@ -5,5 +5,6 @@ namespace BBT.Workflow.Definitions.Functions
         public const string Longpooling = "state";
         public const string View = "view";
         public const string Data = "data";
+        public const string Schema = "schema";
     }
 }

--- a/workers/BBT.Workflow.Workers.Outbox/Microsoft/Extensions/DependencyInjection/OutboxWorkerServiceCollectionExtensions.cs
+++ b/workers/BBT.Workflow.Workers.Outbox/Microsoft/Extensions/DependencyInjection/OutboxWorkerServiceCollectionExtensions.cs
@@ -22,7 +22,7 @@ public static class OutboxWorkerServiceCollectionExtensions
             .AddAspNetCoreModules(configuration)
             .AddResultResilience(configuration)
             .AddDaprClients()
-            .AddEventBus(configuration)
+            .AddAetherEventBus()
             .AddDbContext(configuration)
             .AppMapper()
             .AddTelemetry(configuration)


### PR DESCRIPTION
Introduces the 'schema' function type for workflow instances, enabling retrieval of schema definitions via new endpoints and service methods. Adds DTOs for schema input/output, updates the controller and application service to handle schema queries, and registers the new function type constant. Documentation is updated to reflect the new architecture and flow for transition pipelines and auto transitions.

## Summary by Sourcery

Add support for a new schema function type for workflow instances, exposing schema retrieval via instance functions and documenting the updated transition pipeline and auto transition execution flow.

New Features:
- Expose schema retrieval for workflow instances through a new schema function type and corresponding instance query endpoints.
- Introduce DTOs for schema input and output to standardize schema query contracts.

Enhancements:
- Extend the transition pipeline and auto-transition evaluation documentation to cover TransitionRunner, post-commit inline auto chains, and updated lifecycle ordering.
- Wire schema function handling into the functions controller to support both single-instance and list-based schema responses.
- Update application services to resolve workflow state and transition schemas using the existing cache and result pattern.
- Switch outbox worker configuration to use the Aether event bus registration helper.

Documentation:
- Significantly expand transition pipeline architecture documentation with TransitionRunner, lifecycle ordering, pipeline state management, and post-commit inline auto chain behavior.
- Enhance auto-transition evaluation documentation with implementation samples, TransitionRunner integration, and testing guidance for inline chains and max hop limits.