### PR TITLE
Refactor HTTP client registration and add SSL validation option

### DIFF
--- a/execution/BBT.Workflow.Execution.HttpApi.Host/Microsoft/Extensions/DependencyInjection/ExecutionApiServiceCollectionExtensions.cs
+++ b/execution/BBT.Workflow.Execution.HttpApi.Host/Microsoft/Extensions/DependencyInjection/ExecutionApiServiceCollectionExtensions.cs
@@ -36,7 +36,6 @@ public static class ExecutionApiServiceCollectionExtensions
             .AddDistributedLock(configuration)
             .AddRedis()
             .AddExceptionHandling()
-            .AddWorkflowHttpClient()
             .AddExecutionHealthChecks()
             .AddDaprNotification(configuration)
             .AddTaskInvokers(configuration);

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Microsoft/Extensions/DependencyInjection/OrchestrationApiServiceCollectionExtensions.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Microsoft/Extensions/DependencyInjection/OrchestrationApiServiceCollectionExtensions.cs
@@ -34,7 +34,6 @@ public static class OrchestrationApiServiceCollectionExtensions
             .AddExceptionHandling()
             .AddRuntimeMiddleware()
             .AddHeaderService()
-            .AddWorkflowHttpClient() // TODO: Düşün!!!!
             .AddHostedServices()
             .AddAppHealthChecks();
         return services;

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/DirectTriggerTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/DirectTriggerTask.cs
@@ -68,6 +68,11 @@ public sealed class DirectTriggerTask : WorkflowTask
     /// </summary>
     public bool UseDapr { get; private set; } = false;
 
+    /// <summary>
+    /// Whether to validate SSL certificates
+    /// </summary>
+    public bool ValidateSSL { get; private set; } = true;
+
     public string? Identifier => TriggerInstanceId.HasValue ? TriggerInstanceId.Value.ToString() : TriggerKey;
 
     public void SetTags(string[] tags)
@@ -130,6 +135,11 @@ public sealed class DirectTriggerTask : WorkflowTask
         UseDapr = useDapr;
     }
 
+    public void SetValidateSSL(bool validateSSL)
+    {
+        ValidateSSL = validateSSL;
+    }
+
     /// <summary>
     /// Internal property setters for object pooling
     /// </summary>
@@ -143,6 +153,7 @@ public sealed class DirectTriggerTask : WorkflowTask
     internal void SetTriggerTagsInternal(string[]? tags) => TriggerTags = tags;
     internal void SetTriggerVersionInternal(string? version) => TriggerVersion = version;
     internal void SetUseDaprInternal(bool useDapr) => UseDapr = useDapr;
+    internal void SetValidateSSLInternal(bool validateSSL) => ValidateSSL = validateSSL;
 
     protected override void Configure(JsonElement config)
     {
@@ -180,6 +191,9 @@ public sealed class DirectTriggerTask : WorkflowTask
 
         if (config.TryGetProperty("useDapr", out var useDaprElement))
             UseDapr = useDaprElement.GetBoolean();
+
+        if (config.TryGetProperty("validateSsl", out var validateSslElement))
+            ValidateSSL = validateSslElement.GetBoolean();
     }
 
     public static DirectTriggerTask Create(JsonElement config)
@@ -213,6 +227,7 @@ public sealed class DirectTriggerTask : WorkflowTask
         cloned.TriggerVersion = TriggerVersion;
         cloned.TriggerTags = TriggerTags;
         cloned.UseDapr = UseDapr;
+        cloned.ValidateSSL = ValidateSSL;
         return cloned;
     }
 
@@ -233,6 +248,7 @@ public sealed class DirectTriggerTask : WorkflowTask
         SetTriggerVersionInternal(source.TriggerVersion);
         SetTriggerTagsInternal(source.TriggerTags);
         SetUseDaprInternal(source.UseDapr);
+        SetValidateSSLInternal(source.ValidateSSL);
     }
 
     /// <summary>
@@ -251,6 +267,7 @@ public sealed class DirectTriggerTask : WorkflowTask
         TriggerVersion = null;
         TriggerTags = null;
         UseDapr = false;
+        ValidateSSL = true;
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/GetInstanceDataTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/GetInstanceDataTask.cs
@@ -48,6 +48,11 @@ public sealed class GetInstanceDataTask : WorkflowTask
     /// </summary>
     public bool UseDapr { get; private set; } = false;
 
+    /// <summary>
+    /// Whether to validate SSL certificates
+    /// </summary>
+    public bool ValidateSSL { get; private set; } = true;
+
     public string? Identifier => TriggerInstanceId.HasValue ? TriggerInstanceId.Value.ToString() : TriggerKey;
 
     public void SetInstance(string? instanceId)
@@ -89,6 +94,11 @@ public sealed class GetInstanceDataTask : WorkflowTask
         UseDapr = useDapr;
     }
 
+    public void SetValidateSSL(bool validateSSL)
+    {
+        ValidateSSL = validateSSL;
+    }
+
     /// <summary>
     /// Internal property setters for object pooling
     /// </summary>
@@ -98,6 +108,7 @@ public sealed class GetInstanceDataTask : WorkflowTask
     internal void SetTriggerInstanceIdInternal(Guid? triggerInstanceId) => TriggerInstanceId = triggerInstanceId;
     internal void SetExtensionsInternal(string[]? extensions) => Extensions = extensions;
     internal void SetUseDaprInternal(bool useDapr) => UseDapr = useDapr;
+    internal void SetValidateSSLInternal(bool validateSSL) => ValidateSSL = validateSSL;
 
     protected override void Configure(JsonElement config)
     {
@@ -129,6 +140,9 @@ public sealed class GetInstanceDataTask : WorkflowTask
 
         if (config.TryGetProperty("useDapr", out var useDaprElement))
             UseDapr = useDaprElement.GetBoolean();
+
+        if (config.TryGetProperty("validateSsl", out var validateSslElement))
+            ValidateSSL = validateSslElement.GetBoolean();
     }
 
     public static GetInstanceDataTask Create(JsonElement config)
@@ -158,6 +172,7 @@ public sealed class GetInstanceDataTask : WorkflowTask
         cloned.TriggerInstanceId = TriggerInstanceId;
         cloned.Extensions = Extensions;
         cloned.UseDapr = UseDapr;
+        cloned.ValidateSSL = ValidateSSL;
 
         return cloned;
     }
@@ -175,6 +190,7 @@ public sealed class GetInstanceDataTask : WorkflowTask
         SetTriggerInstanceIdInternal(source.TriggerInstanceId);
         SetExtensionsInternal(source.Extensions);
         SetUseDaprInternal(source.UseDapr);
+        SetValidateSSLInternal(source.ValidateSSL);
     }
 
     /// <summary>
@@ -189,6 +205,7 @@ public sealed class GetInstanceDataTask : WorkflowTask
         TriggerInstanceId = null;
         Extensions = null;
         UseDapr = false;
+        ValidateSSL = true;
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/GetInstancesTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/GetInstancesTask.cs
@@ -54,6 +54,11 @@ public sealed class GetInstancesTask : WorkflowTask
     /// </summary>
     public bool UseDapr { get; private set; } = false;
 
+    /// <summary>
+    /// Whether to validate SSL certificates
+    /// </summary>
+    public bool ValidateSSL { get; private set; } = true;
+
     public void SetDomain(string domain)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(domain, nameof(domain));
@@ -91,6 +96,11 @@ public sealed class GetInstancesTask : WorkflowTask
         UseDapr = useDapr;
     }
 
+    public void SetValidateSSL(bool validateSSL)
+    {
+        ValidateSSL = validateSSL;
+    }
+
     /// <summary>
     /// Internal property setters for object pooling
     /// </summary>
@@ -101,6 +111,7 @@ public sealed class GetInstancesTask : WorkflowTask
     internal void SetSortInternal(string? sort) => Sort = sort;
     internal void SetFilterInternal(string[]? filter) => Filter = filter;
     internal void SetUseDaprInternal(bool useDapr) => UseDapr = useDapr;
+    internal void SetValidateSSLInternal(bool validateSSL) => ValidateSSL = validateSSL;
 
     protected override void Configure(JsonElement config)
     {
@@ -135,6 +146,9 @@ public sealed class GetInstancesTask : WorkflowTask
 
         if (config.TryGetProperty("useDapr", out var useDaprElement))
             UseDapr = useDaprElement.GetBoolean();
+
+        if (config.TryGetProperty("validateSsl", out var validateSslElement))
+            ValidateSSL = validateSslElement.GetBoolean();
     }
 
     public static GetInstancesTask Create(JsonElement config)
@@ -165,6 +179,7 @@ public sealed class GetInstancesTask : WorkflowTask
         cloned.Sort = Sort;
         cloned.Filter = Filter;
         cloned.UseDapr = UseDapr;
+        cloned.ValidateSSL = ValidateSSL;
 
         return cloned;
     }
@@ -183,6 +198,7 @@ public sealed class GetInstancesTask : WorkflowTask
         SetSortInternal(source.Sort);
         SetFilterInternal(source.Filter);
         SetUseDaprInternal(source.UseDapr);
+        SetValidateSSLInternal(source.ValidateSSL);
     }
 
     /// <summary>
@@ -198,6 +214,7 @@ public sealed class GetInstancesTask : WorkflowTask
         Sort = null;
         Filter = null;
         UseDapr = false;
+        ValidateSSL = true;
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/StartTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/StartTask.cs
@@ -59,6 +59,11 @@ public sealed class StartTask : WorkflowTask
     /// </summary>
     public bool UseDapr { get; private set; } = false;
 
+    /// <summary>
+    /// Whether to validate SSL certificates
+    /// </summary>
+    public bool ValidateSSL { get; private set; } = true;
+
     public void SetTags(string[] tags)
     {
         TriggerTags = tags;
@@ -101,6 +106,11 @@ public sealed class StartTask : WorkflowTask
         UseDapr = useDapr;
     }
 
+    public void SetValidateSSL(bool validateSSL)
+    {
+        ValidateSSL = validateSSL;
+    }
+
     /// <summary>
     /// Internal property setters for object pooling
     /// </summary>
@@ -113,6 +123,7 @@ public sealed class StartTask : WorkflowTask
     internal void SetTriggerKeyInternal(string? key) => TriggerKey = key;
     internal void SetTriggerTagsInternal(string[]? tags) => TriggerTags = tags;
     internal void SetUseDaprInternal(bool useDapr) => UseDapr = useDapr;
+    internal void SetValidateSSLInternal(bool validateSSL) => ValidateSSL = validateSSL;
 
     protected override void Configure(JsonElement config)
     {
@@ -144,6 +155,9 @@ public sealed class StartTask : WorkflowTask
 
         if (config.TryGetProperty("useDapr", out var useDaprElement))
             UseDapr = useDaprElement.GetBoolean();
+
+        if (config.TryGetProperty("validateSsl", out var validateSslElement))
+            ValidateSSL = validateSslElement.GetBoolean();
     }
 
     public static StartTask Create(JsonElement config)
@@ -175,6 +189,7 @@ public sealed class StartTask : WorkflowTask
         cloned.TriggerKey = TriggerKey;
         cloned.TriggerTags = TriggerTags;
         cloned.UseDapr = UseDapr;
+        cloned.ValidateSSL = ValidateSSL;
         return cloned;
     }
 
@@ -193,6 +208,7 @@ public sealed class StartTask : WorkflowTask
         SetTriggerKeyInternal(source.TriggerKey);
         SetTriggerTagsInternal(source.TriggerTags);
         SetUseDaprInternal(source.UseDapr);
+        SetValidateSSLInternal(source.ValidateSSL);
     }
 
     /// <summary>
@@ -209,6 +225,7 @@ public sealed class StartTask : WorkflowTask
         TriggerKey = null;
         TriggerTags = null;
         UseDapr = false;
+        ValidateSSL = true;
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/SubProcessTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/SubProcessTask.cs
@@ -53,6 +53,11 @@ public sealed class SubProcessTask : WorkflowTask
     /// </summary>
     public bool UseDapr { get; private set; } = false;
 
+    /// <summary>
+    /// Whether to validate SSL certificates
+    /// </summary>
+    public bool ValidateSSL { get; private set; } = true;
+
     public void SetBody(dynamic body)
     {
         Body = JsonSerializer.SerializeToElement(body);
@@ -90,6 +95,11 @@ public sealed class SubProcessTask : WorkflowTask
         UseDapr = useDapr;
     }
 
+    public void SetValidateSSL(bool validateSSL)
+    {
+        ValidateSSL = validateSSL;
+    }
+
     /// <summary>
     /// Internal property setters for object pooling
     /// </summary>
@@ -101,6 +111,7 @@ public sealed class SubProcessTask : WorkflowTask
     internal void SetBodyInternal(JsonElement? body) => Body = body;
     internal void SetTriggerTagsInternal(string[]? tags) => TriggerTags = tags;
     internal void SetUseDaprInternal(bool useDapr) => UseDapr = useDapr;
+    internal void SetValidateSSLInternal(bool validateSSL) => ValidateSSL = validateSSL;
 
     protected override void Configure(JsonElement config)
     {
@@ -131,6 +142,9 @@ public sealed class SubProcessTask : WorkflowTask
 
         if (config.TryGetProperty("useDapr", out var useDaprElement))
             UseDapr = useDaprElement.GetBoolean();
+
+        if (config.TryGetProperty("validateSsl", out var validateSslElement))
+            ValidateSSL = validateSslElement.GetBoolean();
     }
 
     public static SubProcessTask Create(JsonElement config)
@@ -161,6 +175,7 @@ public sealed class SubProcessTask : WorkflowTask
         cloned.Body = Body;
         cloned.TriggerTags = TriggerTags;
         cloned.UseDapr = UseDapr;
+        cloned.ValidateSSL = ValidateSSL;
         return cloned;
     }
 
@@ -178,6 +193,7 @@ public sealed class SubProcessTask : WorkflowTask
         SetBodyInternal(source.Body);
         SetTriggerTagsInternal(source.TriggerTags);
         SetUseDaprInternal(source.UseDapr);
+        SetValidateSSLInternal(source.ValidateSSL);
     }
 
     /// <summary>
@@ -193,6 +209,7 @@ public sealed class SubProcessTask : WorkflowTask
         Body = null;
         TriggerTags = null;
         UseDapr = false;
+        ValidateSSL = true;
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Domain/Definitions/WorkflowConstants.cs
+++ b/src/BBT.Workflow.Domain/Definitions/WorkflowConstants.cs
@@ -29,14 +29,6 @@ public class ViewConstants
 public class TaskConstants
 {
     public const int MaxKeyLength = WorkflowConstants.MaxKeyLength;
-    /// <summary>
-    /// Named HttpClient for SSL validation enabled requests (default behavior)
-    /// </summary>
-    public const string DefaultHttpClientName = "WorkflowHttpClient";
-    /// <summary>
-    /// Named HttpClient for SSL validation disabled requests
-    /// </summary>
-    public const string NoSslValidationHttpClientName = "WorkflowHttpClient.NoSslValidation";
 }
 
 public class StateConstants

--- a/src/BBT.Workflow.Execution.Abstractions/Bindings/DirectTriggerBinding.cs
+++ b/src/BBT.Workflow.Execution.Abstractions/Bindings/DirectTriggerBinding.cs
@@ -64,6 +64,11 @@ public sealed class DirectTriggerBinding
     public bool UseDapr { get; init; } = false;
 
     /// <summary>
+    /// Whether to validate SSL certificates.
+    /// </summary>
+    public bool ValidateSSL { get; init; } = true;
+
+    /// <summary>
     /// Resolved base URL for HTTP requests.
     /// </summary>
     public string? BaseUrl { get; init; }

--- a/src/BBT.Workflow.Execution.Abstractions/Bindings/GetInstanceDataBinding.cs
+++ b/src/BBT.Workflow.Execution.Abstractions/Bindings/GetInstanceDataBinding.cs
@@ -37,6 +37,11 @@ public sealed class GetInstanceDataBinding
     public bool UseDapr { get; init; } = false;
 
     /// <summary>
+    /// Whether to validate SSL certificates.
+    /// </summary>
+    public bool ValidateSSL { get; init; } = true;
+
+    /// <summary>
     /// Resolved base URL for HTTP requests.
     /// </summary>
     public string? BaseUrl { get; init; }

--- a/src/BBT.Workflow.Execution.Abstractions/Bindings/GetInstancesBinding.cs
+++ b/src/BBT.Workflow.Execution.Abstractions/Bindings/GetInstancesBinding.cs
@@ -42,6 +42,11 @@ public sealed class GetInstancesBinding
     public bool UseDapr { get; init; } = false;
 
     /// <summary>
+    /// Whether to validate SSL certificates.
+    /// </summary>
+    public bool ValidateSSL { get; init; } = true;
+
+    /// <summary>
     /// Resolved base URL for HTTP requests.
     /// </summary>
     public string? BaseUrl { get; init; }

--- a/src/BBT.Workflow.Execution.Abstractions/Bindings/StartTriggerBinding.cs
+++ b/src/BBT.Workflow.Execution.Abstractions/Bindings/StartTriggerBinding.cs
@@ -54,6 +54,11 @@ public sealed class StartTriggerBinding
     public bool UseDapr { get; init; } = false;
 
     /// <summary>
+    /// Whether to validate SSL certificates.
+    /// </summary>
+    public bool ValidateSSL { get; init; } = true;
+
+    /// <summary>
     /// Resolved base URL for HTTP requests.
     /// </summary>
     public string? BaseUrl { get; init; }

--- a/src/BBT.Workflow.Execution.Abstractions/Bindings/SubProcessBinding.cs
+++ b/src/BBT.Workflow.Execution.Abstractions/Bindings/SubProcessBinding.cs
@@ -70,6 +70,11 @@ public sealed class SubProcessBinding
     public bool UseDapr { get; init; } = false;
 
     /// <summary>
+    /// Whether to validate SSL certificates.
+    /// </summary>
+    public bool ValidateSSL { get; init; } = true;
+
+    /// <summary>
     /// Resolved base URL for HTTP requests.
     /// </summary>
     public string? BaseUrl { get; init; }

--- a/src/BBT.Workflow.Execution.Abstractions/WorkflowHttpClientNames.cs
+++ b/src/BBT.Workflow.Execution.Abstractions/WorkflowHttpClientNames.cs
@@ -1,0 +1,17 @@
+namespace BBT.Workflow.Execution;
+
+/// <summary>
+/// Centralized constants for workflow HTTP client names used across all invokers.
+/// </summary>
+public static class WorkflowHttpClientNames
+{
+    /// <summary>
+    /// Named HttpClient for SSL validation enabled requests (default behavior).
+    /// </summary>
+    public const string Default = "WorkflowHttpClient";
+
+    /// <summary>
+    /// Named HttpClient for SSL validation disabled requests.
+    /// </summary>
+    public const string NoSslValidation = "WorkflowHttpClient.NoSslValidation";
+}

--- a/src/BBT.Workflow.Execution/Invokers/DirectTriggerRemoteInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/DirectTriggerRemoteInvoker.cs
@@ -30,8 +30,6 @@ public sealed class DirectTriggerRemoteInvoker : ITaskInvoker<DirectTriggerBindi
     private readonly TriggerRetryOptions _retryOptions;
     private readonly ResiliencePipeline<HttpResponseMessage> _retryPipeline;
 
-    public const string HttpClientName = "TriggerInvoker";
-
     public DirectTriggerRemoteInvoker(
         DaprClient daprClient,
         IHttpClientFactory httpClientFactory,
@@ -190,7 +188,7 @@ public sealed class DirectTriggerRemoteInvoker : ITaskInvoker<DirectTriggerBindi
 
         try
         {
-            var httpClient = _httpClientFactory.CreateClient(HttpClientName);
+            var httpClient = CreateHttpClient(binding, taskKey);
 
             var response = await _retryPipeline.ExecuteAsync(
                 async token =>
@@ -216,6 +214,20 @@ public sealed class DirectTriggerRemoteInvoker : ITaskInvoker<DirectTriggerBindi
                 executionDurationMs: stopwatch.ElapsedMilliseconds,
                 taskType: TaskType,
                 metadata: CreateMetadata(binding, cancelled: true));
+        }
+        catch (HttpRequestException ex)
+        {
+            stopwatch.Stop();
+            _metrics.RecordTaskExecution(TaskType, "failure");
+            _logger.LogError(ex,
+                "DirectTrigger HTTP invocation failed for task {TaskKey}: {Domain}/{Workflow}/{InstanceId}/{TransitionKey}",
+                taskKey, binding.Domain, binding.Workflow, binding.Identifier, binding.TransitionName);
+
+            return TaskInvocationResult.Failure(
+                error: ex.Message,
+                executionDurationMs: stopwatch.ElapsedMilliseconds,
+                taskType: TaskType,
+                metadata: CreateMetadata(binding, exceptionType: ex.GetType().Name));
         }
         catch (Exception ex)
         {
@@ -385,5 +397,21 @@ public sealed class DirectTriggerRemoteInvoker : ITaskInvoker<DirectTriggerBindi
             metadata["ExceptionType"] = exceptionType;
 
         return metadata;
+    }
+
+    private HttpClient CreateHttpClient(DirectTriggerBinding binding, string? taskKey)
+    {
+        var clientName = binding.ValidateSSL
+            ? WorkflowHttpClientNames.Default
+            : WorkflowHttpClientNames.NoSslValidation;
+
+        if (!binding.ValidateSSL)
+        {
+            _logger.LogWarning(
+                "SSL certificate validation is disabled for {TaskType} task {TaskKey}",
+                TaskType, taskKey);
+        }
+
+        return _httpClientFactory.CreateClient(clientName);
     }
 }

--- a/src/BBT.Workflow.Execution/Invokers/GetInstanceDataRemoteInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/GetInstanceDataRemoteInvoker.cs
@@ -21,8 +21,6 @@ public sealed class GetInstanceDataRemoteInvoker : ITaskInvoker<GetInstanceDataB
     private readonly ITaskMetrics _metrics;
     private readonly string _orchestrationAppId;
 
-    public const string HttpClientName = "TriggerInvoker";
-
     public GetInstanceDataRemoteInvoker(
         DaprClient daprClient,
         IHttpClientFactory httpClientFactory,
@@ -131,7 +129,7 @@ public sealed class GetInstanceDataRemoteInvoker : ITaskInvoker<GetInstanceDataB
 
         try
         {
-            var httpClient = _httpClientFactory.CreateClient(HttpClientName);
+            var httpClient = CreateHttpClient(binding, taskKey);
             var request = CreateHttpRequest(binding);
 
             using var response = await httpClient.SendAsync(request, cancellationToken);
@@ -151,6 +149,19 @@ public sealed class GetInstanceDataRemoteInvoker : ITaskInvoker<GetInstanceDataB
                 executionDurationMs: stopwatch.ElapsedMilliseconds,
                 taskType: TaskType,
                 metadata: CreateMetadata(binding, cancelled: true));
+        }
+        catch (HttpRequestException ex)
+        {
+            stopwatch.Stop();
+            _metrics.RecordTaskExecution(TaskType, "failure");
+            _logger.LogError(ex, "GetInstanceData HTTP invocation failed for task {TaskKey}: {Domain}/{Workflow}/{Instance}",
+                taskKey, binding.Domain, binding.Workflow, binding.Instance);
+
+            return TaskInvocationResult.Failure(
+                error: ex.Message,
+                executionDurationMs: stopwatch.ElapsedMilliseconds,
+                taskType: TaskType,
+                metadata: CreateMetadata(binding, exceptionType: ex.GetType().Name));
         }
         catch (Exception ex)
         {
@@ -274,5 +285,21 @@ public sealed class GetInstanceDataRemoteInvoker : ITaskInvoker<GetInstanceDataB
             metadata["ExceptionType"] = exceptionType;
 
         return metadata;
+    }
+
+    private HttpClient CreateHttpClient(GetInstanceDataBinding binding, string? taskKey)
+    {
+        var clientName = binding.ValidateSSL
+            ? WorkflowHttpClientNames.Default
+            : WorkflowHttpClientNames.NoSslValidation;
+
+        if (!binding.ValidateSSL)
+        {
+            _logger.LogWarning(
+                "SSL certificate validation is disabled for {TaskType} task {TaskKey}",
+                TaskType, taskKey);
+        }
+
+        return _httpClientFactory.CreateClient(clientName);
     }
 }

--- a/src/BBT.Workflow.Execution/Invokers/GetInstancesRemoteInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/GetInstancesRemoteInvoker.cs
@@ -21,8 +21,6 @@ public sealed class GetInstancesRemoteInvoker : ITaskInvoker<GetInstancesBinding
     private readonly ITaskMetrics _metrics;
     private readonly string _orchestrationAppId;
 
-    public const string HttpClientName = "TriggerInvoker";
-
     public GetInstancesRemoteInvoker(
         DaprClient daprClient,
         IHttpClientFactory httpClientFactory,
@@ -131,7 +129,7 @@ public sealed class GetInstancesRemoteInvoker : ITaskInvoker<GetInstancesBinding
 
         try
         {
-            var httpClient = _httpClientFactory.CreateClient(HttpClientName);
+            var httpClient = CreateHttpClient(binding, taskKey);
             var request = CreateHttpRequest(binding);
 
             using var response = await httpClient.SendAsync(request, cancellationToken);
@@ -151,6 +149,19 @@ public sealed class GetInstancesRemoteInvoker : ITaskInvoker<GetInstancesBinding
                 executionDurationMs: stopwatch.ElapsedMilliseconds,
                 taskType: TaskType,
                 metadata: CreateMetadata(binding, cancelled: true));
+        }
+        catch (HttpRequestException ex)
+        {
+            stopwatch.Stop();
+            _metrics.RecordTaskExecution(TaskType, "failure");
+            _logger.LogError(ex, "GetInstances HTTP invocation failed for task {TaskKey}: {Domain}/{Workflow}",
+                taskKey, binding.Domain, binding.Workflow);
+
+            return TaskInvocationResult.Failure(
+                error: ex.Message,
+                executionDurationMs: stopwatch.ElapsedMilliseconds,
+                taskType: TaskType,
+                metadata: CreateMetadata(binding, exceptionType: ex.GetType().Name));
         }
         catch (Exception ex)
         {
@@ -282,5 +293,21 @@ public sealed class GetInstancesRemoteInvoker : ITaskInvoker<GetInstancesBinding
             metadata["ExceptionType"] = exceptionType;
 
         return metadata;
+    }
+
+    private HttpClient CreateHttpClient(GetInstancesBinding binding, string? taskKey)
+    {
+        var clientName = binding.ValidateSSL
+            ? WorkflowHttpClientNames.Default
+            : WorkflowHttpClientNames.NoSslValidation;
+
+        if (!binding.ValidateSSL)
+        {
+            _logger.LogWarning(
+                "SSL certificate validation is disabled for {TaskType} task {TaskKey}",
+                TaskType, taskKey);
+        }
+
+        return _httpClientFactory.CreateClient(clientName);
     }
 }

--- a/src/BBT.Workflow.Execution/Invokers/HttpTaskInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/HttpTaskInvoker.cs
@@ -19,16 +19,6 @@ public sealed class HttpTaskInvoker(
 {
     private readonly ITaskMetrics _metrics = metrics ?? NullTaskMetrics.Instance;
 
-    /// <summary>
-    /// Named HttpClient for SSL validation enabled requests (default behavior).
-    /// </summary>
-    public const string DefaultHttpClientName = "WorkflowHttpClient";
-
-    /// <summary>
-    /// Named HttpClient for SSL validation disabled requests.
-    /// </summary>
-    public const string NoSslValidationHttpClientName = "WorkflowHttpClient.NoSslValidation";
-
     /// <inheritdoc />
     public string TaskType => TaskTypes.Http;
 
@@ -187,8 +177,8 @@ public sealed class HttpTaskInvoker(
     private HttpClient CreateHttpClient(HttpTaskBinding binding, string? taskKey)
     {
         var clientName = binding.ValidateSSL
-            ? DefaultHttpClientName
-            : NoSslValidationHttpClientName;
+            ? WorkflowHttpClientNames.Default
+            : WorkflowHttpClientNames.NoSslValidation;
 
         if (!binding.ValidateSSL)
         {

--- a/src/BBT.Workflow.Execution/Invokers/StartTriggerRemoteInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/StartTriggerRemoteInvoker.cs
@@ -22,8 +22,6 @@ public sealed class StartTriggerRemoteInvoker : ITaskInvoker<StartTriggerBinding
     private readonly ITaskMetrics _metrics;
     private readonly string _orchestrationAppId;
 
-    public const string HttpClientName = "TriggerInvoker";
-
     public StartTriggerRemoteInvoker(
         DaprClient daprClient,
         IHttpClientFactory httpClientFactory,
@@ -132,7 +130,7 @@ public sealed class StartTriggerRemoteInvoker : ITaskInvoker<StartTriggerBinding
 
         try
         {
-            var httpClient = _httpClientFactory.CreateClient(HttpClientName);
+            var httpClient = CreateHttpClient(binding, taskKey);
             var request = CreateHttpRequest(binding);
 
             using var response = await httpClient.SendAsync(request, cancellationToken);
@@ -152,6 +150,19 @@ public sealed class StartTriggerRemoteInvoker : ITaskInvoker<StartTriggerBinding
                 executionDurationMs: stopwatch.ElapsedMilliseconds,
                 taskType: TaskType,
                 metadata: CreateMetadata(binding, cancelled: true));
+        }
+        catch (HttpRequestException ex)
+        {
+            stopwatch.Stop();
+            _metrics.RecordTaskExecution(TaskType, "failure");
+            _logger.LogError(ex, "StartTrigger HTTP invocation failed for task {TaskKey}: {Domain}/{Workflow}",
+                taskKey, binding.Domain, binding.Workflow);
+
+            return TaskInvocationResult.Failure(
+                error: ex.Message,
+                executionDurationMs: stopwatch.ElapsedMilliseconds,
+                taskType: TaskType,
+                metadata: CreateMetadata(binding, exceptionType: ex.GetType().Name));
         }
         catch (Exception ex)
         {
@@ -309,5 +320,21 @@ public sealed class StartTriggerRemoteInvoker : ITaskInvoker<StartTriggerBinding
             metadata["ExceptionType"] = exceptionType;
 
         return metadata;
+    }
+
+    private HttpClient CreateHttpClient(StartTriggerBinding binding, string? taskKey)
+    {
+        var clientName = binding.ValidateSSL
+            ? WorkflowHttpClientNames.Default
+            : WorkflowHttpClientNames.NoSslValidation;
+
+        if (!binding.ValidateSSL)
+        {
+            _logger.LogWarning(
+                "SSL certificate validation is disabled for {TaskType} task {TaskKey}",
+                TaskType, taskKey);
+        }
+
+        return _httpClientFactory.CreateClient(clientName);
     }
 }

--- a/src/BBT.Workflow.Execution/Invokers/SubProcessRemoteInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/SubProcessRemoteInvoker.cs
@@ -24,8 +24,6 @@ public sealed class SubProcessRemoteInvoker : ITaskInvoker<SubProcessBinding>
     private readonly ITaskMetrics _metrics;
     private readonly string _orchestrationAppId;
 
-    public const string HttpClientName = "TriggerInvoker";
-
     public SubProcessRemoteInvoker(
         DaprClient daprClient,
         IHttpClientFactory httpClientFactory,
@@ -134,7 +132,7 @@ public sealed class SubProcessRemoteInvoker : ITaskInvoker<SubProcessBinding>
 
         try
         {
-            var httpClient = _httpClientFactory.CreateClient(HttpClientName);
+            var httpClient = CreateHttpClient(binding, taskKey);
             var request = CreateHttpRequest(binding);
 
             using var response = await httpClient.SendAsync(request, cancellationToken);
@@ -154,6 +152,19 @@ public sealed class SubProcessRemoteInvoker : ITaskInvoker<SubProcessBinding>
                 executionDurationMs: stopwatch.ElapsedMilliseconds,
                 taskType: TaskType,
                 metadata: CreateMetadata(binding, cancelled: true));
+        }
+        catch (HttpRequestException ex)
+        {
+            stopwatch.Stop();
+            _metrics.RecordTaskExecution(TaskType, "failure");
+            _logger.LogError(ex, "SubProcess HTTP invocation failed for task {TaskKey}: {Domain}/{Workflow}",
+                taskKey, binding.Domain, binding.Workflow);
+
+            return TaskInvocationResult.Failure(
+                error: ex.Message,
+                executionDurationMs: stopwatch.ElapsedMilliseconds,
+                taskType: TaskType,
+                metadata: CreateMetadata(binding, exceptionType: ex.GetType().Name));
         }
         catch (Exception ex)
         {
@@ -315,5 +326,21 @@ public sealed class SubProcessRemoteInvoker : ITaskInvoker<SubProcessBinding>
             metadata["ExceptionType"] = exceptionType;
 
         return metadata;
+    }
+
+    private HttpClient CreateHttpClient(SubProcessBinding binding, string? taskKey)
+    {
+        var clientName = binding.ValidateSSL
+            ? WorkflowHttpClientNames.Default
+            : WorkflowHttpClientNames.NoSslValidation;
+
+        if (!binding.ValidateSSL)
+        {
+            _logger.LogWarning(
+                "SSL certificate validation is disabled for {TaskType} task {TaskKey}",
+                TaskType, taskKey);
+        }
+
+        return _httpClientFactory.CreateClient(clientName);
     }
 }

--- a/src/BBT.Workflow.Execution/Microsoft/Extensions/DependencyInjection/ExecutionServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Execution/Microsoft/Extensions/DependencyInjection/ExecutionServiceCollectionExtensions.cs
@@ -1,12 +1,10 @@
+using BBT.Workflow.Execution;
 using BBT.Workflow.Execution.Configuration;
 using BBT.Workflow.Execution.Invokers;
 using BBT.Workflow.Execution.Metrics;
 using BBT.Workflow.Execution.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Polly;
-using Polly.Extensions.Http;
-using Polly.Timeout;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -15,11 +13,6 @@ namespace Microsoft.Extensions.DependencyInjection;
 /// </summary>
 public static class ExecutionServiceCollectionExtensions
 {
-    /// <summary>
-    /// Named HttpClient for trigger invoker HTTP requests.
-    /// </summary>
-    public const string TriggerInvokerHttpClientName = "TriggerInvoker";
-
     /// <summary>
     /// Adds the task invoker registry and all built-in invokers to the service collection.
     /// </summary>
@@ -42,24 +35,8 @@ public static class ExecutionServiceCollectionExtensions
             services.Configure<TriggerRetryOptions>(_ => { });
         }
 
-        // Get options for configuring HttpClient policies
-        var triggerOptions = configuration?
-            .GetSection(TriggerRetryOptions.SectionName)
-            .Get<TriggerRetryOptions>() ?? new TriggerRetryOptions();
-
-        // Register named HttpClient for trigger invokers with Polly policies
-        services.AddHttpClient(TriggerInvokerHttpClientName, client =>
-            {
-                client.Timeout = TimeSpan.FromSeconds(triggerOptions.TimeoutSeconds);
-                client.DefaultRequestHeaders.Add("Accept", "application/json");
-            })
-            .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
-            {
-                AutomaticDecompression = System.Net.DecompressionMethods.GZip | System.Net.DecompressionMethods.Deflate
-            })
-            .AddPolicyHandler(GetTimeoutPolicy(triggerOptions))
-            .AddPolicyHandler(GetRetryPolicy(triggerOptions))
-            .AddPolicyHandler(GetCircuitBreakerPolicy(triggerOptions));
+        // Register WorkflowHttpClient instances
+        services.AddWorkflowHttpClient();
 
         // Register the registry
         services.AddSingleton<ITaskInvokerRegistry, TaskInvokerRegistry>();
@@ -84,42 +61,6 @@ public static class ExecutionServiceCollectionExtensions
         
         return services;
     }
-
-    /// <summary>
-    /// Creates a retry policy with exponential backoff for trigger invokers
-    /// </summary>
-    private static IAsyncPolicy<HttpResponseMessage> GetRetryPolicy(TriggerRetryOptions options)
-    {
-        return HttpPolicyExtensions
-            .HandleTransientHttpError()
-            .Or<TimeoutRejectedException>()
-            .WaitAndRetryAsync(
-                retryCount: options.MaxRetryAttempts,
-                sleepDurationProvider: retryAttempt => TimeSpan.FromMilliseconds(
-                    options.RetryDelayMilliseconds * Math.Pow(2, retryAttempt - 1)));
-    }
-
-    /// <summary>
-    /// Creates a circuit breaker policy for trigger invokers
-    /// </summary>
-    private static IAsyncPolicy<HttpResponseMessage> GetCircuitBreakerPolicy(TriggerRetryOptions options)
-    {
-        return HttpPolicyExtensions
-            .HandleTransientHttpError()
-            .CircuitBreakerAsync(
-                handledEventsAllowedBeforeBreaking: options.CircuitBreakerFailureThreshold,
-                durationOfBreak: TimeSpan.FromSeconds(options.CircuitBreakerTimeoutSeconds));
-    }
-
-    /// <summary>
-    /// Creates a timeout policy for trigger invokers
-    /// </summary>
-    private static IAsyncPolicy<HttpResponseMessage> GetTimeoutPolicy(TriggerRetryOptions options)
-    {
-        return Policy.TimeoutAsync<HttpResponseMessage>(
-            TimeSpan.FromSeconds(options.TimeoutSeconds),
-            TimeoutStrategy.Pessimistic);
-    }
     
     /// <summary>
     /// Adds custom task metrics implementation.
@@ -131,6 +72,39 @@ public static class ExecutionServiceCollectionExtensions
         where TMetrics : class, ITaskMetrics
     {
         services.AddSingleton<ITaskMetrics, TMetrics>();
+        return services;
+    }
+
+    /// <summary>
+    /// Registers named HttpClient instances for workflow task execution.
+    /// - WorkflowHttpClient: Default with SSL validation
+    /// - WorkflowHttpClient.NoSslValidation: Without SSL validation
+    /// </summary>
+    private static IServiceCollection AddWorkflowHttpClient(this IServiceCollection services)
+    {
+        // Default HTTP client with SSL validation enabled
+        services.AddHttpClient(WorkflowHttpClientNames.Default, client =>
+            {
+                client.Timeout = TimeSpan.FromSeconds(30);
+            })
+            .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
+            {
+                MaxConnectionsPerServer = 10,
+                UseCookies = false
+            });
+
+        // HTTP client with SSL validation disabled
+        services.AddHttpClient(WorkflowHttpClientNames.NoSslValidation, client =>
+            {
+                client.Timeout = TimeSpan.FromSeconds(30);
+            })
+            .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
+            {
+                MaxConnectionsPerServer = 10,
+                UseCookies = false,
+                ServerCertificateCustomValidationCallback = (_, _, _, _) => true
+            });
+
         return services;
     }
 }

--- a/src/BBT.Workflow.HttpApi.Shared/Microsoft/Extensions/DependencyInjection/WorkflowApiBaseServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.HttpApi.Shared/Microsoft/Extensions/DependencyInjection/WorkflowApiBaseServiceCollectionExtensions.cs
@@ -51,41 +51,6 @@ public static class WorkflowApiBaseServiceCollectionExtensions
         return services;
     }
 
-    /// <summary>
-    /// Adds HTTP client with default configuration for task execution
-    /// </summary>
-    /// <param name="services">The service collection</param>
-    /// <returns>The service collection for chaining</returns>
-    public static IServiceCollection AddWorkflowHttpClient(this IServiceCollection services)
-    {
-        // Default HTTP client with SSL validation enabled
-        services.AddHttpClient(TaskConstants.DefaultHttpClientName, client =>
-            {
-                // Default timeout - will be overridden per request
-                client.Timeout = TimeSpan.FromSeconds(30);
-            })
-            .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
-            {
-                MaxConnectionsPerServer = 10,
-                UseCookies = false
-            });
-
-        // HTTP client with SSL validation disabled
-        services.AddHttpClient(TaskConstants.NoSslValidationHttpClientName, client =>
-            {
-                // Default timeout - will be overridden per request
-                client.Timeout = TimeSpan.FromSeconds(30);
-            })
-            .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
-            {
-                MaxConnectionsPerServer = 10,
-                UseCookies = false,
-                ServerCertificateCustomValidationCallback = (_, _, _, _) => true
-            });
-
-        return services;
-    }
-    
     public static IServiceCollection AddAspNetCoreModules(this IServiceCollection services, IConfiguration configuration)
     {
         services.AddAetherAmbientServiceProvider();

--- a/workers/BBT.Workflow.Workers.Inbox/Microsoft/Extensions/DependencyInjection/InboxWorkerServiceCollectionExtensions.cs
+++ b/workers/BBT.Workflow.Workers.Inbox/Microsoft/Extensions/DependencyInjection/InboxWorkerServiceCollectionExtensions.cs
@@ -42,7 +42,6 @@ public static class InboxWorkerServiceCollectionExtensions
             .AddExceptionHandling()
             .AddRuntimeMiddleware()
             .AddHeaderService()
-            .AddWorkflowHttpClient() // TODO: Düşün!!!!
             .AddHostedServices()
             .AddAppHealthChecks();
         

--- a/workers/BBT.Workflow.Workers.Outbox/Microsoft/Extensions/DependencyInjection/OutboxWorkerServiceCollectionExtensions.cs
+++ b/workers/BBT.Workflow.Workers.Outbox/Microsoft/Extensions/DependencyInjection/OutboxWorkerServiceCollectionExtensions.cs
@@ -41,7 +41,6 @@ public static class OutboxWorkerServiceCollectionExtensions
             .AddExceptionHandling()
             .AddRuntimeMiddleware()
             .AddHeaderService()
-            .AddWorkflowHttpClient() // TODO: Düşün!!!!
             .AddHostedServices()
             .AddAppHealthChecks();
         return services;


### PR DESCRIPTION
Centralizes workflow HTTP client names and registration in WorkflowHttpClientNames and ExecutionServiceCollectionExtensions. Adds ValidateSSL property to workflow task definitions and bindings, allowing per-task SSL certificate validation control. Updates all remote invokers to select the appropriate HttpClient based on ValidateSSL, and removes legacy AddWorkflowHttpClient extension and related constants from other modules.

## Summary by Sourcery

Centralize workflow HTTP client naming and registration and add per-task SSL validation control for all HTTP-based workflow invokers.

Enhancements:
- Introduce a shared WorkflowHttpClientNames class and central AddWorkflowHttpClient registration to standardize HTTP client usage across workflow execution components.
- Extend workflow task definitions and bindings with a ValidateSSL flag and use it in all remote invokers to select between SSL-validating and non-validating HttpClient instances, with logging when SSL validation is disabled.
- Remove legacy HTTP client constants, registration extensions, and Polly-based trigger HttpClient configuration now superseded by the centralized workflow HTTP client setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable SSL certificate validation option for workflow HTTP tasks and triggers, allowing users to control SSL certificate validation behavior on a per-task basis.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->