### PR TITLE
fix(#294): change array merge behavior to replace instead of deep merge

### DIFF
--- a/src/BBT.Workflow.Domain/Shared/Merging/Strategies/CollectionMergeStrategy.cs
+++ b/src/BBT.Workflow.Domain/Shared/Merging/Strategies/CollectionMergeStrategy.cs
@@ -6,16 +6,17 @@ namespace BBT.Workflow.Shared.Merging;
 
 /// <summary>
 /// Merge strategy for collection types including dictionaries and enumerable objects.
-/// Handles dictionary merging with recursive value merging and collection concatenation.
+/// Handles dictionary merging with recursive value merging.
+/// List-like collections are replaced entirely rather than merged to ensure deterministic updates.
 /// </summary>
 public class CollectionMergeStrategy : IMergeStrategy
 {
     /// <summary>
-    /// Merges two collections by concatenating them or merging their contents.
+    /// Merges two collections. Dictionaries are deep merged, while list-like collections are replaced.
     /// </summary>
     /// <param name="target">The target collection.</param>
     /// <param name="source">The source collection.</param>
-    /// <returns>The merged collection.</returns>
+    /// <returns>The merged collection (for dictionaries) or the source collection (for lists).</returns>
     public object? Merge(object? target, object? source)
     {
         if (target is not IEnumerable targetCollection || source is not IEnumerable sourceCollection)
@@ -25,14 +26,14 @@ public class CollectionMergeStrategy : IMergeStrategy
     }
 
     /// <summary>
-    /// Merges two collections by concatenating them or merging dictionary contents.
+    /// Merges two collections. Dictionaries are deep merged, while list-like collections are replaced.
     /// </summary>
     /// <param name="target">The target collection.</param>
     /// <param name="source">The source collection.</param>
-    /// <returns>The merged collection.</returns>
+    /// <returns>The merged collection (for dictionaries) or the source collection (for lists).</returns>
     private static object? MergeCollections(IEnumerable target, IEnumerable source)
     {
-        // Handle Dictionary<string, object> types
+        // Handle Dictionary<string, object> types - deep merge
         if (target is IDictionary<string, object?> targetDict && source is IDictionary<string, object?> sourceDict)
         {
             var result = new ExpandoObject() as IDictionary<string, object?>;
@@ -54,54 +55,16 @@ public class CollectionMergeStrategy : IMergeStrategy
             return (ExpandoObject)result;
         }
 
-        // For other enumerable types, perform full deep merge
+        // For list-like collections, replace entirely with source
+        // This ensures deterministic updates and allows removing items from lists
         try
         {
-            var targetList = target.Cast<object>().ToList();
-            var sourceList = source.Cast<object>().ToList();
-
-            return PerformFullDeepMerge(targetList, sourceList);
+            return source.Cast<object>().ToList();
         }
         catch
         {
-            // If casting fails, return source
+            // If casting fails, return source as-is
             return source;
         }
-    }
-
-    /// <summary>
-    /// Performs full deep merge of two object lists without any key-based restrictions.
-    /// Merges objects at same positions and appends remaining items.
-    /// </summary>
-    /// <param name="targetList">The target object list.</param>
-    /// <param name="sourceList">The source object list.</param>
-    /// <returns>The fully merged object list.</returns>
-    private static List<object> PerformFullDeepMerge(List<object> targetList, List<object> sourceList)
-    {
-        var mergedItems = new List<object>();
-        var maxLength = Math.Max(targetList.Count, sourceList.Count);
-
-        // Merge items at same positions
-        for (int i = 0; i < maxLength; i++)
-        {
-            if (i < targetList.Count && i < sourceList.Count)
-            {
-                // Both lists have items at this position - deep merge them
-                var mergedItem = ObjectMerger.MergeValues(targetList[i], sourceList[i]);
-                mergedItems.Add(mergedItem ?? sourceList[i]);
-            }
-            else if (i < targetList.Count)
-            {
-                // Only target has item at this position
-                mergedItems.Add(targetList[i]);
-            }
-            else
-            {
-                // Only source has item at this position
-                mergedItems.Add(sourceList[i]);
-            }
-        }
-
-        return mergedItems;
     }
 }

--- a/src/BBT.Workflow.Domain/Shared/Merging/Strategies/JsonElementMergeStrategy.cs
+++ b/src/BBT.Workflow.Domain/Shared/Merging/Strategies/JsonElementMergeStrategy.cs
@@ -6,7 +6,8 @@ namespace BBT.Workflow.Shared.Merging;
 
 /// <summary>
 /// Merge strategy for JsonElement instances and mixed JsonElement/ExpandoObject scenarios.
-/// Handles object merging, array concatenation, and type conversions.
+/// Handles object merging (deep merge), array replacement, and type conversions.
+/// Arrays are replaced entirely rather than merged to ensure deterministic updates.
 /// </summary>
 public class JsonElementMergeStrategy : IMergeStrategy
 {
@@ -48,10 +49,11 @@ public class JsonElementMergeStrategy : IMergeStrategy
                 }
             }
 
-            // Handle array merging with full deep merge
+            // Handle array replacement - source array completely replaces target array
+            // This ensures deterministic updates and allows removing items from arrays
             if (targetElement.ValueKind == JsonValueKind.Array && sourceElement.ValueKind == JsonValueKind.Array)
             {
-                return MergeJsonArraysDeep(targetElement, sourceElement);
+                return sourceElement;
             }
 
             // For other JsonElement types, source takes precedence
@@ -89,53 +91,5 @@ public class JsonElementMergeStrategy : IMergeStrategy
 
         // For all other cases, source takes precedence
         return source;
-    }
-
-    /// <summary>
-    /// Performs full deep merge of two JSON arrays without key-based restrictions.
-    /// Merges objects at same positions and appends remaining items.
-    /// </summary>
-    /// <param name="targetArray">The target JSON array.</param>
-    /// <param name="sourceArray">The source JSON array.</param>
-    /// <returns>The fully merged JSON array.</returns>
-    private static JsonElement MergeJsonArraysDeep(JsonElement targetArray, JsonElement sourceArray)
-    {
-        var targetList = targetArray.EnumerateArray().ToList();
-        var sourceList = sourceArray.EnumerateArray().ToList();
-        var mergedItems = new List<JsonElement>();
-        var maxLength = Math.Max(targetList.Count, sourceList.Count);
-
-        // Merge items at same positions
-        for (int i = 0; i < maxLength; i++)
-        {
-            if (i < targetList.Count && i < sourceList.Count)
-            {
-                // Both arrays have items at this position - deep merge them
-                var mergedItem = MergeJsonElements(targetList[i], sourceList[i]);
-                if (mergedItem is JsonElement jsonElement)
-                {
-                    mergedItems.Add(jsonElement);
-                }
-                else
-                {
-                    // Fallback to source item if merge fails
-                    mergedItems.Add(sourceList[i]);
-                }
-            }
-            else if (i < targetList.Count)
-            {
-                // Only target has item at this position
-                mergedItems.Add(targetList[i]);
-            }
-            else
-            {
-                // Only source has item at this position
-                mergedItems.Add(sourceList[i]);
-            }
-        }
-
-        // Convert back to JsonElement
-        var mergedJson = JsonSerializer.Serialize(mergedItems.Select(e => e.GetRawText()).ToArray());
-        return JsonSerializer.Deserialize<JsonElement>(mergedJson);
     }
 }

--- a/test/BBT.Workflow.Domain.Tests/Shared/Merging/CollectionMergeStrategyTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Shared/Merging/CollectionMergeStrategyTests.cs
@@ -73,7 +73,7 @@ public class CollectionMergeStrategyTests
     }
 
     [Fact]
-    public void Merge_ShouldMergeLists_WithSameLength()
+    public void Merge_ShouldReplaceLists_WithSameLength()
     {
         // Arrange
         var target = new List<object> { 1, 2, 3 };
@@ -82,7 +82,7 @@ public class CollectionMergeStrategyTests
         // Act
         var result = _strategy.Merge(target, source) as List<object>;
 
-        // Assert
+        // Assert - Lists are replaced, source completely replaces target
         Assert.NotNull(result);
         Assert.Equal(3, result.Count);
         Assert.Equal(10, result[0]);
@@ -91,7 +91,7 @@ public class CollectionMergeStrategyTests
     }
 
     [Fact]
-    public void Merge_ShouldMergeLists_WithDifferentLengths_TargetLonger()
+    public void Merge_ShouldReplaceLists_WithDifferentLengths_TargetLonger()
     {
         // Arrange
         var target = new List<object> { 1, 2, 3, 4, 5 };
@@ -100,18 +100,15 @@ public class CollectionMergeStrategyTests
         // Act
         var result = _strategy.Merge(target, source) as List<object>;
 
-        // Assert
+        // Assert - Lists are replaced, source completely replaces target
         Assert.NotNull(result);
-        Assert.Equal(5, result.Count);
+        Assert.Equal(2, result.Count);
         Assert.Equal(10, result[0]);
         Assert.Equal(20, result[1]);
-        Assert.Equal(3, result[2]);
-        Assert.Equal(4, result[3]);
-        Assert.Equal(5, result[4]);
     }
 
     [Fact]
-    public void Merge_ShouldMergeLists_WithDifferentLengths_SourceLonger()
+    public void Merge_ShouldReplaceLists_WithDifferentLengths_SourceLonger()
     {
         // Arrange
         var target = new List<object> { 1, 2 };
@@ -120,7 +117,7 @@ public class CollectionMergeStrategyTests
         // Act
         var result = _strategy.Merge(target, source) as List<object>;
 
-        // Assert
+        // Assert - Lists are replaced, source completely replaces target
         Assert.NotNull(result);
         Assert.Equal(4, result.Count);
         Assert.Equal(10, result[0]);
@@ -146,7 +143,7 @@ public class CollectionMergeStrategyTests
     }
 
     [Fact]
-    public void Merge_ShouldHandleEmptySourceList()
+    public void Merge_ShouldReplaceWithEmptySourceList()
     {
         // Arrange
         var target = new List<object> { 1, 2, 3 };
@@ -155,9 +152,9 @@ public class CollectionMergeStrategyTests
         // Act
         var result = _strategy.Merge(target, source) as List<object>;
 
-        // Assert
+        // Assert - Lists are replaced, empty source replaces target
         Assert.NotNull(result);
-        Assert.Equal(3, result.Count);
+        Assert.Empty(result);
     }
 
     [Fact]
@@ -187,7 +184,7 @@ public class CollectionMergeStrategyTests
     }
 
     [Fact]
-    public void Merge_ShouldHandleMixedTypesList()
+    public void Merge_ShouldReplaceMixedTypesList()
     {
         // Arrange
         var target = new List<object> { 1, "two", true };
@@ -196,7 +193,7 @@ public class CollectionMergeStrategyTests
         // Act
         var result = _strategy.Merge(target, source) as List<object>;
 
-        // Assert
+        // Assert - Lists are replaced, source completely replaces target
         Assert.NotNull(result);
         Assert.Equal(3, result.Count);
         Assert.Equal(10, result[0]);
@@ -205,7 +202,7 @@ public class CollectionMergeStrategyTests
     }
 
     [Fact]
-    public void Merge_ShouldHandleArrays()
+    public void Merge_ShouldReplaceArrays()
     {
         // Arrange
         var target = new[] { 1, 2, 3 };
@@ -214,9 +211,11 @@ public class CollectionMergeStrategyTests
         // Act
         var result = _strategy.Merge(target, source) as List<object>;
 
-        // Assert
+        // Assert - Arrays are replaced, source completely replaces target
         Assert.NotNull(result);
-        Assert.Equal(3, result.Count);
+        Assert.Equal(2, result.Count);
+        Assert.Equal(10, result[0]);
+        Assert.Equal(20, result[1]);
     }
 
     [Fact]
@@ -292,7 +291,7 @@ public class CollectionMergeStrategyTests
     }
 
     [Fact]
-    public void Merge_ShouldHandleListsWithNullElements()
+    public void Merge_ShouldReplaceListsWithNullElements()
     {
         // Arrange
         var target = new List<object?> { 1, null, 3 };
@@ -301,14 +300,12 @@ public class CollectionMergeStrategyTests
         // Act
         var result = _strategy.Merge(target, source) as List<object>;
 
-        // Assert
+        // Assert - Lists are replaced, source completely replaces target (including nulls)
         Assert.NotNull(result);
         Assert.Equal(3, result.Count);
         Assert.Equal(10, result[0]);
         Assert.Equal(20, result[1]);
-        // When source is null and target has value, ObjectMerger.MergeValues returns target
-        // So index 2 will keep the target value
-        Assert.Equal(3, result[2]);
+        Assert.Null(result[2]);
     }
 
     [Fact]
@@ -321,7 +318,7 @@ public class CollectionMergeStrategyTests
     }
 
     [Fact]
-    public void Merge_ShouldDeepMergeNestedLists()
+    public void Merge_ShouldReplaceNestedLists()
     {
         // Arrange
         var target = new List<object>
@@ -331,19 +328,20 @@ public class CollectionMergeStrategyTests
 
         var source = new List<object>
         {
-            new Dictionary<string, object?> { { "Id", 1 }, { "Value", "Added" } }
+            new Dictionary<string, object?> { { "Id", 2 }, { "Value", "Added" } }
         };
 
         // Act
         var result = _strategy.Merge(target, source) as List<object>;
 
-        // Assert
+        // Assert - Lists are replaced, source completely replaces target
         Assert.NotNull(result);
         Assert.Single(result);
-        var item = result[0] as ExpandoObject;
+        var item = result[0] as Dictionary<string, object?>;
         Assert.NotNull(item);
-        var dict = (IDictionary<string, object?>)item;
-        Assert.Equal(3, dict.Count);
+        Assert.Equal(2, item.Count);
+        Assert.Equal(2, item["Id"]);
+        Assert.Equal("Added", item["Value"]);
     }
 }
 

--- a/test/BBT.Workflow.Domain.Tests/Shared/Merging/JsonElementMergeStrategyTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Shared/Merging/JsonElementMergeStrategyTests.cs
@@ -95,7 +95,7 @@ public class JsonElementMergeStrategyTests
     }
 
     [Fact]
-    public void Merge_ShouldMergeJsonArrays()
+    public void Merge_ShouldReplaceJsonArrays()
     {
         // Arrange
         var targetJson = JsonDocument.Parse(@"[1, 2, 3]").RootElement;
@@ -108,13 +108,14 @@ public class JsonElementMergeStrategyTests
         Assert.NotNull(result);
         Assert.Equal(JsonValueKind.Array, result.Value.ValueKind);
         var array = result.Value.EnumerateArray().ToList();
-        Assert.Equal(3, array.Count);
-        // Arrays are merged, so we just check count
-        // The actual merge logic combines items at same positions
+        // Arrays are replaced, so source array completely replaces target
+        Assert.Equal(2, array.Count);
+        Assert.Equal(10, array[0].GetInt32());
+        Assert.Equal(20, array[1].GetInt32());
     }
 
     [Fact]
-    public void Merge_ShouldMergeJsonArrays_WithDifferentLengths()
+    public void Merge_ShouldReplaceJsonArrays_WithDifferentLengths()
     {
         // Arrange
         var targetJson = JsonDocument.Parse(@"[1, 2]").RootElement;
@@ -126,8 +127,12 @@ public class JsonElementMergeStrategyTests
         // Assert
         Assert.NotNull(result);
         var array = result.Value.EnumerateArray().ToList();
+        // Arrays are replaced, source array completely replaces target
         Assert.Equal(4, array.Count);
-        // Arrays are merged, checking count is sufficient
+        Assert.Equal(10, array[0].GetInt32());
+        Assert.Equal(20, array[1].GetInt32());
+        Assert.Equal(30, array[2].GetInt32());
+        Assert.Equal(40, array[3].GetInt32());
     }
 
     [Fact]
@@ -270,7 +275,7 @@ public class JsonElementMergeStrategyTests
     }
 
     [Fact]
-    public void Merge_ShouldMergeNestedArraysInObjects()
+    public void Merge_ShouldReplaceNestedArraysInObjects()
     {
         // Arrange
         var targetJson = JsonDocument.Parse(@"{
@@ -288,6 +293,10 @@ public class JsonElementMergeStrategyTests
         Assert.NotNull(result);
         var dict = (IDictionary<string, object?>)result;
         Assert.True(dict.ContainsKey("items"));
+        // Nested arrays should be replaced, not merged
+        var items = dict["items"] as List<object>;
+        Assert.NotNull(items);
+        Assert.Equal(2, items.Count);
     }
 
     [Fact]
@@ -364,7 +373,7 @@ public class JsonElementMergeStrategyTests
     }
 
     [Fact]
-    public void Merge_ShouldMergeArraysWithObjectElements()
+    public void Merge_ShouldReplaceArraysWithObjectElements()
     {
         // Arrange
         var targetJson = JsonDocument.Parse(@"[
@@ -372,7 +381,7 @@ public class JsonElementMergeStrategyTests
         ]").RootElement;
 
         var sourceJson = JsonDocument.Parse(@"[
-            {""id"": 1, ""value"": ""Added""}
+            {""id"": 2, ""value"": ""Added""}
         ]").RootElement;
 
         // Act
@@ -382,6 +391,10 @@ public class JsonElementMergeStrategyTests
         Assert.NotNull(result);
         var array = result.Value.EnumerateArray().ToList();
         Assert.Single(array);
+        // Array is replaced, so we get the source array element
+        var firstItem = array[0];
+        Assert.Equal(2, firstItem.GetProperty("id").GetInt32());
+        Assert.Equal("Added", firstItem.GetProperty("value").GetString());
     }
 
     [Fact]
@@ -396,6 +409,49 @@ public class JsonElementMergeStrategyTests
 
         // Assert
         Assert.Equal(123, result);
+    }
+
+    /// <summary>
+    /// Test case for GitHub Issue #294: Array replacement behavior
+    /// Verifies that arrays are replaced entirely, not merged, allowing items to be removed.
+    /// </summary>
+    [Fact]
+    public void Merge_ShouldReplaceArrays_GitHubIssue294()
+    {
+        // Arrange - Issue scenario
+        // Current data: { "items": [{ "id": 1 }, { "id": 2 }] }
+        // Incoming payload: { "items": [{ "id": 2 }] }
+        // Expected result: { "items": [{ "id": 2 }] }
+        var targetJson = JsonDocument.Parse(@"{
+            ""items"": [
+                { ""id"": 1 },
+                { ""id"": 2 }
+            ]
+        }").RootElement;
+
+        var sourceJson = JsonDocument.Parse(@"{
+            ""items"": [
+                { ""id"": 2 }
+            ]
+        }").RootElement;
+
+        // Act
+        var result = _strategy.Merge(targetJson, sourceJson) as ExpandoObject;
+
+        // Assert - Arrays should be replaced, not merged
+        Assert.NotNull(result);
+        var dict = (IDictionary<string, object?>)result;
+        Assert.True(dict.ContainsKey("items"));
+        
+        var items = dict["items"] as List<object>;
+        Assert.NotNull(items);
+        Assert.Single(items); // Only one item, not two or three
+        
+        var item = items[0] as ExpandoObject;
+        Assert.NotNull(item);
+        var itemDict = (IDictionary<string, object?>)item;
+        // JSON deserialization may produce different numeric types, so we convert to string for comparison
+        Assert.Equal("2", itemDict["id"]?.ToString()); // The item from source with id: 2
     }
 }
 

--- a/test/BBT.Workflow.Domain.Tests/Shared/Merging/ObjectMergerTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Shared/Merging/ObjectMergerTests.cs
@@ -118,7 +118,7 @@ public class ObjectMergerTests
     }
 
     [Fact]
-    public void MergeValues_ShouldMergeLists()
+    public void MergeValues_ShouldReplaceLists()
     {
         // Arrange
         var target = new List<object> { 1, 2, 3 };
@@ -127,12 +127,11 @@ public class ObjectMergerTests
         // Act
         var result = ObjectMerger.MergeValues(target, source) as List<object>;
 
-        // Assert
+        // Assert - Lists are replaced, source completely replaces target
         Assert.NotNull(result);
-        Assert.Equal(3, result.Count);
+        Assert.Equal(2, result.Count);
         Assert.Equal(10, result[0]);
         Assert.Equal(20, result[1]);
-        Assert.Equal(3, result[2]);
     }
 
     [Fact]
@@ -257,7 +256,7 @@ public class ObjectMergerTests
     }
 
     [Fact]
-    public void MergeValues_ShouldHandleArrays()
+    public void MergeValues_ShouldReplaceArrays()
     {
         // Arrange
         var target = new[] { 1, 2, 3 };
@@ -266,9 +265,11 @@ public class ObjectMergerTests
         // Act
         var result = ObjectMerger.MergeValues(target, source) as List<object>;
 
-        // Assert
+        // Assert - Arrays are replaced, source completely replaces target
         Assert.NotNull(result);
-        Assert.Equal(3, result.Count);
+        Assert.Equal(2, result.Count);
+        Assert.Equal(10, result[0]);
+        Assert.Equal(20, result[1]);
     }
 
     [Fact]
@@ -315,7 +316,7 @@ public class ObjectMergerTests
     }
 
     [Fact]
-    public void MergeValues_ShouldHandleJsonArrays()
+    public void MergeValues_ShouldReplaceJsonArrays()
     {
         // Arrange
         var target = JsonDocument.Parse(@"[1, 2, 3]").RootElement;
@@ -324,9 +325,13 @@ public class ObjectMergerTests
         // Act
         var result = ObjectMerger.MergeValues(target, source) as JsonElement?;
 
-        // Assert
+        // Assert - Arrays are replaced, source completely replaces target
         Assert.NotNull(result);
         Assert.Equal(JsonValueKind.Array, result.Value.ValueKind);
+        var array = result.Value.EnumerateArray().ToList();
+        Assert.Equal(2, array.Count);
+        Assert.Equal(10, array[0].GetInt32());
+        Assert.Equal(20, array[1].GetInt32());
     }
 
     [Fact]
@@ -351,7 +356,7 @@ public class ObjectMergerTests
     }
 
     [Fact]
-    public void MergeValues_ShouldHandleNestedLists()
+    public void MergeValues_ShouldReplaceNestedLists()
     {
         // Arrange
         var target = new List<object>
@@ -361,15 +366,20 @@ public class ObjectMergerTests
 
         var source = new List<object>
         {
-            new Dictionary<string, object?> { { "id", 1 }, { "value", "Added" } }
+            new Dictionary<string, object?> { { "id", 2 }, { "value", "Added" } }
         };
 
         // Act
         var result = ObjectMerger.MergeValues(target, source) as List<object>;
 
-        // Assert
+        // Assert - Lists are replaced, source completely replaces target
         Assert.NotNull(result);
         Assert.Single(result);
+        var item = result[0] as Dictionary<string, object?>;
+        Assert.NotNull(item);
+        Assert.Equal(2, item.Count);
+        Assert.Equal(2, item["id"]);
+        Assert.Equal("Added", item["value"]);
     }
 
     [Fact]


### PR DESCRIPTION
Arrays are now replaced entirely during merge operations instead of being deep merged by position. This ensures deterministic updates and allows removing items from arrays.

Changes:
- JsonElementMergeStrategy: return source array directly instead of merging
- CollectionMergeStrategy: replace lists entirely with source
- Remove unused MergeJsonArraysDeep and PerformFullDeepMerge methods
- Update all related tests to reflect replace behavior
- Add specific test case for GitHub Issue #294 scenario

Merge behavior summary:
- Array: Replace (source completely replaces target)
- Object: Deep Merge (unchanged)
- Primitive: Replace (unchanged)

## Summary by Sourcery

Change merge semantics so that arrays and list-like collections are fully replaced by the source while dictionaries continue to be deep merged.

Bug Fixes:
- Ensure array and list merging is deterministic and allows removal of items by replacing target collections with the source, addressing the scenario in GitHub Issue #294.

Enhancements:
- Update JsonElement and collection merge strategies to document and enforce array/list replacement instead of positional deep merging.

Tests:
- Adjust existing merging tests to assert replacement behavior for arrays and lists, and add a dedicated regression test covering the GitHub Issue #294 array scenario.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated collection merging behavior: arrays and lists are now fully replaced by source values instead of being merged. Dictionary objects continue to use deep merge logic for granular updates.

* **Tests**
  * Updated test coverage to validate the new collection replacement semantics across various scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->