### PR TITLE
init-service updated

### DIFF
--- a/init/VNext.Init.Host/README.md
+++ b/init/VNext.Init.Host/README.md
@@ -55,7 +55,10 @@ This endpoint is specifically designed for the core runtime package with special
   "version": "latest",
   "appDomain": "my-domain",
   "npmRegistry": "https://registry.npmjs.org/",
-  "npmToken": "optional-token"
+  "npmToken": "optional-token",
+  "npmUsername": "optional-username",
+  "npmPassword": "optional-password",
+  "npmEmail": "optional-email"
 }
 ```
 
@@ -64,7 +67,12 @@ This endpoint is specifically designed for the core runtime package with special
 | `appDomain` | ✅ **Yes** | Target domain for replacement (e.g., "core", "my-domain") |
 | `version` | No | Package version (default: `latest`) |
 | `npmRegistry` | No | NPM registry URL (default: `https://registry.npmjs.org/`) |
-| `npmToken` | No | NPM token for private registries |
+| `npmToken` | No | NPM token for token-based auth (npmjs.org compatible) |
+| `npmUsername` | No | Username for TFS/Azure DevOps Artifacts auth |
+| `npmPassword` | No | Password for TFS/Azure DevOps Artifacts auth (will be Base64 encoded) |
+| `npmEmail` | No | Email for TFS Artifacts auth (default: `unused@dev.azure.com`) |
+
+> **Note:** Use either `npmToken` OR `npmUsername`+`npmPassword`, not both. See [NPM Authentication](#npm-authentication) for details.
 
 **Success Response (200):**
 ```json
@@ -104,7 +112,10 @@ This endpoint is for publishing any npm package with optional domain replacement
   "version": "latest",
   "appDomain": "my-domain",
   "npmRegistry": "https://registry.npmjs.org/",
-  "npmToken": "optional-token"
+  "npmToken": "optional-token",
+  "npmUsername": "optional-username",
+  "npmPassword": "optional-password",
+  "npmEmail": "optional-email"
 }
 ```
 
@@ -114,7 +125,12 @@ This endpoint is for publishing any npm package with optional domain replacement
 | `appDomain` | No | If provided, replaces all domains. If omitted, no replacement. |
 | `version` | No | Package version (default: `latest`) |
 | `npmRegistry` | No | NPM registry URL |
-| `npmToken` | No | NPM token for private registries |
+| `npmToken` | No | NPM token for token-based auth (npmjs.org compatible) |
+| `npmUsername` | No | Username for TFS/Azure DevOps Artifacts auth |
+| `npmPassword` | No | Password for TFS/Azure DevOps Artifacts auth (will be Base64 encoded) |
+| `npmEmail` | No | Email for TFS Artifacts auth (default: `unused@dev.azure.com`) |
+
+> **Note:** Use either `npmToken` OR `npmUsername`+`npmPassword`, not both. See [NPM Authentication](#npm-authentication) for details.
 
 **Success Response (200):**
 ```json
@@ -270,6 +286,63 @@ Each package must contain a `vnext.config.json` file with the following structur
   }
 }
 ```
+
+---
+
+## NPM Authentication
+
+The service supports two authentication strategies for npm registries:
+
+### Strategy 1: Token-based Authentication (`_authToken`)
+
+For npmjs.org and registries that support token-based authentication:
+
+```json
+{
+  "npmRegistry": "https://registry.npmjs.org/",
+  "npmToken": "your-npm-token"
+}
+```
+
+This generates an `.npmrc` file like:
+```ini
+registry=https://registry.npmjs.org/
+//registry.npmjs.org/:_authToken=your-npm-token
+```
+
+### Strategy 2: TFS/Azure DevOps Artifacts Authentication (`_password`)
+
+For Azure DevOps / TFS Artifacts npm feeds that require username/password authentication:
+
+```json
+{
+  "npmRegistry": "https://pkgs.dev.azure.com/org/project/_packaging/feed/npm/registry/",
+  "npmUsername": "my-user",
+  "npmPassword": "my-password-or-pat",
+  "npmEmail": "user@example.com"
+}
+```
+
+This generates an `.npmrc` file like:
+```ini
+registry=https://pkgs.dev.azure.com/org/project/_packaging/feed/npm/registry/
+//pkgs.dev.azure.com/org/project/_packaging/feed/npm/registry/:username=my-user
+//pkgs.dev.azure.com/org/project/_packaging/feed/npm/registry/:_password=BASE64_ENCODED_PASSWORD
+//pkgs.dev.azure.com/org/project/_packaging/feed/npm/registry/:email=user@example.com
+always-auth=true
+```
+
+> **Note:** The password is automatically Base64 encoded by the service.
+
+### Auth Strategy Decision
+
+| Condition | Strategy Used |
+|-----------|---------------|
+| `npmToken` provided | Token-based (`_authToken`) |
+| `npmUsername` + `npmPassword` provided | TFS Artifacts (`_password` + `username`) |
+| Neither provided | No authentication (public registry) |
+
+> ⚠️ **Important:** Do not provide both `npmToken` and `npmUsername`+`npmPassword` simultaneously. The service will prioritize `npmToken` if both are provided.
 
 ---
 

--- a/init/VNext.Init.Host/package-api-server.js
+++ b/init/VNext.Init.Host/package-api-server.js
@@ -338,15 +338,57 @@ function httpRequest(url, options = {}) {
 
 /**
  * Setup npm registry configuration
+ * 
+ * Supports two authentication strategies:
+ * 1. Token-based authentication (_authToken) - for npmjs.org and compatible registries
+ * 2. Username/Password authentication (_password + username + email) - for Azure DevOps / TFS Artifacts
+ * 
+ * Auth Strategy Decision:
+ * - If npmToken exists → use _authToken
+ * - If npmUsername + npmPassword exists → use _password (Base64 encoded)
+ * - If neither exists → only set registry=
+ * 
+ * @param {string} registry - NPM registry URL
+ * @param {Object} authOptions - Authentication options
+ * @param {string} [authOptions.token] - NPM token for _authToken based auth
+ * @param {string} [authOptions.username] - Username for TFS Artifacts auth
+ * @param {string} [authOptions.password] - Password for TFS Artifacts auth (will be Base64 encoded)
+ * @param {string} [authOptions.email] - Email for TFS Artifacts auth (optional, defaults to 'unused@dev.azure.com')
  */
-async function setupNpmRegistry(registry, token) {
+async function setupNpmRegistry(registry, authOptions = {}) {
     const npmrcPath = path.join(process.env.HOME || '/app', '.npmrc');
+    const registryHost = registry.replace(/^https?:\/\//, '').replace(/\/$/, '');
     let npmrcContent = '';
     
+    const { token, username, password, email } = authOptions;
+    
     if (token) {
-        const registryHost = registry.replace(/^https?:\/\//, '').replace(/\/$/, '');
-        npmrcContent = `//${registryHost}:_authToken=${token}\nregistry=${registry}\n`;
+        // Strategy 1: Token-based authentication (_authToken)
+        // Compatible with npmjs.org and registries that support tokens
+        log.info('Using token-based authentication (_authToken)');
+        npmrcContent = [
+            `registry=${registry}`,
+            `//${registryHost}/:_authToken=${token}`,
+            ''
+        ].join('\n');
+    } else if (username && password) {
+        // Strategy 2: Username/Password authentication for Azure DevOps / TFS Artifacts
+        // Uses _password (Base64 encoded) + username + email
+        log.info('Using TFS Artifacts authentication (_password + username)');
+        const base64Password = Buffer.from(password).toString('base64');
+        const authEmail = email || 'unused@dev.azure.com';
+        
+        npmrcContent = [
+            `registry=${registry}`,
+            `//${registryHost}/:username=${username}`,
+            `//${registryHost}/:_password=${base64Password}`,
+            `//${registryHost}/:email=${authEmail}`,
+            'always-auth=true',
+            ''
+        ].join('\n');
     } else {
+        // No authentication - public registry
+        log.info('No authentication configured - using public registry');
         npmrcContent = `registry=${registry}\n`;
     }
     
@@ -357,12 +399,21 @@ async function setupNpmRegistry(registry, token) {
 /**
  * Download and install npm package
  * ONLY called from API request handler - never automatically
+ * 
+ * @param {string} packageName - Name of the npm package to download
+ * @param {string} version - Version of the package (e.g., 'latest', '1.0.0')
+ * @param {string} registry - NPM registry URL
+ * @param {Object} authOptions - Authentication options
+ * @param {string} [authOptions.token] - NPM token for _authToken based auth
+ * @param {string} [authOptions.username] - Username for TFS Artifacts auth
+ * @param {string} [authOptions.password] - Password for TFS Artifacts auth
+ * @param {string} [authOptions.email] - Email for TFS Artifacts auth
  */
-async function downloadPackage(packageName, version, registry, token) {
+async function downloadPackage(packageName, version, registry, authOptions = {}) {
     log.section(`Downloading Package: ${packageName}@${version}`);
     log.info('This download was triggered by an API call');
     
-    await setupNpmRegistry(registry, token);
+    await setupNpmRegistry(registry, authOptions);
     
     // Ensure package.json exists
     const packageJsonPath = '/app/package.json';
@@ -826,6 +877,9 @@ async function handleRuntimePublish(req, res) {
             version = 'latest',
             npmRegistry = DEFAULT_REGISTRY,
             npmToken,
+            npmUsername,
+            npmPassword,
+            npmEmail,
             appDomain
         } = body;
         
@@ -847,8 +901,16 @@ async function handleRuntimePublish(req, res) {
         // Wait for vnext app to be ready
         await waitForVNextApp();
         
+        // Build auth options
+        const authOptions = {
+            token: npmToken,
+            username: npmUsername,
+            password: npmPassword,
+            email: npmEmail
+        };
+        
         // Download package
-        const packagePath = await downloadPackage(VNEXT_CORE_RUNTIME_PACKAGE, version, npmRegistry, npmToken);
+        const packagePath = await downloadPackage(VNEXT_CORE_RUNTIME_PACKAGE, version, npmRegistry, authOptions);
         
         // Verify package structure
         await verifyPackageStructure(packagePath);
@@ -914,6 +976,9 @@ async function handlePackagePublish(req, res) {
             version = 'latest',
             npmRegistry = DEFAULT_REGISTRY,
             npmToken,
+            npmUsername,
+            npmPassword,
+            npmEmail,
             appDomain
         } = body;
         
@@ -938,8 +1003,16 @@ async function handlePackagePublish(req, res) {
         // Wait for vnext app to be ready
         await waitForVNextApp();
         
+        // Build auth options
+        const authOptions = {
+            token: npmToken,
+            username: npmUsername,
+            password: npmPassword,
+            email: npmEmail
+        };
+        
         // Download package
-        const packagePath = await downloadPackage(packageName, version, npmRegistry, npmToken);
+        const packagePath = await downloadPackage(packageName, version, npmRegistry, authOptions);
         
         // Verify package structure
         await verifyPackageStructure(packagePath);

--- a/init/VNext.Init.Host/test.http
+++ b/init/VNext.Init.Host/test.http
@@ -11,6 +11,12 @@
 @appDomain = core
 @npmRegistry = https://registry.npmjs.org/
 
+### TFS/Azure DevOps Artifacts Variables
+@tfsRegistry = https://pkgs.dev.azure.com/org/project/_packaging/feed/npm/registry/
+@tfsUsername = my-user
+@tfsPassword = my-password-or-pat
+@tfsEmail = user@example.com
+
 ############################################################
 ### Health Check - Checks API server and vnext app health
 ############################################################
@@ -94,6 +100,36 @@ Content-Type: application/json
 }
 
 ############################################################
+###         TFS/AZURE DEVOPS ARTIFACTS EXAMPLES            ###
+###         (Username + Password Authentication)           ###
+############################################################
+
+### Runtime Publish - TFS Artifacts authentication
+POST {{baseUrl}}/api/package/runtime/publish
+Content-Type: application/json
+
+{
+  "version": "{{version}}",
+  "npmRegistry": "{{tfsRegistry}}",
+  "npmUsername": "{{tfsUsername}}",
+  "npmPassword": "{{tfsPassword}}",
+  "npmEmail": "{{tfsEmail}}",
+  "appDomain": "{{appDomain}}"
+}
+
+### Runtime Publish - TFS Artifacts (without email, uses default)
+POST {{baseUrl}}/api/package/runtime/publish
+Content-Type: application/json
+
+{
+  "version": "{{version}}",
+  "npmRegistry": "{{tfsRegistry}}",
+  "npmUsername": "{{tfsUsername}}",
+  "npmPassword": "{{tfsPassword}}",
+  "appDomain": "{{appDomain}}"
+}
+
+############################################################
 ###              STANDARD PACKAGE ENDPOINT                 ###
 ###           POST /api/package/publish                    ###
 ###  - For any npm package                                 ###
@@ -171,6 +207,32 @@ Content-Type: application/json
   "version": "{{version}}"
 }
 
+### Package Publish - TFS Artifacts authentication
+POST {{baseUrl}}/api/package/publish
+Content-Type: application/json
+
+{
+  "packageName": "@my-org/my-workflow-package",
+  "version": "{{version}}",
+  "npmRegistry": "{{tfsRegistry}}",
+  "npmUsername": "{{tfsUsername}}",
+  "npmPassword": "{{tfsPassword}}",
+  "npmEmail": "{{tfsEmail}}",
+  "appDomain": "my-domain"
+}
+
+### Package Publish - TFS Artifacts (without domain replacement)
+POST {{baseUrl}}/api/package/publish
+Content-Type: application/json
+
+{
+  "packageName": "@my-org/my-workflow-package",
+  "version": "{{version}}",
+  "npmRegistry": "{{tfsRegistry}}",
+  "npmUsername": "{{tfsUsername}}",
+  "npmPassword": "{{tfsPassword}}"
+}
+
 ############################################################
 ###                   ERROR CASES                          ###
 ############################################################
@@ -221,5 +283,22 @@ Origin: http://localhost:3001
 #
 # 3. Health Check
 #    GET /health
+#
+############################################################
+###               NPM AUTHENTICATION SUMMARY               ###
+############################################################
+#
+# Strategy 1: Token-based (npmjs.org, GitHub Packages, etc.)
+#    - npmToken: Your npm token
+#    - Generates: _authToken in .npmrc
+#
+# Strategy 2: TFS/Azure DevOps Artifacts
+#    - npmUsername: Your username
+#    - npmPassword: Your password/PAT (Base64 encoded automatically)
+#    - npmEmail: Your email (optional, defaults to unused@dev.azure.com)
+#    - Generates: _password + username + email in .npmrc
+#
+# Priority: If both npmToken and npmUsername are provided,
+#           npmToken takes precedence.
 #
 ############################################################


### PR DESCRIPTION
## Summary by Sourcery

Extend init service npm package publishing to support multiple authentication strategies for private registries and document their usage.

New Features:
- Add support for username/password-based npm authentication for Azure DevOps/TFS Artifacts feeds in addition to token-based auth.
- Allow runtime and package publish endpoints to accept extended npm auth parameters (token, username, password, email).

Enhancements:
- Refine .npmrc generation to handle token-based, username/password-based, and unauthenticated registry access with explicit logging of the chosen strategy.

Documentation:
- Update README to describe the new npm authentication options for publish endpoints and add a dedicated section explaining supported auth strategies and examples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added npm authentication support using username, password, and email credentials as an alternative to token-based authentication, enabling greater flexibility for different registry types.

* **Documentation**
  * Expanded npm authentication documentation with detailed guidance on selecting authentication strategies and comprehensive examples for both token-based and credential-based authentication methods.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->