### PR TITLE
feat: persist task input audit data

### DIFF
--- a/src/BBT.Workflow.Application/Tasks/Coordinator/TaskExecutionEngine.cs
+++ b/src/BBT.Workflow.Application/Tasks/Coordinator/TaskExecutionEngine.cs
@@ -29,7 +29,6 @@ public sealed class TaskExecutionEngine : ITaskExecutionEngine
     private readonly ITaskPersistenceStrategyFactory _persistenceStrategyFactory;
     private readonly IGuidGenerator _guidGenerator;
     private readonly IWorkflowMetrics _workflowMetrics;
-    private readonly IErrorNormalizer _errorNormalizer;
     private readonly IErrorBoundaryResolver _boundaryResolver;
     private readonly IErrorActionExecutor _actionExecutor;
     private readonly IRetryPolicyFactory _retryPolicyFactory;
@@ -45,7 +44,6 @@ public sealed class TaskExecutionEngine : ITaskExecutionEngine
         ITaskPersistenceStrategyFactory persistenceStrategyFactory,
         IGuidGenerator guidGenerator,
         IWorkflowMetrics workflowMetrics,
-        IErrorNormalizer errorNormalizer,
         IErrorBoundaryResolver boundaryResolver,
         IErrorActionExecutor actionExecutor,
         IRetryPolicyFactory retryPolicyFactory,
@@ -57,7 +55,6 @@ public sealed class TaskExecutionEngine : ITaskExecutionEngine
         _persistenceStrategyFactory = persistenceStrategyFactory;
         _guidGenerator = guidGenerator;
         _workflowMetrics = workflowMetrics;
-        _errorNormalizer = errorNormalizer;
         _boundaryResolver = boundaryResolver;
         _actionExecutor = actionExecutor;
         _retryPolicyFactory = retryPolicyFactory;
@@ -493,6 +490,16 @@ public sealed class TaskExecutionEngine : ITaskExecutionEngine
 
         // 8. Execute task
         var executeResult = await executorResult.Value!.ExecuteAsync(executorContext, cancellationToken);
+
+        var requestPayload = new
+        {
+            Task = task,
+            executorContext.InputResponse
+        };
+        var requestJson = new JsonData(JsonSerializer.Serialize(
+            requestPayload,
+            JsonSerializerConstants.JsonOptions));
+        instanceTask.SetRequest(requestJson);
 
         stopwatch.Stop();
 

--- a/src/BBT.Workflow.Application/Tasks/Executors/Core/TaskExecutorBase.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Core/TaskExecutorBase.cs
@@ -56,6 +56,8 @@ public abstract class TaskExecutorBase<TTask>(ILogger logger) : ITaskExecutor
                 taskKey, inputResult.Error.Message);
             return CreateErrorResponse(inputResult.Error, stopwatch.ElapsedMilliseconds);
         }
+        
+        context.InputResponse = inputResult.Value;
 
         // 3. PreProcess (virtual - optional)
         var preProcessResult = await PreProcessAsync(task, context, cancellationToken);
@@ -139,12 +141,12 @@ public abstract class TaskExecutorBase<TTask>(ILogger logger) : ITaskExecutor
     /// Prepares input data and runs input mapping scripts.
     /// Override to implement custom input logic.
     /// </summary>
-    protected virtual Task<Result> PrepareInputAsync(
+    protected virtual Task<Result<ScriptResponse?>> PrepareInputAsync(
         TTask task,
         TaskExecutorContext context,
         CancellationToken cancellationToken)
     {
-        return Task.FromResult(Result.Ok());
+        return Task.FromResult(Result<ScriptResponse?>.Ok(null));
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Application/Tasks/Executors/Dapr/DaprBindingTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Dapr/DaprBindingTaskExecutor.cs
@@ -35,7 +35,7 @@ public sealed class DaprBindingTaskExecutor : TaskExecutorBase<DaprBindingTask>
     public override TaskType TaskType => TaskType.DaprBinding;
 
     /// <inheritdoc />
-    protected override async Task<Result> PrepareInputAsync(
+    protected override async Task<Result<ScriptResponse?>> PrepareInputAsync(
         DaprBindingTask task,
         TaskExecutorContext context,
         CancellationToken cancellationToken)
@@ -43,16 +43,16 @@ public sealed class DaprBindingTaskExecutor : TaskExecutorBase<DaprBindingTask>
         var mapping = context.OnExecuteTask.Mapping;
         if (mapping == null || string.IsNullOrEmpty(mapping.DecodedCode))
         {
-            return Result.Ok();
+            return Result<ScriptResponse?>.Ok(null);
         }
 
-        var result = await ResultExtensions.TryAsync(async ct =>
+        var result = await ResultExtensions.TryAsync<ScriptResponse?>(async ct =>
         {
             var scriptRunner = await _scriptEngine.CompileToInstanceAsync<IMapping>(
                 mapping.DecodedCode,
                 cancellationToken: ct);
 
-            await scriptRunner.InputHandler(task, context.ScriptContext);
+            return await scriptRunner.InputHandler(task, context.ScriptContext);
         }, cancellationToken, ex => Error.Failure(
             WorkflowErrorCodes.TaskExecution,
             $"DaprBinding task input handler failed: {ex.Message}"));

--- a/src/BBT.Workflow.Application/Tasks/Executors/Dapr/DaprHttpEndpointTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Dapr/DaprHttpEndpointTaskExecutor.cs
@@ -35,7 +35,7 @@ public sealed class DaprHttpEndpointTaskExecutor : TaskExecutorBase<DaprHttpEndp
     public override TaskType TaskType => TaskType.DaprHttpEndpoint;
 
     /// <inheritdoc />
-    protected override async Task<Result> PrepareInputAsync(
+    protected override async Task<Result<ScriptResponse?>> PrepareInputAsync(
         DaprHttpEndpointTask task,
         TaskExecutorContext context,
         CancellationToken cancellationToken)
@@ -43,16 +43,16 @@ public sealed class DaprHttpEndpointTaskExecutor : TaskExecutorBase<DaprHttpEndp
         var mapping = context.OnExecuteTask.Mapping;
         if (mapping == null || string.IsNullOrEmpty(mapping.DecodedCode))
         {
-            return Result.Ok();
+            return Result<ScriptResponse?>.Ok(null);
         }
 
-        var result = await ResultExtensions.TryAsync(async ct =>
+        var result = await ResultExtensions.TryAsync<ScriptResponse?>(async ct =>
         {
             var scriptRunner = await _scriptEngine.CompileToInstanceAsync<IMapping>(
                 mapping.DecodedCode,
                 cancellationToken: ct);
 
-            await scriptRunner.InputHandler(task, context.ScriptContext);
+            return await scriptRunner.InputHandler(task, context.ScriptContext);
         }, cancellationToken, ex => Error.Failure(
             WorkflowErrorCodes.TaskExecution,
             $"DaprHttpEndpoint task input handler failed: {ex.Message}"));

--- a/src/BBT.Workflow.Application/Tasks/Executors/Dapr/DaprPubSubTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Dapr/DaprPubSubTaskExecutor.cs
@@ -35,7 +35,7 @@ public sealed class DaprPubSubTaskExecutor : TaskExecutorBase<DaprPubSubTask>
     public override TaskType TaskType => TaskType.DaprPubSub;
 
     /// <inheritdoc />
-    protected override async Task<Result> PrepareInputAsync(
+    protected override async Task<Result<ScriptResponse?>> PrepareInputAsync(
         DaprPubSubTask task,
         TaskExecutorContext context,
         CancellationToken cancellationToken)
@@ -43,16 +43,16 @@ public sealed class DaprPubSubTaskExecutor : TaskExecutorBase<DaprPubSubTask>
         var mapping = context.OnExecuteTask.Mapping;
         if (mapping == null || string.IsNullOrEmpty(mapping.DecodedCode))
         {
-            return Result.Ok();
+            return Result<ScriptResponse?>.Ok(null);
         }
 
-        var result = await ResultExtensions.TryAsync(async ct =>
+        var result = await ResultExtensions.TryAsync<ScriptResponse?>(async ct =>
         {
             var scriptRunner = await _scriptEngine.CompileToInstanceAsync<IMapping>(
                 mapping.DecodedCode,
                 cancellationToken: ct);
 
-            await scriptRunner.InputHandler(task, context.ScriptContext);
+            return await scriptRunner.InputHandler(task, context.ScriptContext);
         }, cancellationToken, ex => Error.Failure(
             WorkflowErrorCodes.TaskExecution,
             $"DaprPubSub task input handler failed: {ex.Message}"));

--- a/src/BBT.Workflow.Application/Tasks/Executors/Dapr/DaprServiceTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Dapr/DaprServiceTaskExecutor.cs
@@ -35,7 +35,7 @@ public sealed class DaprServiceTaskExecutor : TaskExecutorBase<DaprServiceTask>
     public override TaskType TaskType => TaskType.DaprService;
 
     /// <inheritdoc />
-    protected override async Task<Result> PrepareInputAsync(
+    protected override async Task<Result<ScriptResponse?>> PrepareInputAsync(
         DaprServiceTask task,
         TaskExecutorContext context,
         CancellationToken cancellationToken)
@@ -43,16 +43,16 @@ public sealed class DaprServiceTaskExecutor : TaskExecutorBase<DaprServiceTask>
         var mapping = context.OnExecuteTask.Mapping;
         if (mapping == null || string.IsNullOrEmpty(mapping.DecodedCode))
         {
-            return Result.Ok();
+            return Result<ScriptResponse?>.Ok(null);
         }
 
-        var result = await ResultExtensions.TryAsync(async ct =>
+        var result = await ResultExtensions.TryAsync<ScriptResponse?>(async ct =>
         {
             var scriptRunner = await _scriptEngine.CompileToInstanceAsync<IMapping>(
                 mapping.DecodedCode,
                 cancellationToken: ct);
 
-            await scriptRunner.InputHandler(task, context.ScriptContext);
+            return await scriptRunner.InputHandler(task, context.ScriptContext);
         }, cancellationToken, ex => Error.Failure(
             WorkflowErrorCodes.TaskExecution,
             $"DaprService task input handler failed: {ex.Message}"));

--- a/src/BBT.Workflow.Application/Tasks/Executors/Http/HttpTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Http/HttpTaskExecutor.cs
@@ -34,7 +34,7 @@ public sealed class HttpTaskExecutor : TaskExecutorBase<HttpTask>
     public override TaskType TaskType => TaskType.Http;
 
     /// <inheritdoc />
-    protected override async Task<Result> PrepareInputAsync(
+    protected override async Task<Result<ScriptResponse?>> PrepareInputAsync(
         HttpTask task,
         TaskExecutorContext context,
         CancellationToken cancellationToken)
@@ -42,16 +42,16 @@ public sealed class HttpTaskExecutor : TaskExecutorBase<HttpTask>
         var mapping = context.OnExecuteTask.Mapping;
         if (mapping == null || string.IsNullOrEmpty(mapping.DecodedCode))
         {
-            return Result.Ok();
+            return Result<ScriptResponse?>.Ok(null);
         }
 
-        var result = await ResultExtensions.TryAsync(async ct =>
+        var result = await ResultExtensions.TryAsync<ScriptResponse?>(async ct =>
         {
             var scriptRunner = await _scriptEngine.CompileToInstanceAsync<IMapping>(
                 mapping.DecodedCode,
                 cancellationToken: ct);
 
-            await scriptRunner.InputHandler(task, context.ScriptContext);
+            return await scriptRunner.InputHandler(task, context.ScriptContext);
         }, cancellationToken, ex => Error.Failure(
             WorkflowErrorCodes.TaskExecution,
             $"Http task input handler failed: {ex.Message}"));

--- a/src/BBT.Workflow.Application/Tasks/Executors/Notification/NotificationTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Notification/NotificationTaskExecutor.cs
@@ -46,7 +46,7 @@ public sealed class NotificationTaskExecutor : TaskExecutorBase<NotificationTask
     public override TaskType TaskType => TaskType.Notification;
 
     /// <inheritdoc />
-    protected override async Task<Result> PrepareInputAsync(
+    protected override async Task<Result<ScriptResponse?>> PrepareInputAsync(
         NotificationTask task,
         TaskExecutorContext context,
         CancellationToken cancellationToken)
@@ -66,16 +66,16 @@ public sealed class NotificationTaskExecutor : TaskExecutorBase<NotificationTask
 
         if (string.IsNullOrEmpty(scriptCode))
         {
-            return Result.Ok();
+            return Result<ScriptResponse?>.Ok(null);
         }
         
-        var result = await ResultExtensions.TryAsync(async ct =>
+        var result = await ResultExtensions.TryAsync<ScriptResponse?>(async ct =>
         {
             var scriptRunner = await _scriptEngine.CompileToInstanceAsync<IMapping>(
                 scriptCode,
                 cancellationToken: ct);
 
-            await scriptRunner.InputHandler(task, context.ScriptContext);
+            return await scriptRunner.InputHandler(task, context.ScriptContext);
         }, cancellationToken, ex => Error.Failure(
             WorkflowErrorCodes.TaskExecution,
             $"Notification task input handler failed: {ex.Message}"));

--- a/src/BBT.Workflow.Application/Tasks/Executors/Script/ScriptTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Script/ScriptTaskExecutor.cs
@@ -31,7 +31,7 @@ public sealed class ScriptTaskExecutor : TaskExecutorBase<ScriptTask>
     public override TaskType TaskType => TaskType.Script;
 
     /// <inheritdoc />
-    protected override async Task<Result> PrepareInputAsync(
+    protected override async Task<Result<ScriptResponse?>> PrepareInputAsync(
         ScriptTask task,
         TaskExecutorContext context,
         CancellationToken cancellationToken)
@@ -40,16 +40,16 @@ public sealed class ScriptTaskExecutor : TaskExecutorBase<ScriptTask>
         var mapping = context.OnExecuteTask.Mapping;
         if (mapping == null || string.IsNullOrEmpty(mapping.DecodedCode))
         {
-            return Result.Ok();
+            return Result<ScriptResponse?>.Ok(null);
         }
 
-        var result = await ResultExtensions.TryAsync(async ct =>
+        var result = await ResultExtensions.TryAsync<ScriptResponse?>(async ct =>
         {
             var scriptRunner = await _scriptEngine.CompileToInstanceAsync<IMapping>(
                 mapping.DecodedCode,
                 cancellationToken: ct);
 
-            await scriptRunner.InputHandler(task, context.ScriptContext);
+            return await scriptRunner.InputHandler(task, context.ScriptContext);
         }, cancellationToken, ex => Error.Failure(
             WorkflowErrorCodes.TaskExecution,
             $"Script input handler failed: {ex.Message}"));

--- a/src/BBT.Workflow.Application/Tasks/Executors/Trigger/TriggerTaskExecutorBase.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Trigger/TriggerTaskExecutorBase.cs
@@ -43,7 +43,7 @@ public abstract class TriggerTaskExecutorBase<TTask>(
     }
 
     /// <inheritdoc />
-    protected override async Task<Result> PrepareInputAsync(
+    protected override async Task<Result<ScriptResponse?>> PrepareInputAsync(
         TTask task,
         TaskExecutorContext context,
         CancellationToken cancellationToken)
@@ -51,16 +51,16 @@ public abstract class TriggerTaskExecutorBase<TTask>(
         var mapping = context.OnExecuteTask.Mapping;
         if (mapping == null || string.IsNullOrEmpty(mapping.DecodedCode))
         {
-            return Result.Ok();
+            return Result<ScriptResponse?>.Ok(null);
         }
 
-        var result = await ResultExtensions.TryAsync(async ct =>
+        var result = await ResultExtensions.TryAsync<ScriptResponse?>(async ct =>
         {
             var scriptRunner = await ScriptEngine.CompileToInstanceAsync<IMapping>(
                 mapping.DecodedCode,
                 cancellationToken: ct);
 
-            await scriptRunner.InputHandler(task, context.ScriptContext);
+            return await scriptRunner.InputHandler(task, context.ScriptContext);
         }, cancellationToken, ex => Error.Failure(
             WorkflowErrorCodes.TaskExecution,
             $"Input handler failed for {TaskType}: {ex.Message}"));

--- a/src/BBT.Workflow.Domain/Instances/InstanceTask.cs
+++ b/src/BBT.Workflow.Domain/Instances/InstanceTask.cs
@@ -75,6 +75,15 @@ public sealed class InstanceTask : Entity<Guid>
     public JsonData Response { get; private set; }
 
     /// <summary>
+    /// Sets the request payload that was sent to the task.
+    /// </summary>
+    /// <param name="request">The request data from InputHandler.</param>
+    public void SetRequest(JsonData request)
+    {
+        Request = request;
+    }
+
+    /// <summary>
     /// Marks the task as completed with business success.
     /// Platform successfully invoked the task and business logic succeeded.
     /// </summary>

--- a/src/BBT.Workflow.Domain/Tasks/Executors/Core/TaskExecutorContext.cs
+++ b/src/BBT.Workflow.Domain/Tasks/Executors/Core/TaskExecutorContext.cs
@@ -23,5 +23,10 @@ public sealed record TaskExecutorContext(
     /// Gets the task type from the workflow task.
     /// </summary>
     public TaskType TaskType => Task.GetTaskType();
+
+    /// <summary>
+    /// Holds the input handler response for auditing purposes.
+    /// </summary>
+    public ScriptResponse? InputResponse { get; set; }
 }
 


### PR DESCRIPTION
## Summary
- propagate InputHandler ScriptResponse through executors for audit capture
- persist request payload as task snapshot + input response on InstanceTask
- remove unused TaskExecutionEngine error normalizer field/ctor param

## Test plan
- not run (not requested)

## Summary by Sourcery

Persist task input audit data during task execution and clean up unused error normalization dependency.

New Features:
- Capture and store the request payload, including input handler responses, as a request snapshot on InstanceTask for auditing.

Enhancements:
- Propagate ScriptResponse from input handler scripts through task executors into the execution context for later persistence.
- Extend TaskExecutorContext to hold optional input handler responses for audit purposes.
- Simplify TaskExecutionEngine by removing the unused IErrorNormalizer dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced request payload logging and tracking throughout task execution for improved audit trails and traceability.
  * Input handler responses are now captured and stored for auditing purposes.

* **Refactor**
  * Improved internal data flow to support request payload capture and storage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->