### PR TITLE
Fix subflow status in SubFlowStateInfo return

### DIFF
--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -204,7 +204,7 @@ public sealed class InstanceQueryAppService(
                 return new SubFlowStateInfo(
                     AvailableTransitions: transitionNames,
                     CurrentState: subFlowValue.State,
-                    Status: mainInstance.Status,
+                    Status: subFlowValue.Status,
                     SubFlowData: subFlowValue.Data,
                     SubFlowView: subFlowValue.View,
                     SubFlowActiveCorrelations: subFlowValue.ActiveCorrelations);


### PR DESCRIPTION
Updated the SubFlowStateInfo constructor to use subFlowValue.Status instead of mainInstance.Status, ensuring the correct status is reported for subflows.

## Summary by Sourcery

Bug Fixes:
- Report subflow status using the subflow instance status instead of the main workflow instance status in SubFlowStateInfo responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected SubFlow status reporting to accurately reflect each SubFlow's own state, ensuring proper control flow behavior in workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->