### PR TITLE
Add SetBusyStep and ResolveAvailableStep to pipeline

### DIFF
--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ResolveAvailableStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ResolveAvailableStep.cs
@@ -1,0 +1,120 @@
+using System.Diagnostics;
+using BBT.Aether.Aspects;
+using BBT.Aether.Results;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Logging;
+using Microsoft.Extensions.Logging;
+
+namespace BBT.Workflow.Execution.Pipeline.Steps;
+
+/// <summary>
+/// Pipeline step that resolves the Available (Active) status at the end of transition processing.
+/// Sets instance to Active when all conditions are met:
+/// - Auto transition chain is not continuing (NextTransition is null)
+/// - Not a terminal state (SubFlow entry point for parent)
+/// - Target state is not a Finish state
+/// - Target state has only manual/event transitions or no transitions
+/// </summary>
+public sealed class ResolveAvailableStep(
+    IInstanceRepository instanceRepository,
+    ILogger<ResolveAvailableStep> logger) : ITransitionStep
+{
+    /// <inheritdoc />
+    public int Order => LifecycleOrder.ResolveAvailable;
+
+    /// <inheritdoc />
+    [Trace]
+    public async Task<Result<StepOutcome>> ExecuteAsync(
+        TransitionExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        Activity.Current?.SetDisplayName($"[{Order}] {nameof(ResolveAvailableStep)}");
+
+        // Check if instance should become Available
+        if (!ShouldSetAvailable(context))
+        {
+            return Result<StepOutcome>.Ok(StepOutcome.Continue());
+        }
+
+        // Set instance to Active and persist
+        return await Result.Ok(context)
+            .Tap(ctx => ctx.Instance.Active())
+            .TapAsync(ctx => instanceRepository.UpdateAsync(ctx.Instance, true, cancellationToken))
+            .Tap(ctx => logger.LogDebug(
+                "Instance {InstanceId} set to Available after transition to state {TargetState}",
+                ctx.InstanceId,
+                ctx.Target?.Key ?? "unknown"))
+            .Map(_ => StepOutcome.Continue());
+    }
+
+    /// <summary>
+    /// Determines if the instance should be set to Available (Active) status.
+    /// </summary>
+    private bool ShouldSetAvailable(TransitionExecutionContext context)
+    {
+        // Already completed or not busy - nothing to do
+        if (context.Instance.IsCompleted || !context.Instance.IsBusy)
+        {
+            logger.LogDebug(
+                "Instance {InstanceId} is not Busy or already completed, skipping ResolveAvailableStep",
+                context.InstanceId);
+            return false;
+        }
+
+        // Auto transition chain is continuing - stay Busy
+        if (context.Directives.NextTransition != null)
+        {
+            logger.LogDebug(
+                "Instance {InstanceId} has NextTransition ({NextTransition}), staying Busy",
+                context.InstanceId,
+                context.Directives.NextTransition.TransitionKey);
+            return false;
+        }
+
+        // Terminal state reached (SubFlow entry point) - stay Busy
+        if (context.Directives.TerminalReached)
+        {
+            logger.LogDebug(
+                "Instance {InstanceId} reached terminal state, staying Busy",
+                context.InstanceId);
+            return false;
+        }
+
+        // Target is null - should not happen, but defensive
+        if (context.Target == null)
+        {
+            logger.LogWarning(
+                "Instance {InstanceId} has null target state, skipping ResolveAvailableStep",
+                context.InstanceId);
+            return false;
+        }
+
+        // Finish state - will be handled by HandleFinishStep (Completed status)
+        if (context.Target.StateType == StateType.Finish)
+        {
+            logger.LogDebug(
+                "Instance {InstanceId} is in Finish state, status will be Completed",
+                context.InstanceId);
+            return false;
+        }
+
+        // Target state has automatic or scheduled transitions - stay Busy
+        // (This should already be caught by NextTransition check, but defensive)
+        if (!context.Target.HasOnlyManualOrEventTransitions)
+        {
+            logger.LogDebug(
+                "Instance {InstanceId} target state {TargetState} has auto/scheduled transitions, staying Busy",
+                context.InstanceId,
+                context.Target.Key);
+            return false;
+        }
+
+        // All conditions met - set to Available
+        logger.LogDebug(
+            "Instance {InstanceId} meets all conditions for Available status in state {TargetState}",
+            context.InstanceId,
+            context.Target.Key);
+        return true;
+    }
+}

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/SetBusyStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/SetBusyStep.cs
@@ -1,0 +1,64 @@
+using System.Diagnostics;
+using BBT.Aether.Aspects;
+using BBT.Aether.Results;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Logging;
+using Microsoft.Extensions.Logging;
+
+namespace BBT.Workflow.Execution.Pipeline.Steps;
+
+/// <summary>
+/// Pipeline step that sets the instance to Busy status at the start of transition processing.
+/// This prevents concurrent modifications during transition processing.
+/// Skips if instance is already Busy (for chained auto transitions).
+/// </summary>
+public sealed class SetBusyStep(
+    IInstanceRepository instanceRepository,
+    ILogger<SetBusyStep> logger) : ITransitionStep
+{
+    /// <inheritdoc />
+    public int Order => LifecycleOrder.SetBusy;
+
+    /// <inheritdoc />
+    [Trace]
+    public async Task<Result<StepOutcome>> ExecuteAsync(
+        TransitionExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        Activity.Current?.SetDisplayName($"[{Order}] {nameof(SetBusyStep)}");
+
+        // Skip if instance is already Busy (chained auto transitions)
+        if (context.Instance.IsBusy)
+        {
+            logger.LogDebug(
+                "Instance {InstanceId} is already Busy, skipping SetBusyStep",
+                context.InstanceId);
+            return Result<StepOutcome>.Ok(StepOutcome.Continue());
+        }
+
+        // Skip if instance is completed (should not happen, but defensive)
+        if (context.Instance.IsCompleted)
+        {
+            logger.LogDebug(
+                "Instance {InstanceId} is already completed, skipping SetBusyStep",
+                context.InstanceId);
+            return Result<StepOutcome>.Ok(StepOutcome.Continue());
+        }
+
+        // Skip for SubFlow resume - status is managed by ClearBusyOnResumeStep
+        if (context.Directives.IsSubFlowResume)
+        {
+            return Result<StepOutcome>.Ok(StepOutcome.Continue());
+        }
+
+        // Set instance to Busy and persist
+        return await Result.Ok(context)
+            .Tap(ctx => ctx.Instance.Busy())
+            .TapAsync(ctx => instanceRepository.UpdateAsync(ctx.Instance, true, cancellationToken))
+            .Tap(ctx => logger.LogDebug(
+                "Instance {InstanceId} set to Busy for transition {TransitionKey}",
+                ctx.InstanceId,
+                ctx.TransitionKey))
+            .Map(_ => StepOutcome.Continue());
+    }
+}

--- a/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/PipelineServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/PipelineServiceCollectionExtensions.cs
@@ -59,6 +59,7 @@ public static class PipelineServiceCollectionExtensions
         services.AddScoped<ITransitionStep, HandleCancelPreflightStep>();
         services.AddScoped<ITransitionStep, HandleUpdateDataPreflightStep>();
         services.AddScoped<ITransitionStep, ForwardToActiveSubflowStep>();
+        services.AddScoped<ITransitionStep, SetBusyStep>();
         services.AddScoped<ITransitionStep, CreateTransitionRecordStep>();
         services.AddScoped<ITransitionStep, RunOnExecuteTasksStep>();
         services.AddScoped<ITransitionStep, RunOnExitTasksStep>();
@@ -70,6 +71,7 @@ public static class PipelineServiceCollectionExtensions
         services.AddScoped<ITransitionStep, RunAutomaticTransitionsStep>();
         services.AddScoped<ITransitionStep, HandleFinishStep>();
         services.AddScoped<ITransitionStep, FinalizeTransitionStep>();
+        services.AddScoped<ITransitionStep, ResolveAvailableStep>();
 
         // Pipeline
         services.AddScoped<TransitionPipeline>();

--- a/src/BBT.Workflow.Domain/Definitions/States/State.cs
+++ b/src/BBT.Workflow.Domain/Definitions/States/State.cs
@@ -178,6 +178,14 @@ public sealed class State : IHasKey
     
     public IEnumerable<Transition> ScheduledTransitions => Transitions.Where(p => p.TriggerType == TriggerType.Scheduled);
 
+    /// <summary>
+    /// Returns true if the state has only manual/event transitions or no transitions at all.
+    /// Used to determine if instance should become Available after transition.
+    /// </summary>
+    public bool HasOnlyManualOrEventTransitions => 
+        !Transitions.Any() || 
+        Transitions.All(t => t.TriggerType == TriggerType.Manual || t.TriggerType == TriggerType.Event);
+
     public IReadOnlyList<string> TransitionKeys() => Transitions.Select(t => t.Key).ToList();
 
     public static State Create(

--- a/src/BBT.Workflow.Domain/Execution/Transitions/Pipeline/LifecycleOrder.cs
+++ b/src/BBT.Workflow.Domain/Execution/Transitions/Pipeline/LifecycleOrder.cs
@@ -23,6 +23,12 @@ public static class LifecycleOrder
     public const int ForwardToActiveSubflow = 10;
     
     /// <summary>
+    /// Order for setting instance to Busy status at pipeline start.
+    /// Prevents concurrent modifications during transition processing.
+    /// </summary>
+    public const int SetBusy = CreateTransition - 1;
+    
+    /// <summary>
     /// Order for creating the transition record in the database.
     /// This should be the first step to track the transition attempt.
     /// </summary>
@@ -87,4 +93,9 @@ public static class LifecycleOrder
     
     public const int AfterEpilogueRefresh = Finalize + 1;
     
+    /// <summary>
+    /// Order for resolving Available status at pipeline end.
+    /// Sets instance to Active when target state has only manual/event transitions.
+    /// </summary>
+    public const int ResolveAvailable = Finalize + 2;
 }

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/Steps/ResolveAvailableStepTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/Steps/ResolveAvailableStepTests.cs
@@ -1,0 +1,411 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.Results;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Execution;
+using BBT.Workflow.Execution.Pipeline;
+using BBT.Workflow.Execution.Pipeline.Steps;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Shared;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Application.Tests.Execution.Transitions.Pipeline.Steps;
+
+/// <summary>
+/// Unit tests for ResolveAvailableStep
+/// Tests that instance is set to Available (Active) status when appropriate conditions are met
+/// </summary>
+public class ResolveAvailableStepTests
+{
+    private readonly IInstanceRepository _mockInstanceRepository;
+    private readonly ILogger<ResolveAvailableStep> _mockLogger;
+    private readonly ResolveAvailableStep _step;
+
+    public ResolveAvailableStepTests()
+    {
+        _mockInstanceRepository = Substitute.For<IInstanceRepository>();
+        _mockLogger = Substitute.For<ILogger<ResolveAvailableStep>>();
+        _step = new ResolveAvailableStep(_mockInstanceRepository, _mockLogger);
+    }
+
+    [Fact]
+    public void Order_ShouldBeResolveAvailable()
+    {
+        // Assert
+        _step.Order.ShouldBe(LifecycleOrder.ResolveAvailable);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenAllConditionsMet_ShouldSetToActive()
+    {
+        // Arrange
+        var context = CreateTransitionExecutionContext(hasOnlyManualTransitions: true);
+        context.Instance.Busy(); // Set to Busy first
+
+        // Act
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        context.Instance.IsActive.ShouldBeTrue();
+        await _mockInstanceRepository.Received(1).UpdateAsync(context.Instance, true, CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenInstanceNotBusy_ShouldSkipAndNotUpdate()
+    {
+        // Arrange
+        var context = CreateTransitionExecutionContext(hasOnlyManualTransitions: true);
+        // Instance is Active by default
+
+        // Act
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        await _mockInstanceRepository.DidNotReceive().UpdateAsync(Arg.Any<Instance>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenInstanceIsCompleted_ShouldSkipAndNotUpdate()
+    {
+        // Arrange
+        var context = CreateTransitionExecutionContext(hasOnlyManualTransitions: true);
+        context.Instance.Complete();
+
+        // Act
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        await _mockInstanceRepository.DidNotReceive().UpdateAsync(Arg.Any<Instance>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenNextTransitionRequested_ShouldStayBusy()
+    {
+        // Arrange
+        var context = CreateTransitionExecutionContext(hasOnlyManualTransitions: true);
+        context.Instance.Busy();
+        context.Directives.RequestNextTransition(new NextTransitionRequest("auto-transition", "auto"));
+
+        // Act
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        context.Instance.IsBusy.ShouldBeTrue();
+        await _mockInstanceRepository.DidNotReceive().UpdateAsync(Arg.Any<Instance>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenTerminalReached_ShouldStayBusy()
+    {
+        // Arrange
+        var context = CreateTransitionExecutionContext(hasOnlyManualTransitions: true);
+        context.Instance.Busy();
+        context.Directives.MarkTerminal();
+
+        // Act
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        context.Instance.IsBusy.ShouldBeTrue();
+        await _mockInstanceRepository.DidNotReceive().UpdateAsync(Arg.Any<Instance>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenTargetIsFinishState_ShouldStayBusy()
+    {
+        // Arrange
+        var context = CreateTransitionExecutionContextWithFinishState();
+        context.Instance.Busy();
+
+        // Act
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        context.Instance.IsBusy.ShouldBeTrue();
+        await _mockInstanceRepository.DidNotReceive().UpdateAsync(Arg.Any<Instance>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenTargetHasAutoTransitions_ShouldStayBusy()
+    {
+        // Arrange
+        var context = CreateTransitionExecutionContext(hasOnlyManualTransitions: false);
+        context.Instance.Busy();
+
+        // Act
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        context.Instance.IsBusy.ShouldBeTrue();
+        await _mockInstanceRepository.DidNotReceive().UpdateAsync(Arg.Any<Instance>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenTargetIsNull_ShouldSkipAndNotUpdate()
+    {
+        // Arrange
+        var context = CreateTransitionExecutionContext(hasOnlyManualTransitions: true);
+        context.Instance.Busy();
+        context.Target = null;
+
+        // Act
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        context.Instance.IsBusy.ShouldBeTrue();
+        await _mockInstanceRepository.DidNotReceive().UpdateAsync(Arg.Any<Instance>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenTargetHasNoTransitions_ShouldSetToActive()
+    {
+        // Arrange - state with no transitions should be Available
+        var context = CreateTransitionExecutionContextWithNoTransitions();
+        context.Instance.Busy();
+
+        // Act
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        context.Instance.IsActive.ShouldBeTrue();
+        await _mockInstanceRepository.Received(1).UpdateAsync(context.Instance, true, CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldReturnContinueOutcome()
+    {
+        // Arrange
+        var context = CreateTransitionExecutionContext(hasOnlyManualTransitions: true);
+        context.Instance.Busy();
+
+        // Act
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.ShouldNotBeNull();
+        result.Value!.StopPipeline.ShouldBeFalse();
+    }
+
+    private TransitionExecutionContext CreateTransitionExecutionContext(bool hasOnlyManualTransitions)
+    {
+        var instanceId = Guid.NewGuid();
+        var workflowKey = "test-workflow";
+        var domain = "test-domain";
+
+        var workflow = CreateMockWorkflow(workflowKey, domain, hasOnlyManualTransitions);
+        var instance = Instance.Create(instanceId, workflowKey);
+        var state = workflow.GetState("state1").Value!;
+        var transition = Transition.Create("test-transition", null, "state1", TriggerType.Manual, "Patch");
+
+        return new TransitionExecutionContext
+        {
+            InstanceId = instanceId,
+            Domain = domain,
+            WorkflowKey = workflowKey,
+            TransitionKey = "test-transition",
+            Trigger = TriggerType.Manual,
+            Actor = ExecutionActor.User,
+            CorrelationId = Guid.NewGuid().ToString("N"),
+            ExecutionChainId = Guid.NewGuid().ToString("N"),
+            RequestedAt = DateTimeOffset.UtcNow,
+            Workflow = workflow,
+            Current = state,
+            Target = state,
+            Transition = transition,
+            Instance = instance,
+            TraceId = Guid.NewGuid().ToString("N"),
+            SpanId = Guid.NewGuid().ToString("N")[..16]
+        };
+    }
+
+    private TransitionExecutionContext CreateTransitionExecutionContextWithFinishState()
+    {
+        var instanceId = Guid.NewGuid();
+        var workflowKey = "test-workflow";
+        var domain = "test-domain";
+
+        var workflow = CreateMockWorkflowWithFinishState(workflowKey, domain);
+        var instance = Instance.Create(instanceId, workflowKey);
+        var finishState = workflow.GetState("finish").Value!;
+        var transition = Transition.Create("complete", "state1", "finish", TriggerType.Manual, "Patch");
+
+        return new TransitionExecutionContext
+        {
+            InstanceId = instanceId,
+            Domain = domain,
+            WorkflowKey = workflowKey,
+            TransitionKey = "complete",
+            Trigger = TriggerType.Manual,
+            Actor = ExecutionActor.User,
+            CorrelationId = Guid.NewGuid().ToString("N"),
+            ExecutionChainId = Guid.NewGuid().ToString("N"),
+            RequestedAt = DateTimeOffset.UtcNow,
+            Workflow = workflow,
+            Current = workflow.GetState("state1").Value!,
+            Target = finishState,
+            Transition = transition,
+            Instance = instance,
+            TraceId = Guid.NewGuid().ToString("N"),
+            SpanId = Guid.NewGuid().ToString("N")[..16]
+        };
+    }
+
+    private TransitionExecutionContext CreateTransitionExecutionContextWithNoTransitions()
+    {
+        var instanceId = Guid.NewGuid();
+        var workflowKey = "test-workflow";
+        var domain = "test-domain";
+
+        var workflow = CreateMockWorkflowWithNoTransitions(workflowKey, domain);
+        var instance = Instance.Create(instanceId, workflowKey);
+        var state = workflow.GetState("state1").Value!;
+        var transition = Transition.Create("test-transition", null, "state1", TriggerType.Manual, "Patch");
+
+        return new TransitionExecutionContext
+        {
+            InstanceId = instanceId,
+            Domain = domain,
+            WorkflowKey = workflowKey,
+            TransitionKey = "test-transition",
+            Trigger = TriggerType.Manual,
+            Actor = ExecutionActor.User,
+            CorrelationId = Guid.NewGuid().ToString("N"),
+            ExecutionChainId = Guid.NewGuid().ToString("N"),
+            RequestedAt = DateTimeOffset.UtcNow,
+            Workflow = workflow,
+            Current = state,
+            Target = state,
+            Transition = transition,
+            Instance = instance,
+            TraceId = Guid.NewGuid().ToString("N"),
+            SpanId = Guid.NewGuid().ToString("N")[..16]
+        };
+    }
+
+    private Definitions.Workflow CreateMockWorkflow(string key, string domain, bool hasOnlyManualTransitions)
+    {
+        var transitionsJson = hasOnlyManualTransitions
+            ? """[{"key": "submit", "from": "state1", "target": "state2", "triggerType": "Manual", "versionStrategy": "Patch"}]"""
+            : """[{"key": "auto", "from": "state1", "target": "state2", "triggerType": "Automatic", "versionStrategy": "Patch"}]""";
+
+        var json = $$"""
+        {
+            "type": "F",
+            "timeout": null,
+            "labels": [],
+            "functions": [],
+            "features": [],
+            "states": [
+                {
+                    "key": "state1",
+                    "stateType": "Intermediate",
+                    "transitions": {{transitionsJson}}
+                },
+                {
+                    "key": "state2",
+                    "stateType": "Intermediate",
+                    "transitions": []
+                }
+            ],
+            "sharedTransitions": [],
+            "extensions": [],
+            "startTransition": {"key": "start", "from": null, "target": "state1", "triggerType": "Manual", "versionStrategy": "Patch", "labels": [], "onExecutionTasks": [], "view": null}
+        }
+        """;
+
+        var options = new System.Text.Json.JsonSerializerOptions 
+        { 
+            PropertyNameCaseInsensitive = true,
+            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+        };
+        var workflow = System.Text.Json.JsonSerializer.Deserialize<Definitions.Workflow>(json, options)!;
+
+        workflow.SetReference(new Reference(key, domain, "sys-flows", "1.0.0"));
+        return workflow;
+    }
+
+    private Definitions.Workflow CreateMockWorkflowWithFinishState(string key, string domain)
+    {
+        var json = """
+        {
+            "type": "F",
+            "timeout": null,
+            "labels": [],
+            "functions": [],
+            "features": [],
+            "states": [
+                {
+                    "key": "state1",
+                    "stateType": "Intermediate",
+                    "transitions": [{"key": "complete", "from": "state1", "target": "finish", "triggerType": "Manual", "versionStrategy": "Patch"}]
+                },
+                {
+                    "key": "finish",
+                    "stateType": "Finish",
+                    "transitions": []
+                }
+            ],
+            "sharedTransitions": [],
+            "extensions": [],
+            "startTransition": {"key": "start", "from": null, "target": "state1", "triggerType": "Manual", "versionStrategy": "Patch", "labels": [], "onExecutionTasks": [], "view": null}
+        }
+        """;
+
+        var options = new System.Text.Json.JsonSerializerOptions 
+        { 
+            PropertyNameCaseInsensitive = true,
+            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+        };
+        var workflow = System.Text.Json.JsonSerializer.Deserialize<Definitions.Workflow>(json, options)!;
+
+        workflow.SetReference(new Reference(key, domain, "sys-flows", "1.0.0"));
+        return workflow;
+    }
+
+    private Definitions.Workflow CreateMockWorkflowWithNoTransitions(string key, string domain)
+    {
+        var json = """
+        {
+            "type": "F",
+            "timeout": null,
+            "labels": [],
+            "functions": [],
+            "features": [],
+            "states": [
+                {
+                    "key": "state1",
+                    "stateType": "Intermediate",
+                    "transitions": []
+                }
+            ],
+            "sharedTransitions": [],
+            "extensions": [],
+            "startTransition": {"key": "start", "from": null, "target": "state1", "triggerType": "Manual", "versionStrategy": "Patch", "labels": [], "onExecutionTasks": [], "view": null}
+        }
+        """;
+
+        var options = new System.Text.Json.JsonSerializerOptions 
+        { 
+            PropertyNameCaseInsensitive = true,
+            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+        };
+        var workflow = System.Text.Json.JsonSerializer.Deserialize<Definitions.Workflow>(json, options)!;
+
+        workflow.SetReference(new Reference(key, domain, "sys-flows", "1.0.0"));
+        return workflow;
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/Steps/SetBusyStepTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/Steps/SetBusyStepTests.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.Results;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Execution;
+using BBT.Workflow.Execution.Pipeline;
+using BBT.Workflow.Execution.Pipeline.Steps;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Shared;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Application.Tests.Execution.Transitions.Pipeline.Steps;
+
+/// <summary>
+/// Unit tests for SetBusyStep
+/// Tests that instance is set to Busy status at the start of transition processing
+/// </summary>
+public class SetBusyStepTests
+{
+    private readonly IInstanceRepository _mockInstanceRepository;
+    private readonly ILogger<SetBusyStep> _mockLogger;
+    private readonly SetBusyStep _step;
+
+    public SetBusyStepTests()
+    {
+        _mockInstanceRepository = Substitute.For<IInstanceRepository>();
+        _mockLogger = Substitute.For<ILogger<SetBusyStep>>();
+        _step = new SetBusyStep(_mockInstanceRepository, _mockLogger);
+    }
+
+    [Fact]
+    public void Order_ShouldBeSetBusy()
+    {
+        // Assert
+        _step.Order.ShouldBe(LifecycleOrder.SetBusy);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenInstanceIsActive_ShouldSetToBusy()
+    {
+        // Arrange
+        var context = CreateTransitionExecutionContext();
+        context.Instance.IsActive.ShouldBeTrue();
+
+        // Act
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        context.Instance.IsBusy.ShouldBeTrue();
+        await _mockInstanceRepository.Received(1).UpdateAsync(context.Instance, true, CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenInstanceIsAlreadyBusy_ShouldSkipAndNotUpdate()
+    {
+        // Arrange
+        var context = CreateTransitionExecutionContext();
+        context.Instance.Busy(); // Set to Busy before test
+
+        // Act
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        context.Instance.IsBusy.ShouldBeTrue();
+        await _mockInstanceRepository.DidNotReceive().UpdateAsync(Arg.Any<Instance>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenInstanceIsCompleted_ShouldSkipAndNotUpdate()
+    {
+        // Arrange
+        var context = CreateTransitionExecutionContext();
+        context.Instance.Complete(); // Set to Completed before test
+
+        // Act
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        context.Instance.IsCompleted.ShouldBeTrue();
+        await _mockInstanceRepository.DidNotReceive().UpdateAsync(Arg.Any<Instance>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenIsSubFlowResume_ShouldSkipAndNotUpdate()
+    {
+        // Arrange
+        var context = CreateTransitionExecutionContext();
+        context.Directives.MarkAsSubFlowResume();
+
+        // Act
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        context.Instance.IsActive.ShouldBeTrue(); // Should remain Active
+        await _mockInstanceRepository.DidNotReceive().UpdateAsync(Arg.Any<Instance>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldReturnContinueOutcome()
+    {
+        // Arrange
+        var context = CreateTransitionExecutionContext();
+
+        // Act
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.ShouldNotBeNull();
+        result.Value!.StopPipeline.ShouldBeFalse();
+    }
+
+    private TransitionExecutionContext CreateTransitionExecutionContext()
+    {
+        var instanceId = Guid.NewGuid();
+        var workflowKey = "test-workflow";
+        var domain = "test-domain";
+
+        var workflow = CreateMockWorkflow(workflowKey, domain);
+        var instance = Instance.Create(instanceId, workflowKey);
+        var state = workflow.GetState("state1").Value!;
+        var transition = Transition.Create("test-transition", null, "state1", TriggerType.Manual, "Patch");
+
+        return new TransitionExecutionContext
+        {
+            InstanceId = instanceId,
+            Domain = domain,
+            WorkflowKey = workflowKey,
+            TransitionKey = "test-transition",
+            Trigger = TriggerType.Manual,
+            Actor = ExecutionActor.User,
+            CorrelationId = Guid.NewGuid().ToString("N"),
+            ExecutionChainId = Guid.NewGuid().ToString("N"),
+            RequestedAt = DateTimeOffset.UtcNow,
+            Workflow = workflow,
+            Current = state,
+            Transition = transition,
+            Instance = instance,
+            TraceId = Guid.NewGuid().ToString("N"),
+            SpanId = Guid.NewGuid().ToString("N")[..16]
+        };
+    }
+
+    private Definitions.Workflow CreateMockWorkflow(string key, string domain)
+    {
+        var json = """
+        {
+            "type": "F",
+            "timeout": null,
+            "labels": [],
+            "functions": [],
+            "features": [],
+            "states": [
+                {
+                    "key": "state1",
+                    "stateType": "Intermediate",
+                    "transitions": []
+                }
+            ],
+            "sharedTransitions": [],
+            "extensions": [],
+            "startTransition": {"key": "start", "from": null, "target": "state1", "triggerType": "Manual", "versionStrategy": "Patch", "labels": [], "onExecutionTasks": [], "view": null}
+        }
+        """;
+
+        var options = new System.Text.Json.JsonSerializerOptions 
+        { 
+            PropertyNameCaseInsensitive = true,
+            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+        };
+        var workflow = System.Text.Json.JsonSerializer.Deserialize<Definitions.Workflow>(json, options)!;
+
+        workflow.SetReference(new Reference(key, domain, "sys-flows", "1.0.0"));
+        return workflow;
+    }
+}

--- a/test/BBT.Workflow.Domain.Tests/Definitions/StateTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Definitions/StateTests.cs
@@ -401,5 +401,95 @@ public class StateTests
         // Assert
         Assert.Empty(result);
     }
+
+    [Fact]
+    public void HasOnlyManualOrEventTransitions_ShouldReturnTrue_WhenNoTransitions()
+    {
+        // Arrange
+        var state = State.Create("test-state", StateType.Intermediate, StateSubType.Success, "Patch");
+
+        // Act & Assert
+        Assert.True(state.HasOnlyManualOrEventTransitions);
+    }
+
+    [Fact]
+    public void HasOnlyManualOrEventTransitions_ShouldReturnTrue_WhenOnlyManualTransitions()
+    {
+        // Arrange
+        var state = State.Create("test-state", StateType.Intermediate, StateSubType.Success, "Patch");
+        var manualTransition1 = Transition.Create("submit", "test-state", "next", TriggerType.Manual, "Patch");
+        var manualTransition2 = Transition.Create("cancel", "test-state", "cancelled", TriggerType.Manual, "Patch");
+        state.AddTransition(manualTransition1);
+        state.AddTransition(manualTransition2);
+
+        // Act & Assert
+        Assert.True(state.HasOnlyManualOrEventTransitions);
+    }
+
+    [Fact]
+    public void HasOnlyManualOrEventTransitions_ShouldReturnTrue_WhenOnlyEventTransitions()
+    {
+        // Arrange
+        var state = State.Create("test-state", StateType.Intermediate, StateSubType.Success, "Patch");
+        var eventTransition = Transition.Create("on-event", "test-state", "next", TriggerType.Event, "Patch");
+        state.AddTransition(eventTransition);
+
+        // Act & Assert
+        Assert.True(state.HasOnlyManualOrEventTransitions);
+    }
+
+    [Fact]
+    public void HasOnlyManualOrEventTransitions_ShouldReturnTrue_WhenMixOfManualAndEventTransitions()
+    {
+        // Arrange
+        var state = State.Create("test-state", StateType.Intermediate, StateSubType.Success, "Patch");
+        var manualTransition = Transition.Create("submit", "test-state", "next", TriggerType.Manual, "Patch");
+        var eventTransition = Transition.Create("on-event", "test-state", "other", TriggerType.Event, "Patch");
+        state.AddTransition(manualTransition);
+        state.AddTransition(eventTransition);
+
+        // Act & Assert
+        Assert.True(state.HasOnlyManualOrEventTransitions);
+    }
+
+    [Fact]
+    public void HasOnlyManualOrEventTransitions_ShouldReturnFalse_WhenHasAutomaticTransition()
+    {
+        // Arrange
+        var state = State.Create("test-state", StateType.Intermediate, StateSubType.Success, "Patch");
+        var manualTransition = Transition.Create("submit", "test-state", "next", TriggerType.Manual, "Patch");
+        var autoTransition = Transition.Create("auto", "test-state", "other", TriggerType.Automatic, "Patch");
+        state.AddTransition(manualTransition);
+        state.AddTransition(autoTransition);
+
+        // Act & Assert
+        Assert.False(state.HasOnlyManualOrEventTransitions);
+    }
+
+    [Fact]
+    public void HasOnlyManualOrEventTransitions_ShouldReturnFalse_WhenHasScheduledTransition()
+    {
+        // Arrange
+        var state = State.Create("test-state", StateType.Intermediate, StateSubType.Success, "Patch");
+        var manualTransition = Transition.Create("submit", "test-state", "next", TriggerType.Manual, "Patch");
+        var scheduledTransition = Transition.Create("timeout", "test-state", "expired", TriggerType.Scheduled, "Patch");
+        state.AddTransition(manualTransition);
+        state.AddTransition(scheduledTransition);
+
+        // Act & Assert
+        Assert.False(state.HasOnlyManualOrEventTransitions);
+    }
+
+    [Fact]
+    public void HasOnlyManualOrEventTransitions_ShouldReturnFalse_WhenOnlyAutomaticTransitions()
+    {
+        // Arrange
+        var state = State.Create("test-state", StateType.Intermediate, StateSubType.Success, "Patch");
+        var autoTransition = Transition.Create("auto", "test-state", "next", TriggerType.Automatic, "Patch");
+        state.AddTransition(autoTransition);
+
+        // Act & Assert
+        Assert.False(state.HasOnlyManualOrEventTransitions);
+    }
 }
 


### PR DESCRIPTION
Introduces SetBusyStep and ResolveAvailableStep to manage instance status transitions in the workflow pipeline. Updates dependency injection and pipeline order, adds HasOnlyManualOrEventTransitions property to State, and provides comprehensive unit tests for new steps and state logic.

## Summary by Sourcery

Introduce busy/available lifecycle management steps in the transition pipeline and expose state metadata to support them.

Enhancements:
- Add SetBusyStep at the start and ResolveAvailableStep at the end of the transition pipeline to manage instance Busy/Active status and prevent concurrent modifications.
- Extend State with a HasOnlyManualOrEventTransitions property and wire new lifecycle orders into the pipeline configuration and ordering.

Tests:
- Add unit tests for State.HasOnlyManualOrEventTransitions and for the new SetBusyStep and ResolveAvailableStep pipeline behaviors, including edge cases around automatic, scheduled, finish, and terminal transitions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow instances are now automatically marked as busy at the start of transitions to prevent concurrent execution issues.
  * Workflow instances automatically transition to available state after transitions when target states support only manual or event-triggered actions.

* **Tests**
  * Added comprehensive test coverage for new transition pipeline steps and state transition logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->