### PR TITLE
reset timer transition on self state

### DIFF
--- a/docs/timer-reset-on-self-transition.md
+++ b/docs/timer-reset-on-self-transition.md
@@ -1,0 +1,160 @@
+# Timer Reset on Self-Transition
+
+## Overview
+
+Bu geliştirme, workflow'larda self-transition (kendi kendine geçiş) yapıldığında scheduled timer'ların otomatik olarak resetlenmesini sağlar.
+
+## Problem
+
+Bir state'e girildiğinde scheduled transition'lar için timer job'ları oluşturulur. Aynı state'e tekrar geçiş yapıldığında (self-transition), eski timer job'ları cancel edilmiyordu. Bu durum:
+
+- Timer'ın resetlenmemesine
+- Duplicate job execution'larına
+- Beklenmeyen transition tetiklenmelerine
+
+neden oluyordu.
+
+## Çözüm
+
+`ScheduleTransitionsStep` pipeline step'ine timer cancellation logic'i eklendi:
+
+1. State'e her girildiğinde, önce o instance'a ait **tüm aktif job'lar** cancel edilir
+2. Ardından yeni timer job'ları schedule edilir
+3. Bu sayede timer her zaman sıfırdan başlar
+
+## Teknik Detaylar
+
+### Değişen Dosyalar
+
+| Dosya | Değişiklik |
+|-------|------------|
+| `ScheduleTransitionsStep.cs` | `CancelExistingScheduledJobsAsync` metodu eklendi |
+| `WorkflowLogs.cs` | `ExistingTimerJobsCanceled` log message eklendi |
+| `WorkflowEventIds.cs` | Event ID 10015 eklendi |
+| `TransitionExecutionContextExtensions.cs` | `IsSelfTransition()` extension metodu eklendi |
+
+### Akış
+
+```
+State'e Giriş
+    │
+    ▼
+┌─────────────────────────────────┐
+│ HasScheduledTransitions?        │
+└─────────────────────────────────┘
+    │ Evet
+    ▼
+┌─────────────────────────────────┐
+│ CancelExistingScheduledJobsAsync│
+│ - Instance'ın TÜM aktif job'ları│
+│ - Dapr'dan sil                  │
+│ - DB'de IsActive = false        │
+└─────────────────────────────────┘
+    │
+    ▼
+┌─────────────────────────────────┐
+│ ScheduleNewJobsAsync            │
+│ - Yeni timer job'ları oluştur   │
+└─────────────────────────────────┘
+```
+
+### Kod Örneği
+
+```csharp
+private async Task<Result> CancelExistingScheduledJobsAsync(
+    TransitionExecutionContext context,
+    CancellationToken cancellationToken)
+{
+    var activeJobs = await jobRepository.GetListActiveAsync(context.InstanceId, cancellationToken);
+    
+    if (!activeJobs.Any())
+    {
+        return Result.Ok();
+    }
+
+    foreach (var job in activeJobs)
+    {
+        try
+        {
+            // Dapr'dan sil
+            await jobScheduler.DeleteAsync(
+                TransitionTimerJobHandler.HandlerName, 
+                job.JobName, 
+                cancellationToken);
+            
+            // DB'de işaretle
+            job.MarkAsProcessed();
+            await jobRepository.UpdateAsync(job, true, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to cancel timer job: JobName={JobName}", job.JobName);
+        }
+    }
+
+    logger.ExistingTimerJobsCanceled(activeJobs.Count, context.InstanceId);
+    return Result.Ok();
+}
+```
+
+## Güvenlik
+
+| Kapsam | Davranış |
+|--------|----------|
+| Başka Instance | ❌ Etkilenmez - `GetListActiveAsync(instanceId)` filtresi |
+| Başka Flow | ❌ Etkilenmez - Her flow ayrı schema'da |
+| Aynı Instance | ✅ Tüm aktif job'lar cancel edilir |
+
+## Workflow Tanımı Örneği
+
+```json
+{
+  "key": "control-state",
+  "type": "intermediate",
+  "transitions": [
+    {
+      "key": "retry",
+      "target": "$self",
+      "type": "manual"
+    },
+    {
+      "key": "timeout",
+      "target": "$self",
+      "type": "scheduled",
+      "timer": {
+        "duration": "PT5M"
+      }
+    }
+  ]
+}
+```
+
+Bu örnekte:
+- `retry` manual olarak tetiklendiğinde
+- `timeout` timer'ı resetlenir ve 5 dakika yeniden başlar
+
+## Logging
+
+Timer cancellation işlemleri loglanır:
+
+```
+Canceled 1 existing timer job(s) for instance xxx before scheduling new timers
+Scheduled timer job: JobId=xxx, JobName=trans-xxx-to-control-state, InstanceId=xxx
+```
+
+## Test Senaryoları
+
+1. **Self-Transition ile Timer Reset**
+   - State'e gir → Timer başlar
+   - Self-transition yap → Timer resetlenir
+   - Beklenen: Timer sıfırdan sayar
+
+2. **Normal State Değişikliği**
+   - State A'da timer var
+   - State B'ye geç
+   - Beklenen: State A'nın timer'ı cancel olur
+
+3. **Birden Fazla Scheduled Transition**
+   - State'de 2 farklı timer var
+   - Self-transition yap
+   - Beklenen: Her iki timer da resetlenir

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ScheduleTransitionsStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ScheduleTransitionsStep.cs
@@ -20,9 +20,11 @@ namespace BBT.Workflow.Execution.Pipeline.Steps;
 /// Pipeline step that schedules future transitions based on timers.
 /// Enqueues scheduled transitions for later execution.
 /// Uses Result pattern for exception-free error handling.
+/// Cancels existing timer jobs before scheduling new ones to handle self-transitions correctly.
 /// </summary>
 public sealed class ScheduleTransitionsStep(
     IBackgroundJobService backgroundJobService,
+    IJobScheduler jobScheduler,
     ITaskTimerService taskTimerService,
     IScriptContextFactory scriptContextFactory,
     IInstanceJobRepository jobRepository,
@@ -46,6 +48,14 @@ public sealed class ScheduleTransitionsStep(
             return Result<StepOutcome>.Ok(StepOutcome.Continue());
         }
 
+        // Cancel existing timer jobs for scheduled transitions that will be re-scheduled
+        // This handles self-transitions and re-entry scenarios where timers need to reset
+        var cancelResult = await CancelExistingScheduledJobsAsync(context, cancellationToken);
+        if (!cancelResult.IsSuccess)
+        {
+            return Result<StepOutcome>.Fail(cancelResult.Error);
+        }
+
         // Process each scheduled transition
         foreach (var scheduledTransition in context.Target!.ScheduledTransitions)
         {
@@ -64,6 +74,52 @@ public sealed class ScheduleTransitionsStep(
     /// </summary>
     private static bool HasScheduledTransitions(TransitionExecutionContext context)
         => context.Target?.ScheduledTransitions != null && context.Target.ScheduledTransitions.Any();
+
+    /// <summary>
+    /// Cancels existing timer jobs for scheduled transitions that will be re-scheduled.
+    /// This handles self-transitions and re-entry scenarios where timers need to reset.
+    /// </summary>
+    private async Task<Result> CancelExistingScheduledJobsAsync(
+        TransitionExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        var activeJobs = await jobRepository.GetListActiveAsync(context.InstanceId, cancellationToken);
+        
+        if (!activeJobs.Any())
+        {
+            return Result.Ok();
+        }
+
+        foreach (var job in activeJobs)
+        {
+            try
+            {
+                await jobScheduler.DeleteAsync(
+                    TransitionTimerJobHandler.HandlerName, 
+                    job.JobName, 
+                    cancellationToken);
+                
+                job.MarkAsProcessed();
+                await jobRepository.UpdateAsync(job, true, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, 
+                    "Failed to cancel timer job: JobName={JobName}",
+                    job.JobName);
+            }
+        }
+
+        logger.ExistingTimerJobsCanceled(activeJobs.Count, context.InstanceId);
+
+        return Result.Ok();
+    }
+
+    /// <summary>
+    /// Builds the job name for a scheduled transition.
+    /// </summary>
+    private static string BuildJobName(Guid instanceId, string scheduledTransitionKey)
+        => $"trans-{instanceId}-{scheduledTransitionKey}";
 
     /// <summary>
     /// Schedules a single transition for future execution using Railway chain.
@@ -129,7 +185,7 @@ public sealed class ScheduleTransitionsStep(
         Transition scheduledTransition,
         TimerSchedule timerSchedule)
     {
-        var jobName = $"trans-{context.InstanceId}-{context.TransitionKey}";
+        var jobName = $"trans-{context.InstanceId}-{context.Transition?.Key}";
         var activity = Activity.Current;
         
         var payload = new TransitionTimerPayload
@@ -184,6 +240,12 @@ public sealed class ScheduleTransitionsStep(
                 info.Context.InstanceId),
             true,
             cancellationToken);
+
+        logger.LogInformation(
+            "Scheduled timer job: JobId={JobId}, JobName={JobName}, InstanceId={InstanceId}",
+            jobId,
+            info.JobName,
+            info.Context.InstanceId);
 
         return Result.Ok();
     }

--- a/src/BBT.Workflow.Domain/Execution/Transitions/Context/TransitionExecutionContextExtensions.cs
+++ b/src/BBT.Workflow.Domain/Execution/Transitions/Context/TransitionExecutionContextExtensions.cs
@@ -37,5 +37,30 @@ public static class TransitionExecutionContextExtensions
     {
         return ctx.Workflow.Exit?.Key.Equals(ctx.Transition?.Key, StringComparison.OrdinalIgnoreCase) == true;
     }
+    // <summary>
+    /// Determines whether the current transition is a self-transition.
+    /// A self-transition occurs when the source and target states are the same,
+    /// causing the workflow to re-enter the current state.
+    /// This can be expressed either by using the "$self" keyword or by explicitly
+    /// specifying the current state key as the target.
+    /// </summary>
+    /// <param name="ctx">The transition execution context</param>
+    /// <returns>True if this is a self-transition, false otherwise</returns>
+    public static bool IsSelfTransition(this TransitionExecutionContext ctx)
+    {
+        if (ctx.Transition?.Target == null)
+        {
+            return false;
+        }
+ 
+        // Check for explicit $self keyword
+        if (ctx.Transition.Target.Equals(Definitions.WellKnownStateKeys.Self, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+ 
+        // Check if target equals current state key
+        return ctx.Transition.Target.Equals(ctx.Current?.Key, StringComparison.OrdinalIgnoreCase);
+    }
 }
 

--- a/src/BBT.Workflow.Domain/Logging/WorkflowEventIds.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowEventIds.cs
@@ -31,6 +31,7 @@ public static class WorkflowEventIds
     public static readonly EventId UpdateDataSkipToFinish = new(10012, nameof(UpdateDataSkipToFinish));
     public static readonly EventId ExitTransitionDetected = new(10013, nameof(ExitTransitionDetected));
     public static readonly EventId ExitSkipToFinish = new(10014, nameof(ExitSkipToFinish));
+    public static readonly EventId ExistingTimerJobsCanceled = new(10015, nameof(ExistingTimerJobsCanceled));
 
     // Warning (10040-10069)
     public static readonly EventId TransitionRuleFailed = new(10040, nameof(TransitionRuleFailed));

--- a/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
@@ -147,7 +147,18 @@ public static partial class WorkflowLogs
     public static partial void ExitSkipToFinish(
         this ILogger logger,
         Guid instanceId);
-
+    /// <summary>
+    /// Logs when existing timer jobs are canceled before scheduling new ones.
+    /// This typically occurs during self-transitions or re-entry scenarios.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 10015,
+        Level = LogLevel.Information,
+        Message = "Canceled {Count} existing timer job(s) for instance {InstanceId} before scheduling new timers")]
+    public static partial void ExistingTimerJobsCanceled(
+        this ILogger logger,
+        int count,
+        Guid instanceId);
     /// <summary>
     /// Logs when a transition rule validation fails.
     /// </summary>

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/Steps/ScheduleTransitionsStepTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/Steps/ScheduleTransitionsStepTests.cs
@@ -1,0 +1,384 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.BackgroundJob;
+using BBT.Aether.Results;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Definitions.Timer;
+using BBT.Workflow.Execution;
+using BBT.Workflow.Execution.Pipeline;
+using BBT.Workflow.Execution.Pipeline.Steps;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Runtime;
+using BBT.Workflow.Scripting;
+using BBT.Workflow.Shared;
+using BBT.Workflow.Tasks;
+using BBT.Workflow.Tasks.Coordinator;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Application.Tests.Execution.Transitions.Pipeline.Steps;
+
+/// <summary>
+/// Unit tests for ScheduleTransitionsStep
+/// Tests timer job scheduling and cancellation for self-transitions
+/// </summary>
+public class ScheduleTransitionsStepTests
+{
+    private readonly IBackgroundJobService _mockBackgroundJobService;
+    private readonly IJobScheduler _mockJobScheduler;
+    private readonly ITaskTimerService _mockTaskTimerService;
+    private readonly IScriptContextFactory _mockScriptContextFactory;
+    private readonly IInstanceJobRepository _mockJobRepository;
+    private readonly IInstanceRepository _mockInstanceRepository;
+    private readonly ILogger<ScheduleTransitionsStep> _mockLogger;
+    private readonly IRuntimeInfoProvider _mockRuntimeInfoProvider;
+    private readonly ScheduleTransitionsStep _step;
+
+    public ScheduleTransitionsStepTests()
+    {
+        _mockBackgroundJobService = Substitute.For<IBackgroundJobService>();
+        _mockJobScheduler = Substitute.For<IJobScheduler>();
+        _mockTaskTimerService = Substitute.For<ITaskTimerService>();
+        _mockScriptContextFactory = Substitute.For<IScriptContextFactory>();
+        _mockJobRepository = Substitute.For<IInstanceJobRepository>();
+        _mockInstanceRepository = Substitute.For<IInstanceRepository>();
+        _mockLogger = Substitute.For<ILogger<ScheduleTransitionsStep>>();
+        _mockRuntimeInfoProvider = Substitute.For<IRuntimeInfoProvider>();
+
+        _step = new ScheduleTransitionsStep(
+            _mockBackgroundJobService,
+            _mockJobScheduler,
+            _mockTaskTimerService,
+            _mockScriptContextFactory,
+            _mockJobRepository,
+            _mockInstanceRepository,
+            _mockLogger,
+            _mockRuntimeInfoProvider);
+    }
+
+    [Fact]
+    public void Order_ShouldBeSchedule()
+    {
+        // Assert
+        _step.Order.ShouldBe(LifecycleOrder.Schedule);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenNoScheduledTransitions_ShouldSkip()
+    {
+        // Arrange
+        var context = CreateTransitionExecutionContext(hasScheduledTransitions: false);
+
+        // Act
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.StopPipeline.ShouldBeFalse();
+        await _mockJobRepository.DidNotReceive().GetListActiveAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenSelfTransition_ShouldCancelExistingTimerJobs()
+    {
+        // Arrange
+        var instanceId = Guid.NewGuid();
+        var scheduledTransitionKey = "timeout";
+        var existingJobId = Guid.NewGuid();
+        var existingJobName = $"trans-{instanceId}-{scheduledTransitionKey}";
+
+        var context = CreateTransitionExecutionContext(
+            instanceId: instanceId,
+            hasScheduledTransitions: true,
+            scheduledTransitionKey: scheduledTransitionKey);
+
+        var existingJob = InstanceJob.Create(
+            existingJobId,
+            existingJobName,
+            existingJobId,
+            context.Domain,
+            context.WorkflowKey,
+            instanceId);
+
+        _mockJobRepository.GetListActiveAsync(instanceId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new List<InstanceJob> { existingJob }));
+
+        SetupMocksForScheduling(context, scheduledTransitionKey);
+
+        // Act
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        
+        // Verify existing job was canceled via IJobScheduler
+        await _mockJobScheduler.Received(1).DeleteAsync(
+            Arg.Any<string>(), 
+            existingJobName, 
+            Arg.Any<CancellationToken>());
+        await _mockJobRepository.Received(1).UpdateAsync(
+            Arg.Is<InstanceJob>(j => j.JobName == existingJobName && !j.IsActive),
+            true,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenNoExistingJobs_ShouldNotAttemptCancellation()
+    {
+        // Arrange
+        var instanceId = Guid.NewGuid();
+        var context = CreateTransitionExecutionContext(
+            instanceId: instanceId,
+            hasScheduledTransitions: true,
+            scheduledTransitionKey: "timeout");
+
+        _mockJobRepository.GetListActiveAsync(instanceId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new List<InstanceJob>()));
+
+        SetupMocksForScheduling(context, "timeout");
+
+        // Act
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        await _mockJobScheduler.DidNotReceive().DeleteAsync(
+            Arg.Any<string>(), 
+            Arg.Any<string>(), 
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenExistingJobForDifferentTransition_ShouldNotCancelIt()
+    {
+        // Arrange
+        var instanceId = Guid.NewGuid();
+        var existingJobId = Guid.NewGuid();
+        var existingJobName = $"trans-{instanceId}-other-transition";
+
+        var context = CreateTransitionExecutionContext(
+            instanceId: instanceId,
+            hasScheduledTransitions: true,
+            scheduledTransitionKey: "timeout");
+
+        var existingJob = InstanceJob.Create(
+            existingJobId,
+            existingJobName,
+            existingJobId,
+            context.Domain,
+            context.WorkflowKey,
+            instanceId);
+
+        _mockJobRepository.GetListActiveAsync(instanceId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new List<InstanceJob> { existingJob }));
+
+        SetupMocksForScheduling(context, "timeout");
+
+        // Act
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        
+        // The existing job for "other-transition" should NOT be canceled
+        await _mockJobScheduler.DidNotReceive().DeleteAsync(
+            Arg.Any<string>(), 
+            existingJobName, 
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldScheduleNewTimerJob()
+    {
+        // Arrange
+        var instanceId = Guid.NewGuid();
+        var newJobId = Guid.NewGuid();
+        var scheduledTransitionKey = "timeout";
+
+        var context = CreateTransitionExecutionContext(
+            instanceId: instanceId,
+            hasScheduledTransitions: true,
+            scheduledTransitionKey: scheduledTransitionKey);
+
+        _mockJobRepository.GetListActiveAsync(instanceId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new List<InstanceJob>()));
+
+        SetupMocksForScheduling(context, scheduledTransitionKey);
+        
+        _mockBackgroundJobService.EnqueueAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<object>(),
+            Arg.Any<string>(),
+            Arg.Any<Dictionary<string, object>>(),
+            Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(newJobId));
+
+        // Act
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        
+        // Verify new job was scheduled
+        await _mockBackgroundJobService.Received(1).EnqueueAsync(
+            Arg.Any<string>(),
+            Arg.Is<string>(name => name == $"trans-{instanceId}-{scheduledTransitionKey}"),
+            Arg.Any<object>(),
+            Arg.Any<string>(),
+            Arg.Any<Dictionary<string, object>>(),
+            Arg.Any<CancellationToken>());
+        
+        // Verify job record was persisted
+        await _mockJobRepository.Received(1).InsertAsync(
+            Arg.Is<InstanceJob>(j => j.InstanceId == instanceId),
+            true,
+            Arg.Any<CancellationToken>());
+    }
+
+    #region Helper Methods
+
+    private void SetupMocksForScheduling(TransitionExecutionContext context, string scheduledTransitionKey)
+    {
+        var mockScriptContextLogger = Substitute.For<ILogger<ScriptContext>>();
+        var mockScriptContext = new ScriptContext(mockScriptContextLogger);
+        
+        var mockBuilder = Substitute.For<IScriptContextBuilder>();
+        mockBuilder.WithWorkflow(Arg.Any<Definitions.Workflow>()).Returns(mockBuilder);
+        mockBuilder.WithInstance(Arg.Any<Instance>()).Returns(mockBuilder);
+        mockBuilder.WithRuntime(Arg.Any<IRuntimeInfoProvider>()).Returns(mockBuilder);
+        mockBuilder.WithTransition(Arg.Any<Transition>()).Returns(mockBuilder);
+        mockBuilder.WithHeaders(Arg.Any<Dictionary<string, string?>>()).Returns(mockBuilder);
+        mockBuilder.WithRouteValues(Arg.Any<Dictionary<string, string?>>()).Returns(mockBuilder);
+        mockBuilder.BuildAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(mockScriptContext));
+
+        _mockScriptContextFactory.NewBuilder(Arg.Any<IInstanceRepository>()).Returns(mockBuilder);
+
+        var timerSchedule = TimerSchedule.FromDuration(TimeSpan.FromMinutes(5));
+        _mockTaskTimerService.ExecuteTimerAsync(
+            Arg.Any<ScriptCode>(),
+            Arg.Any<ScriptContext>(),
+            Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Result<TimerSchedule>.Ok(timerSchedule)));
+    }
+
+    private TransitionExecutionContext CreateTransitionExecutionContext(
+        Guid? instanceId = null,
+        bool hasScheduledTransitions = false,
+        string scheduledTransitionKey = "timeout")
+    {
+        instanceId ??= Guid.NewGuid();
+        var workflowKey = "test-workflow";
+        var domain = "test-domain";
+
+        var workflow = CreateMockWorkflow(workflowKey, domain);
+        var instance = Instance.Create(instanceId.Value, workflowKey);
+        
+        State state;
+        if (hasScheduledTransitions)
+        {
+            state = CreateStateWithScheduledTransition(scheduledTransitionKey);
+        }
+        else
+        {
+            state = State.Create("state1", StateType.Intermediate, StateSubType.None, "Patch");
+        }
+
+        var transition = Transition.Create("test-transition", null, state.Key, TriggerType.Manual, "Patch");
+
+        return new TransitionExecutionContext
+        {
+            InstanceId = instanceId.Value,
+            Domain = domain,
+            WorkflowKey = workflowKey,
+            TransitionKey = "test-transition",
+            Trigger = TriggerType.Manual,
+            Actor = ExecutionActor.User,
+            CorrelationId = Guid.NewGuid().ToString("N"),
+            ExecutionChainId = Guid.NewGuid().ToString("N"),
+            RequestedAt = DateTimeOffset.UtcNow,
+            Workflow = workflow,
+            Current = state,
+            Target = state,
+            Transition = transition,
+            Instance = instance,
+            TraceId = Guid.NewGuid().ToString("N"),
+            SpanId = Guid.NewGuid().ToString("N")[..16]
+        };
+    }
+
+    private State CreateStateWithScheduledTransition(string transitionKey)
+    {
+        var json = $$"""
+        {
+            "key": "waiting",
+            "stateType": "Intermediate",
+            "subType": "None",
+            "versionStrategy": "Patch",
+            "labels": [],
+            "onEntries": [],
+            "onExits": [],
+            "transitions": [
+                {
+                    "key": "{{transitionKey}}",
+                    "from": "waiting",
+                    "target": "waiting",
+                    "triggerType": "Scheduled",
+                    "versionStrategy": "Patch",
+                    "timer": { "location": "inline", "code": "return TimeSpan.FromMinutes(5);" },
+                    "labels": [],
+                    "onExecutionTasks": []
+                }
+            ]
+        }
+        """;
+
+        var options = new System.Text.Json.JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+        };
+
+        return System.Text.Json.JsonSerializer.Deserialize<State>(json, options)!;
+    }
+
+    private Definitions.Workflow CreateMockWorkflow(string key, string domain)
+    {
+        var json = """
+        {
+            "type": "F",
+            "timeout": null,
+            "labels": [],
+            "functions": [],
+            "features": [],
+            "states": [
+                {
+                    "key": "state1",
+                    "stateType": "Intermediate",
+                    "transitions": []
+                }
+            ],
+            "sharedTransitions": [],
+            "extensions": [],
+            "startTransition": {"key": "start", "from": null, "target": "state1", "triggerType": "Manual", "versionStrategy": "Patch", "labels": [], "onExecutionTasks": [], "view": null}
+        }
+        """;
+
+        var options = new System.Text.Json.JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+        };
+        var workflow = System.Text.Json.JsonSerializer.Deserialize<Definitions.Workflow>(json, options)!;
+
+        workflow.SetReference(new Reference(key, domain, "sys-flows", "1.0.0"));
+        return workflow;
+    }
+
+    #endregion
+}

--- a/test/BBT.Workflow.Domain.Tests/Execution/Transitions/TransitionExecutionContextExtensionsTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Execution/Transitions/TransitionExecutionContextExtensionsTests.cs
@@ -1,0 +1,225 @@
+using System;
+using BBT.Workflow;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Execution;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Shared;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Domain.Tests.Execution.Transitions;
+
+/// <summary>
+/// Unit tests for TransitionExecutionContextExtensions
+/// Tests extension methods that enhance TransitionExecutionContext functionality
+/// </summary>
+public class TransitionExecutionContextExtensionsTests
+{
+    #region IsSelfTransition Tests
+
+    [Fact]
+    public void IsSelfTransition_WhenTargetEqualsCurrent_ShouldReturnTrue()
+    {
+        // Arrange
+        var context = CreateContext(
+            currentStateKey: "waiting",
+            transitionTarget: "waiting");
+
+        // Act
+        var result = context.IsSelfTransition();
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsSelfTransition_WhenTargetDifferentFromCurrent_ShouldReturnFalse()
+    {
+        // Arrange
+        var context = CreateContext(
+            currentStateKey: "waiting",
+            transitionTarget: "approved");
+
+        // Act
+        var result = context.IsSelfTransition();
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsSelfTransition_WhenTargetEqualsCurrent_CaseInsensitive_ShouldReturnTrue()
+    {
+        // Arrange
+        var context = CreateContext(
+            currentStateKey: "Waiting",
+            transitionTarget: "WAITING");
+
+        // Act
+        var result = context.IsSelfTransition();
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsSelfTransition_WhenTransitionIsNull_ShouldReturnFalse()
+    {
+        // Arrange
+        var context = CreateContextWithoutTransition(currentStateKey: "waiting");
+
+        // Act
+        var result = context.IsSelfTransition();
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsSelfTransition_WhenCurrentStateIsNull_ShouldReturnFalse()
+    {
+        // Arrange
+        var context = CreateContextWithoutCurrentState(transitionTarget: "waiting");
+
+        // Act
+        var result = context.IsSelfTransition();
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsSelfTransition_WhenTargetIsSelfKeyword_ShouldReturnTrue()
+    {
+        // Arrange
+        var context = CreateContext(
+            currentStateKey: "waiting",
+            transitionTarget: "$self");
+
+        // Act
+        var result = context.IsSelfTransition();
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsSelfTransition_WhenTargetIsSelfKeyword_CaseInsensitive_ShouldReturnTrue()
+    {
+        // Arrange
+        var context = CreateContext(
+            currentStateKey: "waiting",
+            transitionTarget: "$SELF");
+
+        // Act
+        var result = context.IsSelfTransition();
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static TransitionExecutionContext CreateContext(
+        string currentStateKey,
+        string transitionTarget)
+    {
+        var instanceId = Guid.NewGuid();
+        var workflowKey = "test-workflow";
+        var domain = "test-domain";
+
+        var workflow = WorkflowFactory.CreateDefault();
+        var instance = Instance.Create(instanceId, workflowKey);
+        var state = StateFactory.CreateDefault(currentStateKey, StateType.Intermediate);
+        var transition = TransitionFactory.CreateDefault(
+            key: "self-transition",
+            fromState: currentStateKey,
+            toState: transitionTarget);
+
+        return new TransitionExecutionContext
+        {
+            InstanceId = instanceId,
+            Domain = domain,
+            WorkflowKey = workflowKey,
+            TransitionKey = "self-transition",
+            Trigger = TriggerType.Manual,
+            Actor = ExecutionActor.User,
+            CorrelationId = Guid.NewGuid().ToString("N"),
+            ExecutionChainId = Guid.NewGuid().ToString("N"),
+            RequestedAt = DateTimeOffset.UtcNow,
+            Workflow = workflow,
+            Current = state,
+            Transition = transition,
+            Instance = instance,
+            TraceId = Guid.NewGuid().ToString("N"),
+            SpanId = Guid.NewGuid().ToString("N")[..16]
+        };
+    }
+
+    private static TransitionExecutionContext CreateContextWithoutTransition(string currentStateKey)
+    {
+        var instanceId = Guid.NewGuid();
+        var workflowKey = "test-workflow";
+        var domain = "test-domain";
+
+        var workflow = WorkflowFactory.CreateDefault();
+        var instance = Instance.Create(instanceId, workflowKey);
+        var state = StateFactory.CreateDefault(currentStateKey, StateType.Intermediate);
+
+        return new TransitionExecutionContext
+        {
+            InstanceId = instanceId,
+            Domain = domain,
+            WorkflowKey = workflowKey,
+            TransitionKey = "test-transition",
+            Trigger = TriggerType.Manual,
+            Actor = ExecutionActor.User,
+            CorrelationId = Guid.NewGuid().ToString("N"),
+            ExecutionChainId = Guid.NewGuid().ToString("N"),
+            RequestedAt = DateTimeOffset.UtcNow,
+            Workflow = workflow,
+            Current = state,
+            Transition = null,
+            Instance = instance,
+            TraceId = Guid.NewGuid().ToString("N"),
+            SpanId = Guid.NewGuid().ToString("N")[..16]
+        };
+    }
+
+    private static TransitionExecutionContext CreateContextWithoutCurrentState(string transitionTarget)
+    {
+        var instanceId = Guid.NewGuid();
+        var workflowKey = "test-workflow";
+        var domain = "test-domain";
+
+        var workflow = WorkflowFactory.CreateDefault();
+        var instance = Instance.Create(instanceId, workflowKey);
+        var transition = TransitionFactory.CreateDefault(
+            key: "test-transition",
+            fromState: null,
+            toState: transitionTarget);
+
+        return new TransitionExecutionContext
+        {
+            InstanceId = instanceId,
+            Domain = domain,
+            WorkflowKey = workflowKey,
+            TransitionKey = "test-transition",
+            Trigger = TriggerType.Manual,
+            Actor = ExecutionActor.User,
+            CorrelationId = Guid.NewGuid().ToString("N"),
+            ExecutionChainId = Guid.NewGuid().ToString("N"),
+            RequestedAt = DateTimeOffset.UtcNow,
+            Workflow = workflow,
+            Current = null!,
+            Transition = transition,
+            Instance = instance,
+            TraceId = Guid.NewGuid().ToString("N"),
+            SpanId = Guid.NewGuid().ToString("N")[..16]
+        };
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary by Sourcery

Reset scheduled timer jobs when re-entering the same workflow state and add coverage for self-transition handling.

New Features:
- Introduce self-transition detection on transition execution context.
- Automatically cancel existing timer jobs before scheduling new ones for a workflow instance.

Enhancements:
- Add structured logging and event ID for canceled timer jobs and scheduled timer jobs.

Documentation:
- Document timer reset behavior on self-transitions and its impact on workflow execution.

Tests:
- Add unit tests for timer scheduling and cancellation behavior in ScheduleTransitionsStep, including self-transition scenarios.
- Add unit tests for the new IsSelfTransition extension method on TransitionExecutionContext.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scheduled timers now automatically reset when a self-transition occurs in workflows, ensuring old timer jobs are canceled before new ones are scheduled.

* **Documentation**
  * Added comprehensive documentation covering the timer reset feature, including execution flow, security scope, and test scenarios.

* **Tests**
  * Added unit tests verifying timer cancellation and scheduling behavior across various workflow transition scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->