### PR TITLE
feat(versioning): add 'latest' keyword and major-only version matchin…

### DIFF
--- a/src/BBT.Workflow.Application/Caching/CacheSet.cs
+++ b/src/BBT.Workflow.Application/Caching/CacheSet.cs
@@ -226,8 +226,8 @@ public class CacheSet<T>(
         string? version,
         CancellationToken cancellationToken = default)
     {
-        // 1) If version is null/empty → return latest version
-        if (string.IsNullOrWhiteSpace(version))
+        // 1) If version is null/empty or "latest" → return latest version
+        if (string.IsNullOrWhiteSpace(version) || InstanceDataVersionComparer.IsLatestKeyword(version))
         {
             return await GetLatestByNameAsync(domain, key, cancellationToken);
         }

--- a/src/BBT.Workflow.Application/Caching/CacheSet.cs
+++ b/src/BBT.Workflow.Application/Caching/CacheSet.cs
@@ -227,7 +227,7 @@ public class CacheSet<T>(
         CancellationToken cancellationToken = default)
     {
         // 1) If version is null/empty or "latest" → return latest version
-        if (string.IsNullOrWhiteSpace(version) || InstanceDataVersionComparer.IsLatestKeyword(version))
+        if (InstanceDataVersionComparer.IsRequestingLatest(version))
         {
             return await GetLatestByNameAsync(domain, key, cancellationToken);
         }

--- a/src/BBT.Workflow.Domain/Instances/Instance.cs
+++ b/src/BBT.Workflow.Domain/Instances/Instance.cs
@@ -521,6 +521,11 @@ public sealed class Instance : AggregateRoot<Guid>, IHasCreatedAt, IHasModifyTim
 
     /// <summary>
     /// Finds instance data by version.
+    /// Delegates version resolution to <see cref="InstanceDataVersionComparer.FindBestMatch"/> for consistency.
+    /// </summary>
+    /// <param name="version">Version string to search for (null, empty, or "latest" returns the highest version)</param>
+    /// <returns>The matching InstanceData or null if not found</returns>
+    /// <remarks>
     /// Supports multiple version formats:
     /// <list type="bullet">
     ///     <item><description>null/empty or "latest": Returns the highest available version</description></item>
@@ -529,69 +534,27 @@ public sealed class Instance : AggregateRoot<Guid>, IHasCreatedAt, IHasModifyTim
     ///     <item><description>Partial version: "1.0" → finds highest version among all 1.0.x versions</description></item>
     ///     <item><description>Major-only version: "1" → finds highest version among all 1.x.x versions</description></item>
     /// </list>
-    /// </summary>
-    /// <param name="version">Version string to search for (null, empty, or "latest" returns the highest version)</param>
-    /// <returns>The matching InstanceData or null if not found</returns>
+    /// </remarks>
     public InstanceData? FindData(string? version)
     {
         lock (_dataListLock)
         {
-            // 0. If version is null/empty or "latest" → return the highest version
-            if (string.IsNullOrWhiteSpace(version) || InstanceDataVersionComparer.IsLatestKeyword(version))
-            {
-                return _dataList
-                    .OrderByDescending(d => d, InstanceDataVersionComparer.Instance)
-                    .FirstOrDefault();
-            }
+            if (_dataList.Count == 0)
+                return null;
 
-            // 1. Try exact match first
-            var exactMatch = _dataList.FirstOrDefault(x => x.Version == version);
-            if (exactMatch != null)
-                return exactMatch;
+            // Delegate version resolution to centralized FindBestMatch
+            var availableVersions = _dataList.Select(d => d.Version);
+            var bestVersion = InstanceDataVersionComparer.FindBestMatch(availableVersions, version);
 
-            // 2. Check if this is a full artifact version (MAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH-PRERELEASE)
-            //    Client sends only artifact version, we need to find the highest pkg version
-            //    Supports: 1.0.0, 1.0.0-alpha.1, 1.0.0-beta, 1.0.0-rc.1, etc.
-            if (InstanceDataVersionComparer.IsArtifactVersion(version))
-            {
-                // Find all data entries that match this artifact version
-                // They could be either:
-                // - Simple format: "1.0.0" or "1.0.0-alpha.1" (exact match, already checked above)
-                // - Extended format: "1.0.0-pkg.x.y.z+name" or "1.0.0-alpha.1-pkg.x.y.z+name"
-                var artifactPrefix = $"{version}-pkg.";
-                
-                var matched = _dataList
-                    .Where(d => d.Version.StartsWith(artifactPrefix, StringComparison.Ordinal) ||
-                               InstanceDataVersionComparer.MatchesArtifact(d.Version, version))
-                    .OrderByDescending(d => d, InstanceDataVersionComparer.Instance)
-                    .FirstOrDefault();
+            if (string.IsNullOrEmpty(bestVersion))
+                return null;
 
-                return matched;
-            }
-
-            // 3. Partial version: 1.0 → find the highest version among all 1.0.x versions
-            if (InstanceDataVersionComparer.IsPartialVersion(version))
-            {
-                var matched = _dataList
-                    .Where(d => InstanceDataVersionComparer.MatchesPartial(d.Version, version))
-                    .OrderByDescending(d => d, InstanceDataVersionComparer.Instance)
-                    .FirstOrDefault();
-
-                return matched;
-            }
-
-            // 4. Major-only version: 1 → find the highest version among all 1.x.x versions
-            if (InstanceDataVersionComparer.IsMajorOnlyVersion(version))
-            {
-                var matched = _dataList
-                    .Where(d => InstanceDataVersionComparer.MatchesMajor(d.Version, version))
-                    .OrderByDescending(d => d, InstanceDataVersionComparer.Instance)
-                    .FirstOrDefault();
-
-                return matched;
-            }
-
-            return null;
+            // Resolve the selected version back to InstanceData
+            // If multiple entries exist with the same version, return the highest by HistorySequence
+            return _dataList
+                .Where(d => d.Version == bestVersion)
+                .OrderByDescending(d => d, InstanceDataVersionComparer.Instance)
+                .FirstOrDefault();
         }
     }
 

--- a/src/BBT.Workflow.Domain/Instances/Instance.cs
+++ b/src/BBT.Workflow.Domain/Instances/Instance.cs
@@ -523,20 +523,27 @@ public sealed class Instance : AggregateRoot<Guid>, IHasCreatedAt, IHasModifyTim
     /// Finds instance data by version.
     /// Supports multiple version formats:
     /// <list type="bullet">
+    ///     <item><description>null/empty or "latest": Returns the highest available version</description></item>
     ///     <item><description>Exact match: "1.0.0-pkg.1.17.0+account" or "1.0.0-alpha.1-pkg.1.17.0+account"</description></item>
     ///     <item><description>Artifact version only: "1.0.0" or "1.0.0-alpha.1" → finds highest pkg version for that artifact</description></item>
     ///     <item><description>Partial version: "1.0" → finds highest version among all 1.0.x versions</description></item>
+    ///     <item><description>Major-only version: "1" → finds highest version among all 1.x.x versions</description></item>
     /// </list>
     /// </summary>
-    /// <param name="version">Version string to search for</param>
+    /// <param name="version">Version string to search for (null, empty, or "latest" returns the highest version)</param>
     /// <returns>The matching InstanceData or null if not found</returns>
-    public InstanceData? FindData(string version)
+    public InstanceData? FindData(string? version)
     {
-        if (string.IsNullOrWhiteSpace(version))
-            return null;
-
         lock (_dataListLock)
         {
+            // 0. If version is null/empty or "latest" → return the highest version
+            if (string.IsNullOrWhiteSpace(version) || InstanceDataVersionComparer.IsLatestKeyword(version))
+            {
+                return _dataList
+                    .OrderByDescending(d => d, InstanceDataVersionComparer.Instance)
+                    .FirstOrDefault();
+            }
+
             // 1. Try exact match first
             var exactMatch = _dataList.FirstOrDefault(x => x.Version == version);
             if (exactMatch != null)
@@ -545,8 +552,7 @@ public sealed class Instance : AggregateRoot<Guid>, IHasCreatedAt, IHasModifyTim
             // 2. Check if this is a full artifact version (MAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH-PRERELEASE)
             //    Client sends only artifact version, we need to find the highest pkg version
             //    Supports: 1.0.0, 1.0.0-alpha.1, 1.0.0-beta, 1.0.0-rc.1, etc.
-            var artifactMatch = Regex.Match(version, @"^(\d+\.\d+\.\d+(?:-[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*)?)$");
-            if (artifactMatch.Success)
+            if (InstanceDataVersionComparer.IsArtifactVersion(version))
             {
                 // Find all data entries that match this artifact version
                 // They could be either:
@@ -555,7 +561,8 @@ public sealed class Instance : AggregateRoot<Guid>, IHasCreatedAt, IHasModifyTim
                 var artifactPrefix = $"{version}-pkg.";
                 
                 var matched = _dataList
-                    .Where(d => d.Version.StartsWith(artifactPrefix, StringComparison.Ordinal))
+                    .Where(d => d.Version.StartsWith(artifactPrefix, StringComparison.Ordinal) ||
+                               InstanceDataVersionComparer.MatchesArtifact(d.Version, version))
                     .OrderByDescending(d => d, InstanceDataVersionComparer.Instance)
                     .FirstOrDefault();
 
@@ -563,14 +570,21 @@ public sealed class Instance : AggregateRoot<Guid>, IHasCreatedAt, IHasModifyTim
             }
 
             // 3. Partial version: 1.0 → find the highest version among all 1.0.x versions
-            var partialMatch = Regex.Match(version, @"^(\d+)\.(\d+)$");
-            if (partialMatch.Success)
+            if (InstanceDataVersionComparer.IsPartialVersion(version))
             {
-                var prefix = $"{partialMatch.Groups[1].Value}.{partialMatch.Groups[2].Value}.";
-
                 var matched = _dataList
-                    .Where(d => d.Version.StartsWith(prefix, StringComparison.Ordinal) || 
-                               InstanceDataVersionComparer.GetArtifactVersion(d.Version).StartsWith(prefix, StringComparison.Ordinal))
+                    .Where(d => InstanceDataVersionComparer.MatchesPartial(d.Version, version))
+                    .OrderByDescending(d => d, InstanceDataVersionComparer.Instance)
+                    .FirstOrDefault();
+
+                return matched;
+            }
+
+            // 4. Major-only version: 1 → find the highest version among all 1.x.x versions
+            if (InstanceDataVersionComparer.IsMajorOnlyVersion(version))
+            {
+                var matched = _dataList
+                    .Where(d => InstanceDataVersionComparer.MatchesMajor(d.Version, version))
                     .OrderByDescending(d => d, InstanceDataVersionComparer.Instance)
                     .FirstOrDefault();
 

--- a/src/BBT.Workflow.Domain/Instances/InstanceDataVersionComparer.cs
+++ b/src/BBT.Workflow.Domain/Instances/InstanceDataVersionComparer.cs
@@ -302,6 +302,20 @@ public partial class InstanceDataVersionComparer : IComparer<InstanceData>
     }
 
     /// <summary>
+    /// Checks if the version request should resolve to the latest available version.
+    /// This is true when the version is null, empty, whitespace, or the "latest" keyword.
+    /// </summary>
+    /// <param name="version">Version string to check</param>
+    /// <returns>True if the request should resolve to the latest version</returns>
+    /// <remarks>
+    /// Use this method to centralize the "latest" resolution logic across the codebase.
+    /// </remarks>
+    public static bool IsRequestingLatest(string? version)
+    {
+        return string.IsNullOrWhiteSpace(version) || IsLatestKeyword(version);
+    }
+
+    /// <summary>
     /// Checks if a full version matches the given artifact version.
     /// </summary>
     /// <param name="fullVersion">Full version string (e.g., "1.0.0-pkg.1.17.0+account")</param>
@@ -317,38 +331,62 @@ public partial class InstanceDataVersionComparer : IComparer<InstanceData>
     }
 
     /// <summary>
-    /// Checks if a full version matches the given partial version prefix (MAJOR.MINOR format).
+    /// Checks if a full version matches the given partial version (MAJOR.MINOR format).
+    /// Uses explicit MAJOR.MINOR extraction to avoid false positives with multi-digit versions.
     /// </summary>
     /// <param name="fullVersion">Full version string (e.g., "1.0.5-pkg.1.17.0+account")</param>
-    /// <param name="partialVersion">Partial version prefix in MAJOR.MINOR format (e.g., "1.0")</param>
-    /// <returns>True if the full version's artifact part starts with the partial version prefix</returns>
+    /// <param name="partialVersion">Partial version in MAJOR.MINOR format (e.g., "1.0")</param>
+    /// <returns>True if the full version's MAJOR.MINOR matches the given partial version</returns>
     /// <remarks>
     /// For major-only version matching (e.g., "1"), use <see cref="MatchesMajor"/> instead.
     /// </remarks>
+    /// <example>
+    /// MatchesPartial("1.0.5-pkg.1.0.0+account", "1.0") → true
+    /// MatchesPartial("1.20.0-pkg.1.0.0+account", "1.2") → false (not a false positive)
+    /// MatchesPartial("1.2.3-pkg.1.0.0+account", "1.2") → true
+    /// </example>
     public static bool MatchesPartial(string? fullVersion, string? partialVersion)
     {
         if (string.IsNullOrWhiteSpace(fullVersion) || string.IsNullOrWhiteSpace(partialVersion))
             return false;
 
         var parsed = ParseVersion(fullVersion);
-        var prefix = $"{partialVersion}.";
-        return parsed.ArtifactVersion.StartsWith(prefix, StringComparison.Ordinal);
+
+        // Extract MAJOR.MINOR from artifact version
+        var parts = parsed.ArtifactVersion.Split('.');
+        if (parts.Length < 2)
+            return false;
+
+        var artifactMajorMinor = $"{parts[0]}.{parts[1]}";
+        return string.Equals(artifactMajorMinor, partialVersion, StringComparison.Ordinal);
     }
 
     /// <summary>
     /// Checks if a full version matches the given major version.
+    /// Uses explicit major version extraction to avoid false positives with multi-digit versions.
     /// </summary>
     /// <param name="fullVersion">Full version string (e.g., "1.0.5-pkg.1.17.0+account")</param>
     /// <param name="majorVersion">Major version to match (e.g., "1")</param>
-    /// <returns>True if the full version's artifact part starts with the major version</returns>
+    /// <returns>True if the full version's major component equals the given major version</returns>
+    /// <example>
+    /// MatchesMajor("1.2.3-pkg.1.0.0+account", "1") → true
+    /// MatchesMajor("12.0.0-pkg.1.0.0+account", "1") → false (not a false positive)
+    /// MatchesMajor("12.0.0-pkg.1.0.0+account", "12") → true
+    /// </example>
     public static bool MatchesMajor(string? fullVersion, string? majorVersion)
     {
         if (string.IsNullOrWhiteSpace(fullVersion) || string.IsNullOrWhiteSpace(majorVersion))
             return false;
 
         var parsed = ParseVersion(fullVersion);
-        var prefix = $"{majorVersion}.";
-        return parsed.ArtifactVersion.StartsWith(prefix, StringComparison.Ordinal);
+        
+        // Extract the major version from artifact (first segment before '.')
+        var dotIndex = parsed.ArtifactVersion.IndexOf('.');
+        if (dotIndex < 0)
+            return false;
+
+        var artifactMajor = parsed.ArtifactVersion[..dotIndex];
+        return string.Equals(artifactMajor, majorVersion, StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -374,7 +412,7 @@ public partial class InstanceDataVersionComparer : IComparer<InstanceData>
             return null;
 
         // 1. If requestedVersion is null/empty or "latest" → return latest version
-        if (string.IsNullOrWhiteSpace(requestedVersion) || IsLatestKeyword(requestedVersion))
+        if (IsRequestingLatest(requestedVersion))
         {
             return versionList
                 .OrderByDescending(v => v, StringVersionComparer.Instance)

--- a/src/BBT.Workflow.Domain/Instances/InstanceDataVersionComparer.cs
+++ b/src/BBT.Workflow.Domain/Instances/InstanceDataVersionComparer.cs
@@ -29,6 +29,15 @@ namespace BBT.Workflow.Instances;
 ///     <item><description>If equal, compare package version</description></item>
 ///     <item><description>Build metadata (+PKG_NAME, +build.xxx) is ignored in comparisons</description></item>
 /// </list>
+/// 
+/// Version Resolution (FindBestMatch):
+/// <list type="bullet">
+///     <item><description>"latest" or null/empty → Returns the highest available version</description></item>
+///     <item><description>"1.0.0-pkg.1.17.0+account" (full version) → Exact match only</description></item>
+///     <item><description>"1.0.0" (artifact version) → Finds highest pkg version for that artifact</description></item>
+///     <item><description>"1.0" (partial version) → Finds highest version matching the prefix</description></item>
+///     <item><description>"1" (major-only version) → Finds highest version matching the major</description></item>
+/// </list>
 /// </remarks>
 public partial class InstanceDataVersionComparer : IComparer<InstanceData>
 {
@@ -270,6 +279,29 @@ public partial class InstanceDataVersionComparer : IComparer<InstanceData>
     }
 
     /// <summary>
+    /// Checks if the version is a major-only version format (single number).
+    /// </summary>
+    /// <param name="version">Version string to check</param>
+    /// <returns>True if the version matches major-only format (e.g., "1", "2", "10")</returns>
+    public static bool IsMajorOnlyVersion(string? version)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+            return false;
+
+        return MajorOnlyVersionRegex().IsMatch(version);
+    }
+
+    /// <summary>
+    /// Checks if the version string represents the "latest" keyword.
+    /// </summary>
+    /// <param name="version">Version string to check</param>
+    /// <returns>True if the version is "latest" (case-insensitive)</returns>
+    public static bool IsLatestKeyword(string? version)
+    {
+        return string.Equals(version, "latest", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
     /// Checks if a full version matches the given artifact version.
     /// </summary>
     /// <param name="fullVersion">Full version string (e.g., "1.0.0-pkg.1.17.0+account")</param>
@@ -285,11 +317,14 @@ public partial class InstanceDataVersionComparer : IComparer<InstanceData>
     }
 
     /// <summary>
-    /// Checks if a full version matches the given partial version prefix.
+    /// Checks if a full version matches the given partial version prefix (MAJOR.MINOR format).
     /// </summary>
     /// <param name="fullVersion">Full version string (e.g., "1.0.5-pkg.1.17.0+account")</param>
-    /// <param name="partialVersion">Partial version prefix (e.g., "1.0")</param>
-    /// <returns>True if the full version's artifact part starts with the partial version</returns>
+    /// <param name="partialVersion">Partial version prefix in MAJOR.MINOR format (e.g., "1.0")</param>
+    /// <returns>True if the full version's artifact part starts with the partial version prefix</returns>
+    /// <remarks>
+    /// For major-only version matching (e.g., "1"), use <see cref="MatchesMajor"/> instead.
+    /// </remarks>
     public static bool MatchesPartial(string? fullVersion, string? partialVersion)
     {
         if (string.IsNullOrWhiteSpace(fullVersion) || string.IsNullOrWhiteSpace(partialVersion))
@@ -297,6 +332,22 @@ public partial class InstanceDataVersionComparer : IComparer<InstanceData>
 
         var parsed = ParseVersion(fullVersion);
         var prefix = $"{partialVersion}.";
+        return parsed.ArtifactVersion.StartsWith(prefix, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Checks if a full version matches the given major version.
+    /// </summary>
+    /// <param name="fullVersion">Full version string (e.g., "1.0.5-pkg.1.17.0+account")</param>
+    /// <param name="majorVersion">Major version to match (e.g., "1")</param>
+    /// <returns>True if the full version's artifact part starts with the major version</returns>
+    public static bool MatchesMajor(string? fullVersion, string? majorVersion)
+    {
+        if (string.IsNullOrWhiteSpace(fullVersion) || string.IsNullOrWhiteSpace(majorVersion))
+            return false;
+
+        var parsed = ParseVersion(fullVersion);
+        var prefix = $"{majorVersion}.";
         return parsed.ArtifactVersion.StartsWith(prefix, StringComparison.Ordinal);
     }
 
@@ -309,10 +360,11 @@ public partial class InstanceDataVersionComparer : IComparer<InstanceData>
     /// <remarks>
     /// Matching logic:
     /// <list type="number">
-    ///     <item><description>If requestedVersion is null/empty → returns the latest version</description></item>
+    ///     <item><description>If requestedVersion is null/empty or "latest" → returns the latest version</description></item>
     ///     <item><description>If requestedVersion is a full version → exact match only</description></item>
     ///     <item><description>If requestedVersion is an artifact version → finds highest pkg version for that artifact</description></item>
-    ///     <item><description>If requestedVersion is a partial version → finds highest version matching the prefix</description></item>
+    ///     <item><description>If requestedVersion is a partial version (MAJOR.MINOR) → finds highest version matching the prefix</description></item>
+    ///     <item><description>If requestedVersion is a major-only version (e.g., "1") → finds highest version matching the major</description></item>
     /// </list>
     /// </remarks>
     public static string? FindBestMatch(IEnumerable<string> versions, string? requestedVersion)
@@ -321,8 +373,8 @@ public partial class InstanceDataVersionComparer : IComparer<InstanceData>
         if (versionList.Count == 0)
             return null;
 
-        // 1. If requestedVersion is null/empty → return latest version
-        if (string.IsNullOrWhiteSpace(requestedVersion))
+        // 1. If requestedVersion is null/empty or "latest" → return latest version
+        if (string.IsNullOrWhiteSpace(requestedVersion) || IsLatestKeyword(requestedVersion))
         {
             return versionList
                 .OrderByDescending(v => v, StringVersionComparer.Instance)
@@ -352,11 +404,22 @@ public partial class InstanceDataVersionComparer : IComparer<InstanceData>
             return matched;
         }
 
-        // 5. If requestedVersion is a partial version → find highest version matching prefix
+        // 5. If requestedVersion is a partial version (MAJOR.MINOR) → find highest version matching prefix
         if (IsPartialVersion(requestedVersion))
         {
             var matched = versionList
                 .Where(v => MatchesPartial(v, requestedVersion))
+                .OrderByDescending(v => v, StringVersionComparer.Instance)
+                .FirstOrDefault();
+
+            return matched;
+        }
+
+        // 6. If requestedVersion is a major-only version (e.g., "1") → find highest version matching major
+        if (IsMajorOnlyVersion(requestedVersion))
+        {
+            var matched = versionList
+                .Where(v => MatchesMajor(v, requestedVersion))
                 .OrderByDescending(v => v, StringVersionComparer.Instance)
                 .FirstOrDefault();
 
@@ -406,6 +469,12 @@ public partial class InstanceDataVersionComparer : IComparer<InstanceData>
     /// </summary>
     [GeneratedRegex(@"^(\d+)\.(\d+)$", RegexOptions.Compiled)]
     private static partial Regex PartialVersionRegex();
+
+    /// <summary>
+    /// Regex pattern for major-only version format: MAJOR (single number)
+    /// </summary>
+    [GeneratedRegex(@"^(\d+)$", RegexOptions.Compiled)]
+    private static partial Regex MajorOnlyVersionRegex();
 
     /// <summary>
     /// Represents a parsed version with artifact and optional package version.


### PR DESCRIPTION
…g support

- Add IsLatestKeyword() to detect 'latest' version requests
- Add IsMajorOnlyVersion() to detect major-only versions (e.g., '1')
- Add MatchesMajor() helper for major version matching
- Update FindBestMatch() to handle 'latest' and major-only versions
- Update CacheSet.GetByVersionAsync() to support 'latest' keyword
- Update Instance.FindData() to support 'latest' and major-only versions
- Refactor Instance.FindData() to use InstanceDataVersionComparer helpers
- Update XML documentation with new version resolution rules

## Summary by Sourcery

Extend version resolution to support a "latest" keyword and major-only version matching across instance data and caching APIs.

New Features:
- Add handling of the "latest" keyword in version comparison, instance data lookup, and cache retrieval APIs.
- Support major-only version strings to resolve the highest matching major version of instance data.

Enhancements:
- Refine version matching helpers to distinguish artifact, partial (MAJOR.MINOR), and major-only versions, and reuse them in Instance.FindData.
- Document the updated version resolution behavior and formats in XML comments for version comparison and instance data lookup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Treats null/empty or the "latest" keyword as a request for the most recent instance data
  * Supports major-only (e.g., "2"), partial (e.g., "2.1"), and full version strings for selection
  * More consistent and robust version-resolution behavior across lookups

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->