### PR TITLE
feat: improve package loading response and add troubleshooting docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,43 @@ This approach ensures that production images remain small and secure while devel
 #### Mac
 To run the script on MacOS, you need to install PowerShell. You can find the official documentation for installing PowerShell on MacOS [here](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-macos).
 
+---
+
+## Troubleshooting
+
+### PostSharp Targeting Pack Error
+
+If you encounter the following error during compilation:
+
+```
+POSTSHARP : error : error: Unhandled exception (PostSharp.Compiler.Hosting.CommandLine.dll 2025.1.10 release | .NET 9.0.11 (Arm64)): Requested targeting pack NETStandard.Library.Ref, version=2.1.0 is not installed in
+```
+
+**Solution:**
+
+1. First, clean the `bin` and `obj` folders. You can use one of the following methods:
+
+   **Option A - Using shell command (Linux/macOS):**
+   ```bash
+   find . -type d \( -name bin -o -name obj \) -exec rm -rf {} + 2>/dev/null
+   ```
+
+   **Option B - Using PowerShell script (Windows/macOS with PowerShell):**
+   ```powershell
+   ./delete-bin-obj.ps1
+   ```
+
+2. Then, rebuild the project:
+   ```bash
+   dotnet clean
+   dotnet restore
+   dotnet build
+   ```
+
+This issue typically occurs when there are stale build artifacts that conflict with PostSharp's targeting pack resolution.
+
+---
+
 ## License
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 

--- a/init/VNext.Init.Host/package-api-server.js
+++ b/init/VNext.Init.Host/package-api-server.js
@@ -856,10 +856,24 @@ async function handleRuntimePublish(req, res) {
         // Process and publish with isRuntimePackage=true (special ordering)
         const results = await processPackage(packagePath, VNEXT_CORE_RUNTIME_PACKAGE, appDomain, true);
         
-        res.writeHead(200, { 'Content-Type': 'application/json' });
+        // Determine success status and message based on results
+        let success = true;
+        let message = 'Runtime package processed and published successfully';
+        
+        if (results.success.length === 0 && results.failed.length > 0) {
+            // All packages failed
+            success = false;
+            message = 'Runtime package processing failed. No packages were loaded.';
+        } else if (results.success.length > 0 && results.failed.length > 0) {
+            // Partial success
+            success = false;
+            message = `Runtime package partially processed. ${results.success.length} packages loaded successfully, ${results.failed.length} packages failed to load.`;
+        }
+        
+        res.writeHead(success ? 200 : 207, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({
-            success: true,
-            message: 'Runtime package processed and published successfully',
+            success: success,
+            message: message,
             packageName: VNEXT_CORE_RUNTIME_PACKAGE,
             appDomain: appDomain,
             results: {
@@ -934,10 +948,24 @@ async function handlePackagePublish(req, res) {
         // appDomain is null if not provided (no replacement)
         const results = await processPackage(packagePath, packageName, shouldReplaceDomain ? appDomain : null, false);
         
-        res.writeHead(200, { 'Content-Type': 'application/json' });
+        // Determine success status and message based on results
+        let success = true;
+        let message = 'Package processed and published successfully';
+        
+        if (results.success.length === 0 && results.failed.length > 0) {
+            // All packages failed
+            success = false;
+            message = 'Package processing failed. No packages were loaded.';
+        } else if (results.success.length > 0 && results.failed.length > 0) {
+            // Partial success
+            success = false;
+            message = `Package partially processed. ${results.success.length} packages loaded successfully, ${results.failed.length} packages failed to load.`;
+        }
+        
+        res.writeHead(success ? 200 : 207, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({
-            success: true,
-            message: 'Package processed and published successfully',
+            success: success,
+            message: message,
             packageName: packageName,
             appDomain: shouldReplaceDomain ? appDomain : null,
             domainReplacement: shouldReplaceDomain,


### PR DESCRIPTION
- Add success/failure status logic for package publish endpoints
  - Return success=false when all packages fail
  - Return success=false with partial message when some packages fail
  - Use HTTP 207 for partial/failed results
- Add Troubleshooting section to README.md
  - Document PostSharp targeting pack error solution
  - Include bin/obj cleanup commands for Linux/macOS and Windows

## Summary by Sourcery

Improve package publish responses with explicit success status and partial-failure handling, and document troubleshooting steps for a common PostSharp targeting pack build error.

New Features:
- Return structured success status and descriptive messages for runtime and standard package publish endpoints, including partial-failure handling with HTTP 207 responses.

Documentation:
- Add a troubleshooting section to the README describing how to resolve a PostSharp targeting pack error using bin/obj cleanup and rebuild steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting section for PostSharp Targeting Pack Error with remediation steps including build cleanup and restore procedures.

* **Bug Fixes**
  * API publish responses now return accurate HTTP status codes (200 for full success, 207 for partial success) and operation results instead of always reporting success.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->