### PR TITLE
feat(init): add configurable server timeout settings

### DIFF
--- a/init/VNext.Init.Host/Dockerfile
+++ b/init/VNext.Init.Host/Dockerfile
@@ -3,7 +3,11 @@ FROM node:20-slim
 ENV VNEXT_CORE_RUNTIME_VERSION=latest \
     NPM_REGISTRY=https://registry.npmjs.org/ \
     NPM_CONFIG_CACHE=/app/.npm-cache \
-    HOME=/app
+    HOME=/app \
+    # Server timeout configuration (milliseconds) - default 10 minutes
+    SERVER_TIMEOUT_MS=600000 \
+    SERVER_KEEP_ALIVE_TIMEOUT_MS=600000 \
+    SERVER_HEADERS_TIMEOUT_MS=610000
 
 WORKDIR /app
 

--- a/init/VNext.Init.Host/README.md
+++ b/init/VNext.Init.Host/README.md
@@ -348,6 +348,8 @@ always-auth=true
 
 ## Environment Variables
 
+### Core Configuration
+
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `NPM_REGISTRY` | NPM registry URL | `https://registry.npmjs.org/` |
@@ -356,6 +358,41 @@ always-auth=true
 | `PACKAGE_API_PORT` | Port for the API server | `3000` |
 
 > **Note:** There is no default value for `appDomain`. It must be explicitly provided in the request when domain replacement is needed.
+
+### Server Timeout Configuration
+
+These environment variables control HTTP server timeouts. Increase these values for long-running pipelines with many components.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `SERVER_TIMEOUT_MS` | Total request timeout in milliseconds | `600000` (10 min) |
+| `SERVER_KEEP_ALIVE_TIMEOUT_MS` | Keep-alive connection timeout in milliseconds | `600000` (10 min) |
+| `SERVER_HEADERS_TIMEOUT_MS` | Headers timeout in milliseconds (must be > keep-alive) | `610000` (10 min + 10 sec) |
+
+#### Example: 30 Minute Timeout
+
+For pipelines with many components that take longer to process:
+
+```yaml
+# docker-compose.yml
+services:
+  vnext-init:
+    environment:
+      SERVER_TIMEOUT_MS: 1800000        # 30 minutes
+      SERVER_KEEP_ALIVE_TIMEOUT_MS: 1800000
+      SERVER_HEADERS_TIMEOUT_MS: 1810000
+```
+
+Or via command line:
+
+```bash
+docker run -e SERVER_TIMEOUT_MS=1800000 \
+           -e SERVER_KEEP_ALIVE_TIMEOUT_MS=1800000 \
+           -e SERVER_HEADERS_TIMEOUT_MS=1810000 \
+           your-image
+```
+
+> **Tip:** If you're experiencing timeout errors during package publishing, try increasing these values. The `SERVER_HEADERS_TIMEOUT_MS` should always be slightly larger than `SERVER_KEEP_ALIVE_TIMEOUT_MS`.
 
 ---
 

--- a/init/VNext.Init.Host/package-api-server.js
+++ b/init/VNext.Init.Host/package-api-server.js
@@ -25,6 +25,15 @@ const VNEXT_APP_URL = process.env.VNEXT_APP_URL || 'http://host.docker.internal:
 const API_ENDPOINT = `${VNEXT_APP_URL}/api/v1/definitions/publish`;
 const DEFAULT_REGISTRY = process.env.NPM_REGISTRY || 'https://registry.npmjs.org/';
 
+/**
+ * Server timeout configuration (in milliseconds)
+ * These can be overridden via environment variables for long-running pipelines
+ * Default: 10 minutes (600000ms)
+ */
+const SERVER_TIMEOUT_MS = parseInt(process.env.SERVER_TIMEOUT_MS, 10) || 600000;
+const SERVER_KEEP_ALIVE_TIMEOUT_MS = parseInt(process.env.SERVER_KEEP_ALIVE_TIMEOUT_MS, 10) || 600000;
+const SERVER_HEADERS_TIMEOUT_MS = parseInt(process.env.SERVER_HEADERS_TIMEOUT_MS, 10) || (SERVER_KEEP_ALIVE_TIMEOUT_MS + 10000);
+
 /** 
  * The special core runtime package that requires domain replacement for SYS files
  */
@@ -1156,6 +1165,12 @@ async function runAutomaticInit() {
 function startServer() {
     const server = http.createServer(handleRequest);
     
+    // Increase timeouts for long-running package publish operations
+    // Configurable via env vars: SERVER_TIMEOUT_MS, SERVER_KEEP_ALIVE_TIMEOUT_MS, SERVER_HEADERS_TIMEOUT_MS
+    server.timeout = SERVER_TIMEOUT_MS;
+    server.keepAliveTimeout = SERVER_KEEP_ALIVE_TIMEOUT_MS;
+    server.headersTimeout = SERVER_HEADERS_TIMEOUT_MS;
+    
     server.listen(PORT, () => {
         log.section('Package API Server Started');
         log.success(`Server running on port ${PORT}`);
@@ -1170,6 +1185,11 @@ function startServer() {
         log.detail(`  - appDomain is OPTIONAL`);
         log.detail(`  - If appDomain provided, replaces all domains`);
         log.info(`VNext App URL: ${VNEXT_APP_URL}`);
+        log.subsection('Timeout Configuration');
+        log.info(`Server Timeout: ${SERVER_TIMEOUT_MS}ms (${SERVER_TIMEOUT_MS / 60000} min)`);
+        log.info(`Keep-Alive Timeout: ${SERVER_KEEP_ALIVE_TIMEOUT_MS}ms (${SERVER_KEEP_ALIVE_TIMEOUT_MS / 60000} min)`);
+        log.info(`Headers Timeout: ${SERVER_HEADERS_TIMEOUT_MS}ms`);
+        log.detail(`  - Override via: SERVER_TIMEOUT_MS, SERVER_KEEP_ALIVE_TIMEOUT_MS, SERVER_HEADERS_TIMEOUT_MS`);
     });
     
     server.on('error', (err) => {


### PR DESCRIPTION
- Add SERVER_TIMEOUT_MS, SERVER_KEEP_ALIVE_TIMEOUT_MS, SERVER_HEADERS_TIMEOUT_MS env vars
- Default timeout: 10 minutes (600000ms) for long-running package publish operations
- Add curl timeout options to publish-component.sh (--max-time 600, --connect-timeout 30)
- Update Dockerfile with default timeout ENV values
- Update README with timeout configuration documentation and examples

This fixes timeout issues where the publisher client disconnects before the init service completes processing large packages.

## Summary by Sourcery

Introduce configurable HTTP server timeout settings for the init package API server to better support long-running package publish operations.

New Features:
- Add environment-configurable server timeouts (SERVER_TIMEOUT_MS, SERVER_KEEP_ALIVE_TIMEOUT_MS, SERVER_HEADERS_TIMEOUT_MS) with 10-minute defaults for the init API server.

Enhancements:
- Apply configured timeout values to the Node.js HTTP server and log the effective timeout settings at startup.
- Set default timeout environment variables in the Dockerfile for containerized deployments.
- Document server timeout configuration, defaults, and usage examples in the README, including docker-compose and docker run snippets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable server timeout settings via environment variables (request timeout, keep-alive timeout, headers timeout) with sensible defaults.

* **Documentation**
  * Added environment variable configuration guide with usage examples for server timeout settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->