### PR TITLE
feat: implement fail-fast extension execution with error target

### DIFF
--- a/src/BBT.Workflow.Application/Execution/ErrorHandling/ExecutionError.cs
+++ b/src/BBT.Workflow.Application/Execution/ErrorHandling/ExecutionError.cs
@@ -70,7 +70,7 @@ public sealed record ExecutionError
             code = $"{code}:{exceptionType}";
         }
 
-        return Error.Failure(code, ErrorMessage ?? "Task execution failed");
+        return Error.Failure(code, ErrorMessage ?? "Task execution failed", detail: TaskKey);
     }
 
 

--- a/src/BBT.Workflow.Application/Extensions/Services/InstanceExtensionService.cs
+++ b/src/BBT.Workflow.Application/Extensions/Services/InstanceExtensionService.cs
@@ -4,6 +4,7 @@ using BBT.Aether.MultiSchema;
 using BBT.Aether.Results;
 using BBT.Workflow.Caching;
 using BBT.Workflow.Definitions;
+using BBT.Workflow.Logging;
 using BBT.Workflow.Runtime;
 using BBT.Workflow.Scripting;
 using BBT.Workflow.Tasks.Coordinator;
@@ -38,17 +39,27 @@ public sealed class InstanceExtensionService(
             : null;
 
         // Process core system extensions first (runtime-wide, always included)
-        // Core extensions failing should not block workflow extensions
-        await ProcessCoreExtensionsAsync(requestedSet, scriptContext, currentScope, context, cancellationToken);
+        // Fail-fast: if core extensions fail, return error immediately
+        var coreResult = await ProcessCoreExtensionsAsync(requestedSet, scriptContext, currentScope, context, cancellationToken);
+        if (!coreResult.IsSuccess)
+        {
+            return Result<Dictionary<string, object>>.Fail(coreResult.Error);
+        }
 
         // Process workflow-specific extensions (excluding already executed core extensions)
-        await ProcessWorkflowExtensionsAsync(
+        // Fail-fast: if workflow extensions fail, return error immediately
+        var workflowResult = await ProcessWorkflowExtensionsAsync(
             requestedSet,
             scriptContext,
             workflow,
             currentScope,
             context,
             cancellationToken);
+        
+        if (!workflowResult.IsSuccess)
+        {
+            return Result<Dictionary<string, object>>.Fail(workflowResult.Error);
+        }
 
         return Result<Dictionary<string, object>>.Ok(context.Response);
     }
@@ -56,9 +67,9 @@ public sealed class InstanceExtensionService(
     /// <summary>
     /// Processes core extensions that are runtime-wide and always included in instance responses.
     /// Core extensions provide essential data like state, createBy, etc.
-    /// Failures here are logged but don't break the flow - the system continues without core extensions.
+    /// Uses fail-fast behavior: if any core extension fails, returns error immediately.
     /// </summary>
-    private async Task ProcessCoreExtensionsAsync(
+    private async Task<Result> ProcessCoreExtensionsAsync(
         HashSet<string>? extensionRequested,
         ScriptContext scriptContext,
         ExtensionScope currentScope,
@@ -68,9 +79,9 @@ public sealed class InstanceExtensionService(
         var coreExtensionsResult = await GetCoreExtensionsAsync(extensionRequested, cancellationToken);
 
         if (!coreExtensionsResult.IsSuccess || coreExtensionsResult.Value!.Count == 0)
-            return;
+            return Result.Ok();
 
-        await ExecuteExtensionsInternalAsync(
+        return await ExecuteExtensionsInternalAsync(
             null,
             scriptContext,
             coreExtensionsResult.Value,
@@ -81,8 +92,9 @@ public sealed class InstanceExtensionService(
 
     /// <summary>
     /// Processes workflow-specific extensions excluding already executed core extensions.
+    /// Uses fail-fast behavior: if any workflow extension fails, returns error immediately.
     /// </summary>
-    private async Task ProcessWorkflowExtensionsAsync(
+    private async Task<Result> ProcessWorkflowExtensionsAsync(
         HashSet<string>? extensionRequested,
         ScriptContext scriptContext,
         Definitions.Workflow workflow,
@@ -98,7 +110,7 @@ public sealed class InstanceExtensionService(
             .Where(ext => !context.ExecutedKeys.Contains(ext.Key))
             .ToList();
 
-        await ExecuteExtensionsInternalAsync(
+        return await ExecuteExtensionsInternalAsync(
             extensionRequested,
             scriptContext,
             filteredExtensions,
@@ -175,9 +187,9 @@ public sealed class InstanceExtensionService(
 
     /// <summary>
     /// Executes extensions and extracts their responses into the context.
-    /// Extension execution errors are logged but don't propagate - extensions are best-effort enrichment.
+    /// Uses fail-fast behavior: if any extension fails, returns error with target indicating which extension failed.
     /// </summary>
-    private async Task ExecuteExtensionsInternalAsync(
+    private async Task<Result> ExecuteExtensionsInternalAsync(
         HashSet<string>? extensionRequested,
         ScriptContext scriptContext,
         List<Extension> extensions,
@@ -190,11 +202,11 @@ public sealed class InstanceExtensionService(
             .ToList();
 
         if (executableExtensions.Count == 0)
-            return;
+            return Result.Ok();
 
         var tasks = executableExtensions.Select(ext => ext.Task);
 
-        // Execute tasks and log errors (extensions are best-effort, don't fail the chain)
+        // Execute tasks with fail-fast behavior
         var executeResult = await taskCoordinator.ExecuteAsync(
             tasks,
             null,
@@ -204,17 +216,48 @@ public sealed class InstanceExtensionService(
 
         if (!executeResult.IsSuccess)
         {
-            logger.LogWarning(
-                "Extension task execution failed: {ErrorCode} - {ErrorMessage}. Extensions are best-effort, continuing.",
+            var failedExtensionKey = FindFailedExtensionKey(executableExtensions, scriptContext);
+            
+            logger.LogError(
+                "Extension execution failed for '{ExtensionKey}': {ErrorCode} - {ErrorMessage}",
+                failedExtensionKey,
                 executeResult.Error.Code,
                 executeResult.Error.Message);
+            
+            return Result.Fail(WorkflowErrors.ExtensionExecutionFailed(
+                failedExtensionKey,
+                executeResult.Error.Message ?? "Unknown error"));
         }
 
-        // Extract responses from executed extensions (even partial results)
+        // Extract responses from executed extensions
         foreach (var extension in executableExtensions)
         {
             ExtractExtensionResponse(extension, scriptContext, context);
         }
+        
+        return Result.Ok();
+    }
+    
+    /// <summary>
+    /// Finds the key of the extension that failed execution.
+    /// Identifies the failed extension by checking which task output is missing from the script context.
+    /// </summary>
+    /// <param name="extensions">List of extensions that were executed.</param>
+    /// <param name="scriptContext">The script context containing task outputs.</param>
+    /// <returns>The key of the failed extension, or "unknown" if not determinable.</returns>
+    private static string FindFailedExtensionKey(
+        List<Extension> extensions,
+        ScriptContext scriptContext)
+    {
+        // Find extension whose task output is missing (failed)
+        foreach (var extension in extensions)
+        {
+            var variableKey = extension.Task.Task.Key.ToVariableName();
+            if (!scriptContext.OutputResponse.ContainsKey(variableKey))
+                return extension.Key;
+        }
+        
+        return extensions.FirstOrDefault()?.Key ?? "unknown";
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -57,7 +57,13 @@ public sealed class InstanceQueryAppService(
                         input.QueryParameters,
                         cancellationToken);
 
-                    return ConditionalResult<GetInstanceOutput>.Success(result);
+                    // Propagate extension errors - fail-fast behavior
+                    if (!result.IsSuccess)
+                    {
+                        return ConditionalResult<GetInstanceOutput>.Fail(result.Error);
+                    }
+
+                    return ConditionalResult<GetInstanceOutput>.Success(result.Value!);
                 },
                 onFailure: error => ConditionalResult<GetInstanceOutput>.Fail(error));
     }
@@ -149,7 +155,7 @@ public sealed class InstanceQueryAppService(
                 var list = new List<GetInstanceOutput>();
                 foreach (var instance in pagedList.Items)
                 {
-                    var instanceOutput = await BuildInstanceOutputAsync(
+                    var instanceOutputResult = await BuildInstanceOutputAsync(
                         input.Domain,
                         input.Extension,
                         input.Workflow,
@@ -160,7 +166,16 @@ public sealed class InstanceQueryAppService(
                         input.QueryParameters,
                         ct);
 
-                    list.Add(instanceOutput);
+                    // Propagate extension errors - fail-fast behavior
+                    if (!instanceOutputResult.IsSuccess)
+                    {
+                        throw new UserFriendlyException(
+                            instanceOutputResult.Error.Code,
+                            instanceOutputResult.Error.Message,
+                            instanceOutputResult.Error.Detail).WithData("Target", instanceOutputResult.Error.Target ?? string.Empty);
+                    }
+
+                    list.Add(instanceOutputResult.Value!);
                 }
 
                 var resultPagedList = new HateoasPagedList<GetInstanceOutput>(list, pagedList.CurrentPage, pagedList.PageSize,
@@ -183,7 +198,7 @@ public sealed class InstanceQueryAppService(
                 var transitions = new List<GetInstanceOutput>();
                 foreach (var instanceData in instance.DataList.OrderBy(d => d.EnteredAt))
                 {
-                    var transitionOutput = await BuildInstanceOutputAsync(
+                    var transitionOutputResult = await BuildInstanceOutputAsync(
                         input.Domain,
                         input.Extension,
                         input.Workflow,
@@ -194,7 +209,13 @@ public sealed class InstanceQueryAppService(
                         input.QueryParameters,
                         cancellationToken);
 
-                    transitions.Add(transitionOutput);
+                    // Propagate extension errors - fail-fast behavior
+                    if (!transitionOutputResult.IsSuccess)
+                    {
+                        return Result<GetInstanceHistoryOutput>.Fail(transitionOutputResult.Error);
+                    }
+
+                    transitions.Add(transitionOutputResult.Value!);
                 }
 
                 return Result<GetInstanceHistoryOutput>.Ok(new GetInstanceHistoryOutput
@@ -342,7 +363,7 @@ public sealed class InstanceQueryAppService(
         return instance.EnsureNotNull(WorkflowErrors.InstanceNotFound(instanceIdentifier));
     }
 
-    private async Task<GetInstanceOutput> BuildInstanceOutputAsync(
+    private async Task<Result<GetInstanceOutput>> BuildInstanceOutputAsync(
         string domain,
         string[]? extensionRequested,
         string workflow,
@@ -371,7 +392,7 @@ public sealed class InstanceQueryAppService(
 
         if (flow == null)
         {
-            return response;
+            return Result<GetInstanceOutput>.Ok(response);
         }
 
         var scriptContext = await scriptContextFactory.NewBuilder(instanceRepository)
@@ -384,6 +405,7 @@ public sealed class InstanceQueryAppService(
             .WithQueryParameters(queryParameters)
             .BuildAsync(cancellationToken);
 
+        // Execute extensions with fail-fast behavior
         var extensionsResult = await instanceExtensionService.ProcessExtensionsAsync(
             extensionRequested,
             scriptContext,
@@ -391,10 +413,15 @@ public sealed class InstanceQueryAppService(
             currentScope,
             cancellationToken);
 
-        // Extensions are optional enrichment - use empty dictionary if processing fails
-        response.Extensions = extensionsResult.ValueOrDefault(new Dictionary<string, object>())!;
+        // Propagate extension errors - fail-fast behavior
+        if (!extensionsResult.IsSuccess)
+        {
+            return Result<GetInstanceOutput>.Fail(extensionsResult.Error);
+        }
 
-        return response;
+        response.Extensions = extensionsResult.Value!;
+
+        return Result<GetInstanceOutput>.Ok(response);
     }
 
     public async Task<ConditionalResult<GetInstanceDataOutput>> GetInstanceDataAsync(
@@ -451,6 +478,7 @@ public sealed class InstanceQueryAppService(
                         .WithQueryParameters(input.QueryParameters)
                         .BuildAsync(cancellationToken);
 
+                    // Execute extensions with fail-fast behavior
                     var extensionsResult = await instanceExtensionService.ProcessExtensionsAsync(
                         input.Extensions,
                         scriptContext,
@@ -458,8 +486,13 @@ public sealed class InstanceQueryAppService(
                         ExtensionScope.GetInstance,
                         cancellationToken);
 
-                    // Extensions are optional enrichment - use empty dictionary if processing fails
-                    result.Extensions = extensionsResult.ValueOrDefault(new Dictionary<string, object>())!;
+                    // Propagate extension errors - fail-fast behavior
+                    if (!extensionsResult.IsSuccess)
+                    {
+                        return ConditionalResult<GetInstanceDataOutput>.Fail(extensionsResult.Error);
+                    }
+
+                    result.Extensions = extensionsResult.Value!;
 
                     return ConditionalResult<GetInstanceDataOutput>.Success(result);
                 },
@@ -744,7 +777,7 @@ public sealed class InstanceQueryAppService(
             .WithQueryParameters(input.QueryParameters)
             .BuildAsync(cancellationToken);
 
-        // Execute extensions
+        // Execute extensions with fail-fast behavior
         var extensionsResult = await instanceExtensionService.ProcessExtensionsAsync(
             input.Extensions ?? [],
             scriptContext,
@@ -752,10 +785,16 @@ public sealed class InstanceQueryAppService(
             ExtensionScope.GetInstance,
             cancellationToken);
 
+        // Propagate extension errors - fail-fast behavior
+        if (!extensionsResult.IsSuccess)
+        {
+            return Result<GetExtensionsOutput>.Fail(extensionsResult.Error);
+        }
+
         // Return extension results
         return Result<GetExtensionsOutput>.Ok(new GetExtensionsOutput
         {
-            Extensions = extensionsResult.ValueOrDefault(new Dictionary<string, object>())!
+            Extensions = extensionsResult.Value!
         });
     }
 

--- a/src/BBT.Workflow.Domain/Logging/WorkflowErrors.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowErrors.cs
@@ -264,5 +264,20 @@ public static class WorkflowErrors
             target: stateKey);
 
     #endregion
+
+    #region Extension Errors
+
+    /// <summary>
+    /// Extension execution failed during instance data enrichment.
+    /// </summary>
+    /// <param name="extensionKey">The key of the extension that failed.</param>
+    /// <param name="message">The error message from the failed execution.</param>
+    public static Error ExtensionExecutionFailed(string extensionKey, string message)
+        => Error.Validation(
+            WorkflowErrorCodes.ExtensionExecutionFailed,
+            $"Extension '{extensionKey}' execution failed: {message}",
+            target: extensionKey);
+
+    #endregion
 }
 

--- a/src/BBT.Workflow.Domain/WorkflowErrorCodes.cs
+++ b/src/BBT.Workflow.Domain/WorkflowErrorCodes.cs
@@ -104,4 +104,10 @@ public static class WorkflowErrorCodes
     public const string TriggerInvalidResponseStructure = "Trigger:500009";
     
     #endregion
+    
+    #region Extension Errors (600xxx)
+    
+    public const string ExtensionExecutionFailed = "Extension:600001";
+    
+    #endregion
 }

--- a/test/BBT.Workflow.Application.Tests/Extensions/InstanceExtensionServiceTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Extensions/InstanceExtensionServiceTests.cs
@@ -1,0 +1,67 @@
+using BBT.Workflow.Logging;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Extensions;
+
+/// <summary>
+/// Unit tests for fail-fast extension execution behavior.
+/// Tests verify error codes, error factory methods, and target tracking.
+/// </summary>
+public class InstanceExtensionServiceTests
+{
+    [Fact]
+    public void WorkflowErrors_ExtensionExecutionFailed_ShouldIncludeTarget()
+    {
+        // Arrange
+        var extensionKey = "test-extension";
+        var message = "Connection timeout";
+
+        // Act
+        var error = WorkflowErrors.ExtensionExecutionFailed(extensionKey, message);
+
+        // Assert
+        error.Code.ShouldBe(WorkflowErrorCodes.ExtensionExecutionFailed);
+        error.Target.ShouldBe(extensionKey);
+        error.Message.ShouldNotBeNull();
+        error.Message!.ShouldContain(extensionKey);
+        error.Message.ShouldContain(message);
+    }
+
+    [Fact]
+    public void WorkflowErrorCodes_ShouldHaveExtensionExecutionFailedCode()
+    {
+        // Assert
+        WorkflowErrorCodes.ExtensionExecutionFailed.ShouldBe("Extension:600001");
+    }
+
+    [Fact]
+    public void WorkflowErrors_ExtensionExecutionFailed_ShouldFormatMessageCorrectly()
+    {
+        // Arrange
+        var extensionKey = "my-data-extension";
+        var message = "HTTP 500 - Internal Server Error";
+
+        // Act
+        var error = WorkflowErrors.ExtensionExecutionFailed(extensionKey, message);
+
+        // Assert
+        error.Message.ShouldNotBeNull();
+        error.Message!.ShouldBe($"Extension '{extensionKey}' execution failed: {message}");
+    }
+
+    [Fact]
+    public void WorkflowErrors_ExtensionExecutionFailed_ShouldBeValidationError()
+    {
+        // Arrange
+        var extensionKey = "test-extension";
+        var message = "Test error";
+
+        // Act
+        var error = WorkflowErrors.ExtensionExecutionFailed(extensionKey, message);
+
+        // Assert - Error.Validation creates an error with Type = Validation
+        // This ensures proper HTTP status code mapping (400 for validation errors)
+        error.Code.ShouldStartWith("Extension:");
+    }
+}


### PR DESCRIPTION
Replace best-effort extension execution with fail-fast behavior to ensure consistent client behavior. When any extension fails, the request now terminates immediately with an error containing the failed extension key as the target field.

Changes:
- Add ExtensionExecutionFailed error code (Extension:600001)
- Add WorkflowErrors.ExtensionExecutionFailed factory method with target
- Update InstanceExtensionService to propagate errors instead of bypassing
- Update all extension call sites in InstanceQueryAppService:
  - GetInstanceAsync, GetInstanceListAsync, GetInstanceHistoryAsync
  - GetInstanceDataAsync, BuildExtensionsOutputAsync
- Add ExecutionError.ToError() detail parameter for task key tracking
- Add unit tests for error code and error factory

Closes #306

## Summary by Sourcery

Implement fail-fast behavior for workflow extensions and surface extension execution failures to clients with targeted error information.

Enhancements:
- Change instance extension processing to stop on first failure for both core and workflow-specific extensions and return an error instead of silently continuing.
- Propagate extension execution errors through instance query APIs so failed extensions cause request failure rather than best-effort enrichment.
- Add a dedicated ExtensionExecutionFailed error code and factory that includes the failing extension key as the error target, and track task keys in execution errors for better diagnostics.

Tests:
- Add unit tests validating the new extension execution error code, factory behavior, and error message formatting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Extension execution failures now halt processing immediately and return detailed error information instead of continuing with partial results.
  * Improved error propagation and reporting throughout the extension processing pipeline.
  * Enhanced error context preservation with extension identifiers included in error messages.

* **Tests**
  * Added comprehensive unit tests for extension execution error handling and validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->