### PR TITLE
Add DefaultAutoTransition as fallback for automatic transitions

### DIFF
--- a/src/BBT.Workflow.Application/Execution/Transitions/Evaluation/AutoConditionEvaluator.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Evaluation/AutoConditionEvaluator.cs
@@ -30,6 +30,11 @@ public sealed class AutoConditionEvaluator(
         TransitionExecutionContext context,
         CancellationToken cancellationToken = default)
     {
+        if(transition.TriggerKind == TransitionKind.DefaultAutoTransition)
+        {
+            return Task.FromResult(Result<AutoConditionEvaluation>.Ok(AutoConditionEvaluation.Satisfied(transition.Key)));
+        }
+
         return ValidateTransitionRule(transition)
             .BindAsync(_ => ExecuteConditionSafelyAsync(transition, context, cancellationToken));
     }

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/RunAutomaticTransitionsStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/RunAutomaticTransitionsStep.cs
@@ -70,8 +70,9 @@ public sealed class RunAutomaticTransitionsStep(
         CancellationToken cancellationToken)
     {
         var evaluations = new List<AutoConditionEvaluation>();
+        var orderedTransitions = context.Target!.AutoTransitions.OrderBy(t => t.TriggerKind);
 
-        foreach (var automaticTransition in context.Target!.AutoTransitions)
+        foreach (var automaticTransition in orderedTransitions)
         {
             var evalResult = await autoConditionEvaluator.EvaluateAsync(
                 automaticTransition,
@@ -84,6 +85,10 @@ public sealed class RunAutomaticTransitionsStep(
             }
 
             evaluations.Add(evalResult.Value);
+            if (evalResult.Value.IsSuccess)
+            {
+                break;
+            }
         }
 
         return Result<List<AutoConditionEvaluation>>.Ok(evaluations);

--- a/src/BBT.Workflow.Domain/Definitions/Transitions/Transition.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Transitions/Transition.cs
@@ -72,6 +72,15 @@ public sealed class Transition : IHasKey
     /// <see cref="TriggerType"/>
     /// </summary>
     public TriggerType TriggerType { get; private set; }
+    
+    /// <summary>
+    /// Optional transition kind that defines special behavior.
+    /// When set to <see cref="TransitionKind.DefaultAutoTransition"/>, this transition acts as a fallback
+    /// when no other automatic transitions are satisfied.
+    /// </summary>
+    [JsonInclude] 
+    public TransitionKind? TriggerKind { get; private set; }
+    
     [JsonInclude] public ScriptCode? Timer { get; private set; }
     [JsonInclude] public ScriptCode? Rule { get; private set; }
     [JsonInclude] public Reference? Schema { get; private set; }

--- a/src/BBT.Workflow.Domain/Definitions/Transitions/TransitionEnums.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Transitions/TransitionEnums.cs
@@ -9,19 +9,32 @@ public enum TriggerType
     /// Manual trigger - initiated by user or external API call.
     /// </summary>
     Manual = 0,
-    
+
     /// <summary>
     /// Automatic trigger - initiated by system based on conditions or rules.
     /// </summary>
     Automatic = 1,
-    
+
     /// <summary>
     /// Scheduled trigger - initiated by timer or cron expression.
     /// </summary>
     Scheduled = 2,
-    
+
     /// <summary>
     /// Event trigger - initiated by external event or message.
     /// </summary>
     Event = 3
-} 
+}
+
+/// <summary>
+/// Defines special behavior kinds for transitions.
+/// </summary>
+public enum TransitionKind
+{
+    NA = 0,
+    /// <summary>
+    /// Default automatic transition - used as fallback when no other automatic transition conditions are satisfied.
+    /// This transition is evaluated last and only executed if no regular automatic transitions matched.
+    /// </summary>
+    DefaultAutoTransition = 10
+}

--- a/src/BBT.Workflow.Domain/Definitions/Validators/WorkflowValidator.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Validators/WorkflowValidator.cs
@@ -33,6 +33,7 @@ public class WorkflowValidator
         // State level validations
         ValidateStateLabels(workflow, result);
         ValidateWizardStateTransitions(workflow, result);
+        ValidateDefaultAutoTransitions(workflow, result);
 
         // Transition level validations
         ValidateTransitionLabels(workflow, result);
@@ -207,6 +208,40 @@ public class WorkflowValidator
         }
     }
 
+    /// <summary>
+    /// Validates DefaultAutoTransition rules:
+    /// - Each state can have at most one DefaultAutoTransition
+    /// - DefaultAutoTransition must have TriggerType.Automatic
+    /// </summary>
+    private void ValidateDefaultAutoTransitions(Workflow workflow, WorkflowValidationResult result)
+    {
+        foreach (var state in workflow.States)
+        {
+            var defaultAutoTransitions = state.Transitions
+                .Where(t => t.TriggerKind == TransitionKind.DefaultAutoTransition)
+                .ToList();
+
+            // Validate at most one DefaultAutoTransition per state
+            if (defaultAutoTransitions.Count > 1)
+            {
+                result.AddError(new ValidationResult(
+                    $"State '{state.Key}' can have at most one DefaultAutoTransition. Found: {defaultAutoTransitions.Count}.",
+                    [$"{nameof(Workflow)}.{nameof(Workflow.States)}[{state.Key}].{nameof(State.Transitions)}"]));
+            }
+
+            // Validate DefaultAutoTransition must be Automatic trigger type
+            foreach (var transition in defaultAutoTransitions)
+            {
+                if (transition.TriggerType != TriggerType.Automatic)
+                {
+                    result.AddError(new ValidationResult(
+                        $"DefaultAutoTransition '{transition.Key}' in state '{state.Key}' must have TriggerType.Automatic.",
+                        [$"{nameof(Workflow)}.{nameof(Workflow.States)}[{state.Key}].{nameof(State.Transitions)}[{transition.Key}].{nameof(Transition.TriggerType)}"]));
+                }
+            }
+        }
+    }
+
     #endregion
 
     #region Transition Level Validations
@@ -333,13 +368,13 @@ public class WorkflowValidator
 
     /// <summary>
     /// Validates Auto (Automatic) transition rules:
-    /// - Rule is required
+    /// - Rule is required (except for DefaultAutoTransition which acts as fallback)
     /// - Timer, Schema, View, and Mapping are not allowed
     /// </summary>
     private void ValidateAutoTransition(Transition transition, string basePath, WorkflowValidationResult result)
     {
-        // Rule is required for Auto transitions
-        if (transition.Rule == null)
+        // Rule is required for Auto transitions, except for DefaultAutoTransition (fallback)
+        if (transition.Rule == null && transition.TriggerKind != TransitionKind.DefaultAutoTransition)
         {
             result.AddError(new ValidationResult(
                 $"Auto transition '{transition.Key}' must have a rule defined.",

--- a/test/BBT.Workflow.Domain.Tests/Definitions/TransitionTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Definitions/TransitionTests.cs
@@ -436,5 +436,79 @@ public class TransitionTests : DomainTestBase<DomainEntryPoint>
         // Assert
         Assert.Null(transition.Timer);
     }
+
+    [Fact]
+    public void Kind_ShouldBeNull_ByDefault()
+    {
+        // Act
+        var transition = Transition.Create("key", "from", "to", TriggerType.Automatic, "Patch");
+
+        // Assert
+        Assert.Null(transition.TriggerKind);
+    }
+
+    [Fact]
+    public void Kind_ShouldDeserialize_FromJson()
+    {
+        // Arrange
+        var json = """
+        {
+            "key": "default-transition",
+            "from": "state1",
+            "target": "state2",
+            "triggerType": "Automatic",
+            "kind": "DefaultAutoTransition",
+            "versionStrategy": "Patch",
+            "labels": [],
+            "onExecutionTasks": [],
+            "view": null
+        }
+        """;
+
+        var options = new System.Text.Json.JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+        };
+
+        // Act
+        var transition = System.Text.Json.JsonSerializer.Deserialize<Transition>(json, options);
+
+        // Assert
+        Assert.NotNull(transition);
+        Assert.Equal(TransitionKind.DefaultAutoTransition, transition.TriggerKind);
+        Assert.Equal(TriggerType.Automatic, transition.TriggerType);
+    }
+
+    [Fact]
+    public void Kind_ShouldBeNull_WhenNotInJson()
+    {
+        // Arrange
+        var json = """
+        {
+            "key": "regular-transition",
+            "from": "state1",
+            "target": "state2",
+            "triggerType": "Automatic",
+            "versionStrategy": "Patch",
+            "labels": [],
+            "onExecutionTasks": [],
+            "view": null
+        }
+        """;
+
+        var options = new System.Text.Json.JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+        };
+
+        // Act
+        var transition = System.Text.Json.JsonSerializer.Deserialize<Transition>(json, options);
+
+        // Assert
+        Assert.NotNull(transition);
+        Assert.Null(transition.TriggerKind);
+    }
 }
 

--- a/test/BBT.Workflow.Domain.Tests/Definitions/Validators/WorkflowValidatorTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Definitions/Validators/WorkflowValidatorTests.cs
@@ -1,0 +1,308 @@
+using System.Linq;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Definitions.Validators;
+using Shouldly;
+using Xunit;
+using WorkflowDefinition = BBT.Workflow.Definitions.Workflow;
+
+namespace BBT.Workflow.Domain.Tests.Definitions.Validators;
+
+/// <summary>
+/// Unit tests for WorkflowValidator
+/// </summary>
+public class WorkflowValidatorTests : DomainTestBase<DomainEntryPoint>
+{
+    private readonly WorkflowValidator _validator;
+
+    public WorkflowValidatorTests()
+    {
+        _validator = new WorkflowValidator();
+    }
+
+    #region DefaultAutoTransition Validation Tests
+
+    [Fact]
+    public void Validate_ShouldPass_WhenStateHasSingleDefaultAutoTransition()
+    {
+        // Arrange
+        var workflow = CreateWorkflowWithDefaultAutoTransition();
+
+        // Act
+        var result = _validator.Validate(workflow);
+
+        // Assert
+        // Filter out unrelated validation errors (like labels) to focus on DefaultAutoTransition
+        var defaultAutoErrors = result.ValidationErrors
+            .Where(e => e.ErrorMessage!.Contains("DefaultAutoTransition") || 
+                        e.ErrorMessage!.Contains("rule defined"))
+            .ToList();
+        defaultAutoErrors.ShouldBeEmpty($"Unexpected errors: {string.Join(", ", defaultAutoErrors.Select(e => e.ErrorMessage))}");
+    }
+
+    [Fact]
+    public void Validate_ShouldFail_WhenStateHasMultipleDefaultAutoTransitions()
+    {
+        // Arrange
+        var workflow = CreateWorkflowWithMultipleDefaultAutoTransitions();
+
+        // Act
+        var result = _validator.Validate(workflow);
+
+        // Assert
+        result.IsValid.ShouldBeFalse();
+        result.ValidationErrors.ShouldContain(e => 
+            e.ErrorMessage!.Contains("at most one DefaultAutoTransition"));
+    }
+
+    [Fact]
+    public void Validate_ShouldFail_WhenDefaultAutoTransitionHasNonAutomaticTrigger()
+    {
+        // Arrange
+        var workflow = CreateWorkflowWithDefaultAutoTransitionAndManualTrigger();
+
+        // Act
+        var result = _validator.Validate(workflow);
+
+        // Assert
+        result.IsValid.ShouldBeFalse();
+        result.ValidationErrors.ShouldContain(e => 
+            e.ErrorMessage!.Contains("must have TriggerType.Automatic"));
+    }
+
+    [Fact]
+    public void Validate_ShouldPass_WhenDefaultAutoTransitionHasNoRule()
+    {
+        // Arrange
+        var workflow = CreateWorkflowWithDefaultAutoTransitionWithoutRule();
+
+        // Act
+        var result = _validator.Validate(workflow);
+
+        // Assert
+        // DefaultAutoTransition should not require a rule
+        var ruleErrors = result.ValidationErrors
+            .Where(e => e.ErrorMessage!.Contains("must have a rule defined"))
+            .ToList();
+        ruleErrors.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Validate_ShouldFail_WhenRegularAutoTransitionHasNoRule()
+    {
+        // Arrange
+        var workflow = CreateWorkflowWithRegularAutoTransitionWithoutRule();
+
+        // Act
+        var result = _validator.Validate(workflow);
+
+        // Assert
+        result.IsValid.ShouldBeFalse();
+        result.ValidationErrors.ShouldContain(e => 
+            e.ErrorMessage!.Contains("must have a rule defined"));
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private WorkflowDefinition CreateWorkflowWithDefaultAutoTransition()
+    {
+        var json = """
+        {
+            "type": "F",
+            "labels": [{"label": "Test", "language": "en"}],
+            "states": [
+                {
+                    "key": "initial",
+                    "stateType": "initial",
+                    "labels": [{"label": "Initial", "language": "en"}],
+                    "transitions": [
+                        {
+                            "key": "auto-approve",
+                            "target": "approved",
+                            "triggerType": "automatic",
+                            "rule": {"location": "inline", "code": "dHJ1ZQ=="}
+                        },
+                        {
+                            "key": "default-pending",
+                            "target": "pending",
+                            "triggerType": "automatic",
+                            "kind": "defaultAutoTransition"
+                        }
+                    ]
+                },
+                {
+                    "key": "approved",
+                    "stateType": "finish",
+                    "labels": [{"label": "Approved", "language": "en"}],
+                    "transitions": []
+                },
+                {
+                    "key": "pending",
+                    "stateType": "intermediate",
+                    "labels": [{"label": "Pending", "language": "en"}],
+                    "transitions": []
+                }
+            ],
+            "sharedTransitions": [],
+            "startTransition": {
+                "key": "start",
+                "target": "initial",
+                "triggerType": "manual",
+                "labels": [{"label": "Start", "language": "en"}]
+            }
+        }
+        """;
+
+        return DeserializeWorkflow(json);
+    }
+
+    private WorkflowDefinition CreateWorkflowWithMultipleDefaultAutoTransitions()
+    {
+        var json = """
+        {
+            "type": "F",
+            "labels": [{"label": "Test", "language": "en"}],
+            "states": [
+                {
+                    "key": "initial",
+                    "stateType": "initial",
+                    "labels": [{"label": "Initial", "language": "en"}],
+                    "transitions": [
+                        {
+                            "key": "default-1",
+                            "target": "approved",
+                            "triggerType": "automatic",
+                            "kind": "defaultAutoTransition"
+                        },
+                        {
+                            "key": "default-2",
+                            "target": "pending",
+                            "triggerType": "automatic",
+                            "kind": "defaultAutoTransition"
+                        }
+                    ]
+                },
+                {
+                    "key": "approved",
+                    "stateType": "finish",
+                    "labels": [{"label": "Approved", "language": "en"}],
+                    "transitions": []
+                },
+                {
+                    "key": "pending",
+                    "stateType": "intermediate",
+                    "labels": [{"label": "Pending", "language": "en"}],
+                    "transitions": []
+                }
+            ],
+            "sharedTransitions": [],
+            "startTransition": {
+                "key": "start",
+                "target": "initial",
+                "triggerType": "manual",
+                "labels": [{"label": "Start", "language": "en"}]
+            }
+        }
+        """;
+
+        return DeserializeWorkflow(json);
+    }
+
+    private WorkflowDefinition CreateWorkflowWithDefaultAutoTransitionAndManualTrigger()
+    {
+        var json = """
+        {
+            "type": "F",
+            "labels": [{"label": "Test", "language": "en"}],
+            "states": [
+                {
+                    "key": "initial",
+                    "stateType": "initial",
+                    "labels": [{"label": "Initial", "language": "en"}],
+                    "transitions": [
+                        {
+                            "key": "invalid-default",
+                            "target": "approved",
+                            "triggerType": "manual",
+                            "kind": "defaultAutoTransition",
+                            "labels": [{"label": "Invalid", "language": "en"}]
+                        }
+                    ]
+                },
+                {
+                    "key": "approved",
+                    "stateType": "finish",
+                    "labels": [{"label": "Approved", "language": "en"}],
+                    "transitions": []
+                }
+            ],
+            "sharedTransitions": [],
+            "startTransition": {
+                "key": "start",
+                "target": "initial",
+                "triggerType": "manual",
+                "labels": [{"label": "Start", "language": "en"}]
+            }
+        }
+        """;
+
+        return DeserializeWorkflow(json);
+    }
+
+    private WorkflowDefinition CreateWorkflowWithDefaultAutoTransitionWithoutRule()
+    {
+        // Same as CreateWorkflowWithDefaultAutoTransition - DefaultAutoTransition has no rule
+        return CreateWorkflowWithDefaultAutoTransition();
+    }
+
+    private WorkflowDefinition CreateWorkflowWithRegularAutoTransitionWithoutRule()
+    {
+        var json = """
+        {
+            "type": "F",
+            "labels": [{"label": "Test", "language": "en"}],
+            "states": [
+                {
+                    "key": "initial",
+                    "stateType": "initial",
+                    "labels": [{"label": "Initial", "language": "en"}],
+                    "transitions": [
+                        {
+                            "key": "auto-no-rule",
+                            "target": "approved",
+                            "triggerType": "automatic",
+                            "labels": [{"label": "Auto", "language": "en"}]
+                        }
+                    ]
+                },
+                {
+                    "key": "approved",
+                    "stateType": "finish",
+                    "labels": [{"label": "Approved", "language": "en"}],
+                    "transitions": []
+                }
+            ],
+            "sharedTransitions": [],
+            "startTransition": {
+                "key": "start",
+                "target": "initial",
+                "triggerType": "manual",
+                "labels": [{"label": "Start", "language": "en"}]
+            }
+        }
+        """;
+
+        return DeserializeWorkflow(json);
+    }
+
+    private static WorkflowDefinition DeserializeWorkflow(string json)
+    {
+        var workflow = System.Text.Json.JsonSerializer.Deserialize<WorkflowDefinition>(json, JsonSerializerConstants.JsonOptions)!;
+        workflow.SetReference(new Reference("test-flow", "test-domain", "sys-flows", "1.0.0"));
+        return workflow;
+    }
+
+    #endregion
+}
+


### PR DESCRIPTION
## Summary by Sourcery

Introduce a DefaultAutoTransition kind for automatic transitions and enforce its semantics in workflow validation and execution.

New Features:
- Add optional TransitionKind enum with DefaultAutoTransition to mark fallback automatic transitions.
- Support JSON serialization/deserialization of transition kind on transitions and use it to order auto transition evaluation so default transitions run last and stop further evaluation on success.

Enhancements:
- Extend workflow validation to restrict each state to at most one DefaultAutoTransition, require it to be Automatic, and exempt it from the auto-transition rule requirement.

Tests:
- Add unit tests for transition TriggerKind defaults and JSON handling, and comprehensive WorkflowValidator tests covering DefaultAutoTransition validation rules and rule requirements for automatic transitions.