### PR TITLE
214 start subprocess and transition task outbox pattern

### DIFF
--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ChangeStateStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ChangeStateStep.cs
@@ -87,6 +87,7 @@ public sealed class ChangeStateStep(
         var result = context.Workflow.GetState(context.Instance.GetCurrentState)
             .Map(state =>
             {
+                context.Current = state;
                 context.Target = state;
                 return context;
             });

--- a/src/BBT.Workflow.Application/Gateway/IInstanceCommandGateway.cs
+++ b/src/BBT.Workflow.Application/Gateway/IInstanceCommandGateway.cs
@@ -1,0 +1,63 @@
+using BBT.Aether.Results;
+using BBT.Workflow.Instances;
+using BBT.Workflow.SubFlow;
+
+namespace BBT.Workflow.Gateway;
+
+/// <summary>
+/// Gateway interface for instance command operations.
+/// Routes between local and remote execution based on target domain.
+/// When target domain matches the current runtime, executes locally with proper transaction.
+/// When target domain differs, delegates to remote HTTP service.
+/// </summary>
+public interface IInstanceCommandGateway
+{
+    /// <summary>
+    /// Starts a new workflow instance.
+    /// Routes to local or remote based on target domain in input.
+    /// </summary>
+    /// <param name="input">The start instance input containing domain, workflow, and instance data.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result containing the started instance output.</returns>
+    Task<Result<StartInstanceOutput>> StartAsync(
+        StartInstanceInput input,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Starts a new sub workflow instance (SubFlow/SubProcess).
+    /// Routes to local or remote based on target domain in input.
+    /// </summary>
+    /// <param name="input">The start instance input containing domain, workflow, and instance data.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result containing the started instance output.</returns>
+    Task<Result<StartInstanceOutput>> StartSubAsync(
+        StartInstanceInput input,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Executes a transition on an existing workflow instance.
+    /// Routes to local or remote based on target domain in input.
+    /// </summary>
+    /// <param name="instanceId">The instance identifier (GUID).</param>
+    /// <param name="transitionKey">The transition key to execute.</param>
+    /// <param name="input">The transition input containing domain, workflow, and transition data.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result containing the transition output.</returns>
+    Task<Result<TransitionOutput>> TransitionAsync(
+        Guid instanceId,
+        string transitionKey,
+        TransitionInput input,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Completes a sub workflow instance and notifies the parent.
+    /// Routes to local or remote based on target domain in input.
+    /// </summary>
+    /// <param name="input">The flow completed input containing domain, flow, and completion data.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result indicating success or failure.</returns>
+    Task<Result> CompleteAsync(
+        FlowCompletedInput input,
+        CancellationToken cancellationToken = default);
+}
+

--- a/src/BBT.Workflow.Application/Gateway/IInstanceQueryGateway.cs
+++ b/src/BBT.Workflow.Application/Gateway/IInstanceQueryGateway.cs
@@ -1,0 +1,98 @@
+using BBT.Aether.Results;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Instances.DTOs;
+
+namespace BBT.Workflow.Gateway;
+
+/// <summary>
+/// Gateway interface for instance query operations.
+/// Routes between local and remote execution based on target domain.
+/// When target domain matches the current runtime, executes locally.
+/// When target domain differs, delegates to remote HTTP service.
+/// </summary>
+public interface IInstanceQueryGateway
+{
+    /// <summary>
+    /// Retrieves a single instance with optional extensions for data enrichment.
+    /// Routes to local or remote based on target domain in input.
+    /// </summary>
+    /// <param name="input">The get instance input containing domain, workflow, and instance identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Conditional result containing the instance output or not modified status.</returns>
+    Task<ConditionalResult<GetInstanceOutput>> GetInstanceAsync(
+        GetInstanceInput input,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves only the instance data (attributes) with optional ETag support and extensions.
+    /// Routes to local or remote based on target domain in input.
+    /// </summary>
+    /// <param name="input">The get instance data input containing domain, workflow, instance, and extensions.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Conditional result containing the instance data output or not modified status.</returns>
+    Task<ConditionalResult<GetInstanceDataOutput>> GetInstanceDataAsync(
+        GetInstanceDataInput input,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the complete history of an instance (all data transitions).
+    /// Routes to local or remote based on target domain in input.
+    /// </summary>
+    /// <param name="input">The get instance history input containing domain, workflow, and instance identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result containing the instance history output.</returns>
+    Task<Result<GetInstanceHistoryOutput>> GetInstanceHistoryAsync(
+        GetInstanceHistoryInput input,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the complete state information for an instance.
+    /// Routes to local or remote based on target domain in input.
+    /// </summary>
+    /// <param name="input">The get function with instance input containing domain, workflow, and instance.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result containing the instance state output.</returns>
+    Task<Result<GetInstanceStateOutput>> GetFunctionWithStateAsync(
+        GetFunctionWithInstanceInput input,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves platform-specific view content for an instance.
+    /// Routes to local or remote based on target domain in input.
+    /// </summary>
+    /// <param name="input">The get function with instance input containing domain, workflow, and instance.</param>
+    /// <param name="platform">Optional platform identifier (web, ios, android).</param>
+    /// <param name="transitionKey">Optional transition key for transition-specific views.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result containing the view output.</returns>
+    Task<Result<GetViewOutput>> GetFunctionWithViewAsync(
+        GetFunctionWithInstanceInput input,
+        string? platform,
+        string? transitionKey,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves schema for an instance transition.
+    /// Routes to local or remote based on target domain in input.
+    /// </summary>
+    /// <param name="input">The get function with instance input containing domain, workflow, and instance.</param>
+    /// <param name="transitionKey">The transition key to get schema for.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result containing the schema output.</returns>
+    Task<Result<GetSchemaOutput>> GetFunctionWithSchemaAsync(
+        GetFunctionWithInstanceInput input,
+        string transitionKey,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves and executes extensions for an instance.
+    /// Routes to local or remote based on target domain in input.
+    /// </summary>
+    /// <param name="input">The get function with instance input containing domain, workflow, instance, and extensions.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result containing the extensions output.</returns>
+    Task<Result<GetExtensionsOutput>> GetFunctionWithExtensionsAsync(
+        GetFunctionWithInstanceInput input,
+        CancellationToken cancellationToken = default);
+}
+

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -6,8 +6,8 @@ using BBT.Workflow.Caching;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Logging;
 using BBT.Workflow.Extentions;
+using BBT.Workflow.Gateway;
 using BBT.Workflow.Instances.DTOs;
-using BBT.Workflow.Instances.Remote;
 using BBT.Workflow.Runtime;
 using BBT.Workflow.Scripting;
 using Microsoft.Extensions.Logging;
@@ -22,7 +22,7 @@ public sealed class InstanceQueryAppService(
     IInstanceRepository instanceRepository,
     IInstanceExtensionService instanceExtensionService,
     IScriptContextFactory scriptContextFactory,
-    IRemoteInstanceQueryAppService remoteInstanceQueryAppService,
+    IInstanceQueryGateway instanceQueryGateway,
     ILogger<InstanceQueryAppService> logger)
     : ApplicationService(serviceProvider), IInstanceQueryAppService
 {
@@ -187,7 +187,7 @@ public sealed class InstanceQueryAppService(
                 Extensions = extensions
             };
 
-            var subFlowResult = await remoteInstanceQueryAppService.GetFunctionWithStateAsync(
+            var subFlowResult = await instanceQueryGateway.GetFunctionWithStateAsync(
                 subFlowInput,
                 cancellationToken);
 
@@ -703,7 +703,7 @@ public sealed class InstanceQueryAppService(
             Extensions = extensions
         };
 
-        return await remoteInstanceQueryAppService.GetFunctionWithExtensionsAsync(
+        return await instanceQueryGateway.GetFunctionWithExtensionsAsync(
             subFlowInput,
             cancellationToken);
     }
@@ -783,7 +783,7 @@ public sealed class InstanceQueryAppService(
             Instance = subflow.SubFlowInstanceId.ToString()
         };
 
-        return await remoteInstanceQueryAppService.GetFunctionWithSchemaAsync(
+        return await instanceQueryGateway.GetFunctionWithSchemaAsync(
             subFlowInput,
             transitionKey,
             cancellationToken);
@@ -863,7 +863,7 @@ public sealed class InstanceQueryAppService(
         string? transitionKey = null,
         CancellationToken cancellationToken = default)
     {
-        var subFlowViewResult = await remoteInstanceQueryAppService.GetFunctionWithViewAsync(
+        var subFlowViewResult = await instanceQueryGateway.GetFunctionWithViewAsync(
             new GetFunctionWithInstanceInput
             {
                 Instance = instance.Subflow!.SubFlowInstanceId.ToString(),

--- a/src/BBT.Workflow.Application/SubFlow/Services/ChildSubflowCancellationService.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/ChildSubflowCancellationService.cs
@@ -1,8 +1,8 @@
 using BBT.Aether.Application.Services;
 using BBT.Aether.Results;
 using BBT.Workflow.Definitions;
+using BBT.Workflow.Gateway;
 using BBT.Workflow.Instances;
-using BBT.Workflow.Instances.Remote;
 using BBT.Workflow.Logging;
 using Microsoft.Extensions.Logging;
 
@@ -11,6 +11,7 @@ namespace BBT.Workflow.SubFlow;
 /// <summary>
 /// Service for handling child subflow cancellation operations.
 /// Propagates cancellation requests to child subflows.
+/// Uses IInstanceCommandGateway to route between local and remote execution based on target domain.
 /// </summary>
 /// <remarks>
 /// This service encapsulates the business logic for child subflow cancellation,
@@ -18,7 +19,7 @@ namespace BBT.Workflow.SubFlow;
 /// </remarks>
 public sealed class ChildSubflowCancellationService(
     IServiceProvider serviceProvider,
-    IRemoteInstanceCommandAppService commandAppService,
+    IInstanceCommandGateway instanceCommandGateway,
     ILogger<ChildSubflowCancellationService> logger)
     : ApplicationService(serviceProvider), IChildSubflowCancellationService
 {
@@ -32,10 +33,10 @@ public sealed class ChildSubflowCancellationService(
     {
         try
         {
-            var result = await commandAppService.TransitionAsync(
+            var result = await instanceCommandGateway.TransitionAsync(
                 instanceId,
                 WellKnownTransitionKeys.Cancel,
-                new TransitionInput(
+                new Instances.TransitionInput(
                     domain: domain,
                     workflow: flow,
                     version: version),

--- a/src/BBT.Workflow.Application/SubFlow/Services/SubflowForwardingService.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubflowForwardingService.cs
@@ -1,13 +1,14 @@
+using BBT.Workflow.Gateway;
 using BBT.Workflow.Instances;
-using BBT.Workflow.Instances.Remote;
 
 namespace BBT.Workflow.SubFlow;
 
 /// <summary>
 /// Service for forwarding transitions to active subflow instances.
+/// Uses IInstanceCommandGateway to route between local and remote execution based on target domain.
 /// </summary>
 public sealed class SubflowForwardingService(
-    IRemoteInstanceCommandAppService remoteInstanceCommandAppService)
+    IInstanceCommandGateway instanceCommandGateway)
     : ISubflowForwardingService
 {
     /// <inheritdoc />
@@ -20,7 +21,7 @@ public sealed class SubflowForwardingService(
         using var activity = SubFlowActivityHelper.StartActivity($"SubFlow.Forward/{input.Domain}/{input.Workflow}/{transitionKey}");
         SubFlowActivityHelper.EnrichWithForward(activity, instanceId, transitionKey);
 
-        var result = await remoteInstanceCommandAppService
+        var result = await instanceCommandGateway
             .TransitionAsync(
                 instanceId,
                 transitionKey,

--- a/src/BBT.Workflow.Application/SubFlow/Services/SubflowStarter.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubflowStarter.cs
@@ -1,8 +1,8 @@
 using System.Text.Json;
 using BBT.Aether;
 using BBT.Workflow.Definitions;
+using BBT.Workflow.Gateway;
 using BBT.Workflow.Instances;
-using BBT.Workflow.Instances.Remote;
 using BBT.Workflow.Scripting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -13,13 +13,14 @@ namespace BBT.Workflow.SubFlow;
 /// Service for managing SubFlow and SubProcess workflows.
 /// SubFlow: Runs on the main flow, preserves main flow state, acts as a wrapper.
 /// SubProcess: Creates separate instances via remote calls (unchanged behavior).
+/// Uses IInstanceCommandGateway to route between local and remote execution based on target domain.
 /// </summary>
-/// <param name="remoteInstanceCommandAppService">Manages remote requests to trigger SubProcess only.</param>
+/// <param name="instanceCommandGateway">Gateway for instance commands, routes local/remote based on domain.</param>
 /// <param name="configuration">Configuration provider for accessing application settings.</param>
 /// <param name="scriptEngine">Script engine for compiling and executing mapping scripts.</param>
 /// <param name="logger">Logger for SubFlow telemetry.</param>
 public sealed class SubflowStarter(
-    IRemoteInstanceCommandAppService remoteInstanceCommandAppService,
+    IInstanceCommandGateway instanceCommandGateway,
     IConfiguration configuration,
     IScriptEngine scriptEngine,
     ILogger<SubflowStarter> logger) : ISubflowStarter
@@ -172,7 +173,7 @@ public sealed class SubflowStarter(
                 RouteValues = inputMappingResult?.RouteValues ?? new Dictionary<string, string?>()
             };
 
-            var startResult = await remoteInstanceCommandAppService.StartSubAsync(subFlowStartInput, cancellationToken);
+            var startResult = await instanceCommandGateway.StartSubAsync(subFlowStartInput, cancellationToken);
 
             if (!startResult.IsSuccess)
             {

--- a/src/BBT.Workflow.Infrastructure/Gateway/LocalInstanceCommandGateway.cs
+++ b/src/BBT.Workflow.Infrastructure/Gateway/LocalInstanceCommandGateway.cs
@@ -1,0 +1,107 @@
+using BBT.Aether.MultiSchema;
+using BBT.Aether.Results;
+using BBT.Aether.Uow;
+using BBT.Workflow.Gateway;
+using BBT.Workflow.Instances;
+using BBT.Workflow.SubFlow;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BBT.Workflow.Infrastructure.Gateway;
+
+/// <summary>
+/// Local implementation of instance command gateway.
+/// Executes commands locally with proper schema context and unit of work management.
+/// Uses IServiceScopeFactory to create fresh scope for each operation ensuring clean transaction state.
+/// </summary>
+public sealed class LocalInstanceCommandGateway : IInstanceCommandGateway
+{
+    private readonly IServiceScopeFactory _serviceScopeFactory;
+
+    /// <summary>
+    /// Initializes a new instance of LocalInstanceCommandGateway.
+    /// </summary>
+    /// <param name="serviceScopeFactory">Factory for creating service scopes.</param>
+    public LocalInstanceCommandGateway(IServiceScopeFactory serviceScopeFactory)
+    {
+        _serviceScopeFactory = serviceScopeFactory;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<StartInstanceOutput>> StartAsync(
+        StartInstanceInput input,
+        CancellationToken cancellationToken = default)
+    {
+        await using var scope = _serviceScopeFactory.CreateAsyncScope();
+        var currentSchema = scope.ServiceProvider.GetRequiredService<ICurrentSchema>();
+        var commandService = scope.ServiceProvider.GetRequiredService<IInstanceCommandAppService>();
+
+        using (currentSchema.Use(input.Workflow))
+        {
+            return await commandService.StartAsync(input, cancellationToken);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<StartInstanceOutput>> StartSubAsync(
+        StartInstanceInput input,
+        CancellationToken cancellationToken = default)
+    {
+        // StartSubAsync uses the same StartAsync endpoint but with sub-specific handling
+        // The IInstanceCommandAppService.StartAsync handles both normal and sub-flow starts
+        await using var scope = _serviceScopeFactory.CreateAsyncScope();
+        var currentSchema = scope.ServiceProvider.GetRequiredService<ICurrentSchema>();
+        var commandService = scope.ServiceProvider.GetRequiredService<IInstanceCommandAppService>();
+
+        using (currentSchema.Use(input.Workflow))
+        {
+            return await commandService.StartAsync(input, cancellationToken);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<TransitionOutput>> TransitionAsync(
+        Guid instanceId,
+        string transitionKey,
+        TransitionInput input,
+        CancellationToken cancellationToken = default)
+    {
+        await using var scope = _serviceScopeFactory.CreateAsyncScope();
+        var currentSchema = scope.ServiceProvider.GetRequiredService<ICurrentSchema>();
+        var commandService = scope.ServiceProvider.GetRequiredService<IInstanceCommandAppService>();
+
+        using (currentSchema.Use(input.Workflow))
+        {
+            return await commandService.TransitionAsync(
+                instanceId.ToString(),
+                transitionKey,
+                input,
+                cancellationToken);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<Result> CompleteAsync(
+        FlowCompletedInput input,
+        CancellationToken cancellationToken = default)
+    {
+        await using var scope = _serviceScopeFactory.CreateAsyncScope();
+        var currentSchema = scope.ServiceProvider.GetRequiredService<ICurrentSchema>();
+        var subflowCompletionService = scope.ServiceProvider.GetRequiredService<ISubflowCompletionService>();
+        var unitOfWorkManager = scope.ServiceProvider.GetRequiredService<IUnitOfWorkManager>();
+
+        using (currentSchema.Use(input.Flow))
+        {
+            await using var uow = await unitOfWorkManager.BeginAsync(new UnitOfWorkOptions
+            {
+                Scope = UnitOfWorkScopeOption.RequiresNew
+            }, cancellationToken);
+
+            await subflowCompletionService.CompletionAsync(input, cancellationToken);
+            await uow.SaveChangesAsync(cancellationToken);
+            await uow.CommitAsync(cancellationToken);
+
+            return Result.Ok();
+        }
+    }
+}
+

--- a/src/BBT.Workflow.Infrastructure/Gateway/LocalInstanceQueryGateway.cs
+++ b/src/BBT.Workflow.Infrastructure/Gateway/LocalInstanceQueryGateway.cs
@@ -1,0 +1,166 @@
+using BBT.Aether.MultiSchema;
+using BBT.Aether.Results;
+using BBT.Workflow.Gateway;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Instances.DTOs;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BBT.Workflow.Infrastructure.Gateway;
+
+/// <summary>
+/// Local implementation of instance query gateway.
+/// Executes queries locally with proper schema context.
+/// Uses IServiceScopeFactory to create fresh scope for each operation.
+/// </summary>
+public sealed class LocalInstanceQueryGateway : IInstanceQueryGateway
+{
+    private readonly IServiceScopeFactory _serviceScopeFactory;
+
+    /// <summary>
+    /// Initializes a new instance of LocalInstanceQueryGateway.
+    /// </summary>
+    /// <param name="serviceScopeFactory">Factory for creating service scopes.</param>
+    public LocalInstanceQueryGateway(IServiceScopeFactory serviceScopeFactory)
+    {
+        _serviceScopeFactory = serviceScopeFactory;
+    }
+
+    /// <inheritdoc />
+    public async Task<ConditionalResult<GetInstanceOutput>> GetInstanceAsync(
+        GetInstanceInput input,
+        CancellationToken cancellationToken = default)
+    {
+        await using var scope = _serviceScopeFactory.CreateAsyncScope();
+        var currentSchema = scope.ServiceProvider.GetRequiredService<ICurrentSchema>();
+        var queryService = scope.ServiceProvider.GetRequiredService<IInstanceQueryAppService>();
+
+        using (currentSchema.Use(input.Workflow))
+        {
+            return await queryService.GetInstanceAsync(input, cancellationToken);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<ConditionalResult<GetInstanceDataOutput>> GetInstanceDataAsync(
+        GetInstanceDataInput input,
+        CancellationToken cancellationToken = default)
+    {
+        await using var scope = _serviceScopeFactory.CreateAsyncScope();
+        var currentSchema = scope.ServiceProvider.GetRequiredService<ICurrentSchema>();
+        var queryService = scope.ServiceProvider.GetRequiredService<IInstanceQueryAppService>();
+
+        using (currentSchema.Use(input.Workflow))
+        {
+            return await queryService.GetInstanceDataAsync(input, cancellationToken);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<GetInstanceHistoryOutput>> GetInstanceHistoryAsync(
+        GetInstanceHistoryInput input,
+        CancellationToken cancellationToken = default)
+    {
+        await using var scope = _serviceScopeFactory.CreateAsyncScope();
+        var currentSchema = scope.ServiceProvider.GetRequiredService<ICurrentSchema>();
+        var queryService = scope.ServiceProvider.GetRequiredService<IInstanceQueryAppService>();
+
+        using (currentSchema.Use(input.Workflow))
+        {
+            return await queryService.GetInstanceHistoryAsync(input, cancellationToken);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<GetInstanceStateOutput>> GetFunctionWithStateAsync(
+        GetFunctionWithInstanceInput input,
+        CancellationToken cancellationToken = default)
+    {
+        await using var scope = _serviceScopeFactory.CreateAsyncScope();
+        var currentSchema = scope.ServiceProvider.GetRequiredService<ICurrentSchema>();
+        var queryService = scope.ServiceProvider.GetRequiredService<IInstanceQueryAppService>();
+
+        using (currentSchema.Use(input.Workflow))
+        {
+            var stateInput = new GetInstanceStateInput
+            {
+                Domain = input.Domain,
+                Workflow = input.Workflow,
+                Version = input.Version,
+                Instance = input.Instance,
+                Extensions = input.Extensions
+            };
+            return await queryService.GetInstanceStateAsync(stateInput, cancellationToken);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<GetViewOutput>> GetFunctionWithViewAsync(
+        GetFunctionWithInstanceInput input,
+        string? platform,
+        string? transitionKey,
+        CancellationToken cancellationToken = default)
+    {
+        await using var scope = _serviceScopeFactory.CreateAsyncScope();
+        var currentSchema = scope.ServiceProvider.GetRequiredService<ICurrentSchema>();
+        var queryService = scope.ServiceProvider.GetRequiredService<IInstanceQueryAppService>();
+
+        using (currentSchema.Use(input.Workflow))
+        {
+            var viewInput = new GetViewInput
+            {
+                Domain = input.Domain,
+                Workflow = input.Workflow,
+                Version = input.Version,
+                Instance = input.Instance
+            };
+            return await queryService.GetPlatformSpecificViewAsync(viewInput, platform, transitionKey, cancellationToken);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<GetSchemaOutput>> GetFunctionWithSchemaAsync(
+        GetFunctionWithInstanceInput input,
+        string transitionKey,
+        CancellationToken cancellationToken = default)
+    {
+        await using var scope = _serviceScopeFactory.CreateAsyncScope();
+        var currentSchema = scope.ServiceProvider.GetRequiredService<ICurrentSchema>();
+        var queryService = scope.ServiceProvider.GetRequiredService<IInstanceQueryAppService>();
+
+        using (currentSchema.Use(input.Workflow))
+        {
+            var schemaInput = new GetSchemaInput
+            {
+                Domain = input.Domain,
+                Workflow = input.Workflow,
+                Version = input.Version,
+                Instance = input.Instance
+            };
+            return await queryService.GetSchemaAsync(schemaInput, transitionKey, cancellationToken);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<GetExtensionsOutput>> GetFunctionWithExtensionsAsync(
+        GetFunctionWithInstanceInput input,
+        CancellationToken cancellationToken = default)
+    {
+        await using var scope = _serviceScopeFactory.CreateAsyncScope();
+        var currentSchema = scope.ServiceProvider.GetRequiredService<ICurrentSchema>();
+        var queryService = scope.ServiceProvider.GetRequiredService<IInstanceQueryAppService>();
+
+        using (currentSchema.Use(input.Workflow))
+        {
+            var extensionsInput = new GetExtensionsInput
+            {
+                Domain = input.Domain,
+                Workflow = input.Workflow,
+                Version = input.Version,
+                Instance = input.Instance,
+                Extensions = input.Extensions
+            };
+            return await queryService.GetExtensionsAsync(extensionsInput, cancellationToken);
+        }
+    }
+}
+

--- a/src/BBT.Workflow.Infrastructure/Gateway/RemoteInstanceCommandGateway.cs
+++ b/src/BBT.Workflow.Infrastructure/Gateway/RemoteInstanceCommandGateway.cs
@@ -1,0 +1,61 @@
+using BBT.Aether.Results;
+using BBT.Workflow.Gateway;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Instances.Remote;
+using BBT.Workflow.SubFlow;
+
+namespace BBT.Workflow.Infrastructure.Gateway;
+
+/// <summary>
+/// Remote implementation of instance command gateway.
+/// Delegates all operations to IRemoteInstanceCommandAppService for HTTP-based execution.
+/// Used when target domain differs from the current runtime domain.
+/// </summary>
+public sealed class RemoteInstanceCommandGateway : IInstanceCommandGateway
+{
+    private readonly IRemoteInstanceCommandAppService _remoteService;
+
+    /// <summary>
+    /// Initializes a new instance of RemoteInstanceCommandGateway.
+    /// </summary>
+    /// <param name="remoteService">The remote instance command service for HTTP calls.</param>
+    public RemoteInstanceCommandGateway(IRemoteInstanceCommandAppService remoteService)
+    {
+        _remoteService = remoteService;
+    }
+
+    /// <inheritdoc />
+    public Task<Result<StartInstanceOutput>> StartAsync(
+        StartInstanceInput input,
+        CancellationToken cancellationToken = default)
+    {
+        return _remoteService.StartAsync(input, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<Result<StartInstanceOutput>> StartSubAsync(
+        StartInstanceInput input,
+        CancellationToken cancellationToken = default)
+    {
+        return _remoteService.StartSubAsync(input, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<Result<TransitionOutput>> TransitionAsync(
+        Guid instanceId,
+        string transitionKey,
+        TransitionInput input,
+        CancellationToken cancellationToken = default)
+    {
+        return _remoteService.TransitionAsync(instanceId, transitionKey, input, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<Result> CompleteAsync(
+        FlowCompletedInput input,
+        CancellationToken cancellationToken = default)
+    {
+        return _remoteService.CompleteAsync(input, cancellationToken);
+    }
+}
+

--- a/src/BBT.Workflow.Infrastructure/Gateway/RemoteInstanceQueryGateway.cs
+++ b/src/BBT.Workflow.Infrastructure/Gateway/RemoteInstanceQueryGateway.cs
@@ -1,0 +1,86 @@
+using BBT.Aether.Results;
+using BBT.Workflow.Gateway;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Instances.DTOs;
+using BBT.Workflow.Instances.Remote;
+
+namespace BBT.Workflow.Infrastructure.Gateway;
+
+/// <summary>
+/// Remote implementation of instance query gateway.
+/// Delegates all operations to IRemoteInstanceQueryAppService for HTTP-based execution.
+/// Used when target domain differs from the current runtime domain.
+/// </summary>
+public sealed class RemoteInstanceQueryGateway : IInstanceQueryGateway
+{
+    private readonly IRemoteInstanceQueryAppService _remoteService;
+
+    /// <summary>
+    /// Initializes a new instance of RemoteInstanceQueryGateway.
+    /// </summary>
+    /// <param name="remoteService">The remote instance query service for HTTP calls.</param>
+    public RemoteInstanceQueryGateway(IRemoteInstanceQueryAppService remoteService)
+    {
+        _remoteService = remoteService;
+    }
+
+    /// <inheritdoc />
+    public Task<ConditionalResult<GetInstanceOutput>> GetInstanceAsync(
+        GetInstanceInput input,
+        CancellationToken cancellationToken = default)
+    {
+        return _remoteService.GetInstanceAsync(input, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<ConditionalResult<GetInstanceDataOutput>> GetInstanceDataAsync(
+        GetInstanceDataInput input,
+        CancellationToken cancellationToken = default)
+    {
+        return _remoteService.GetInstanceDataAsync(input, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<Result<GetInstanceHistoryOutput>> GetInstanceHistoryAsync(
+        GetInstanceHistoryInput input,
+        CancellationToken cancellationToken = default)
+    {
+        return _remoteService.GetInstanceHistoryAsync(input, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<Result<GetInstanceStateOutput>> GetFunctionWithStateAsync(
+        GetFunctionWithInstanceInput input,
+        CancellationToken cancellationToken = default)
+    {
+        return _remoteService.GetFunctionWithStateAsync(input, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<Result<GetViewOutput>> GetFunctionWithViewAsync(
+        GetFunctionWithInstanceInput input,
+        string? platform,
+        string? transitionKey,
+        CancellationToken cancellationToken = default)
+    {
+        return _remoteService.GetFunctionWithViewAsync(input, platform, transitionKey, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<Result<GetSchemaOutput>> GetFunctionWithSchemaAsync(
+        GetFunctionWithInstanceInput input,
+        string transitionKey,
+        CancellationToken cancellationToken = default)
+    {
+        return _remoteService.GetFunctionWithSchemaAsync(input, transitionKey, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<Result<GetExtensionsOutput>> GetFunctionWithExtensionsAsync(
+        GetFunctionWithInstanceInput input,
+        CancellationToken cancellationToken = default)
+    {
+        return _remoteService.GetFunctionWithExtensionsAsync(input, cancellationToken);
+    }
+}
+

--- a/src/BBT.Workflow.Infrastructure/Gateway/RoutedInstanceCommandGateway.cs
+++ b/src/BBT.Workflow.Infrastructure/Gateway/RoutedInstanceCommandGateway.cs
@@ -1,0 +1,78 @@
+using BBT.Aether.Results;
+using BBT.Workflow.Gateway;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Runtime;
+using BBT.Workflow.SubFlow;
+
+namespace BBT.Workflow.Infrastructure.Gateway;
+
+/// <summary>
+/// Routed implementation of instance command gateway.
+/// Routes between local and remote execution based on target domain.
+/// Uses IRuntimeInfoProvider.IsDomainMatch() to determine if target domain is local.
+/// </summary>
+public sealed class RoutedInstanceCommandGateway : IInstanceCommandGateway
+{
+    private readonly LocalInstanceCommandGateway _local;
+    private readonly RemoteInstanceCommandGateway _remote;
+    private readonly IRuntimeInfoProvider _runtimeInfoProvider;
+
+    /// <summary>
+    /// Initializes a new instance of RoutedInstanceCommandGateway.
+    /// </summary>
+    /// <param name="local">The local gateway for same-domain execution.</param>
+    /// <param name="remote">The remote gateway for cross-domain execution.</param>
+    /// <param name="runtimeInfoProvider">Provider for runtime domain information.</param>
+    public RoutedInstanceCommandGateway(
+        LocalInstanceCommandGateway local,
+        RemoteInstanceCommandGateway remote,
+        IRuntimeInfoProvider runtimeInfoProvider)
+    {
+        _local = local;
+        _remote = remote;
+        _runtimeInfoProvider = runtimeInfoProvider;
+    }
+
+    /// <inheritdoc />
+    public Task<Result<StartInstanceOutput>> StartAsync(
+        StartInstanceInput input,
+        CancellationToken cancellationToken = default)
+    {
+        return _runtimeInfoProvider.IsDomainMatch(input.Domain)
+            ? _local.StartAsync(input, cancellationToken)
+            : _remote.StartAsync(input, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<Result<StartInstanceOutput>> StartSubAsync(
+        StartInstanceInput input,
+        CancellationToken cancellationToken = default)
+    {
+        return _runtimeInfoProvider.IsDomainMatch(input.Domain)
+            ? _local.StartSubAsync(input, cancellationToken)
+            : _remote.StartSubAsync(input, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<Result<TransitionOutput>> TransitionAsync(
+        Guid instanceId,
+        string transitionKey,
+        TransitionInput input,
+        CancellationToken cancellationToken = default)
+    {
+        return _runtimeInfoProvider.IsDomainMatch(input.Domain)
+            ? _local.TransitionAsync(instanceId, transitionKey, input, cancellationToken)
+            : _remote.TransitionAsync(instanceId, transitionKey, input, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<Result> CompleteAsync(
+        FlowCompletedInput input,
+        CancellationToken cancellationToken = default)
+    {
+        return _runtimeInfoProvider.IsDomainMatch(input.Domain)
+            ? _local.CompleteAsync(input, cancellationToken)
+            : _remote.CompleteAsync(input, cancellationToken);
+    }
+}
+

--- a/src/BBT.Workflow.Infrastructure/Gateway/RoutedInstanceQueryGateway.cs
+++ b/src/BBT.Workflow.Infrastructure/Gateway/RoutedInstanceQueryGateway.cs
@@ -1,0 +1,109 @@
+using BBT.Aether.Results;
+using BBT.Workflow.Gateway;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Instances.DTOs;
+using BBT.Workflow.Runtime;
+
+namespace BBT.Workflow.Infrastructure.Gateway;
+
+/// <summary>
+/// Routed implementation of instance query gateway.
+/// Routes between local and remote execution based on target domain.
+/// Uses IRuntimeInfoProvider.IsDomainMatch() to determine if target domain is local.
+/// </summary>
+public sealed class RoutedInstanceQueryGateway : IInstanceQueryGateway
+{
+    private readonly LocalInstanceQueryGateway _local;
+    private readonly RemoteInstanceQueryGateway _remote;
+    private readonly IRuntimeInfoProvider _runtimeInfoProvider;
+
+    /// <summary>
+    /// Initializes a new instance of RoutedInstanceQueryGateway.
+    /// </summary>
+    /// <param name="local">The local gateway for same-domain execution.</param>
+    /// <param name="remote">The remote gateway for cross-domain execution.</param>
+    /// <param name="runtimeInfoProvider">Provider for runtime domain information.</param>
+    public RoutedInstanceQueryGateway(
+        LocalInstanceQueryGateway local,
+        RemoteInstanceQueryGateway remote,
+        IRuntimeInfoProvider runtimeInfoProvider)
+    {
+        _local = local;
+        _remote = remote;
+        _runtimeInfoProvider = runtimeInfoProvider;
+    }
+
+    /// <inheritdoc />
+    public Task<ConditionalResult<GetInstanceOutput>> GetInstanceAsync(
+        GetInstanceInput input,
+        CancellationToken cancellationToken = default)
+    {
+        return _runtimeInfoProvider.IsDomainMatch(input.Domain)
+            ? _local.GetInstanceAsync(input, cancellationToken)
+            : _remote.GetInstanceAsync(input, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<ConditionalResult<GetInstanceDataOutput>> GetInstanceDataAsync(
+        GetInstanceDataInput input,
+        CancellationToken cancellationToken = default)
+    {
+        return _runtimeInfoProvider.IsDomainMatch(input.Domain)
+            ? _local.GetInstanceDataAsync(input, cancellationToken)
+            : _remote.GetInstanceDataAsync(input, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<Result<GetInstanceHistoryOutput>> GetInstanceHistoryAsync(
+        GetInstanceHistoryInput input,
+        CancellationToken cancellationToken = default)
+    {
+        return _runtimeInfoProvider.IsDomainMatch(input.Domain)
+            ? _local.GetInstanceHistoryAsync(input, cancellationToken)
+            : _remote.GetInstanceHistoryAsync(input, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<Result<GetInstanceStateOutput>> GetFunctionWithStateAsync(
+        GetFunctionWithInstanceInput input,
+        CancellationToken cancellationToken = default)
+    {
+        return _runtimeInfoProvider.IsDomainMatch(input.Domain)
+            ? _local.GetFunctionWithStateAsync(input, cancellationToken)
+            : _remote.GetFunctionWithStateAsync(input, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<Result<GetViewOutput>> GetFunctionWithViewAsync(
+        GetFunctionWithInstanceInput input,
+        string? platform,
+        string? transitionKey,
+        CancellationToken cancellationToken = default)
+    {
+        return _runtimeInfoProvider.IsDomainMatch(input.Domain)
+            ? _local.GetFunctionWithViewAsync(input, platform, transitionKey, cancellationToken)
+            : _remote.GetFunctionWithViewAsync(input, platform, transitionKey, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<Result<GetSchemaOutput>> GetFunctionWithSchemaAsync(
+        GetFunctionWithInstanceInput input,
+        string transitionKey,
+        CancellationToken cancellationToken = default)
+    {
+        return _runtimeInfoProvider.IsDomainMatch(input.Domain)
+            ? _local.GetFunctionWithSchemaAsync(input, transitionKey, cancellationToken)
+            : _remote.GetFunctionWithSchemaAsync(input, transitionKey, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<Result<GetExtensionsOutput>> GetFunctionWithExtensionsAsync(
+        GetFunctionWithInstanceInput input,
+        CancellationToken cancellationToken = default)
+    {
+        return _runtimeInfoProvider.IsDomainMatch(input.Domain)
+            ? _local.GetFunctionWithExtensionsAsync(input, cancellationToken)
+            : _remote.GetFunctionWithExtensionsAsync(input, cancellationToken);
+    }
+}
+

--- a/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceSubCompletedEventHook.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceSubCompletedEventHook.cs
@@ -1,9 +1,6 @@
-using BBT.Aether.MultiSchema;
-using BBT.Aether.Uow;
 using BBT.Workflow.Events.Hooks;
-using BBT.Workflow.Instances.Remote;
+using BBT.Workflow.Gateway;
 using BBT.Workflow.Logging;
-using BBT.Workflow.Runtime;
 using BBT.Workflow.SubFlow;
 using Microsoft.Extensions.Logging;
 
@@ -12,7 +9,7 @@ namespace BBT.Workflow.Instances.Events;
 /// <summary>
 /// Hook executed before InstanceSubCompletedEvent is published.
 /// Performs pre-publish processing for sub-flow completion events.
-/// This hook delegates the actual completion logic to ISubflowCompletionService.
+/// Uses IInstanceCommandGateway to route between local and remote execution based on target domain.
 /// </summary>
 /// <remarks>
 /// Register this hook in DI using:
@@ -22,15 +19,11 @@ namespace BBT.Workflow.Instances.Events;
 /// </remarks>
 public sealed class InstanceSubCompletedEventHook(
     ILogger<InstanceSubCompletedEventHook> logger,
-    IRemoteInstanceCommandAppService remoteInstanceCommandAppService,
-    ISubflowCompletionService subflowCompletionService,
-    IRuntimeInfoProvider runtimeInfoProvider,
-    ICurrentSchema currentSchema,
-    IUnitOfWorkManager unitOfWorkManager) : IEventPublishHook<InstanceSubCompletedEvent>
+    IInstanceCommandGateway instanceCommandGateway) : IEventPublishHook<InstanceSubCompletedEvent>
 {
     /// <summary>
     /// Executes hook logic before the InstanceSubCompletedEvent is published.
-    /// Routes to local or remote processing based on domain match.
+    /// Delegates to IInstanceCommandGateway which handles local/remote routing automatically.
     /// </summary>
     /// <param name="eventData">The strongly-typed event data.</param>
     /// <param name="context">The hook context with metadata.</param>
@@ -47,13 +40,23 @@ public sealed class InstanceSubCompletedEventHook(
         {
             var input = MapToFlowCompletedInput(eventData);
 
-            if (runtimeInfoProvider.IsDomainMatch(eventData.Domain))
+            // Gateway handles local/remote routing based on domain
+            var result = await instanceCommandGateway.CompleteAsync(input, cancellationToken);
+
+            if (!result.IsSuccess)
             {
-                await ProcessLocalAsync(input, cancellationToken);
-            }
-            else
-            {
-                await remoteInstanceCommandAppService.CompleteAsync(input, cancellationToken);
+                logger.SubFlowCompletionFailed(
+                    new Exception(result.Error.Message),
+                    eventData.SubInstanceId,
+                    eventData.InstanceId);
+
+                return EventHookResult.Fail(
+                    new Exception(result.Error.Message),
+                    new Dictionary<string, string>
+                    {
+                        ["hook_error"] = "SubFlowCompletionFailed",
+                        ["error_code"] = result.Error.Code ?? "unknown"
+                    });
             }
 
             return EventHookResult.Ok(new Dictionary<string, string>
@@ -71,25 +74,6 @@ public sealed class InstanceSubCompletedEventHook(
             {
                 ["hook_error"] = "SubFlowCompletionHookFailed"
             });
-        }
-    }
-
-    /// <summary>
-    /// Processes the subflow completion locally with proper schema and UoW scope.
-    /// </summary>
-    private async Task ProcessLocalAsync(FlowCompletedInput input, CancellationToken cancellationToken)
-    {
-        using (currentSchema.Use(input.Flow))
-        {
-            await using (var uow = await unitOfWorkManager.BeginAsync(new UnitOfWorkOptions
-                         {
-                             Scope = UnitOfWorkScopeOption.RequiresNew
-                         }, cancellationToken))
-            {
-                await subflowCompletionService.CompletionAsync(input, cancellationToken);
-                await uow.SaveChangesAsync(cancellationToken);
-                await uow.CommitAsync(cancellationToken);
-            }
         }
     }
 

--- a/src/BBT.Workflow.Infrastructure/Microsoft/Extensions/DependencyInjection/GatewayServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Infrastructure/Microsoft/Extensions/DependencyInjection/GatewayServiceCollectionExtensions.cs
@@ -1,0 +1,35 @@
+using BBT.Workflow.Gateway;
+using BBT.Workflow.Infrastructure.Gateway;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Extension methods for registering gateway services in an <see cref="IServiceCollection" />.
+/// </summary>
+public static class GatewayServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds the gateway pattern services for instance command and query operations.
+    /// Gateways route between local and remote execution based on target domain.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
+    /// <returns>The <see cref="IServiceCollection" /> so that additional calls can be chained.</returns>
+    public static IServiceCollection AddInstanceGatewayServices(this IServiceCollection services)
+    {
+        // Local gateways - execute locally with schema context
+        services.AddScoped<LocalInstanceCommandGateway>();
+        services.AddScoped<LocalInstanceQueryGateway>();
+
+        // Remote gateways - delegate to HTTP clients
+        services.AddScoped<RemoteInstanceCommandGateway>();
+        services.AddScoped<RemoteInstanceQueryGateway>();
+
+        // Routed gateways - route based on IRuntimeInfoProvider.IsDomainMatch()
+        // These are registered as the interface implementations
+        services.AddScoped<IInstanceCommandGateway, RoutedInstanceCommandGateway>();
+        services.AddScoped<IInstanceQueryGateway, RoutedInstanceQueryGateway>();
+
+        return services;
+    }
+}
+

--- a/src/BBT.Workflow.Infrastructure/Microsoft/Extensions/DependencyInjection/WorkflowInfrastructureModuleServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Infrastructure/Microsoft/Extensions/DependencyInjection/WorkflowInfrastructureModuleServiceCollectionExtensions.cs
@@ -47,6 +47,9 @@ public static class WorkflowInfrastructureModuleServiceCollectionExtensions
         // Remote vnext api
         services.AddVNextApiServices();
         
+        // Instance Gateways - route between local and remote execution
+        services.AddInstanceGatewayServices();
+        
         // Monitoring
         services.AddSingleton<IWorkflowMetrics, PrometheusWorkflowMetrics>();
         services.AddSingleton<WorkflowDatabaseInterceptor>();


### PR DESCRIPTION
## Summary by Sourcery

Introduce gateway pattern for workflow instance commands and queries to route between local and remote execution based on domain, and wire it into subflow lifecycle handling and DI registration.

Bug Fixes:
- Improve error handling for subflow completion failures by surfacing gateway error codes and hook metadata.

Enhancements:
- Replace direct uses of remote instance services and local completion logic with IInstanceCommandGateway and IInstanceQueryGateway across subflow completion, starting, forwarding, cancellation, and instance querying.
- Add local, remote, and routed implementations of instance command and query gateways, including schema-scoped local execution and domain-based routing.
- Wire new gateway services into dependency injection via AddInstanceGatewayServices and integrate into the infrastructure module.
- Ensure transition pipeline keeps the current workflow state in the execution context when changing state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added intelligent routing layer for workflow operations that automatically selects between local and remote execution based on domain configuration.

* **Bug Fixes**
  * Fixed state context initialization to properly set both current and target states during state resolution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->