### PR TITLE
fix memory leak issue

### DIFF
--- a/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Evaluators/CSharpEvaluator.cs
+++ b/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Evaluators/CSharpEvaluator.cs
@@ -4,6 +4,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.Loader;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -13,19 +16,68 @@ using Microsoft.CodeAnalysis.Scripting;
 
 namespace BBT.Workflow.Scripting.Evaluators;
 
+/// <summary>
+/// Memory-safe C# script evaluator with assembly sharing.
+/// Caches compiled Types so the same script code reuses the same assembly.
+/// Uses collectible AssemblyLoadContext for proper memory management.
+/// </summary>
 public class CSharpEvaluator : IEvaluator
 {
-    private static readonly ConcurrentDictionary<string, Script<object>> ScriptCache = new();
+    /// <summary>
+    /// Cached compiled types indexed by code hash.
+    /// Stores (LoadContext, Type) tuple so we can track the context for potential cleanup.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, (AssemblyLoadContext Context, Type CompiledType)> _typeCache = new();
 
+    /// <summary>
+    /// Cached metadata references - created once and reused for all compilations.
+    /// </summary>
+    private static readonly Lazy<IReadOnlyList<MetadataReference>> DefaultMetadataReferences = new(
+        CreateDefaultReferences, 
+        LazyThreadSafetyMode.ExecutionAndPublication);
+
+    /// <summary>
+    /// Gets the number of cached script types (unique scripts compiled).
+    /// </summary>
+    public int CachedTypeCount => _typeCache.Count;
+
+    /// <inheritdoc />
     public Task<T> CompileToInstanceAsync<T>(
         string code, 
         IEnumerable<MetadataReference>? extraReferences = null,
         IEnumerable<string>? usingDirectives = null,
         CancellationToken cancellationToken = default)
     {
+        if (string.IsNullOrWhiteSpace(code))
+            throw new ArgumentException("Code cannot be null or empty", nameof(code));
+
+        // Generate cache key from code + target type + configuration
+        var cacheKey = GenerateCacheKey(code, typeof(T), extraReferences, usingDirectives);
+
+        // Try to get cached type and create instance from it
+        if (_typeCache.TryGetValue(cacheKey, out var cached))
+        {
+            var instance = (T)Activator.CreateInstance(cached.CompiledType)!;
+            return Task.FromResult(instance);
+        }
+
+        // Compile, cache the type, and return instance
+        return CompileAndCacheAsync<T>(code, cacheKey, extraReferences, usingDirectives, cancellationToken);
+    }
+
+    /// <summary>
+    /// Compiles the code, caches the Type, and returns an instance.
+    /// </summary>
+    private Task<T> CompileAndCacheAsync<T>(
+        string code,
+        string cacheKey,
+        IEnumerable<MetadataReference>? extraReferences,
+        IEnumerable<string>? usingDirectives,
+        CancellationToken cancellationToken)
+    {
         var syntaxTree = CSharpSyntaxTree.ParseText(code, cancellationToken: cancellationToken);
 
-        // Eğer usingDirectives varsa root'a ekle
+        // Add using directives if provided
         if (usingDirectives != null && usingDirectives.Any())
         {
             var root = syntaxTree.GetRoot(cancellationToken);
@@ -34,27 +86,28 @@ public class CSharpEvaluator : IEvaluator
             syntaxTree = syntaxTree.WithRootAndOptions(newRoot, syntaxTree.Options);
         }
 
-        // Gerekli tüm assembly referanslarını al
-        var defaultReferences = AppDomain.CurrentDomain.GetAssemblies()
-            .Where(a => !a.IsDynamic && !string.IsNullOrWhiteSpace(a.Location))
-            .Select(a => MetadataReference.CreateFromFile(a.Location));
+        // Use cached references and add any extra ones
+        var references = DefaultMetadataReferences.Value;
+        if (extraReferences != null && extraReferences.Any())
+        {
+            references = references.Concat(extraReferences).ToList();
+        }
 
-        var references = defaultReferences
-            .Concat(extraReferences ?? Enumerable.Empty<MetadataReference>())
-            .Distinct();
-
+        var assemblyName = $"Script_{cacheKey[..Math.Min(16, cacheKey.Length)]}";
+        
         var compilation = CSharpCompilation.Create(
-            assemblyName: Path.GetRandomFileName(),
+            assemblyName: assemblyName,
             syntaxTrees: [syntaxTree],
             references: references,
-            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
-        
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithOptimizationLevel(OptimizationLevel.Release));
+
         using var ms = new MemoryStream();
         var emitResult = compilation.Emit(ms, cancellationToken: cancellationToken);
 
         if (!emitResult.Success)
         {
-            var errors = string.Join("\n", emitResult.Diagnostics
+            var errors = string.Join(Environment.NewLine, emitResult.Diagnostics
                 .Where(d => d.Severity == DiagnosticSeverity.Error)
                 .Select(d => d.ToString()));
 
@@ -62,24 +115,145 @@ public class CSharpEvaluator : IEvaluator
         }
 
         ms.Seek(0, SeekOrigin.Begin);
-        var assembly = Assembly.Load(ms.ToArray());
 
-        // Daha detaylı type arama: hem interface hem de sınıf adı üzerinden
+        // Use collectible context so we CAN unload if needed (e.g., ClearCache)
+        var loadContext = new ScriptAssemblyLoadContext(assemblyName);
+        var assembly = loadContext.LoadFromStream(ms);
+
+        // Find the type that implements T
         var types = assembly.GetTypes();
-
         var matchedType = types.FirstOrDefault(t =>
             typeof(T).IsAssignableFrom(t) && !t.IsInterface && !t.IsAbstract);
 
         if (matchedType == null)
         {
+            loadContext.Unload();
+            
             var available = string.Join(", ", types.Select(t => t.FullName));
             throw new InvalidOperationException(
                 $"No type implementing {typeof(T).FullName} found.\nAvailable types: {available}");
         }
 
+        // Cache the type for future reuse (same script = same assembly = same type)
+        _typeCache.TryAdd(cacheKey, (loadContext, matchedType));
+
+        // Create and return instance
         return Task.FromResult((T)Activator.CreateInstance(matchedType)!);
     }
 
+    /// <summary>
+    /// Generates a stable cache key from the code and configuration.
+    /// </summary>
+    private static string GenerateCacheKey(
+        string code, 
+        Type targetType,
+        IEnumerable<MetadataReference>? extraReferences,
+        IEnumerable<string>? usingDirectives)
+    {
+        var sb = new StringBuilder();
+        sb.Append(code);
+        sb.Append('|');
+        sb.Append(targetType.AssemblyQualifiedName);
+        
+        if (usingDirectives != null)
+        {
+            foreach (var directive in usingDirectives.OrderBy(u => u))
+            {
+                sb.Append('|');
+                sb.Append(directive);
+            }
+        }
+
+        if (extraReferences != null)
+        {
+            foreach (var reference in extraReferences.OrderBy(r => r.Display))
+            {
+                sb.Append('|');
+                sb.Append(reference.Display);
+            }
+        }
+
+        var bytes = Encoding.UTF8.GetBytes(sb.ToString());
+        var hash = SHA256.HashData(bytes);
+        return Convert.ToHexString(hash);
+    }
+
+    /// <summary>
+    /// Creates the default metadata references from loaded assemblies.
+    /// This is cached and reused across all compilations.
+    /// </summary>
+    private static IReadOnlyList<MetadataReference> CreateDefaultReferences()
+    {
+        return AppDomain.CurrentDomain.GetAssemblies()
+            .Where(a => !a.IsDynamic && !string.IsNullOrWhiteSpace(a.Location))
+            .Select(a =>
+            {
+                try
+                {
+                    return MetadataReference.CreateFromFile(a.Location);
+                }
+                catch
+                {
+                    return null;
+                }
+            })
+            .Where(r => r != null)
+            .Cast<MetadataReference>()
+            .ToList();
+    }
+
+    /// <summary>
+    /// Clears all cached types and unloads their assemblies.
+    /// Call this to reclaim memory if script definitions change.
+    /// </summary>
+    public void ClearCache()
+    {
+        foreach (var key in _typeCache.Keys.ToList())
+        {
+            if (_typeCache.TryRemove(key, out var cached))
+            {
+                try
+                {
+                    cached.Context.Unload();
+                }
+                catch
+                {
+                    // Ignore unload failures
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Removes a specific script from the cache by its code.
+    /// Useful when a script definition is updated.
+    /// </summary>
+    public bool InvalidateScript<T>(
+        string code,
+        IEnumerable<MetadataReference>? extraReferences = null,
+        IEnumerable<string>? usingDirectives = null)
+    {
+        var cacheKey = GenerateCacheKey(code, typeof(T), extraReferences, usingDirectives);
+        
+        if (_typeCache.TryRemove(cacheKey, out var cached))
+        {
+            try
+            {
+                cached.Context.Unload();
+            }
+            catch
+            {
+                // Ignore
+            }
+            return true;
+        }
+        
+        return false;
+    }
+
+    /// <summary>
+    /// Creates default script options with standard imports.
+    /// </summary>
     private static ScriptOptions CreateDefaultOptions(Func<ScriptOptions, ScriptOptions>? configureScriptOptions)
     {
         var defaultOptions = CSharpScriptOptionProvider.Default;

--- a/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Evaluators/ScriptAssemblyLoadContext.cs
+++ b/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Evaluators/ScriptAssemblyLoadContext.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace BBT.Workflow.Scripting.Evaluators;
+
+/// <summary>
+/// A collectible AssemblyLoadContext that allows dynamic script assemblies to be unloaded
+/// when they are no longer referenced. This prevents memory leaks from accumulated script compilations.
+/// </summary>
+internal sealed class ScriptAssemblyLoadContext : AssemblyLoadContext
+{
+    /// <summary>
+    /// Creates a new collectible script assembly load context.
+    /// </summary>
+    /// <param name="name">Optional name for debugging purposes</param>
+    public ScriptAssemblyLoadContext(string? name = null) 
+        : base(name ?? $"ScriptContext-{Guid.NewGuid():N}", isCollectible: true)
+    {
+    }
+
+    /// <summary>
+    /// Resolves assembly references. Returns null to use default resolution.
+    /// </summary>
+    protected override Assembly? Load(AssemblyName assemblyName)
+    {
+        // Return null to fall back to default resolution
+        // This allows the script to use assemblies from the main application
+        return null;
+    }
+}
+

--- a/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/TaskServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/TaskServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using BBT.Workflow.Scripting;
+using BBT.Workflow.Scripting.Evaluators;
 using BBT.Workflow.Tasks.Coordinator;
 using BBT.Workflow.Tasks.Evaluation;
 using BBT.Workflow.Tasks.Evaluators;
@@ -154,10 +155,16 @@ public static class TaskServiceCollectionExtensions
 
     /// <summary>
     /// Adds scripting services for script execution context.
+    /// CSharpEvaluator uses collectible AssemblyLoadContext to prevent memory leaks
+    /// from dynamic script compilation - assemblies can be GC'd when no longer referenced.
     /// </summary>
     private static IServiceCollection AddScriptingServices(this IServiceCollection services)
     {
         services.TryAddSingleton<IScriptContextFactory, ScriptContextFactory>();
+        
+        // Evaluator is stateless - singleton for efficiency (caches MetadataReferences only)
+        services.TryAddSingleton<IEvaluator, CSharpEvaluator>();
+        
         services.TryAddScoped<IScriptEngine, ScriptEngine>();
         
         return services;

--- a/src/BBT.Workflow.Application/Scripting/ScriptEngine.cs
+++ b/src/BBT.Workflow.Application/Scripting/ScriptEngine.cs
@@ -14,14 +14,17 @@ namespace BBT.Workflow.Scripting;
 /// Integrates with Dapr for distributed computing scenarios and provides global functions for scripts.
 /// Uses Roslyn's scripting APIs for dynamic C# code execution.
 /// </summary>
+/// <param name="evaluator">The underlying C# evaluator responsible for script compilation and execution (injected as singleton for shared caching)</param>
 /// <param name="workflowMetrics">The workflow metrics service for recording script engine metrics</param>
 public sealed class ScriptEngine(
+    IEvaluator evaluator,
     IWorkflowMetrics workflowMetrics) : IScriptEngine
 {
     /// <summary>
-    /// The underlying C# evaluator responsible for script compilation and execution
+    /// The underlying C# evaluator responsible for script compilation and execution.
+    /// Injected as a singleton to share the script cache across all requests.
     /// </summary>
-    private readonly IEvaluator _evaluator = new CSharpEvaluator();
+    private readonly IEvaluator _evaluator = evaluator;
 
     /// <summary>
     /// Lazily-initialized default metadata references used for script compilation.


### PR DESCRIPTION
## Summary by Sourcery

Introduce a memory-safe C# script evaluator that uses collectible assembly load contexts and shared caching to prevent memory leaks from dynamic script compilation, and wire it into the application’s scripting services.

Bug Fixes:
- Prevent memory leaks from dynamically compiled C# scripts by loading assemblies into collectible AssemblyLoadContexts and providing cache invalidation APIs.

Enhancements:
- Replace per-call script compilation with a cache of compiled script types keyed by a stable hash of code and configuration.
- Centralize and cache default Roslyn metadata references to avoid repeated discovery of loaded assemblies.
- Expose methods to clear or selectively invalidate cached scripts and report the number of cached script types.
- Inject the C# evaluator as a singleton into the script engine so its cache is shared application-wide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added script cache management capabilities: clear entire cache, invalidate specific scripts, and monitor cached entry count.
  * Enhanced memory efficiency with automatic unloading of compiled script assemblies to prevent memory leaks.

* **Refactor**
  * Refactored script evaluation to use dependency injection for improved maintainability and testability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->