### PR TITLE
fix: use separate query parameters for extensions instead of comma-se…

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -48,7 +48,7 @@ review:
     - "**/*.suo"
     - "**/packages/**"
     - "**/.vs/**"
-    - "**/node_modules/**",
+    - "**/node_modules/**"
     - "**/etc/docker/config/**"
 
 # Chat settings

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -390,7 +390,7 @@ public sealed class InstanceQueryAppService(
 
                     return ConditionalResult<GetInstanceDataOutput>.Success(result);
                 },
-                onFailure: error => ConditionalResult<GetInstanceDataOutput>.Fail(error));
+                onFailure: ConditionalResult<GetInstanceDataOutput>.Fail);
     }
 
     /// <summary>
@@ -501,7 +501,7 @@ public sealed class InstanceQueryAppService(
                 {
                     Href = allExtensions.Length > 0
                         ? InstanceUrlTemplates.DataWithExtensions(input.Domain, input.Workflow, instance.Id.ToString(),
-                            string.Join(",", allExtensions))
+                            allExtensions)
                         : InstanceUrlTemplates.Data(input.Domain, input.Workflow, instance.Id.ToString())
                 };
 
@@ -527,7 +527,7 @@ public sealed class InstanceQueryAppService(
                         Href = allExtensions.Length > 0
                             ? InstanceUrlTemplates.DataWithExtensions(correlation.SubFlowDomain, correlation.SubFlowName,
                                 correlation.SubFlowInstanceId.ToString(),
-                                string.Join(",", allExtensions))
+                                allExtensions)
                             : InstanceUrlTemplates.Data(correlation.SubFlowDomain, correlation.SubFlowName,
                                 correlation.SubFlowInstanceId.ToString())
                     }).ToList();

--- a/src/BBT.Workflow.Domain/Definitions/InstanceUrlTemplates.cs
+++ b/src/BBT.Workflow.Domain/Definitions/InstanceUrlTemplates.cs
@@ -46,10 +46,11 @@ public static class InstanceUrlTemplates
     public const string DataTemplate = "/{0}/workflows/{1}/instances/{2}/functions/data";
 
     /// <summary>
-    /// URL template for instance data endpoints with extensions.
-    /// Format: /{domain}/workflows/{workflow}/instances/{instanceId}/functions/data?extensions={extensions}
+    /// URL template for instance data endpoints with extensions (base path only).
+    /// Format: /{domain}/workflows/{workflow}/instances/{instanceId}/functions/data
+    /// Extensions are added as separate query parameters: ?extensions=ext1&amp;extensions=ext2
     /// </summary>
-    public const string DataWithExtensionsTemplate = "/{0}/workflows/{1}/instances/{2}/functions/data?extensions={3}";
+    public const string DataWithExtensionsTemplate = "/{0}/workflows/{1}/instances/{2}/functions/data";
 
     /// <summary>
     /// URL template for instance view endpoints.
@@ -165,15 +166,20 @@ public static class InstanceUrlTemplates
 
     /// <summary>
     /// Generates URL for instance data function endpoint with extensions.
+    /// Each extension is added as a separate query parameter: ?extensions=ext1&amp;extensions=ext2
     /// </summary>
     /// <param name="domain">The domain name</param>
     /// <param name="workflow">The workflow name</param>
     /// <param name="instance">The instance key or ID</param>
-    /// <param name="extensions">The extensions parameter</param>
+    /// <param name="extensions">The collection of extension names</param>
     /// <param name="apiVersionPrefix">Optional API version prefix (e.g., "api/v1")</param>
-    /// <returns>Generated URL</returns>
-    public static string DataWithExtensions(string domain, string workflow, string instance, string extensions, string? apiVersionPrefix = null)
-        => BuildUrl(DataWithExtensionsTemplate, apiVersionPrefix, domain, workflow, instance, extensions);
+    /// <returns>Generated URL with each extension as a separate query parameter</returns>
+    public static string DataWithExtensions(string domain, string workflow, string instance, IEnumerable<string> extensions, string? apiVersionPrefix = null)
+    {
+        var basePath = BuildUrl(DataWithExtensionsTemplate, apiVersionPrefix, domain, workflow, instance);
+        var extensionParams = string.Join("&", extensions.Select(e => $"extensions={Uri.EscapeDataString(e)}"));
+        return string.IsNullOrEmpty(extensionParams) ? basePath : $"{basePath}?{extensionParams}";
+    }
 
     /// <summary>
     /// Generates URL for instance view function endpoint.

--- a/src/BBT.Workflow.Domain/Definitions/InstanceUrlTemplates.cs
+++ b/src/BBT.Workflow.Domain/Definitions/InstanceUrlTemplates.cs
@@ -177,7 +177,7 @@ public static class InstanceUrlTemplates
     public static string DataWithExtensions(string domain, string workflow, string instance, IEnumerable<string> extensions, string? apiVersionPrefix = null)
     {
         var basePath = BuildUrl(DataWithExtensionsTemplate, apiVersionPrefix, domain, workflow, instance);
-        var extensionParams = string.Join("&", extensions.Select(e => $"extensions={Uri.EscapeDataString(e)}"));
+        var extensionParams = string.Join("&", extensions.Where(e => !string.IsNullOrEmpty(e)).Select(e => $"extensions={Uri.EscapeDataString(e)}"));
         return string.IsNullOrEmpty(extensionParams) ? basePath : $"{basePath}?{extensionParams}";
     }
 

--- a/src/BBT.Workflow.Execution/Invokers/GetInstanceDataRemoteInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/GetInstanceDataRemoteInvoker.cs
@@ -204,9 +204,9 @@ public sealed class GetInstanceDataRemoteInvoker : ITaskInvoker<GetInstanceDataB
     {
         var path = $"/api/v1/{binding.Domain}/workflows/{binding.Workflow}/instances/{binding.Instance}/data";
 
-        if (binding.Extensions != null && binding.Extensions.Length > 0)
+        if (binding.Extensions is { Length: > 0 })
         {
-            var extensionsParam = string.Join("&", binding.Extensions.Select(e => $"extensions={Uri.EscapeDataString(e)}"));
+            var extensionsParam = string.Join("&", binding.Extensions.Where(e => !string.IsNullOrEmpty(e)).Select(e => $"extensions={Uri.EscapeDataString(e)}"));
             path += $"?{extensionsParam}";
         }
 

--- a/src/BBT.Workflow.Execution/Invokers/GetInstanceDataRemoteInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/GetInstanceDataRemoteInvoker.cs
@@ -206,8 +206,8 @@ public sealed class GetInstanceDataRemoteInvoker : ITaskInvoker<GetInstanceDataB
 
         if (binding.Extensions != null && binding.Extensions.Length > 0)
         {
-            var extensionsParam = string.Join(",", binding.Extensions);
-            path += $"?extensions={Uri.EscapeDataString(extensionsParam)}";
+            var extensionsParam = string.Join("&", binding.Extensions.Select(e => $"extensions={Uri.EscapeDataString(e)}"));
+            path += $"?{extensionsParam}";
         }
 
         return path;


### PR DESCRIPTION
…parated

Previously, extensions were combined in a single query parameter with commas: ?extensions=ext1,ext2,ext3

Now each extension is added as a separate query parameter: ?extensions=ext1&extensions=ext2&extensions=ext3

This ensures extensions are processed correctly by the platform.

Files changed:
- InstanceUrlTemplates.cs: Updated DataWithExtensions to accept IEnumerable<string>
- InstanceQueryAppService.cs: Pass array directly instead of joining
- GetInstanceDataRemoteInvoker.cs: Build proper query string with separate params

## Summary by Sourcery

Use separate query parameters for instance data extensions instead of a single comma-separated parameter.

Bug Fixes:
- Ensure instance data extension parameters are sent in a format correctly understood by the platform by using repeated query parameters instead of a comma-separated list.

Enhancements:
- Update instance URL generation helpers and remote invoker to construct extension query strings from collections of extension names.
- Simplify instance query application service callbacks when handling failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of extensions in workflow instance data retrieval to use separate query parameters instead of comma-separated values.
  * Enhanced path construction logic for better parameter encoding.

* **Chores**
  * Updated code review configuration formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->