### PR TITLE
Switch Docker base image to node:20-slim and update package install

### DIFF
--- a/init/VNext.Init.Host/Dockerfile
+++ b/init/VNext.Init.Host/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:20-slim
 
 ENV VNEXT_CORE_RUNTIME_VERSION=latest \
     NPM_REGISTRY=https://registry.npmjs.org/ \
@@ -7,8 +7,11 @@ ENV VNEXT_CORE_RUNTIME_VERSION=latest \
 
 WORKDIR /app
 
-# Install required packages - avoid apk upgrade for QEMU/multi-arch compatibility
-RUN apk add --no-cache bash curl jq
+# Install required packages (Debian-based - better QEMU/multi-arch compatibility)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl jq \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
 
 # Set up directories and permissions
 RUN mkdir -p /app/.npm-cache \


### PR DESCRIPTION
Changed the Dockerfile base image from node:20-alpine to node:20-slim for improved QEMU/multi-arch compatibility. Updated package installation commands to use apt-get instead of apk, and removed bash from the installed packages.