### PR TITLE
Add extensions function support for workflow instances

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -48,7 +48,8 @@ review:
     - "**/*.suo"
     - "**/packages/**"
     - "**/.vs/**"
-    - "**/node_modules/**"
+    - "**/node_modules/**",
+    - "**/etc/docker/config/**"
 
 # Chat settings
 chat:

--- a/etc/docker/config/mockoon/migration-api.json
+++ b/etc/docker/config/mockoon/migration-api.json
@@ -2073,7 +2073,7 @@
       "responses": [
         {
           "uuid": "7198d479-8589-4487-a458-d9454d94f398",
-          "body": "{{setVar 'eTag' (faker 'string.alphanumeric' 32)}}\n{{setVar 'port' (faker 'number.int' min=4200 max=5000)}}\n{\n    \"data\": {\n        \"eTag\": \"\\\"{{@eTag}}\\\"\",\n        \"appId\": \"vnext-{{urlParam 'domain'}}.test-vnext-{{urlParam 'domain'}}\",\n        \"baseUrl\": \"http://localhost:{{@port}}\",\n        \"healthUrl\": \"https://localhost:{{@port}}/health\",\n        \"domainName\": \"{{urlParam 'domain'}}\"\n    },\n    \"etag\":  \"\\\"{{@eTag}}\\\"\",\n    \"extensions\": {}\n}\n ",
+          "body": "{{setVar 'eTag' (faker 'string.alphanumeric' 32)}}\n\n{{#if (eq (urlParam 'domain') 'core')}}\n  {{setVar 'port' 4201}}\n{{else}}\n  {{setVar 'port' (faker 'number.int' min=4200 max=5000)}}\n{{/if}}\n\n{\n    \"data\": {\n        \"eTag\": \"\\\"{{@eTag}}\\\"\",\n        \"appId\": \"vnext-{{urlParam 'domain'}}.test-vnext-{{urlParam 'domain'}}\",\n        \"baseUrl\": \"http://localhost:{{@port}}\",\n        \"healthUrl\": \"https://localhost:{{@port}}/health\",\n        \"domainName\": \"{{urlParam 'domain'}}\"\n    },\n    \"etag\":  \"\\\"{{@eTag}}\\\"\",\n    \"extensions\": {}\n}\n ",
           "latency": 0,
           "statusCode": 200,
           "label": "Domain servis bilgisini döner",
@@ -2081,6 +2081,10 @@
             {
               "key": "Content-Type",
               "value": "application/json"
+            },
+            {
+              "key": "x-change-port",
+              "value": "true"
             }
           ],
           "bodyType": "INLINE",

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs
@@ -9,6 +9,8 @@ using BBT.Workflow.Functions;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Instances.DTOs;
 using BBT.Workflow.Runtime;
+using GetExtensionsInput = BBT.Workflow.Instances.DTOs.GetExtensionsInput;
+using GetExtensionsOutput = BBT.Workflow.Instances.DTOs.GetExtensionsOutput;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 
@@ -113,6 +115,12 @@ public sealed class FunctionController(
                 cancellationToken));
         }
 
+        if (functionType == Definitions.Functions.FunctionTypeConst.Extensions)
+        {
+            return FromResult(await ProcessExtensionsFunctionListAsync(domain, workflow, instanceListResult.Value!,
+                requestContext.Headers, requestContext.QueryParameters, cancellationToken));
+        }
+
         return FromResult(await ProcessCustomFunctionListAsync(function, workflow, domain, instanceListResult.Value!,
             requestContext.Headers, requestContext.QueryParameters, cancellationToken));
     }
@@ -161,6 +169,12 @@ public sealed class FunctionController(
         {
             return FromResult(await ProcessSchemaFunctionAsync(domain, workflow, instance, parameters.Version,
                 parameters.TransitionKey, cancellationToken));
+        }
+
+        if (functionType == Definitions.Functions.FunctionTypeConst.Extensions)
+        {
+            return FromResult(await ProcessExtensionsFunctionAsync(domain, workflow, instance, parameters.Version,
+                parameters.Extensions, requestContext.Headers, requestContext.QueryParameters, cancellationToken));
         }
 
         return FromResult(await functionAppService.GetFunctionByInstanceAsync(function, workflow, domain, instance,
@@ -262,6 +276,67 @@ public sealed class FunctionController(
         };
 
         return await queryAppService.GetSchemaAsync(input, transitionKey, cancellationToken);
+    }
+
+    private async Task<Result<GetExtensionsOutput>> ProcessExtensionsFunctionAsync(
+        string domain,
+        string workflow,
+        string instance,
+        string? version,
+        string[]? extensions,
+        Dictionary<string, string?> headers,
+        Dictionary<string, string?> queryParams,
+        CancellationToken cancellationToken)
+    {
+        var input = new GetExtensionsInput
+        {
+            Domain = domain,
+            Workflow = workflow,
+            Instance = instance,
+            Version = version,
+            Extensions = extensions,
+            Headers = headers,
+            QueryParameters = queryParams
+        };
+
+        return await queryAppService.GetExtensionsAsync(input, cancellationToken);
+    }
+
+    private async Task<Result<HateoasPagedResultDto<GetExtensionsOutput>>> ProcessExtensionsFunctionListAsync(
+        string domain,
+        string workflow,
+        HateoasPagedList<GetInstanceOutput> instanceListResult,
+        Dictionary<string, string?> headers,
+        Dictionary<string, string?> queryParams,
+        CancellationToken cancellationToken)
+    {
+        var list = new List<GetExtensionsOutput>();
+
+        foreach (var instance in instanceListResult.Items)
+        {
+            var result = await ProcessExtensionsFunctionAsync(
+                domain,
+                workflow,
+                instance.Key!,
+                instance.FlowVersion,
+                null,
+                headers,
+                queryParams,
+                cancellationToken);
+
+            if (!result.IsSuccess)
+            {
+                continue;
+            }
+
+            list.Add(result.Value!);
+        }
+
+        var route = InstanceUrlTemplates.FunctionList(domain, workflow,
+            Definitions.Functions.FunctionTypeConst.Extensions, InstanceUrlTemplates.GetApiVersionPrefix("1"));
+        var output = linkGenerator.CreateHateoasResult(instanceListResult, list, route);
+
+        return Result<HateoasPagedResultDto<GetExtensionsOutput>>.Ok(output);
     }
 
     private async Task<Result<HateoasPagedResultDto<GetSchemaOutput>>> ProcessSchemaFunctionListAsync(

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs
@@ -208,25 +208,11 @@ public sealed class FunctionController(
         HateoasPagedList<GetInstanceOutput> instanceListResult,
         CancellationToken cancellationToken)
     {
-        var list = new List<GetInstanceStateOutput>();
+        var tasks = instanceListResult.Items.Select(instance =>
+            ProcessLongpoolingFunctionAsync(domain, workflow, instance.Key!, instance.FlowVersion, null, cancellationToken));
 
-        foreach (var instance in instanceListResult.Items)
-        {
-            var result = await ProcessLongpoolingFunctionAsync(
-                domain,
-                workflow,
-                instance.Key!,
-                instance.FlowVersion,
-                null,
-                cancellationToken);
-
-            if (!result.IsSuccess)
-            {
-                continue;
-            }
-
-            list.Add(result.Value!);
-        }
+        var results = await Task.WhenAll(tasks);
+        var list = results.Where(r => r.IsSuccess).Select(r => r.Value!).ToList();
 
         var route = InstanceUrlTemplates.FunctionList(domain, workflow,
             Definitions.Functions.FunctionTypeConst.Longpooling, InstanceUrlTemplates.GetApiVersionPrefix("1"));
@@ -310,27 +296,11 @@ public sealed class FunctionController(
         Dictionary<string, string?> queryParams,
         CancellationToken cancellationToken)
     {
-        var list = new List<GetExtensionsOutput>();
+        var tasks = instanceListResult.Items.Select(instance =>
+            ProcessExtensionsFunctionAsync(domain, workflow, instance.Key!, instance.FlowVersion, null, headers, queryParams, cancellationToken));
 
-        foreach (var instance in instanceListResult.Items)
-        {
-            var result = await ProcessExtensionsFunctionAsync(
-                domain,
-                workflow,
-                instance.Key!,
-                instance.FlowVersion,
-                null,
-                headers,
-                queryParams,
-                cancellationToken);
-
-            if (!result.IsSuccess)
-            {
-                continue;
-            }
-
-            list.Add(result.Value!);
-        }
+        var results = await Task.WhenAll(tasks);
+        var list = results.Where(r => r.IsSuccess).Select(r => r.Value!).ToList();
 
         var route = InstanceUrlTemplates.FunctionList(domain, workflow,
             Definitions.Functions.FunctionTypeConst.Extensions, InstanceUrlTemplates.GetApiVersionPrefix("1"));
@@ -345,25 +315,11 @@ public sealed class FunctionController(
         HateoasPagedList<GetInstanceOutput> instanceListResult,
         CancellationToken cancellationToken)
     {
-        var list = new List<GetSchemaOutput>();
+        var tasks = instanceListResult.Items.Select(instance =>
+            ProcessSchemaFunctionAsync(domain, workflow, instance.Key!, instance.FlowVersion, string.Empty, cancellationToken));
 
-        foreach (var instance in instanceListResult.Items)
-        {
-            var result = await ProcessSchemaFunctionAsync(
-                domain,
-                workflow,
-                instance.Key!,
-                instance.FlowVersion,
-                string.Empty,
-                cancellationToken);
-
-            if (!result.IsSuccess)
-            {
-                continue;
-            }
-
-            list.Add(result.Value!);
-        }
+        var results = await Task.WhenAll(tasks);
+        var list = results.Where(r => r.IsSuccess).Select(r => r.Value!).ToList();
 
         var route = InstanceUrlTemplates.FunctionList(domain, workflow,
             Definitions.Functions.FunctionTypeConst.Schema, InstanceUrlTemplates.GetApiVersionPrefix("1"));
@@ -378,26 +334,11 @@ public sealed class FunctionController(
         HateoasPagedList<GetInstanceOutput> instanceListResult,
         CancellationToken cancellationToken)
     {
-        var list = new List<GetViewOutput>();
+        var tasks = instanceListResult.Items.Select(instance =>
+            ProcessViewFunctionAsync(domain, workflow, instance.Key!, instance.FlowVersion, string.Empty, string.Empty, cancellationToken));
 
-        foreach (var instance in instanceListResult.Items)
-        {
-            var result = await ProcessViewFunctionAsync(
-                domain,
-                workflow,
-                instance.Key!,
-                instance.FlowVersion,
-                string.Empty,
-                string.Empty,
-                cancellationToken);
-
-            if (!result.IsSuccess)
-            {
-                continue;
-            }
-
-            list.Add(result.Value!);
-        }
+        var results = await Task.WhenAll(tasks);
+        var list = results.Where(r => r.IsSuccess).Select(r => r.Value!).ToList();
 
         var route = InstanceUrlTemplates.FunctionList(domain, workflow,
             Definitions.Functions.FunctionTypeConst.View, InstanceUrlTemplates.GetApiVersionPrefix("1"));
@@ -445,9 +386,7 @@ public sealed class FunctionController(
         Dictionary<string, string?> queryParams,
         CancellationToken cancellationToken)
     {
-        var list = new List<GetInstanceDataOutput>();
-
-        foreach (var instance in instanceListResult.Items)
+        var tasks = instanceListResult.Items.Select(instance =>
         {
             var input = new GetInstanceDataInput
             {
@@ -457,10 +396,11 @@ public sealed class FunctionController(
                 Headers = headers,
                 QueryParameters = queryParams
             };
+            return queryAppService.GetInstanceDataAsync(input, cancellationToken);
+        });
 
-            var response = await queryAppService.GetInstanceDataAsync(input, cancellationToken);
-            list.Add(response.Result.Value!);
-        }
+        var results = await Task.WhenAll(tasks);
+        var list = results.Where(r => r.Result.IsSuccess).Select(r => r.Result.Value!).ToList();
 
         var route = InstanceUrlTemplates.FunctionList(domain, workflow,
             Definitions.Functions.FunctionTypeConst.Data, InstanceUrlTemplates.GetApiVersionPrefix("1"));
@@ -477,23 +417,11 @@ public sealed class FunctionController(
         Dictionary<string, string?> queryParams,
         CancellationToken cancellationToken)
     {
-        var list = new List<Dictionary<string, dynamic?>>();
+        var tasks = instanceListResult.Items.Select(instance =>
+            functionAppService.GetFunctionByInstanceAsync(function, workflow, domain, instance.Key!, headers, queryParams, cancellationToken));
 
-        foreach (var instance in instanceListResult.Items)
-        {
-            var result = await functionAppService.GetFunctionByInstanceAsync(function, workflow, domain,
-                instance.Key!,
-                headers, queryParams, cancellationToken);
-
-            if (!result.IsSuccess)
-            {
-                continue;
-            }
-
-            list.Add(
-                result.Value!
-            );
-        }
+        var results = await Task.WhenAll(tasks);
+        var list = results.Where(r => r.IsSuccess).Select(r => r.Value!).ToList();
 
         var route = InstanceUrlTemplates.FunctionList(domain, workflow, function,
             InstanceUrlTemplates.GetApiVersionPrefix("1"));

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/appsettings.json
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/appsettings.json
@@ -139,7 +139,7 @@
     ]
   },
   "ServiceDiscovery": {
-    "Enabled": true,
+    "Enabled": false,
     "BaseUrl": "http://localhost:3001/api/v1",
     "Domain": "discovery",
     "RegistryFlow": "domain-registration",

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/appsettings.json
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/appsettings.json
@@ -141,6 +141,7 @@
   "ServiceDiscovery": {
     "Enabled": false,
     "BaseUrl": "http://localhost:3001/api/v1",
+    "ValidateSsl": false,
     "Domain": "discovery",
     "RegistryFlow": "domain-registration",
     "TimeoutSeconds": 30,

--- a/src/BBT.Workflow.Application/Definitions/DefinitionAppService.cs
+++ b/src/BBT.Workflow.Application/Definitions/DefinitionAppService.cs
@@ -174,7 +174,8 @@ public sealed class DefinitionAppService(
         instance.AddDataWithVersion(
             GuidGenerator.Create(),
             new JsonData(input.Attributes),
-            input.Version
+            input.Version,
+            false
         );
 
         await instanceRepository.UpdateAsync(instance, true, cancellationToken);

--- a/src/BBT.Workflow.Application/Discovery/ServiceDiscoveryOptions.cs
+++ b/src/BBT.Workflow.Application/Discovery/ServiceDiscoveryOptions.cs
@@ -84,4 +84,11 @@ public sealed class ServiceDiscoveryOptions
     /// Default: "/discovery/workflows/domain/instances/{0}/functions/data"
     /// </summary>
     public string DiscoveryEndpointTemplate { get; set; } = "/discovery/workflows/domain/instances/{0}/functions/data";
+
+    /// <summary>
+    /// Gets or sets whether SSL certificate validation is enabled.
+    /// When set to false, SSL certificate errors will be ignored (useful for development environments).
+    /// Default is true for security reasons.
+    /// </summary>
+    public bool ValidateSsl { get; set; } = true;
 }

--- a/src/BBT.Workflow.Application/Instances/DTOs/GetExtensionsInput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/GetExtensionsInput.cs
@@ -1,0 +1,63 @@
+using System.ComponentModel.DataAnnotations;
+using BBT.Workflow.Definitions;
+
+namespace BBT.Workflow.Instances.DTOs;
+
+/// <summary>
+/// Input for retrieving instance extensions
+/// </summary>
+public sealed class GetExtensionsInput : IHasDomain
+{
+    /// <summary>
+    /// Domain name
+    /// </summary>
+    [Required]
+    [StringLength(WorkflowConstants.MaxDomainLength)]
+    public string Domain { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Workflow name
+    /// </summary>
+    [Required]
+    [StringLength(WorkflowConstants.MaxFlowLength)]
+    public string Workflow { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Version of the workflow
+    /// </summary>
+    [StringLength(WorkflowConstants.MaxVersionLength)]
+    public string? Version { get; set; }
+
+    /// <summary>
+    /// Instance identifier (ID or Key)
+    /// </summary>
+    [Required]
+    public string Instance { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Extensions to execute
+    /// </summary>
+    public string[]? Extensions { get; set; }
+
+    /// <summary>
+    /// Request headers for script context
+    /// </summary>
+    public Dictionary<string, string?> Headers { get; set; } = new();
+
+    /// <summary>
+    /// Query parameters for script context
+    /// </summary>
+    public Dictionary<string, string?> QueryParameters { get; set; } = new();
+}
+
+/// <summary>
+/// Output containing executed extension results
+/// </summary>
+public sealed class GetExtensionsOutput
+{
+    /// <summary>
+    /// Extension execution results as key-value pairs
+    /// </summary>
+    public Dictionary<string, object> Extensions { get; set; } = new();
+}
+

--- a/src/BBT.Workflow.Application/Instances/DTOs/GetExtensionsInput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/GetExtensionsInput.cs
@@ -37,7 +37,7 @@ public sealed class GetExtensionsInput : IHasDomain
     /// <summary>
     /// Extensions to execute
     /// </summary>
-    public string[]? Extensions { get; set; }
+    public string[]? Extensions { get; init; }
 
     /// <summary>
     /// Request headers for script context

--- a/src/BBT.Workflow.Application/Instances/IInstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/IInstanceQueryAppService.cs
@@ -59,4 +59,11 @@ public interface IInstanceQueryAppService : IApplicationService
         GetSchemaInput input,
         string? transitionKey,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves and executes extensions for an instance
+    /// </summary>
+    Task<Result<GetExtensionsOutput>> GetExtensionsAsync(
+        GetExtensionsInput input,
+        CancellationToken cancellationToken = default);
 }

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -20,7 +20,6 @@ public sealed class InstanceQueryAppService(
     IRuntimeInfoProvider runtimeInfoProvider,
     IComponentCacheStore componentCacheStore,
     IInstanceRepository instanceRepository,
-    IInstanceCorrelationRepository instanceCorrelationRepository,
     IInstanceExtensionService instanceExtensionService,
     IScriptContextFactory scriptContextFactory,
     IRemoteInstanceQueryAppService remoteInstanceQueryAppService,
@@ -135,36 +134,47 @@ public sealed class InstanceQueryAppService(
     /// <summary>
     /// Builds instance transition information including status, current state, and correlations.
     /// This method consolidates the logic for determining instance information based on instance status.
+    /// Uses instance.ActiveCorrelations directly to avoid extra database call.
     /// </summary>
     /// <param name="instance">The workflow instance</param>
-    /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>A tuple containing status, current state, and correlations</returns>
-    private async
-        Task<(InstanceStatus Status, string? CurrentState, List<InstanceCorrelationInfo>
-            ActiveCorrelations)> BuildInstanceTransitionInfoAsync(
-            Instance instance,
-            CancellationToken cancellationToken = default)
+    private (InstanceStatus Status, string? CurrentState, List<InstanceCorrelationInfo> ActiveCorrelations)
+        BuildInstanceTransitionInfo(Instance instance)
     {
-        // Get active correlations
-        var activeCorrelations = await GetActiveCorrelationsAsync(instance.Id, cancellationToken);
+        // Map active correlations from entity to DTO
+        var activeCorrelations = instance.ActiveCorrelations
+            .Select(c => new InstanceCorrelationInfo
+            {
+                CorrelationId = c.Id,
+                ParentState = c.ParentState,
+                SubFlowInstanceId = c.SubFlowInstanceId,
+                SubFlowType = c.SubFlowType,
+                SubFlowDomain = c.SubFlowDomain,
+                SubFlowName = c.SubFlowName,
+                SubFlowVersion = c.SubFlowVersion,
+                IsCompleted = c.IsCompleted
+            })
+            .ToList();
 
         return (instance.Status, instance.CurrentState, activeCorrelations);
     }
 
     /// <summary>
-    /// Gets available transitions from a remote SubFlow instance.
+    /// Gets available transitions and state information from a remote SubFlow instance.
+    /// Includes view extensions and active correlations from the SubFlow.
     /// </summary>
     /// <param name="activeSubFlowCorrelation">The active SubFlow correlation</param>
     /// <param name="mainInstance">The main workflow instance</param>
     /// <param name="currentWorkflow">The current workflow definition</param>
+    /// <param name="extensions">Extensions to pass to the SubFlow for data href building</param>
     /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>Tuple containing available transitions and current state from SubFlow, status always from main flow</returns>
-    private async Task<(List<string> AvailableTransitions, string? CurrentState, InstanceStatus? Status)>
-        GetSubFlowTransitionsAsync(
-            InstanceCorrelationInfo activeSubFlowCorrelation,
-            Instance mainInstance,
-            BBT.Workflow.Definitions.Workflow currentWorkflow,
-            CancellationToken cancellationToken = default)
+    /// <returns>SubFlowStateInfo containing transitions, state, view extensions, and active correlations from SubFlow</returns>
+    private async Task<SubFlowStateInfo> GetSubFlowTransitionsAsync(
+        InstanceCorrelationInfo activeSubFlowCorrelation,
+        Instance mainInstance,
+        BBT.Workflow.Definitions.Workflow currentWorkflow,
+        string[]? extensions,
+        CancellationToken cancellationToken = default)
     {
         try
         {
@@ -173,7 +183,8 @@ public sealed class InstanceQueryAppService(
                 Domain = activeSubFlowCorrelation.SubFlowDomain,
                 Workflow = activeSubFlowCorrelation.SubFlowName,
                 Version = activeSubFlowCorrelation.SubFlowVersion,
-                Instance = activeSubFlowCorrelation.SubFlowInstanceId.ToString()
+                Instance = activeSubFlowCorrelation.SubFlowInstanceId.ToString(),
+                Extensions = extensions
             };
 
             var subFlowResult = await remoteInstanceQueryAppService.GetFunctionWithStateAsync(
@@ -182,12 +193,21 @@ public sealed class InstanceQueryAppService(
 
             if (subFlowResult.IsSuccess && subFlowResult.Value != null)
             {
-                // Use SubFlow transitions and current state, but always use main instance status
+                var subFlowValue = subFlowResult.Value;
+                
                 // Extract transition names from TransitionItem list
-                var transitionNames = subFlowResult.Value.Transitions
+                var transitionNames = subFlowValue.Transitions
                     .Select(t => t.Name)
                     .ToList();
-                return (transitionNames, subFlowResult.Value.State, mainInstance.Status);
+
+                // Return complete SubFlow state including view extensions and active correlations
+                return new SubFlowStateInfo(
+                    AvailableTransitions: transitionNames,
+                    CurrentState: subFlowValue.State,
+                    Status: mainInstance.Status,
+                    SubFlowData: subFlowValue.Data,
+                    SubFlowView: subFlowValue.View,
+                    SubFlowActiveCorrelations: subFlowValue.ActiveCorrelations);
             }
         }
         catch (Exception ex)
@@ -210,8 +230,8 @@ public sealed class InstanceQueryAppService(
     /// <param name="instance">The workflow instance</param>
     /// <param name="currentWorkflow">The current workflow definition</param>
     /// <param name="transitionInfo">Optional transition info (used when called from main method)</param>
-    /// <returns>Tuple containing available transitions, current state, and status from main flow</returns>
-    private (List<string> AvailableTransitions, string? CurrentState, InstanceStatus? Status) GetMainFlowTransitions(
+    /// <returns>SubFlowStateInfo containing available transitions, current state, and status from main flow (no SubFlow-specific data)</returns>
+    private SubFlowStateInfo GetMainFlowTransitions(
         Instance instance,
         BBT.Workflow.Definitions.Workflow currentWorkflow,
         (InstanceStatus Status, string? CurrentState, List<InstanceCorrelationInfo> ActiveCorrelations)?
@@ -231,34 +251,10 @@ public sealed class InstanceQueryAppService(
         var currentState = transitionInfo?.CurrentState ?? instance.CurrentState;
         var status = transitionInfo?.Status ?? instance.Status;
 
-        return (availableTransitions, currentState, status);
-    }
-
-    /// <summary>
-    /// Gets active SubFlow/SubProcess correlations for the instance.
-    /// </summary>
-    /// <param name="instanceId">The workflow instance ID</param>
-    /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>List of active correlation information</returns>
-    private async Task<List<InstanceCorrelationInfo>> GetActiveCorrelationsAsync(
-        Guid instanceId,
-        CancellationToken cancellationToken = default)
-    {
-        var correlations = await instanceCorrelationRepository.GetActiveByParentAsync(instanceId, cancellationToken);
-
-        return correlations
-            .Select(c => new InstanceCorrelationInfo
-            {
-                CorrelationId = c.Id,
-                ParentState = c.ParentState,
-                SubFlowInstanceId = c.SubFlowInstanceId,
-                SubFlowType = c.SubFlowType,
-                SubFlowDomain = c.SubFlowDomain,
-                SubFlowName = c.SubFlowName,
-                SubFlowVersion = c.SubFlowVersion,
-                IsCompleted = c.IsCompleted
-            })
-            .ToList();
+        return new SubFlowStateInfo(
+            AvailableTransitions: availableTransitions,
+            CurrentState: currentState,
+            Status: status);
     }
 
     /// <summary>
@@ -358,6 +354,22 @@ public sealed class InstanceQueryAppService(
                         Etag = instance.LatestData?.ETag ?? string.Empty
                     };
 
+                    // If there's an active SubFlow and extensions are requested, fetch from SubFlow
+                    if (instance.Subflow != null)
+                    {
+                        var subFlowExtensionsResult = await GetSubFlowExtensionsAsync(
+                            instance.Subflow,
+                            input.Extensions,
+                            cancellationToken);
+
+                        result.Extensions = subFlowExtensionsResult.IsSuccess
+                            ? subFlowExtensionsResult.Value?.Extensions ?? new Dictionary<string, object>()
+                            : new Dictionary<string, object>();
+
+                        return ConditionalResult<GetInstanceDataOutput>.Success(result);
+                    }
+
+                    // No active SubFlow - process extensions locally
                     var scriptContext = await scriptContextFactory.NewBuilder(instanceRepository)
                         .WithWorkflow(flow)
                         .WithInstance(instance)
@@ -442,6 +454,7 @@ public sealed class InstanceQueryAppService(
 
     /// <summary>
     /// Builds the complete instance state output including transitions, correlations, and view information.
+    /// When there's an active SubFlow, includes the SubFlow's view extensions in data href and merges active correlations.
     /// </summary>
     private async Task<Result<GetInstanceStateOutput>> BuildInstanceStateOutputAsync(
         Instance instance,
@@ -449,8 +462,8 @@ public sealed class InstanceQueryAppService(
         GetInstanceStateInput input,
         CancellationToken cancellationToken)
     {
-        // Build instance transition information using shared logic
-        var transitionInfo = await BuildInstanceTransitionInfoAsync(instance, cancellationToken);
+        // Build instance transition information using shared logic (no DB call - uses instance.ActiveCorrelations)
+        var transitionInfo = BuildInstanceTransitionInfo(instance);
 
         // Check if there are any active SubFlow correlations
         var activeSubFlowCorrelation = transitionInfo.ActiveCorrelations
@@ -458,15 +471,16 @@ public sealed class InstanceQueryAppService(
             .OrderByDescending(c => c.CorrelationId)
             .FirstOrDefault();
 
-        var (availableTransitions, currentState, status) = activeSubFlowCorrelation != null
-            ? await GetSubFlowTransitionsAsync(activeSubFlowCorrelation, instance, currentWorkflow, cancellationToken)
+        var subFlowStateInfo = activeSubFlowCorrelation != null
+            ? await GetSubFlowTransitionsAsync(activeSubFlowCorrelation, instance, currentWorkflow, input.Extensions, cancellationToken)
             : GetMainFlowTransitions(instance, currentWorkflow, transitionInfo);
 
         // Build transition items with href links
-        var transitionItems = availableTransitions.Select(transitionKey => new TransitionItem
+        var transitionItems = subFlowStateInfo.AvailableTransitions.Select(transitionKey => new TransitionItem
         {
             Name = transitionKey,
-            Href = InstanceUrlTemplates.Transition(input.Domain, input.Workflow, instance.Id.ToString(), transitionKey)
+            Href = InstanceUrlTemplates.Transition(input.Domain, input.Workflow, instance.Id.ToString(), transitionKey),
+            Schema = new HrefBase { Href = InstanceUrlTemplates.Schema(input.Domain, input.Workflow, instance.Id.ToString(), transitionKey) }
         }).ToList();
 
         // Get current state using Railway pattern
@@ -476,11 +490,15 @@ public sealed class InstanceQueryAppService(
                 Error.NotFound("notfound", $"State {instance.CurrentState} not found in workflow {input.Workflow}"))
             .Map(currentStateValue =>
             {
-                // Get view definition
+                // Get view definition from main flow
                 var viewDefinition = GetViewDefinition(instance, currentWorkflow, currentStateValue);
 
                 // Build data href with extensions
-                var allExtensions = (input.Extensions ?? []).Concat(viewDefinition?.Extensions ?? []).ToArray();
+                // If SubFlow is active, use SubFlow's extensions; otherwise use main flow extensions
+                var allExtensions = subFlowStateInfo.SubFlowData != null
+                    ? ExtractExtensionsFromDataHref(subFlowStateInfo.SubFlowData.Href)
+                    : (input.Extensions ?? []).Concat(viewDefinition?.Extensions ?? []).ToArray();
+                
                 var dataHref = new DataHref
                 {
                     Href = allExtensions.Length > 0
@@ -489,15 +507,15 @@ public sealed class InstanceQueryAppService(
                         : InstanceUrlTemplates.Data(input.Domain, input.Workflow, instance.Id.ToString())
                 };
 
-                // Build view href
+                // Build view href - use SubFlow view's LoadData if available, otherwise use main flow
                 var viewHref = new ViewHref
                 {
                     Href = InstanceUrlTemplates.View(input.Domain, input.Workflow, instance.Id.ToString()),
-                    LoadData = viewDefinition?.LoadData == true
+                    LoadData = subFlowStateInfo.SubFlowView?.LoadData ?? viewDefinition?.LoadData == true
                 };
 
-                // Build active correlations with href links
-                var activeCorrelationHrefs = transitionInfo.ActiveCorrelations.Select(correlation =>
+                // Build active correlations with href links from main flow
+                var mainFlowCorrelationHrefs = transitionInfo.ActiveCorrelations.Select(correlation =>
                     new ActiveCorrelationHref
                     {
                         CorrelationId = correlation.CorrelationId,
@@ -508,21 +526,66 @@ public sealed class InstanceQueryAppService(
                         SubFlowName = correlation.SubFlowName,
                         SubFlowVersion = correlation.SubFlowVersion,
                         IsCompleted = correlation.IsCompleted,
-                        Href = InstanceUrlTemplates.Data(correlation.SubFlowDomain, correlation.SubFlowName,
-                            correlation.SubFlowInstanceId.ToString())
+                        Href = allExtensions.Length > 0
+                            ? InstanceUrlTemplates.DataWithExtensions(correlation.SubFlowDomain, correlation.SubFlowName,
+                                correlation.SubFlowInstanceId.ToString(),
+                                string.Join(",", allExtensions))
+                            : InstanceUrlTemplates.Data(correlation.SubFlowDomain, correlation.SubFlowName,
+                                correlation.SubFlowInstanceId.ToString())
                     }).ToList();
+
+                // Merge SubFlow active correlations if available
+                var allActiveCorrelations = subFlowStateInfo.SubFlowActiveCorrelations != null
+                    ? mainFlowCorrelationHrefs.Concat(subFlowStateInfo.SubFlowActiveCorrelations).ToList()
+                    : mainFlowCorrelationHrefs;
 
                 return new GetInstanceStateOutput
                 {
                     Data = dataHref,
                     View = viewHref,
-                    State = currentState ?? string.Empty,
-                    Status = status,
-                    ActiveCorrelations = activeCorrelationHrefs,
+                    State = subFlowStateInfo.CurrentState ?? string.Empty,
+                    Status = subFlowStateInfo.Status,
+                    ActiveCorrelations = allActiveCorrelations,
                     Transitions = transitionItems,
                     ETag = instance.LatestData?.ETag ?? string.Empty
                 };
             });
+    }
+
+    /// <summary>
+    /// Extracts extension parameters from a data href URL.
+    /// </summary>
+    /// <param name="dataHref">The data href URL potentially containing extensions</param>
+    /// <returns>Array of extension names extracted from the URL</returns>
+    private static string[] ExtractExtensionsFromDataHref(string? dataHref)
+    {
+        if (string.IsNullOrEmpty(dataHref))
+        {
+            return [];
+        }
+
+        // Parse the URL to extract extensions query parameter
+        // Expected format: /instances/{domain}/{workflow}/{instanceId}/data?extensions=ext1,ext2
+        var uri = new Uri(dataHref, UriKind.RelativeOrAbsolute);
+        var query = uri.IsAbsoluteUri ? uri.Query : dataHref.Contains('?') ? dataHref[(dataHref.IndexOf('?'))..] : string.Empty;
+        
+        if (string.IsNullOrEmpty(query))
+        {
+            return [];
+        }
+
+        // Parse query string manually to extract extensions
+        var queryParams = query.TrimStart('?').Split('&');
+        foreach (var param in queryParams)
+        {
+            var keyValue = param.Split('=', 2);
+            if (keyValue.Length == 2 && keyValue[0].Equals("extensions", StringComparison.OrdinalIgnoreCase))
+            {
+                return keyValue[1].Split(',', StringSplitOptions.RemoveEmptyEntries);
+            }
+        }
+
+        return [];
     }
 
     public async Task<Result<GetViewOutput>> GetPlatformSpecificViewAsync(
@@ -566,7 +629,97 @@ public sealed class InstanceQueryAppService(
     }
 
     /// <summary>
+    /// Retrieves and executes extensions for an instance.
+    /// </summary>
+    /// <param name="input">The extensions request input containing domain, workflow, instance, and extensions to execute</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Result containing the executed extension results or error information</returns>
+    public async Task<Result<GetExtensionsOutput>> GetExtensionsAsync(
+        GetExtensionsInput input,
+        CancellationToken cancellationToken = default)
+    {
+        runtimeInfoProvider.Check(input.Domain);
+
+        // Railway chain: Get Instance → Get Workflow → Build Extensions Output
+        return await GetInstanceByIdOrKeyAsync(input.Instance, cancellationToken)
+            .BindAsync(instance =>
+                componentCacheStore.GetFlowAsync(input.Domain, input.Workflow, input.Version, cancellationToken)
+                    .MapAsync(workflow => (instance, workflow)))
+            .ThenAsync(data =>
+                BuildExtensionsOutputAsync(data.instance, data.workflow, input, cancellationToken));
+    }
+
+    /// <summary>
+    /// Builds the extensions output by executing the requested extensions.
+    /// If the instance has an active SubFlow, forwards the request to the SubFlow.
+    /// </summary>
+    private async Task<Result<GetExtensionsOutput>> BuildExtensionsOutputAsync(
+        Instance instance,
+        Definitions.Workflow currentWorkflow,
+        GetExtensionsInput input,
+        CancellationToken cancellationToken)
+    {
+        // Check if there's an active SubFlow - if so, forward the request to SubFlow
+        // instance.Subflow returns the first active subflow (Type: S and not completed)
+        if (instance.Subflow != null)
+        {
+            return await GetSubFlowExtensionsAsync(instance.Subflow, input.Extensions, cancellationToken);
+        }
+
+        // No active SubFlow - handle locally
+        var instanceData = instance.LatestData;
+
+        // Build script context for extension execution
+        var scriptContext = await scriptContextFactory.NewBuilder(instanceRepository)
+            .WithWorkflow(currentWorkflow)
+            .WithInstance(instance)
+            .WithRuntime(runtimeInfoProvider)
+            .WithTransition(string.Empty)
+            .WithBody(instanceData?.Data ?? new JsonData("{}"))
+            .WithHeaders(input.Headers)
+            .WithQueryParameters(input.QueryParameters)
+            .BuildAsync(cancellationToken);
+
+        // Execute extensions
+        var extensionsResult = await instanceExtensionService.ProcessExtensionsAsync(
+            input.Extensions ?? [],
+            scriptContext,
+            currentWorkflow,
+            ExtensionScope.GetInstance,
+            cancellationToken);
+
+        // Return extension results
+        return Result<GetExtensionsOutput>.Ok(new GetExtensionsOutput
+        {
+            Extensions = extensionsResult.ValueOrDefault(new Dictionary<string, object>())!
+        });
+    }
+
+    /// <summary>
+    /// Gets extensions from a remote SubFlow instance.
+    /// </summary>
+    private async Task<Result<GetExtensionsOutput>> GetSubFlowExtensionsAsync(
+        InstanceCorrelation subflow,
+        string[]? extensions,
+        CancellationToken cancellationToken)
+    {
+        var subFlowInput = new GetFunctionWithInstanceInput
+        {
+            Domain = subflow.SubFlowDomain,
+            Workflow = subflow.SubFlowName,
+            Version = subflow.SubFlowVersion,
+            Instance = subflow.SubFlowInstanceId.ToString(),
+            Extensions = extensions
+        };
+
+        return await remoteInstanceQueryAppService.GetFunctionWithExtensionsAsync(
+            subFlowInput,
+            cancellationToken);
+    }
+
+    /// <summary>
     /// Builds the schema output for a specific transition.
+    /// If the instance has an active SubFlow, forwards the request to the SubFlow.
     /// Handles state resolution and schema lookup using Railway pattern.
     /// </summary>
     private async Task<Result<GetSchemaOutput>> BuildSchemaOutputAsync(
@@ -576,6 +729,20 @@ public sealed class InstanceQueryAppService(
         string? transitionKey,
         CancellationToken cancellationToken)
     {
+        if (string.IsNullOrEmpty(transitionKey))
+        {
+            return Result<GetSchemaOutput>.Fail(
+                Error.Validation("validation", "Transition key is required to get schema"));
+        }
+
+        // Check if there's an active SubFlow - if so, forward the request to SubFlow
+        // instance.Subflow returns the first active subflow (Type: S and not completed)
+        if (instance.Subflow != null)
+        {
+            return await GetSubFlowSchemaAsync(instance.Subflow, transitionKey, cancellationToken);
+        }
+
+        // No active SubFlow - handle locally
         // Get current state using Railway pattern
         var currentStateResult = currentWorkflow.GetState(instance.GetCurrentState);
         if (!currentStateResult.IsSuccess || currentStateResult.Value == null)
@@ -585,12 +752,6 @@ public sealed class InstanceQueryAppService(
         }
 
         var currentState = currentStateResult.Value;
-
-        if (string.IsNullOrEmpty(transitionKey))
-        {
-            return Result<GetSchemaOutput>.Fail(
-                Error.Validation("validation", "Transition key is required to get schema"));
-        }
 
         var transition = currentWorkflow.ResolveTransition(transitionKey, currentState);
 
@@ -613,6 +774,28 @@ public sealed class InstanceQueryAppService(
                 Type = schema.Type,
                 Schema = schema.Schema
             });
+    }
+
+    /// <summary>
+    /// Gets schema from a remote SubFlow instance.
+    /// </summary>
+    private async Task<Result<GetSchemaOutput>> GetSubFlowSchemaAsync(
+        InstanceCorrelation subflow,
+        string transitionKey,
+        CancellationToken cancellationToken)
+    {
+        var subFlowInput = new GetFunctionWithInstanceInput
+        {
+            Domain = subflow.SubFlowDomain,
+            Workflow = subflow.SubFlowName,
+            Version = subflow.SubFlowVersion,
+            Instance = subflow.SubFlowInstanceId.ToString()
+        };
+
+        return await remoteInstanceQueryAppService.GetFunctionWithSchemaAsync(
+            subFlowInput,
+            transitionKey,
+            cancellationToken);
     }
 
     /// <summary>
@@ -776,4 +959,22 @@ public sealed class InstanceQueryAppService(
             _ => view.Content
         };
     }
+
+    /// <summary>
+    /// Represents the complete state information retrieved from a SubFlow or main flow.
+    /// Used to pass transitions, state, status, and additional SubFlow-specific data like view extensions and active correlations.
+    /// </summary>
+    /// <param name="AvailableTransitions">Available transitions from the flow</param>
+    /// <param name="CurrentState">Current state of the flow</param>
+    /// <param name="Status">Status of the instance (always from main instance)</param>
+    /// <param name="SubFlowData">Data href from SubFlow (contains extensions info) - null for main flow</param>
+    /// <param name="SubFlowView">View href from SubFlow - null for main flow</param>
+    /// <param name="SubFlowActiveCorrelations">Active correlations from SubFlow - empty for main flow</param>
+    private sealed record SubFlowStateInfo(
+        List<string> AvailableTransitions,
+        string? CurrentState,
+        InstanceStatus? Status,
+        DataHref? SubFlowData = null,
+        ViewHref? SubFlowView = null,
+        List<ActiveCorrelationHref>? SubFlowActiveCorrelations = null);
 }

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -362,9 +362,7 @@ public sealed class InstanceQueryAppService(
                             input.Extensions,
                             cancellationToken);
 
-                        result.Extensions = subFlowExtensionsResult.IsSuccess
-                            ? subFlowExtensionsResult.Value?.Extensions ?? new Dictionary<string, object>()
-                            : new Dictionary<string, object>();
+                        result.Extensions = subFlowExtensionsResult.Value?.Extensions ?? new Dictionary<string, object>();
 
                         return ConditionalResult<GetInstanceDataOutput>.Success(result);
                     }
@@ -564,25 +562,18 @@ public sealed class InstanceQueryAppService(
             return [];
         }
 
-        // Parse the URL to extract extensions query parameter
-        // Expected format: /instances/{domain}/{workflow}/{instanceId}/data?extensions=ext1,ext2
-        var uri = new Uri(dataHref, UriKind.RelativeOrAbsolute);
-        var query = uri.IsAbsoluteUri ? uri.Query : dataHref.Contains('?') ? dataHref[(dataHref.IndexOf('?'))..] : string.Empty;
-        
-        if (string.IsNullOrEmpty(query))
+        var queryIndex = dataHref.IndexOf('?');
+        if (queryIndex == -1)
         {
             return [];
         }
 
-        // Parse query string manually to extract extensions
-        var queryParams = query.TrimStart('?').Split('&');
-        foreach (var param in queryParams)
+        var query = dataHref.Substring(queryIndex);
+        var queryParams = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(query);
+
+        if (queryParams.TryGetValue("extensions", out var extensionsValues))
         {
-            var keyValue = param.Split('=', 2);
-            if (keyValue.Length == 2 && keyValue[0].Equals("extensions", StringComparison.OrdinalIgnoreCase))
-            {
-                return keyValue[1].Split(',', StringSplitOptions.RemoveEmptyEntries);
-            }
+            return extensionsValues.SelectMany(v => v?.Split(',', StringSplitOptions.RemoveEmptyEntries) ?? []).ToArray();
         }
 
         return [];

--- a/src/BBT.Workflow.Application/Instances/Remote/IRemoteInstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/Remote/IRemoteInstanceQueryAppService.cs
@@ -46,4 +46,21 @@ public interface IRemoteInstanceQueryAppService
         string? platform,
         string? transitionKey,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves schema function result for an instance (returns GetSchemaOutput with transition schema)
+    /// GET {baseUrl}/api/v{version}/{domain}/workflows/{workflow}/instances/{instance}/functions/schema?transitionKey={transitionKey}
+    /// </summary>
+    Task<Result<DTOs.GetSchemaOutput>> GetFunctionWithSchemaAsync(
+        GetFunctionWithInstanceInput input,
+        string transitionKey,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves extensions function result for an instance (returns GetExtensionsOutput with executed extension results)
+    /// GET {baseUrl}/api/v{version}/{domain}/workflows/{workflow}/instances/{instance}/functions/extensions?extensions={extensions}
+    /// </summary>
+    Task<Result<DTOs.GetExtensionsOutput>> GetFunctionWithExtensionsAsync(
+        GetFunctionWithInstanceInput input,
+        CancellationToken cancellationToken = default);
 } 

--- a/src/BBT.Workflow.Application/Tasks/Executors/Trigger/DirectTriggerTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Trigger/DirectTriggerTaskExecutor.cs
@@ -78,10 +78,10 @@ public sealed class DirectTriggerTaskExecutor : TriggerTaskExecutorBase<DirectTr
             "DirectTrigger task {TaskKey} targeting domain {TargetDomain}, instance {InstanceId}, same domain: {IsSameDomain}",
             task.Key, task.TriggerDomain, instanceIdentifier, isSameDomain);
 
-        // if (isSameDomain)
-        // {
-        //     return await ExecuteLocalAsync(task, instanceIdentifier, context, cancellationToken);
-        // }
+        if (isSameDomain)
+        {
+            return await ExecuteLocalAsync(task, instanceIdentifier, context, cancellationToken);
+        }
 
         return await ExecuteRemoteAsync(task, context, cancellationToken);
     }
@@ -259,7 +259,7 @@ public sealed class DirectTriggerTaskExecutor : TriggerTaskExecutorBase<DirectTr
             Domain = task.TriggerDomain,
             Workflow = task.TriggerFlow,
             InstanceId = task.TriggerInstanceId,
-            Key = task.Key,
+            Key = task.TriggerKey,
             TransitionName = task.TransitionName,
             Tags = task.TriggerTags,
             Version = task.TriggerVersion,

--- a/src/BBT.Workflow.Application/Tasks/Executors/Trigger/GetInstanceDataTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Trigger/GetInstanceDataTaskExecutor.cs
@@ -71,10 +71,10 @@ public sealed class GetInstanceDataTaskExecutor : TriggerTaskExecutorBase<GetIns
             "GetInstanceData task {TaskKey} targeting domain {TargetDomain}, instance {InstanceId}, same domain: {IsSameDomain}",
             task.Key, task.TriggerDomain, instanceIdentifier, isSameDomain);
 
-        // if (isSameDomain)
-        // {
-        //     return await ExecuteLocalAsync(task, instanceIdentifier, context, cancellationToken);
-        // }
+        if (isSameDomain)
+        {
+            return await ExecuteLocalAsync(task, instanceIdentifier, context, cancellationToken);
+        }
 
         return await ExecuteRemoteAsync(task, instanceIdentifier, context, cancellationToken);
     }

--- a/src/BBT.Workflow.Application/Tasks/Executors/Trigger/StartTriggerTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Trigger/StartTriggerTaskExecutor.cs
@@ -57,10 +57,10 @@ public sealed class StartTriggerTaskExecutor : TriggerTaskExecutorBase<StartTask
         Logger.LogDebug("StartTrigger task {TaskKey} targeting domain {TargetDomain}, same domain: {IsSameDomain}",
             task.Key, task.TriggerDomain, isSameDomain);
 
-        // if (isSameDomain)
-        // {
-        //     return await ExecuteLocalAsync(task, context, cancellationToken);
-        // }
+        if (isSameDomain)
+        {
+            return await ExecuteLocalAsync(task, context, cancellationToken);
+        }
 
         return await ExecuteRemoteAsync(task, context, cancellationToken);
     }

--- a/src/BBT.Workflow.Application/Tasks/Executors/Trigger/SubProcessTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Trigger/SubProcessTaskExecutor.cs
@@ -75,14 +75,14 @@ public sealed class SubProcessTaskExecutor : TriggerTaskExecutorBase<SubProcessT
 
         TaskInvocationResult result;
 
-        // if (isSameDomain)
-        // {
-        //     result = await ExecuteLocalAsync(task, context, subFlowInstanceId, correlationId, cancellationToken);
-        // }
-        // else
-        // {
+        if (isSameDomain)
+        {
+            result = await ExecuteLocalAsync(task, context, subFlowInstanceId, correlationId, cancellationToken);
+        }
+        else
+        {
             result = await ExecuteRemoteAsync(task, context, subFlowInstanceId, correlationId, cancellationToken);
-        // }
+        }
 
         return Result<TaskInvocationResult>.Ok(result);
     }

--- a/src/BBT.Workflow.Domain/Definitions/Functions/FunctionTypeConst.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Functions/FunctionTypeConst.cs
@@ -6,5 +6,6 @@ namespace BBT.Workflow.Definitions.Functions
         public const string View = "view";
         public const string Data = "data";
         public const string Schema = "schema";
+        public const string Extensions = "extensions";
     }
 }

--- a/src/BBT.Workflow.Domain/Definitions/InstanceUrlTemplates.cs
+++ b/src/BBT.Workflow.Domain/Definitions/InstanceUrlTemplates.cs
@@ -58,6 +58,18 @@ public static class InstanceUrlTemplates
     public const string ViewTemplate = "/{0}/workflows/{1}/instances/{2}/functions/view";
 
     /// <summary>
+    /// URL template for instance schema endpoints.
+    /// Format: /{domain}/workflows/{workflow}/instances/{instanceId}/functions/schema?transitionKey={transitionKey}
+    /// </summary>
+    public const string SchemaTemplate = "/{0}/workflows/{1}/instances/{2}/functions/schema?transitionKey={3}";
+
+    /// <summary>
+    /// URL template for instance extensions endpoints.
+    /// Format: /{domain}/workflows/{workflow}/instances/{instanceId}/functions/extensions
+    /// </summary>
+    public const string ExtensionsTemplate = "/{0}/workflows/{1}/instances/{2}/functions/extensions";
+
+    /// <summary>
     /// URL template for start instance endpoints.
     /// Format: /{domain}/workflows/{workflow}/instances/start
     /// </summary>
@@ -173,6 +185,29 @@ public static class InstanceUrlTemplates
     /// <returns>Generated URL</returns>
     public static string View(string domain, string workflow, string instance, string? apiVersionPrefix = null)
         => BuildUrl(ViewTemplate, apiVersionPrefix, domain, workflow, instance);
+
+    /// <summary>
+    /// Generates URL for instance schema function endpoint.
+    /// </summary>
+    /// <param name="domain">The domain name</param>
+    /// <param name="workflow">The workflow name</param>
+    /// <param name="instanceId">The instance ID</param>
+    /// <param name="transitionKey">The transition key</param>
+    /// <param name="apiVersionPrefix">Optional API version prefix (e.g., "api/v1")</param>
+    /// <returns>Generated URL</returns>
+    public static string Schema(string domain, string workflow, string instanceId, string transitionKey, string? apiVersionPrefix = null)
+        => BuildUrl(SchemaTemplate, apiVersionPrefix, domain, workflow, instanceId, transitionKey);
+
+    /// <summary>
+    /// Generates URL for instance extensions function endpoint.
+    /// </summary>
+    /// <param name="domain">The domain name</param>
+    /// <param name="workflow">The workflow name</param>
+    /// <param name="instanceId">The instance ID</param>
+    /// <param name="apiVersionPrefix">Optional API version prefix (e.g., "api/v1")</param>
+    /// <returns>Generated URL</returns>
+    public static string Extensions(string domain, string workflow, string instanceId, string? apiVersionPrefix = null)
+        => BuildUrl(ExtensionsTemplate, apiVersionPrefix, domain, workflow, instanceId);
 
     /// <summary>
     /// Generates URL for start instance endpoint.

--- a/src/BBT.Workflow.Domain/Instances/Instance.cs
+++ b/src/BBT.Workflow.Domain/Instances/Instance.cs
@@ -450,12 +450,12 @@ public sealed class Instance : AggregateRoot<Guid>, IHasCreatedAt, IHasModifyTim
         return policy.Validate(state, transition, executionActor);
     }
 
-    public InstanceData AddDataWithVersion(Guid id, JsonData inputData, string version)
+    public InstanceData AddDataWithVersion(Guid id, JsonData inputData, string version, bool ignoreSameData = true)
     {
         lock (_dataListLock)
         {
             var latestData = _dataList.OrderByDescending(x => x, InstanceDataVersionComparer.Instance).FirstOrDefault();
-            if (latestData?.HasSameData(inputData) == true)
+            if (ignoreSameData && latestData?.HasSameData(inputData) == true)
             {
                 // Data hasn't changed, return the existing latest data
                 return latestData;

--- a/src/BBT.Workflow.Domain/Shared/HrefBase.cs
+++ b/src/BBT.Workflow.Domain/Shared/HrefBase.cs
@@ -23,6 +23,10 @@ public sealed class TransitionItem : HrefBase
     /// Transition name
     /// </summary>
     public string Name { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Schema href link
+    /// </summary>
     public HrefBase? Schema {get; set; }
 }
 

--- a/src/BBT.Workflow.Domain/Shared/HrefBase.cs
+++ b/src/BBT.Workflow.Domain/Shared/HrefBase.cs
@@ -23,6 +23,7 @@ public sealed class TransitionItem : HrefBase
     /// Transition name
     /// </summary>
     public string Name { get; set; } = string.Empty;
+    public HrefBase? Schema {get; set; }
 }
 
 /// <summary>

--- a/src/BBT.Workflow.Infrastructure/Discovery/DomainDiscoveryResolver.cs
+++ b/src/BBT.Workflow.Infrastructure/Discovery/DomainDiscoveryResolver.cs
@@ -38,10 +38,10 @@ public sealed class DomainDiscoveryResolver(
         var options = serviceDiscoveryOptions.Value;
 
         // If service discovery is disabled, fall back to static BaseUrl
-        if (!options.Enabled)
-        {
-            return GetFallbackEndpoint(domain);
-        }
+        // if (!options.Enabled)
+        // {
+        //     return GetFallbackEndpoint(domain);
+        // }
 
         // Try to get from cache first
         var cacheKey = GetCacheKey(domain);

--- a/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceQueryAppService.cs
@@ -298,6 +298,89 @@ public sealed class RemoteInstanceQueryAppService(
     }
 
     /// <summary>
+    /// Retrieves schema function result for an instance (returns GetSchemaOutput with transition schema)
+    /// GET {baseUrl}/api/v{version}/{domain}/workflows/{workflow}/instances/{instance}/functions/schema?transitionKey={transitionKey}
+    /// </summary>
+    public async Task<Result<DTOs.GetSchemaOutput>> GetFunctionWithSchemaAsync(
+        GetFunctionWithInstanceInput input,
+        string transitionKey,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            // Resolve endpoint dynamically based on target domain
+            var endpoint = await endpointResolver.GetEndpointAsync(input.Domain, EndpointKind.Url, cancellationToken);
+
+            var relativePath = InstanceUrlTemplates.Schema(input.Domain, input.Workflow, input.Instance, transitionKey, ApiVersionPrefix);
+
+            var queryParams = new List<string>();
+            if (!string.IsNullOrEmpty(input.Version))
+            {
+                queryParams.Add($"{nameof(input.Version).ToLowerInvariant()}={Uri.EscapeDataString(input.Version)}");
+            }
+
+            if (queryParams.Count > 0)
+                relativePath += "&" + string.Join("&", queryParams);
+
+            var requestUri = new Uri(endpoint.BaseUrl, relativePath.TrimStart('/'));
+            var response = await httpClient.GetAsync(requestUri, cancellationToken);
+
+            // Status code → Result.Fail (per Railway Pattern)
+            return await HandleResponseAsync<DTOs.GetSchemaOutput>(response, cancellationToken);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or OperationCanceledException)
+        {
+            // Network errors → Transient error (per Railway Pattern)
+            return Result<DTOs.GetSchemaOutput>.Fail(Error.Transient("remote_network_error", ex.Message));
+        }
+    }
+
+    /// <summary>
+    /// Retrieves extensions function result for an instance (returns GetExtensionsOutput with executed extension results)
+    /// GET {baseUrl}/api/v{version}/{domain}/workflows/{workflow}/instances/{instance}/functions/extensions?extensions={extensions}
+    /// </summary>
+    public async Task<Result<DTOs.GetExtensionsOutput>> GetFunctionWithExtensionsAsync(
+        GetFunctionWithInstanceInput input,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            // Resolve endpoint dynamically based on target domain
+            var endpoint = await endpointResolver.GetEndpointAsync(input.Domain, EndpointKind.Url, cancellationToken);
+
+            var relativePath = InstanceUrlTemplates.Extensions(input.Domain, input.Workflow, input.Instance, ApiVersionPrefix);
+
+            var queryParams = new List<string>();
+            if (!string.IsNullOrEmpty(input.Version))
+            {
+                queryParams.Add($"{nameof(input.Version).ToLowerInvariant()}={Uri.EscapeDataString(input.Version)}");
+            }
+
+            if (input.Extensions?.Length > 0)
+            {
+                foreach (var ext in input.Extensions)
+                {
+                    queryParams.Add($"{nameof(input.Extensions).ToLowerInvariant()}={Uri.EscapeDataString(ext)}");
+                }
+            }
+
+            if (queryParams.Count > 0)
+                relativePath += "?" + string.Join("&", queryParams);
+
+            var requestUri = new Uri(endpoint.BaseUrl, relativePath.TrimStart('/'));
+            var response = await httpClient.GetAsync(requestUri, cancellationToken);
+
+            // Status code → Result.Fail (per Railway Pattern)
+            return await HandleResponseAsync<DTOs.GetExtensionsOutput>(response, cancellationToken);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or OperationCanceledException)
+        {
+            // Network errors → Transient error (per Railway Pattern)
+            return Result<DTOs.GetExtensionsOutput>.Fail(Error.Transient("remote_network_error", ex.Message));
+        }
+    }
+
+    /// <summary>
     /// Handles HTTP response by mapping status codes to appropriate Result types.
     /// Follows Railway Pattern: Status code → Result.Fail (not exceptions).
     /// </summary>

--- a/src/BBT.Workflow.Infrastructure/Microsoft/Extensions/DependencyInjection/DiscoveryServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Infrastructure/Microsoft/Extensions/DependencyInjection/DiscoveryServiceCollectionExtensions.cs
@@ -60,9 +60,20 @@ public static class DiscoveryServiceCollectionExtensions
                     client.DefaultRequestHeaders.Add(clientOptions.InternalOperationHeader, "true");
                 }
             })
-            .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
+            .ConfigurePrimaryHttpMessageHandler(() =>
             {
-                AutomaticDecompression = System.Net.DecompressionMethods.GZip | System.Net.DecompressionMethods.Deflate
+                var handler = new HttpClientHandler
+                {
+                    AutomaticDecompression = System.Net.DecompressionMethods.GZip | System.Net.DecompressionMethods.Deflate
+                };
+
+                // Disable SSL validation if configured (useful for development environments)
+                if (!options.ValidateSsl)
+                {
+                    handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+                }
+
+                return handler;
             })
             .AddPolicyHandler(GetTimeoutPolicy(options))
             .AddPolicyHandler(GetRetryPolicy(options))

--- a/workers/BBT.Workflow.Workers.Inbox/appsettings.json
+++ b/workers/BBT.Workflow.Workers.Inbox/appsettings.json
@@ -17,11 +17,11 @@
   "vNextApi": {
     "BaseUrl": "http://localhost:4201",
     "ApiVersion": "1",
-    "TimeoutSeconds": 30,
+    "TimeoutSeconds": 60,
     "MaxRetryAttempts": 3,
     "RetryDelayMilliseconds": 1000,
     "CircuitBreakerFailureThreshold": 20,
-    "CircuitBreakerTimeoutSeconds": 30,
+    "CircuitBreakerTimeoutSeconds": 60,
     "EnableCircuitBreakerBypass": true,
     "InternalOperationHeader": "X-Internal-Operation"
   },
@@ -117,7 +117,7 @@
     ]
   },
   "ServiceDiscovery": {
-    "Enabled": true,
+    "Enabled": false,
     "BaseUrl": "http://localhost:3001/api/v1",
     "Domain": "discovery",
     "RegistryFlow": "domain-registration",

--- a/workers/BBT.Workflow.Workers.Inbox/appsettings.json
+++ b/workers/BBT.Workflow.Workers.Inbox/appsettings.json
@@ -119,6 +119,7 @@
   "ServiceDiscovery": {
     "Enabled": false,
     "BaseUrl": "http://localhost:3001/api/v1",
+    "ValidateSsl": false,
     "Domain": "discovery",
     "RegistryFlow": "domain-registration",
     "TimeoutSeconds": 30,


### PR DESCRIPTION
Introduces the 'extensions' function type for workflow instances, enabling retrieval and execution of instance extensions via new endpoints and DTOs. Updates controllers, services, and remote interfaces to support extension queries, including forwarding to subflows when present. Also refactors transition and schema handling for subflows, adds schema and extensions URL templates, and enables local execution for trigger task executors. Service discovery is disabled in appsettings for local development.

## Summary by Sourcery

Add instance-level extensions function support across APIs and remote calls, with subflow-aware state/schema handling and local trigger execution improvements.

New Features:
- Expose an extensions function for workflow instances via new DTOs, controller endpoints, and remote query interfaces.
- Support querying and executing instance extensions both locally and on remote subflows, including list and single-instance variants.
- Provide URL templates for instance schema and extensions functions and include schema links on transition items.

Bug Fixes:
- Use the configured trigger key rather than the task key when building direct trigger bindings.
- Allow adding instance data with the same content when updating existing instances by optionally bypassing same-data checks.

Enhancements:
- Optimize instance transition building by using in-memory active correlations instead of additional repository calls.
- Enrich instance state responses to merge subflow correlations, propagate subflow view/data extension info, and include schema hrefs for transitions.
- Add helper utilities to extract extensions from data URLs and centralize subflow state/schema/extensions retrieval.
- Enable local execution paths for same-domain trigger task executors (start, direct trigger, get instance data, and subprocess).
- Extend the remote instance query service to fetch schema and extensions function results from other domains.

Deployment:
- Relax inbox worker HTTP client timeouts and circuit breaker thresholds for orchestration API calls.
- Disable service discovery in local orchestration and worker configurations to favor static base URLs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extensions retrieval for workflow instances.
  * Schema endpoint support for transitions.
  * Discovery responses now include an x-change-port header and vary reported port by domain.

* **Improvements**
  * Prefer local execution for same-domain tasks to reduce remote calls.
  * Increased API timeouts from 30s to 60s for improved reliability.

* **Configuration**
  * Service discovery disabled by default; new ValidateSsl option added (can ignore certificate errors).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->