### PR TITLE
Discovery ssl fix

### DIFF
--- a/src/BBT.Workflow.Application/Discovery/DomainRegistrationService.cs
+++ b/src/BBT.Workflow.Application/Discovery/DomainRegistrationService.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Json;
 using System.Text.Json;
+using BBT.Workflow.Definitions;
 using BBT.Workflow.Runtime;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -72,9 +73,20 @@ public sealed class DomainRegistrationService(
         var registryFlow= options.RegistryFlow;
         var requestUrl = $"{registryBaseUrl}/{registryDomain}/workflows/{registryFlow}/instances/start?sync=false";
 
+        var httpClientName = options.ValidateSsl
+            ? TaskConstants.DefaultHttpClientName
+            : TaskConstants.NoSslValidationHttpClientName;
+
+        if (!options.ValidateSsl)
+        {
+            logger.LogWarning(
+                "SSL certificate validation is disabled for domain registration to '{RegistryUrl}'. This should only be used in development environments.",
+                requestUrl);
+        }
+
         try
         {
-            var httpClient = httpClientFactory.CreateClient(HttpClientName);
+            var httpClient = httpClientFactory.CreateClient(httpClientName);
             
             var response = await httpClient.PostAsJsonAsync(requestUrl, requestBody, JsonOptions, cancellationToken);
 

--- a/src/BBT.Workflow.Application/Discovery/ServiceDiscoveryOptions.cs
+++ b/src/BBT.Workflow.Application/Discovery/ServiceDiscoveryOptions.cs
@@ -32,5 +32,17 @@ public sealed class ServiceDiscoveryOptions
     /// Default is "core".
     /// </summary>
     public string Domain { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets or sets the registry flow name to use in the HTTP call path.
+    /// This is the workflow flow name for domain registration.
+    /// </summary>
     public string RegistryFlow { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets whether SSL certificate validation should be performed for HTTP requests to the registry.
+    /// When set to false, SSL certificate validation is disabled (useful for development with self-signed certificates).
+    /// Default is true (SSL validation enabled) for production security.
+    /// </summary>
+    public bool ValidateSsl { get; set; } = true;
 }


### PR DESCRIPTION
## Summary by Sourcery

Make domain registration HTTP client selection depend on a new SSL validation option.

Enhancements:
- Add configuration option to control SSL certificate validation for service discovery registry calls and select the appropriate named HTTP client.
- Log a warning when SSL certificate validation is disabled for domain registration requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable SSL certificate validation for service discovery operations, allowing you to enable or disable secure connection validation
  * Added registry flow configuration option to customize HTTP call paths
  * Warning notifications now display when SSL certificate validation is disabled

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->