### PR TITLE
Remove Idempotency from ForwardToSubflowJob

### DIFF
--- a/src/BBT.Workflow.Domain/Execution/PostCommit/IPostCommitJob.cs
+++ b/src/BBT.Workflow.Domain/Execution/PostCommit/IPostCommitJob.cs
@@ -43,7 +43,6 @@ public sealed record StartSubflowJob(
 /// <summary>
 /// Post-commit job for forwarding a transition to an active subflow.
 /// Contains the data needed to forward the transition after lock release.
-/// Implements idempotency to prevent duplicate forwards on retries.
 /// </summary>
 /// <param name="SubflowInstanceId">The instance ID of the active subflow to forward to.</param>
 /// <param name="TransitionKey">The transition key being forwarded.</param>
@@ -65,9 +64,7 @@ public sealed record ForwardToSubflowJob(
     string[]? Tags,
     JsonElement? DataElement,
     Dictionary<string, string?> Headers,
-    Dictionary<string, string?> RouteValues) : IIdempotentPostCommitJob
+    Dictionary<string, string?> RouteValues) : IPostCommitJob
 {
-    /// <inheritdoc />
-    public string IdempotencyKey => $"forward:{SubflowInstanceId}:{TransitionKey}";
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Change ForwardToSubflowJob to implement the generic post-commit job interface instead of the idempotent variant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed idempotent execution semantics from ForwardToSubflowJob. The job may now execute multiple times if invoked repeatedly, potentially affecting workflow behavior and reliability patterns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->