### PR TITLE
Add strict idempotency for subflow and service-to-service starts

### DIFF
--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
@@ -86,7 +86,8 @@ public sealed class InstanceController(
                 Attributes = request.Attributes,
                 Callback = request.Callback,
                 ExtraProperties = new ExtraPropertyDictionary(request.ExtraProperties)
-            }
+            },
+            StrictIdempotency = true
         };
         var httpContext = httpContextAccessor.HttpContext;
         if (httpContext is not null)

--- a/src/BBT.Workflow.Application/Execution/PostCommit/Handlers/StartSubflowJobHandler.cs
+++ b/src/BBT.Workflow.Application/Execution/PostCommit/Handlers/StartSubflowJobHandler.cs
@@ -29,10 +29,7 @@ public sealed class StartSubflowJobHandler(
         var instanceResult = await instanceRepository.GetResultAsync(context.InstanceId.ToString(), true, cancellationToken);
         if (!instanceResult.IsSuccess)
         {
-            logger.LogError(
-                "Instance {InstanceId} not found while starting subflow for correlation {CorrelationId}",
-                context.InstanceId,
-                job.CorrelationId);
+            logger.SubFlowInstanceNotFound(context.InstanceId, job.CorrelationId);
             return Result.Fail(instanceResult.Error);
         }
 
@@ -42,60 +39,37 @@ public sealed class StartSubflowJobHandler(
         var correlation = instance.ChildCorrelations.SingleOrDefault(x => x.Id == job.CorrelationId);
         if (correlation is null)
         {
-            logger.LogError(
-                "Correlation {CorrelationId} not found for instance {InstanceId}",
-                job.CorrelationId,
-                context.InstanceId);
-            return Result.Fail(WorkflowErrors.ConfigInvalid(context.InstanceId, $"Correlation {job.CorrelationId} not found"));
+            logger.SubFlowCorrelationNotFoundForStart(job.CorrelationId, context.InstanceId);
+            return Result.Fail(WorkflowErrors.SubFlowCorrelationNotFound(job.CorrelationId, context.InstanceId));
         }
 
         // Resolve target state from job's target state key
         var target = context.Workflow.States.SingleOrDefault(s => s.Key == job.TargetStateKey);
         if (target?.SubFlow is null)
         {
-            logger.LogError(
-                "Target state {TargetStateKey} not found or has no SubFlow configuration for instance {InstanceId}",
-                job.TargetStateKey,
-                context.InstanceId);
-            return Result.Fail(WorkflowErrors.ConfigInvalid(context.InstanceId, job.TargetStateKey));
+            logger.SubFlowTargetStateNotFound(job.TargetStateKey, context.InstanceId);
+            return Result.Fail(WorkflowErrors.SubFlowTargetStateNotFound(job.TargetStateKey, context.InstanceId));
         }
         
-        // Start the subflow (this is the remote call that was causing lock issues)
-        try
-        {
-            // Build script context for subflow mapping
-            await using var scriptContext = await CreateScriptContextAsync(context, instance, cancellationToken);
+        // Build script context for subflow mapping
+        await using var scriptContext = await CreateScriptContextAsync(context, instance, cancellationToken);
 
-            await subflowStarter.StartAsync(
-                context.Workflow,
-                instance,
-                target,
-                context.Transition!,
-                correlation,
-                scriptContext,
-                cancellationToken);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(
-                ex,
-                "Subflow start failed for instance {InstanceId}, correlation {CorrelationId}, target {TargetStateKey}",
-                context.InstanceId,
-                job.CorrelationId,
-                job.TargetStateKey);
+        // Start the subflow (Result pattern - no try-catch needed)
+        var startResult = await subflowStarter.StartAsync(
+            context.Workflow,
+            instance,
+            target,
+            context.Transition!,
+            correlation,
+            scriptContext,
+            cancellationToken);
 
-            return Result.Fail(Error.Failure(
-                WorkflowErrorCodes.SubflowStartFailed,
-                $"Failed to start subflow for correlation {job.CorrelationId}: {ex.Message}"));
+        if (startResult.IsSuccess)
+        {
+            logger.SubFlowStarted(job.TargetStateKey, context.InstanceId);
         }
 
-        logger.LogInformation(
-            "Subflow started for instance {InstanceId}, correlation {CorrelationId}, target {TargetStateKey}",
-            context.InstanceId,
-            job.CorrelationId,
-            job.TargetStateKey);
-
-        return Result.Ok();
+        return startResult;
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Application/Instances/DTOs/StartInstanceInput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/StartInstanceInput.cs
@@ -21,6 +21,13 @@ public sealed class StartInstanceInput(
     public Dictionary<string, string?> RouteValues { get; set; } = new();
 
     /// <summary>
+    /// When true, returns 409 Conflict if an active instance with same key exists.
+    /// Used for service-to-service calls to prevent false positive correlations.
+    /// Default false preserves idempotent behavior for client calls.
+    /// </summary>
+    public bool StrictIdempotency { get; set; } = false;
+
+    /// <summary>
     /// Creates a WorkflowExecutionContext from this StartInstanceInput for starting a new workflow instance.
     /// </summary>
     /// <param name="instanceId">The workflow instance identifier</param>

--- a/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
@@ -69,11 +69,13 @@ public sealed class InstanceCommandAppService(
 
     /// <summary>
     /// Checks if an active instance already exists before starting workflow creation.
-    /// Implements idempotent behavior for active instances only.
+    /// Implements idempotent behavior for active instances only (when StrictIdempotency is false).
+    /// When StrictIdempotency is true (service-to-service calls), returns 409 Conflict.
     /// </summary>
     /// <returns>
     /// - null: No existing instance OR existing completed instance, continue with creation
-    /// - Ok: Existing active instance found, return its current status (idempotent)
+    /// - Ok: Existing active instance found, return its current status (idempotent, only when StrictIdempotency is false)
+    /// - Fail: Existing active instance found and StrictIdempotency is true (409 Conflict)
     /// </returns>
     private async Task<Result<StartInstanceOutput>?> CheckExistingInstanceAsync(
         StartInstanceInput input,
@@ -93,7 +95,20 @@ public sealed class InstanceCommandAppService(
 
         if (existingInstance.IsCompleted)
             return null; // Completed instance, allow creating new one
+        
+        // Strict idempotency: Return 409 Conflict for service-to-service calls
+        // This prevents false positive correlations in SubFlow/SubProcess scenarios
+        if (input.StrictIdempotency)
+        {
+            logger.LogWarning(
+                "Strict idempotency check failed: Active instance already exists with key '{InstanceKey}' or id '{InstanceId}'",
+                instanceKey, existingInstance.Id);
             
+            return Result<StartInstanceOutput>.Fail(
+                WorkflowErrors.ActiveInstanceAlreadyExists(existingInstance.Id, instanceKey));
+        }
+        
+        // Default idempotent behavior for client calls
         return Result<StartInstanceOutput>.Ok(new StartInstanceOutput
         {
             Id = existingInstance.Id,

--- a/src/BBT.Workflow.Application/SubFlow/Contracts/ISubflowStarter.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Contracts/ISubflowStarter.cs
@@ -1,10 +1,9 @@
+using BBT.Aether.Results;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Scripting;
 
 namespace BBT.Workflow.SubFlow;
-
-//TODO: Result implementation 
 
 /// <summary>
 /// Interface for service managing SubFlow and SubProcess workflows.
@@ -21,12 +20,10 @@ public interface ISubflowStarter
     /// <param name="parentInstance">The main workflow instance that initiates the sub-flow.</param>
     /// <param name="targetState">The target state containing SubFlow configuration.</param>
     /// <param name="transition">The current transition.</param>
-    /// <param name="correlation"></param>
+    /// <param name="correlation">Correlation information for tracking.</param>
     /// <param name="context">The script context containing execution data and headers.</param>
     /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
-    /// <returns>A task representing the asynchronous sub-flow initiation operation.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when required parameters are null.</exception>
-    /// <exception cref="InvalidOperationException">Thrown when the SubFlow configuration is invalid.</exception>
+    /// <returns>Result indicating success or failure of the sub-flow initiation.</returns>
     /// <remarks>
     /// <para>
     /// SubFlow (Type: "S"): Creates a separate instance and blocks the parent workflow until completion. 
@@ -37,7 +34,7 @@ public interface ISubflowStarter
     /// The parent workflow can continue immediately after starting the SubProcess.
     /// </para>
     /// </remarks>
-    Task StartAsync(
+    Task<Result> StartAsync(
         Definitions.Workflow workflow,
         Instance parentInstance,
         State targetState,
@@ -58,8 +55,8 @@ public interface ISubflowStarter
     /// <param name="subFlowType">Type code of the SubFlow ("S" or "P").</param>
     /// <param name="inputMappingResult">Optional input mapping result containing data, headers, and key information.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>A task representing the asynchronous sub-flow initiation operation.</returns>
-    Task SubStartAsync(
+    /// <returns>Result indicating success or failure of the sub-flow initiation.</returns>
+    Task<Result> SubStartAsync(
         Definitions.Workflow workflow,
         Instance parentInstance,
         Reference subFlowReference,

--- a/src/BBT.Workflow.Application/SubFlow/Services/SubflowStarter.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubflowStarter.cs
@@ -1,8 +1,10 @@
 using System.Text.Json;
 using BBT.Aether;
+using BBT.Aether.Results;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Gateway;
 using BBT.Workflow.Instances;
+using BBT.Workflow.Logging;
 using BBT.Workflow.Scripting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -26,7 +28,7 @@ public sealed class SubflowStarter(
     ILogger<SubflowStarter> logger) : ISubflowStarter
 {
     /// <inheritdoc />
-    public async Task StartAsync(
+    public async Task<Result> StartAsync(
         Definitions.Workflow workflow,
         Instance parentInstance,
         State targetState,
@@ -41,10 +43,15 @@ public sealed class SubflowStarter(
         ScriptResponse? inputMappingResult = null;
         if (subFlowConfig.Mapping != null)
         {
-            inputMappingResult = await HandleInputMappingAsync(subFlowConfig, context, cancellationToken);
+            var mappingResult = await HandleInputMappingAsync(subFlowConfig, context, cancellationToken);
+            if (!mappingResult.IsSuccess)
+            {
+                return Result.Fail(mappingResult.Error);
+            }
+            inputMappingResult = mappingResult.Value;
         }
 
-        await StartSubFlowInternalAsync(
+        return await StartSubFlowInternalAsync(
             workflow,
             parentInstance,
             subFlowConfig.Process,
@@ -56,19 +63,8 @@ public sealed class SubflowStarter(
             cancellationToken);
     }
 
-    /// <summary>
-    /// Starts a SubProcess workflow without requiring a target state or mapping.
-    /// Used for triggering SubProcess workflows from tasks.
-    /// </summary>
-    /// <param name="workflow">The parent workflow.</param>
-    /// <param name="parentInstance">The parent instance.</param>
-    /// <param name="subFlowReference">Reference to the SubFlow/SubProcess to start.</param>
-    /// <param name="transition">The transition triggering the SubProcess.</param>
-    /// <param name="correlation">Correlation information for tracking.</param>
-    /// <param name="subFlowType">Type code of the SubFlow ("S" or "P").</param>
-    /// <param name="inputMappingResult">Optional input mapping result containing data, headers, and key information.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    public async Task SubStartAsync(
+    /// <inheritdoc />
+    public async Task<Result> SubStartAsync(
         Definitions.Workflow workflow,
         Instance parentInstance,
         Reference subFlowReference,
@@ -78,7 +74,7 @@ public sealed class SubflowStarter(
         ScriptResponse? inputMappingResult = null,
         CancellationToken cancellationToken = default)
     {
-        await StartSubFlowInternalAsync(
+        return await StartSubFlowInternalAsync(
             workflow,
             parentInstance,
             subFlowReference,
@@ -93,7 +89,8 @@ public sealed class SubflowStarter(
     /// <summary>
     /// Internal method that contains the common logic for starting SubFlow/SubProcess workflows.
     /// </summary>
-    private async Task StartSubFlowInternalAsync(
+    /// <returns>Result indicating success or failure of the SubFlow start operation.</returns>
+    private async Task<Result> StartSubFlowInternalAsync(
         Definitions.Workflow workflow,
         Instance parentInstance,
         Reference subFlowReference,
@@ -115,99 +112,83 @@ public sealed class SubflowStarter(
         activity?.SetTag("vnext.subflow.parent.state", stateKey);
         activity?.SetTag("vnext.subflow.parent.transition", transitionKey);
 
-        try
+        // Prepare instance creation input
+        var createInstanceInput = new CreateInstanceInput
         {
-            // Prepare instance creation input
-            var createInstanceInput = new CreateInstanceInput
+            Id = correlation.SubFlowInstanceId,
+            Callback = configuration["DAPR_APP_ID"],
+            Key = parentInstance.Key ?? string.Empty,
+            Attributes = inputMappingResult?.Data != null
+                ? JsonSerializer.SerializeToElement(inputMappingResult.Data)
+                : null,
+            Tags =
+            [
+                $"parent.key:{parentInstance.Key}",
+                $"parent.domain:{workflow.Domain}",
+                $"parent.flow:{workflow.Key}"
+            ],
+            ExtraProperties = new ExtraPropertyDictionary
             {
-                Id = correlation.SubFlowInstanceId,
-                Callback = configuration["DAPR_APP_ID"],
-                Key = parentInstance.Key ?? string.Empty,
-                Attributes = inputMappingResult?.Data != null
-                    ? JsonSerializer.SerializeToElement(inputMappingResult.Data)
-                    : null,
-                Tags =
-                [
-                    $"parent.key:{parentInstance.Key}",
-                    $"parent.domain:{workflow.Domain}",
-                    $"parent.flow:{workflow.Key}"
-                ],
-                ExtraProperties = new ExtraPropertyDictionary
-                {
-                    [DomainConsts.MetaDataKeys.Id] = parentInstance.Id,
-                    [DomainConsts.MetaDataKeys.Key] = parentInstance.Key ?? string.Empty,
-                    [DomainConsts.MetaDataKeys.Domain] = workflow.Domain,
-                    [DomainConsts.MetaDataKeys.Flow] = workflow.Key,
-                    [DomainConsts.MetaDataKeys.Version] = workflow.Version,
-                    [DomainConsts.MetaDataKeys.State] = stateKey,
-                    [DomainConsts.MetaDataKeys.Transition] = transitionKey,
-                    [DomainConsts.MetaDataKeys.FlowType] = subFlowTypeCode
-                }
-            };
+                [DomainConsts.MetaDataKeys.Id] = parentInstance.Id,
+                [DomainConsts.MetaDataKeys.Key] = parentInstance.Key ?? string.Empty,
+                [DomainConsts.MetaDataKeys.Domain] = workflow.Domain,
+                [DomainConsts.MetaDataKeys.Flow] = workflow.Key,
+                [DomainConsts.MetaDataKeys.Version] = workflow.Version,
+                [DomainConsts.MetaDataKeys.State] = stateKey,
+                [DomainConsts.MetaDataKeys.Transition] = transitionKey,
+                [DomainConsts.MetaDataKeys.FlowType] = subFlowTypeCode
+            }
+        };
 
-            // Apply additional properties from input mapping if available
-            if (inputMappingResult != null)
+        // Apply additional properties from input mapping if available
+        if (inputMappingResult != null)
+        {
+            if (!inputMappingResult.Key.IsNullOrEmpty())
             {
-                if (!inputMappingResult.Key.IsNullOrEmpty())
-                {
-                    createInstanceInput.Key = inputMappingResult.Key;
-                }
-
-                if (!inputMappingResult.Tags.IsNullOrEmpty())
-                {
-                    var existingTags = createInstanceInput.Tags?.ToList() ?? new List<string>();
-                    existingTags.AddRange(inputMappingResult.Tags);
-                    createInstanceInput.Tags = existingTags.ToArray();
-                }
+                createInstanceInput.Key = inputMappingResult.Key;
             }
 
-            var subFlowStartInput = new StartInstanceInput(
-                subFlowReference.Domain,
-                subFlowReference.Key,
-                subFlowReference.Version,
-                sync: true
-            )
+            if (!inputMappingResult.Tags.IsNullOrEmpty())
             {
-                Instance = createInstanceInput,
-                Headers = inputMappingResult?.Headers ?? new Dictionary<string, string?>(),
-                RouteValues = inputMappingResult?.RouteValues ?? new Dictionary<string, string?>()
-            };
-
-            var startResult = await instanceCommandGateway.StartSubAsync(subFlowStartInput, cancellationToken);
-
-            if (!startResult.IsSuccess)
-            {
-                var error = startResult.Error;
-
-                SubFlowActivityHelper.SetError(activity, $"{error.Code}: {error.Message}");
-                logger.LogError(
-                    "SubFlow {SubFlowKey} start failed for instance {InstanceId}: {ErrorCode} - {ErrorMessage}",
-                    subFlowReference.Key,
-                    parentInstance.Id,
-                    error.Code,
-                    error.Message);
-
-                throw new InvalidOperationException(
-                    $"Failed to start SubFlow {subFlowReference.Key}: {error.Message}",
-                    new Exception(error.Code));
+                var existingTags = createInstanceInput.Tags?.ToList() ?? new List<string>();
+                existingTags.AddRange(inputMappingResult.Tags);
+                createInstanceInput.Tags = existingTags.ToArray();
             }
-
-            SubFlowActivityHelper.SetSuccess(activity);
-            logger.LogInformation(
-                "SubFlow {SubFlowKey} started successfully for instance {InstanceId}",
-                subFlowReference.Key,
-                parentInstance.Id);
         }
-        catch (Exception ex)
+
+        var subFlowStartInput = new StartInstanceInput(
+            subFlowReference.Domain,
+            subFlowReference.Key,
+            subFlowReference.Version,
+            sync: true
+        )
         {
-            SubFlowActivityHelper.SetError(activity, ex.Message, ex);
-            logger.LogError(ex,
-                "SubFlow {SubFlowKey} start failed for instance {InstanceId}",
-                subFlowReference.Key,
-                parentInstance.Id);
+            Instance = createInstanceInput,
+            Headers = inputMappingResult?.Headers ?? new Dictionary<string, string?>(),
+            RouteValues = inputMappingResult?.RouteValues ?? new Dictionary<string, string?>(),
+            StrictIdempotency = true // Service-to-service call: return 409 if active instance exists
+        };
 
-            throw;
+        var startResult = await instanceCommandGateway.StartSubAsync(subFlowStartInput, cancellationToken);
+
+        if (!startResult.IsSuccess)
+        {
+            var error = startResult.Error;
+
+            SubFlowActivityHelper.SetError(activity, $"{error.Code}: {error.Message}");
+            logger.SubFlowStartFailed(
+                subFlowReference.Key,
+                parentInstance.Id,
+                error.Code,
+                error.Message ?? string.Empty);
+
+            return Result.Fail(error);
         }
+
+        SubFlowActivityHelper.SetSuccess(activity);
+        logger.SubFlowStarted(subFlowReference.Key, parentInstance.Id);
+
+        return Result.Ok();
     }
 
     /// <summary>
@@ -216,8 +197,8 @@ public sealed class SubflowStarter(
     /// <param name="subFlowConfig">The SubFlow configuration containing mapping information.</param>
     /// <param name="context">The script context for mapping execution.</param>
     /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
-    /// <returns>The result of the input mapping handler.</returns>
-    private async Task<ScriptResponse?> HandleInputMappingAsync(
+    /// <returns>Result containing the mapping response or error.</returns>
+    private async Task<Result<ScriptResponse?>> HandleInputMappingAsync(
         Definitions.SubFlow subFlowConfig,
         ScriptContext context,
         CancellationToken cancellationToken = default)
@@ -229,23 +210,27 @@ public sealed class SubflowStarter(
             ? typeof(ISubFlowMapping)
             : typeof(ISubProcessMapping);
 
-        // Compile the mapping script to the appropriate interface
-        var mappingInstance = await scriptEngine.CompileToInstanceAsync<object>(
-            mappingCode,
-            cancellationToken: cancellationToken);
-
-        // Cast to the appropriate mapping interface and execute InputHandler
-        if (subFlowConfig.Type.Code == "S" && mappingInstance is ISubFlowMapping subFlowMapping)
+        return await ResultExtensions.TryAsync<ScriptResponse?>(async ct =>
         {
-            return await subFlowMapping.InputHandler(context);
-        }
+            // Compile the mapping script to the appropriate interface
+            var mappingInstance = await scriptEngine.CompileToInstanceAsync<object>(
+                mappingCode,
+                cancellationToken: ct);
 
-        if (subFlowConfig.Type.Code == "P" && mappingInstance is ISubProcessMapping subProcessMapping)
-        {
-            return await subProcessMapping.InputHandler(context);
-        }
+            // Cast to the appropriate mapping interface and execute InputHandler
+            if (subFlowConfig.Type.Code == "S" && mappingInstance is ISubFlowMapping subFlowMapping)
+            {
+                return await subFlowMapping.InputHandler(context);
+            }
 
-        throw new InvalidOperationException(
-            $"Failed to cast mapping instance to {mappingInterfaceType.Name} for SubFlow type '{subFlowConfig.Type.Code}'");
+            if (subFlowConfig.Type.Code == "P" && mappingInstance is ISubProcessMapping subProcessMapping)
+            {
+                return await subProcessMapping.InputHandler(context);
+            }
+
+            // If we reach here, casting failed
+            throw new InvalidOperationException(
+                $"Failed to cast mapping instance to {mappingInterfaceType.Name} for SubFlow type '{subFlowConfig.Type.Code}'");
+        }, cancellationToken, ex => WorkflowErrors.SubFlowInputMappingFailed(subFlowConfig.Process.Key, ex.Message));
     }
 }

--- a/src/BBT.Workflow.Application/Tasks/Executors/Trigger/SubProcessTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Trigger/SubProcessTaskExecutor.cs
@@ -276,7 +276,8 @@ public sealed class SubProcessTaskExecutor : TriggerTaskExecutorBase<SubProcessT
                     Callback = GetCallbackAppId(),
                     ExtraProperties = BuildExtraProperties(context, task)
                 },
-                Headers = ExtractHeaders(context) ?? new Dictionary<string, string?>()
+                Headers = ExtractHeaders(context) ?? new Dictionary<string, string?>(),
+                StrictIdempotency = true // Service-to-service call: return 409 if active instance exists
             };
     }
 

--- a/src/BBT.Workflow.Domain/Logging/WorkflowErrors.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowErrors.cs
@@ -1,5 +1,4 @@
 using BBT.Aether.Results;
-using BBT.Aether.Validation;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Shared;
 
@@ -12,15 +11,18 @@ namespace BBT.Workflow.Logging;
 public static class WorkflowErrors
 {
     #region Instance Errors
-
+    
     /// <summary>
-    /// Instance already exists with the given key.
+    /// Active instance already exists with the given key (strict idempotency check).
+    /// Used for service-to-service calls to prevent false positive correlations.
     /// </summary>
-    public static Error InstanceAlreadyExists(string instanceKey)
+    /// <param name="instanceId">The ID of the existing active instance.</param>
+    /// <param name="key">The key of the existing active instance (optional).</param>
+    public static Error ActiveInstanceAlreadyExists(Guid instanceId, string? key)
         => Error.Conflict(
-            WorkflowErrorCodes.ConflictWorkflow,
-            $"An active instance with key \"{instanceKey}\" already exists",
-            target: instanceKey);
+            WorkflowErrorCodes.ActiveInstanceAlreadyExists,
+            $"An active instance already exists with {(key != null ? $"key '{key}'" : $"id '{instanceId}'")}",
+            target: key ?? instanceId.ToString());
 
     /// <summary>
     /// Instance was not found by ID or key.
@@ -212,6 +214,54 @@ public static class WorkflowErrors
         => Error.Failure(
             WorkflowErrorCodes.ChildSubflowCancellationFailed,
             $"Failed to cancel child subflow {instanceId}: {reason}");
+
+    #endregion
+
+    #region SubFlow Errors
+
+    /// <summary>
+    /// SubFlow start operation failed.
+    /// </summary>
+    /// <param name="subFlowKey">The key of the SubFlow that failed to start.</param>
+    /// <param name="reason">The reason for the failure.</param>
+    public static Error SubFlowStartFailed(string subFlowKey, string reason)
+        => Error.Failure(
+            WorkflowErrorCodes.SubflowStartFailed,
+            $"Failed to start SubFlow '{subFlowKey}': {reason}",
+            detail: subFlowKey);
+
+    /// <summary>
+    /// SubFlow input mapping failed.
+    /// </summary>
+    /// <param name="subFlowKey">The key of the SubFlow.</param>
+    /// <param name="reason">The reason for the mapping failure.</param>
+    public static Error SubFlowInputMappingFailed(string subFlowKey, string reason)
+        => Error.Failure(
+            WorkflowErrorCodes.SubflowStartFailed,
+            $"SubFlow '{subFlowKey}' input mapping failed: {reason}",
+            detail: subFlowKey);
+
+    /// <summary>
+    /// Correlation not found for SubFlow start.
+    /// </summary>
+    /// <param name="correlationId">The correlation ID that was not found.</param>
+    /// <param name="instanceId">The instance ID.</param>
+    public static Error SubFlowCorrelationNotFound(Guid correlationId, Guid instanceId)
+        => Error.NotFound(
+            WorkflowErrorCodes.ConfigInvalid,
+            $"Correlation '{correlationId}' not found for instance '{instanceId}'",
+            target: correlationId.ToString());
+
+    /// <summary>
+    /// Target state not found or has no SubFlow configuration.
+    /// </summary>
+    /// <param name="stateKey">The state key that was not found.</param>
+    /// <param name="instanceId">The instance ID.</param>
+    public static Error SubFlowTargetStateNotFound(string stateKey, Guid instanceId)
+        => Error.NotFound(
+            WorkflowErrorCodes.ConfigInvalid,
+            $"Target state '{stateKey}' not found or has no SubFlow configuration for instance '{instanceId}'",
+            target: stateKey);
 
     #endregion
 }

--- a/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
@@ -561,6 +561,68 @@ public static partial class WorkflowLogs
         Guid subInstanceId,
         Guid parentInstanceId);
 
+    /// <summary>
+    /// Logs when a SubFlow start operation completes successfully.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 40030,
+        Level = LogLevel.Information,
+        Message = "SubFlow {SubFlowKey} started successfully for parent instance {ParentInstanceId}")]
+    public static partial void SubFlowStarted(
+        this ILogger logger,
+        string subFlowKey,
+        Guid parentInstanceId);
+
+    /// <summary>
+    /// Logs when a SubFlow start operation fails.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 40080,
+        Level = LogLevel.Error,
+        Message = "SubFlow {SubFlowKey} start failed for parent instance {ParentInstanceId}: {ErrorCode} - {ErrorMessage}")]
+    public static partial void SubFlowStartFailed(
+        this ILogger logger,
+        string subFlowKey,
+        Guid parentInstanceId,
+        string errorCode,
+        string errorMessage);
+
+    /// <summary>
+    /// Logs when instance is not found during subflow start.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 40081,
+        Level = LogLevel.Error,
+        Message = "Instance {InstanceId} not found while starting subflow for correlation {CorrelationId}")]
+    public static partial void SubFlowInstanceNotFound(
+        this ILogger logger,
+        Guid instanceId,
+        Guid correlationId);
+
+    /// <summary>
+    /// Logs when correlation is not found during subflow start.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 40082,
+        Level = LogLevel.Error,
+        Message = "Correlation {CorrelationId} not found for instance {InstanceId}")]
+    public static partial void SubFlowCorrelationNotFoundForStart(
+        this ILogger logger,
+        Guid correlationId,
+        Guid instanceId);
+
+    /// <summary>
+    /// Logs when target state is not found or has no SubFlow configuration.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 40083,
+        Level = LogLevel.Error,
+        Message = "Target state {TargetStateKey} not found or has no SubFlow configuration for instance {InstanceId}")]
+    public static partial void SubFlowTargetStateNotFound(
+        this ILogger logger,
+        string targetStateKey,
+        Guid instanceId);
+
     #endregion
 
     #region Instance Management

--- a/src/BBT.Workflow.Domain/WorkflowErrorCodes.cs
+++ b/src/BBT.Workflow.Domain/WorkflowErrorCodes.cs
@@ -39,6 +39,7 @@ public static class WorkflowErrorCodes
     public const string SubflowCompletionFailed = "Instance:100022";
     public const string SubflowStartFailed = "Instance:100023";
     public const string UpdateDataNotConfiguredForWorkflow = "Instance:100024";
+    public const string ActiveInstanceAlreadyExists = "Instance:100025";
     
     #endregion
     

--- a/src/BBT.Workflow.Execution/Invokers/SubProcessRemoteInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/SubProcessRemoteInvoker.cs
@@ -213,6 +213,8 @@ public sealed class SubProcessRemoteInvoker : ITaskInvoker<SubProcessBinding>
         if (binding.Sync)
             queryParams.Add("sync=true");
 
+        queryParams.Add("strictIdempotency=true");
+
         if (queryParams.Count > 0)
             path += "?" + string.Join("&", queryParams);
 

--- a/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceCommandAppService.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceCommandAppService.cs
@@ -112,6 +112,8 @@ public sealed class RemoteInstanceCommandAppService(
             if (input.Sync)
                 queryParams.Add($"sync={input.Sync}");
 
+            queryParams.Add("strictIdempotency=true");
+
             if (queryParams.Count > 0)
                 relativePath += "?" + string.Join("&", queryParams);
 


### PR DESCRIPTION
Introduces a StrictIdempotency flag to StartInstanceInput and propagates it through subflow, subprocess, and remote invocations to enforce 409 Conflict when an active instance with the same key exists. Refactors subflow start logic to use Result pattern, adds new error codes and logging for subflow operations, and updates interfaces and services to support strict idempotency for service-to-service calls, preventing false positive correlations.

## Summary by Sourcery

Introduce strict idempotency handling for subflow and service-to-service workflow starts and adopt a Result-based pattern for subflow start operations and error reporting.

New Features:
- Add a StrictIdempotency flag to workflow start requests to enforce conflict responses when an active instance with the same key exists, primarily for service-to-service scenarios.

Enhancements:
- Change subflow and subprocess start operations to return Result objects instead of throwing exceptions, improving error propagation and handling.
- Propagate strict idempotency semantics through subflow, subprocess, and remote invocation paths, ensuring consistent behavior across local and remote starts.
- Extend workflow error codes and logging helpers with dedicated entries for subflow start, input mapping, correlation, and target state failures, as well as for active-instance conflicts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added strict idempotency control for workflow instance creation, returning a 409 Conflict response when attempting to create duplicate active instances in service-to-service calls.

* **Bug Fixes**
  * Improved error handling and reporting for subflow operations with dedicated error responses for missing instances, correlations, and target states.

* **Improvements**
  * Enhanced logging and diagnostics for subflow execution failures with clearer error messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->