### PR TITLE
fix: fail fast on localhost vNextApi base url

### DIFF
--- a/src/BBT.Workflow.Domain/ExceptionHandling/InvalidConfigurationException.cs
+++ b/src/BBT.Workflow.Domain/ExceptionHandling/InvalidConfigurationException.cs
@@ -1,0 +1,9 @@
+using BBT.Aether;
+
+namespace BBT.Workflow.ExceptionHandling;
+
+/// <summary>
+/// Represents a fatal configuration error that should stop the application startup.
+/// </summary>
+public sealed class InvalidConfigurationException(string message)
+    : UserFriendlyException(code: WorkflowErrorCodes.ValidationErrors, message: message);

--- a/src/BBT.Workflow.Infrastructure/Discovery/DomainRegistrationService.cs
+++ b/src/BBT.Workflow.Infrastructure/Discovery/DomainRegistrationService.cs
@@ -1,7 +1,10 @@
+using System;
 using System.Net.Http.Json;
 using System.Text.Json;
+using BBT.Workflow.ExceptionHandling;
 using BBT.Workflow.Runtime;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -17,6 +20,7 @@ public sealed class DomainRegistrationService(
     IRuntimeInfoProvider runtimeInfoProvider,
     IOptions<ServiceDiscoveryOptions> serviceDiscoveryOptions,
     IConfiguration configuration,
+    IHostEnvironment hostEnvironment,
     ILogger<DomainRegistrationService> logger) : IDomainRegistrationService
 {
     /// <summary>
@@ -43,6 +47,14 @@ public sealed class DomainRegistrationService(
                 "Domain registration skipped: '{ConfigKey}' is not configured",
                 VNextApiBaseUrlKey);
             return;
+        }
+
+        if (IsLocalhostBaseUrl(vNextApiBaseUrl) && !hostEnvironment.IsDevelopment())
+        {
+            throw new InvalidConfigurationException(
+                $"Invalid configuration: '{VNextApiBaseUrlKey}' points to localhost ('{vNextApiBaseUrl}') " +
+                $"in environment '{hostEnvironment.EnvironmentName}'. " +
+                "Use a reachable base URL in non-development environments.");
         }
 
         var domainName = runtimeInfoProvider.Domain;
@@ -106,4 +118,24 @@ public sealed class DomainRegistrationService(
                 domainName);
         }
     }
+
+    private static bool IsLocalhostBaseUrl(string baseUrl)
+    {
+        if (Uri.TryCreate(baseUrl, UriKind.Absolute, out var uri))
+        {
+            return IsLocalhostHost(uri.Host);
+        }
+
+        return ContainsLocalhostToken(baseUrl);
+    }
+
+    private static bool IsLocalhostHost(string host)
+        => host.Equals("localhost", StringComparison.OrdinalIgnoreCase)
+           || host.Equals("127.0.0.1", StringComparison.OrdinalIgnoreCase)
+           || host.Equals("::1", StringComparison.OrdinalIgnoreCase);
+
+    private static bool ContainsLocalhostToken(string baseUrl)
+        => baseUrl.Contains("localhost", StringComparison.OrdinalIgnoreCase)
+           || baseUrl.Contains("127.0.0.1", StringComparison.OrdinalIgnoreCase)
+           || baseUrl.Contains("::1", StringComparison.OrdinalIgnoreCase);
 }


### PR DESCRIPTION
## Summary
- add a domain-level configuration exception for invalid settings
- fail fast when vNextApi:BaseUrl points to localhost outside Development

## Test plan
- [ ] Not run (configuration guard)

## Summary by Sourcery

Enforce early failure on invalid vNextApi base URL configuration and introduce a dedicated domain-level configuration exception.

Bug Fixes:
- Prevent application startup when vNextApi:BaseUrl is configured to use localhost in non-development environments.

Enhancements:
- Add detection logic for localhost-style base URLs, including IP and token-based variants, to guard against invalid configuration in higher environments.
- Introduce an InvalidConfigurationException to represent fatal configuration errors tied to invalid settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent localhost endpoints from being used in production environments, catching misconfiguration errors at startup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->