### PR TITLE
use explicit status check, if one evaluation satisfies return it

### DIFF
--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/RunAutomaticTransitionsStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/RunAutomaticTransitionsStep.cs
@@ -85,7 +85,7 @@ public sealed class RunAutomaticTransitionsStep(
             }
 
             evaluations.Add(evalResult.Value);
-            if (evalResult.Value.IsSuccess)
+            if (evalResult.Value.Status == AutoConditionStatus.Satisfied)
             {
                 break;
             }


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure automatic transitions short-circuit only when an AutoCondition reaches the Satisfied status instead of any generic success state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the automatic transition evaluation logic in workflow execution to check for explicit condition satisfaction status instead of relying on generic success indicators, ensuring transitions are evaluated with more precise control flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->