### PR TITLE
Incident retry

### DIFF
--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
@@ -20,6 +20,7 @@ namespace BBT.Workflow.Orchestration.Controllers.Instances;
 public sealed class InstanceController(
     IInstanceCommandAppService commandAppService,
     IInstanceQueryAppService queryAppService,
+    IInstanceRetryAppService retryAppService,
     IHttpContextAccessor httpContextAccessor,
     ISubflowCompletionService subflowCompletionService,
     ISubflowStateService subflowStateService,
@@ -180,6 +181,56 @@ public sealed class InstanceController(
             input,
             cancellationToken);
         
+        return FromResult(result);
+    }
+
+    /// <summary>
+    /// Retries a faulted workflow instance by re-executing the incomplete transition.
+    /// </summary>
+    /// <param name="domain">The domain name.</param>
+    /// <param name="workflow">The workflow name.</param>
+    /// <param name="instance">The instance identifier (ID or key).</param>
+    /// <param name="data">Optional transition data to pass during retry.</param>
+    /// <param name="version">Optional workflow version.</param>
+    /// <param name="sync">Whether to execute synchronously.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <response code="200">Instance retry executed successfully</response>
+    /// <response code="400">Instance is not in faulted state or validation failed</response>
+    /// <response code="404">Instance or workflow not found</response>
+    [HttpPost("{domain}/workflows/{workflow}/instances/{instance}/retry")]
+    [ProducesResponseType(typeof(RetryInstanceOutput), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> RetryAsync(
+        [FromRoute] string domain,
+        [FromRoute] string workflow,
+        [FromRoute] string instance,
+        [FromBody] TransitionDataInput? data = null,
+        [FromQuery] string? version = null,
+        [FromQuery] bool sync = false,
+        CancellationToken cancellationToken = default)
+    {
+        var httpContext = httpContextAccessor.HttpContext;
+        var headers = httpContext?.Request.Headers.ToDictionary(
+            s => s.Key.ToLower(),
+            s => s.Value.FirstOrDefault()?.ToString()) ?? [];
+        var routeValues = httpContext?.Request.RouteValues.ToDictionary(
+            r => r.Key,
+            r => r.Value?.ToString()) ?? [];
+
+        var input = new RetryInstanceInput
+        {
+            Domain = domain,
+            Workflow = workflow,
+            Instance = instance,
+            Data = data,
+            Version = version,
+            Sync = sync,
+            Headers = headers,
+            RouteValues = routeValues
+        };
+
+        var result = await retryAppService.RetryAsync(input, cancellationToken);
         return FromResult(result);
     }
     

--- a/src/BBT.Workflow.Application/Gateway/IInstanceRetryGateway.cs
+++ b/src/BBT.Workflow.Application/Gateway/IInstanceRetryGateway.cs
@@ -1,0 +1,24 @@
+using BBT.Aether.Results;
+using BBT.Workflow.Instances;
+
+namespace BBT.Workflow.Gateway;
+
+/// <summary>
+/// Gateway interface for instance retry operations.
+/// Routes between local and remote execution based on target domain.
+/// When target domain matches the current runtime, executes locally.
+/// When target domain differs, delegates to remote HTTP service.
+/// </summary>
+public interface IInstanceRetryGateway
+{
+    /// <summary>
+    /// Retries a faulted workflow instance.
+    /// Routes to local or remote based on target domain in input.
+    /// </summary>
+    /// <param name="input">The retry input containing domain, workflow, instance, and retry options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result containing the retry output or an error.</returns>
+    Task<Result<RetryInstanceOutput>> RetryAsync(
+        RetryInstanceInput input,
+        CancellationToken cancellationToken = default);
+}

--- a/src/BBT.Workflow.Application/Instances/DTOs/RetryInstanceInput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/RetryInstanceInput.cs
@@ -1,0 +1,86 @@
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Execution;
+
+namespace BBT.Workflow.Instances;
+
+/// <summary>
+/// Input parameters for retrying a faulted workflow instance.
+/// </summary>
+public sealed class RetryInstanceInput
+{
+    /// <summary>
+    /// The domain/tenant identifier.
+    /// </summary>
+    public required string Domain { get; init; }
+
+    /// <summary>
+    /// The workflow key.
+    /// </summary>
+    public required string Workflow { get; init; }
+
+    /// <summary>
+    /// The workflow version. If not specified, uses the version from the incomplete transition.
+    /// </summary>
+    public string? Version { get; init; }
+
+    /// <summary>
+    /// The instance identifier (ID or key).
+    /// </summary>
+    public required string Instance { get; init; }
+
+    /// <summary>
+    /// Whether to execute synchronously.
+    /// </summary>
+    public bool Sync { get; init; }
+
+    /// <summary>
+    /// Optional data payload for the retry execution.
+    /// </summary>
+    public TransitionDataInput? Data { get; init; }
+
+    /// <summary>
+    /// Request headers for context propagation.
+    /// </summary>
+    public Dictionary<string, string?> Headers { get; init; } = new();
+
+    /// <summary>
+    /// Route values from the HTTP request.
+    /// </summary>
+    public Dictionary<string, string?> RouteValues { get; init; } = new();
+
+    /// <summary>
+    /// Creates a WorkflowExecutionContext for retry execution.
+    /// </summary>
+    /// <param name="instanceId">The workflow instance identifier.</param>
+    /// <param name="transitionKey">The transition key to retry.</param>
+    /// <param name="version">The workflow version.</param>
+    /// <param name="completedTaskIds">IDs of tasks that completed successfully and should be bypassed.</param>
+    /// <returns>A new WorkflowExecutionContext configured for retry.</returns>
+    public WorkflowExecutionContext ToExecutionContext(
+        Guid instanceId,
+        string transitionKey,
+        string? version,
+        IEnumerable<string>? completedTaskIds = null)
+    {
+        return new WorkflowExecutionContext
+        {
+            Domain = Domain,
+            InstanceId = instanceId.ToString(),
+            WorkflowKey = Workflow,
+            WorkflowVersion = version ?? Version,
+            TransitionKey = transitionKey,
+            TriggerType = TriggerType.Manual, // Retry is always manual
+            Mode = Sync ? ExecMode.Sync : ExecMode.Async,
+            CorrelationId = Guid.NewGuid().ToString("N"),
+            RequestedAt = DateTimeOffset.UtcNow,
+            Headers = Headers,
+            RouteValues = RouteValues,
+            IsReentry = true, // Retry is a re-entry scenario
+            Execution = new ExecutionInfo
+            {
+                ExecutionChainId = Guid.NewGuid().ToString("N"),
+                ChainDepth = 0
+            }
+        };
+    }
+}

--- a/src/BBT.Workflow.Application/Instances/DTOs/RetryInstanceInput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/RetryInstanceInput.cs
@@ -1,6 +1,3 @@
-using BBT.Workflow.Definitions;
-using BBT.Workflow.Execution;
-
 namespace BBT.Workflow.Instances;
 
 /// <summary>
@@ -47,40 +44,4 @@ public sealed class RetryInstanceInput
     /// Route values from the HTTP request.
     /// </summary>
     public Dictionary<string, string?> RouteValues { get; init; } = new();
-
-    /// <summary>
-    /// Creates a WorkflowExecutionContext for retry execution.
-    /// </summary>
-    /// <param name="instanceId">The workflow instance identifier.</param>
-    /// <param name="transitionKey">The transition key to retry.</param>
-    /// <param name="version">The workflow version.</param>
-    /// <param name="completedTaskIds">IDs of tasks that completed successfully and should be bypassed.</param>
-    /// <returns>A new WorkflowExecutionContext configured for retry.</returns>
-    public WorkflowExecutionContext ToExecutionContext(
-        Guid instanceId,
-        string transitionKey,
-        string? version,
-        IEnumerable<string>? completedTaskIds = null)
-    {
-        return new WorkflowExecutionContext
-        {
-            Domain = Domain,
-            InstanceId = instanceId.ToString(),
-            WorkflowKey = Workflow,
-            WorkflowVersion = version ?? Version,
-            TransitionKey = transitionKey,
-            TriggerType = TriggerType.Manual, // Retry is always manual
-            Mode = Sync ? ExecMode.Sync : ExecMode.Async,
-            CorrelationId = Guid.NewGuid().ToString("N"),
-            RequestedAt = DateTimeOffset.UtcNow,
-            Headers = Headers,
-            RouteValues = RouteValues,
-            IsReentry = true, // Retry is a re-entry scenario
-            Execution = new ExecutionInfo
-            {
-                ExecutionChainId = Guid.NewGuid().ToString("N"),
-                ChainDepth = 0
-            }
-        };
-    }
 }

--- a/src/BBT.Workflow.Application/Instances/DTOs/RetryInstanceOutput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/RetryInstanceOutput.cs
@@ -1,0 +1,22 @@
+namespace BBT.Workflow.Instances;
+
+/// <summary>
+/// Output from a retry operation on a faulted workflow instance.
+/// </summary>
+public sealed class RetryInstanceOutput
+{
+    /// <summary>
+    /// The workflow instance identifier.
+    /// </summary>
+    public Guid Id { get; init; }
+
+    /// <summary>
+    /// Instance status after retry (Active, Busy, Completed, Faulted, etc.)
+    /// </summary>
+    public InstanceStatus? Status { get; init; }
+
+    /// <summary>
+    /// The ID of the transition that was retried.
+    /// </summary>
+    public Guid RetriedTransitionId { get; init; }
+}

--- a/src/BBT.Workflow.Application/Instances/IInstanceRetryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/IInstanceRetryAppService.cs
@@ -1,0 +1,21 @@
+using BBT.Aether.Application;
+using BBT.Aether.Results;
+
+namespace BBT.Workflow.Instances;
+
+/// <summary>
+/// Application service for retrying faulted workflow instances.
+/// </summary>
+public interface IInstanceRetryAppService : IApplicationService
+{
+    /// <summary>
+    /// Retries a faulted workflow instance by re-executing the incomplete transition.
+    /// Bypasses tasks that completed successfully before the fault occurred.
+    /// </summary>
+    /// <param name="input">The retry input parameters.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result containing the retry output or an error.</returns>
+    Task<Result<RetryInstanceOutput>> RetryAsync(
+        RetryInstanceInput input,
+        CancellationToken cancellationToken = default);
+}

--- a/src/BBT.Workflow.Application/Instances/InstanceRetryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceRetryAppService.cs
@@ -1,0 +1,282 @@
+using BBT.Aether.Application.Services;
+using BBT.Aether.Results;
+using BBT.Aether.Uow;
+using BBT.Workflow.Caching;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Execution;
+using BBT.Workflow.Execution.Services;
+using BBT.Workflow.Gateway;
+using BBT.Workflow.Logging;
+using BBT.Workflow.Runtime;
+using Microsoft.Extensions.Logging;
+using WorkflowDefinition = BBT.Workflow.Definitions.Workflow;
+
+namespace BBT.Workflow.Instances;
+
+/// <summary>
+/// Application service for retrying faulted workflow instances.
+/// Supports two scenarios:
+/// 1. Instance is Faulted → retry the instance's incomplete transition
+/// 2. Instance has a Faulted SubFlow → retry the SubFlow (delegated to gateway)
+/// </summary>
+public sealed class InstanceRetryAppService(
+    IServiceProvider serviceProvider,
+    IRuntimeInfoProvider runtimeInfoProvider,
+    IInstanceRepository instanceRepository,
+    IInstanceTransitionRepository instanceTransitionRepository,
+    IInstanceQueryGateway instanceQueryGateway,
+    IInstanceRetryGateway instanceRetryGateway,
+    IComponentCacheStore componentCacheStore,
+    IWorkflowExecutionService workflowExecutionService,
+    ILogger<InstanceRetryAppService> logger)
+    : ApplicationService(serviceProvider), IInstanceRetryAppService
+{
+    /// <inheritdoc />
+    public async Task<Result<RetryInstanceOutput>> RetryAsync(
+        RetryInstanceInput input,
+        CancellationToken cancellationToken = default)
+    {
+        // Validate domain
+        runtimeInfoProvider.Check(input.Domain);
+
+        logger.InstanceRetryRequested(input.Instance, input.Workflow);
+
+        // Step 1: Load instance with details (including correlations)
+        var instanceResult = await instanceRepository.GetResultAsync(input.Instance, includeDetails: true, cancellationToken);
+        if (!instanceResult.IsSuccess)
+            return Result<RetryInstanceOutput>.Fail(instanceResult.Error);
+
+        var instance = instanceResult.Value!;
+
+        // Step 2: Scenario 1 - Instance itself is Faulted
+        if (instance.Status.Equals(InstanceStatus.Faulted))
+        {
+            return await RetryFaultedInstanceAsync(instance, input, cancellationToken);
+        }
+
+        // Step 3: Scenario 2 - Check if instance has an active SubFlow
+        var subflowCorrelation = instance.Subflow;
+        if (subflowCorrelation == null)
+        {
+            // No SubFlow + Instance not Faulted → Error
+            return Result<RetryInstanceOutput>.Fail(Error.Validation(
+                WorkflowErrorCodes.InstanceNotFaulted,
+                $"Instance {input.Instance} is not in faulted state. Current status: {instance.Status.Code}",
+                input.Instance));
+        }
+
+        // Step 4: SubFlow exists - check if it's Faulted and retry it
+        return await RetrySubFlowAsync(instance, subflowCorrelation, input, cancellationToken);
+    }
+
+    /// <summary>
+    /// Retries a SubFlow that is in faulted state.
+    /// Uses IInstanceQueryGateway to support cross-domain SubFlow queries.
+    /// </summary>
+    private async Task<Result<RetryInstanceOutput>> RetrySubFlowAsync(
+        Instance parentInstance,
+        InstanceCorrelation subflowCorrelation,
+        RetryInstanceInput input,
+        CancellationToken cancellationToken)
+    {
+        // Query SubFlow state via gateway (supports cross-domain)
+        var subflowStateInput = new GetFunctionWithInstanceInput
+        {
+            Domain = subflowCorrelation.SubFlowDomain,
+            Workflow = subflowCorrelation.SubFlowName,
+            Version = subflowCorrelation.SubFlowVersion,
+            Instance = subflowCorrelation.SubFlowInstanceId.ToString(),
+            Headers = input.Headers,
+            QueryParams = input.RouteValues
+        };
+
+        var subflowStateResult = await instanceQueryGateway.GetFunctionWithStateAsync(
+            subflowStateInput,
+            cancellationToken);
+
+        if (!subflowStateResult.IsSuccess)
+        {
+            return Result<RetryInstanceOutput>.Fail(subflowStateResult.Error);
+        }
+
+        var subflowState = subflowStateResult.Value!;
+
+        // SubFlow not Faulted → Error (both instance and subflow are not faulted)
+        if (subflowState.Status == null || !subflowState.Status.Equals(InstanceStatus.Faulted))
+        {
+            return Result<RetryInstanceOutput>.Fail(Error.Validation(
+                WorkflowErrorCodes.InstanceNotFaulted,
+                $"Instance {input.Instance} is not in faulted state. Current status: {parentInstance.Status.Code}",
+                input.Instance));
+        }
+
+        // Create retry input for SubFlow
+        var subflowInput = new RetryInstanceInput
+        {
+            Domain = subflowCorrelation.SubFlowDomain,
+            Workflow = subflowCorrelation.SubFlowName,
+            Version = subflowCorrelation.SubFlowVersion,
+            Instance = subflowCorrelation.SubFlowInstanceId.ToString(),
+            Sync = input.Sync,
+            Data = input.Data,
+            Headers = input.Headers,
+            RouteValues = input.RouteValues
+        };
+
+        logger.InstanceRetryRequested(subflowCorrelation.SubFlowInstanceId.ToString(), subflowCorrelation.SubFlowName);
+
+        // Use gateway for retry - routes to local or remote based on domain
+        return await instanceRetryGateway.RetryAsync(subflowInput, cancellationToken);
+    }
+
+    /// <summary>
+    /// Retries a faulted instance by re-executing its incomplete transition.
+    /// </summary>
+    private async Task<Result<RetryInstanceOutput>> RetryFaultedInstanceAsync(
+        Instance instance,
+        RetryInstanceInput input,
+        CancellationToken cancellationToken)
+    {
+        // Railway chain: Load workflow -> Find incomplete transition -> Unfault -> Execute
+        return await LoadWorkflowAsync(input, instance, cancellationToken)
+            .BindAsync(data => FindIncompleteTransitionAsync(data.Instance, data.Workflow, cancellationToken))
+            .BindAsync(data => UnfaultAndPersistAsync(data, cancellationToken))
+            .BindAsync(data => ExecuteRetryAsync(data, input, cancellationToken));
+    }
+
+    /// <summary>
+    /// Load the workflow definition.
+    /// </summary>
+    private async Task<Result<(Instance Instance, WorkflowDefinition Workflow)>> LoadWorkflowAsync(
+        RetryInstanceInput input,
+        Instance instance,
+        CancellationToken cancellationToken)
+    {
+        var workflowResult = await componentCacheStore.GetFlowAsync(
+            input.Domain,
+            input.Workflow,
+            input.Version,
+            cancellationToken);
+
+        return workflowResult.Map(workflow => (instance, workflow));
+    }
+
+    /// <summary>
+    /// Find the incomplete transition (faulted transition) for the instance.
+    /// </summary>
+    private async Task<Result<(Instance Instance, WorkflowDefinition Workflow, InstanceTransition Transition)>> 
+        FindIncompleteTransitionAsync(
+            Instance instance,
+            WorkflowDefinition workflow,
+            CancellationToken cancellationToken)
+    {
+        var transition = await instanceTransitionRepository.GetLatestIncompleteAsync(
+            instance.Id,
+            cancellationToken);
+
+        if (transition == null)
+        {
+            return Result<(Instance, WorkflowDefinition, InstanceTransition)>.Fail(
+                Error.Validation(
+                    WorkflowErrorCodes.NoIncompleteTransitionFound,
+                    $"No incomplete transition found for instance {instance.Id}",
+                    instance.Id.ToString()));
+        }
+
+        return Result<(Instance, WorkflowDefinition, InstanceTransition)>.Ok((instance, workflow, transition));
+    }
+
+    /// <summary>
+    /// Unfault the instance and persist the change.
+    /// </summary>
+    private async Task<Result<(Instance Instance, WorkflowDefinition Workflow, InstanceTransition Transition)>>
+        UnfaultAndPersistAsync(
+            (Instance Instance, WorkflowDefinition Workflow, InstanceTransition Transition) data,
+            CancellationToken cancellationToken)
+    {
+        await using var uow = await UnitOfWorkManager.BeginRequiresNew(cancellationToken);
+
+        var unfaulted = data.Instance.Unfault();
+        if (!unfaulted)
+        {
+            return Result<(Instance, WorkflowDefinition, InstanceTransition)>.Fail(
+                Error.Validation(
+                    WorkflowErrorCodes.InstanceNotFaulted,
+                    $"Instance {data.Instance.Id} could not be unfaulted",
+                    data.Instance.Id.ToString()));
+        }
+
+        logger.InstanceUnfaulted(data.Instance.Id);
+
+        await instanceRepository.UpdateAsync(data.Instance, true, cancellationToken);
+        await uow.CommitAsync(cancellationToken);
+
+        return Result<(Instance, WorkflowDefinition, InstanceTransition)>.Ok(data);
+    }
+
+    /// <summary>
+    /// Execute the transition retry using the workflow execution service.
+    /// </summary>
+    private async Task<Result<RetryInstanceOutput>> ExecuteRetryAsync(
+        (Instance Instance, WorkflowDefinition Workflow, InstanceTransition Transition) data,
+        RetryInstanceInput input,
+        CancellationToken cancellationToken)
+    {
+        var context = new WorkflowExecutionContext
+        {
+            Domain = input.Domain,
+            InstanceId = data.Instance.Id.ToString(),
+            WorkflowKey = input.Workflow,
+            WorkflowVersion = input.Version ?? data.Workflow.Version,
+            TransitionKey = data.Transition.TransitionId,
+            TriggerType = TriggerType.Manual, // Retry is always manual
+            Mode = input.Sync ? ExecMode.Sync : ExecMode.Async,
+            Actor = Shared.ExecutionActor.User,
+            CorrelationId = Guid.NewGuid().ToString("N"),
+            RequestedAt = DateTimeOffset.UtcNow,
+            Headers = input.Headers,
+            RouteValues = input.RouteValues,
+            IsReentry = true, // Retry is a re-entry scenario
+            Data = input.Data != null 
+                ? new TransitionDataInfo(input.Data.Key, input.Data.Attributes) { Tags = input.Data.Tags } 
+                : null,
+            Execution = new ExecutionInfo
+            {
+                ExecutionChainId = Guid.NewGuid().ToString("N"),
+                ChainDepth = 0
+            },
+            Retry = new RetryInfo
+            {
+                TransitionId = data.Transition.Id
+            }
+        };
+
+        var result = await workflowExecutionService.ExecuteTransitionAsync(context, cancellationToken);
+
+        if (!result.IsSuccess)
+            return Result<RetryInstanceOutput>.Fail(result.Error);
+
+        // Reload instance to get current status
+        var refreshedInstance = await instanceRepository.FindByIdentifierAsReadOnlyAsync(
+            data.Instance.Id.ToString(),
+            cancellationToken);
+
+        var currentStatus = refreshedInstance?.Status ?? result.Value!.Status;
+
+        if (currentStatus?.Equals(InstanceStatus.Faulted) == true)
+        {
+            logger.InstanceRetryFailed(data.Instance.Id, "Instance faulted again after retry");
+        }
+        else
+        {
+            logger.InstanceRetrySucceeded(data.Instance.Id);
+        }
+
+        return Result<RetryInstanceOutput>.Ok(new RetryInstanceOutput
+        {
+            Id = result.Value!.Id,
+            Status = currentStatus,
+            RetriedTransitionId = data.Transition.Id
+        });
+    }
+}

--- a/src/BBT.Workflow.Application/Instances/Remote/IRemoteInstanceRetryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/Remote/IRemoteInstanceRetryAppService.cs
@@ -1,0 +1,21 @@
+using BBT.Aether.Results;
+
+namespace BBT.Workflow.Instances.Remote;
+
+/// <summary>
+/// Remote service interface for instance retry operations.
+/// Acts as a client to the InstanceController retry endpoint for remote workflow instances.
+/// </summary>
+public interface IRemoteInstanceRetryAppService
+{
+    /// <summary>
+    /// Retries a faulted workflow instance by calling the remote API.
+    /// POST {baseUrl}/api/v{version}/{domain}/workflows/{workflow}/instances/{instance}/retry
+    /// </summary>
+    /// <param name="input">The retry input containing domain, workflow, instance, and retry options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result containing the retry output or an error.</returns>
+    Task<Result<RetryInstanceOutput>> RetryAsync(
+        RetryInstanceInput input,
+        CancellationToken cancellationToken = default);
+}

--- a/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
@@ -51,6 +51,7 @@ public static class WorkflowApplicationModuleServiceCollectionExtensions
         services.AddScoped<IDefinitionAppService, DefinitionAppService>();
         services.AddScoped<IInstanceCommandAppService, InstanceCommandAppService>();
         services.AddScoped<IInstanceQueryAppService, InstanceQueryAppService>();
+        services.AddScoped<IInstanceRetryAppService, InstanceRetryAppService>();
         services.AddScoped<IFunctionAppService, FunctionAppService>();
         services.AddScoped<IInstanceExtensionService, InstanceExtensionService>();
         services.AddScoped<ISubflowCompletionService, SubflowCompletionService>();

--- a/src/BBT.Workflow.Domain/Definitions/InstanceUrlTemplates.cs
+++ b/src/BBT.Workflow.Domain/Definitions/InstanceUrlTemplates.cs
@@ -95,6 +95,12 @@ public static class InstanceUrlTemplates
     public const string SubFlowStateTemplate = "/{0}/workflows/{1}/instances/{2}/sub/state";
 
     /// <summary>
+    /// URL template for retry instance endpoints.
+    /// Format: /{domain}/workflows/{workflow}/instances/{instance}/retry
+    /// </summary>
+    public const string RetryTemplate = "/{0}/workflows/{1}/instances/{2}/retry";
+
+    /// <summary>
     /// URL template for function list endpoints.
     /// Format: /{domain}/workflows/{workflow}/functions/{function}
     /// </summary>
@@ -262,6 +268,17 @@ public static class InstanceUrlTemplates
     /// <returns>Generated URL</returns>
     public static string SubFlowState(string domain, string workflow, string instance, string? apiVersionPrefix = null)
         => BuildUrl(SubFlowStateTemplate, apiVersionPrefix, domain, workflow, instance);
+
+    /// <summary>
+    /// Generates URL for retry instance endpoint.
+    /// </summary>
+    /// <param name="domain">The domain name</param>
+    /// <param name="workflow">The workflow name</param>
+    /// <param name="instance">The instance key or ID</param>
+    /// <param name="apiVersionPrefix">Optional API version prefix (e.g., "api/v1")</param>
+    /// <returns>Generated URL</returns>
+    public static string Retry(string domain, string workflow, string instance, string? apiVersionPrefix = null)
+        => BuildUrl(RetryTemplate, apiVersionPrefix, domain, workflow, instance);
 
     /// <summary>
     /// Generates URL for function list endpoint.

--- a/src/BBT.Workflow.Domain/Execution/Transitions/Context/WorkflowExecutionContext.cs
+++ b/src/BBT.Workflow.Domain/Execution/Transitions/Context/WorkflowExecutionContext.cs
@@ -63,6 +63,18 @@ public sealed class WorkflowExecutionContext
     
     /// <summary>Gets or sets the route values from the HTTP request.</summary>
     public Dictionary<string, string?> RouteValues { get; set; } = new();
+    
+    /// <summary>Gets or sets retry information for retry operations.</summary>
+    public RetryInfo? Retry { get; set; }
+}
+
+/// <summary>
+/// Contains information about a retry operation.
+/// </summary>
+public sealed class RetryInfo
+{
+    /// <summary>Gets or sets the ID of the transition being retried.</summary>
+    public Guid TransitionId { get; set; }
 }
 
 public sealed class TransitionDataInfo 

--- a/src/BBT.Workflow.Domain/Instances/IInstanceTransitionRepository.cs
+++ b/src/BBT.Workflow.Domain/Instances/IInstanceTransitionRepository.cs
@@ -11,4 +11,13 @@ public interface IInstanceTransitionRepository : IRepository<InstanceTransition,
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     Task UpdateCompletedAsync(InstanceTransition transition, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets the latest incomplete (not completed) transition for an instance.
+    /// Used for retry operations to find the faulted transition.
+    /// </summary>
+    /// <param name="instanceId">The instance ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The latest incomplete transition, or null if none found.</returns>
+    Task<InstanceTransition?> GetLatestIncompleteAsync(Guid instanceId, CancellationToken cancellationToken = default);
 }

--- a/src/BBT.Workflow.Domain/Instances/Instance.cs
+++ b/src/BBT.Workflow.Domain/Instances/Instance.cs
@@ -298,7 +298,21 @@ public sealed class Instance : AggregateRoot<Guid>, IHasCreatedAt, IHasModifyTim
             FaultedAt = CompletedAt.Value
         });
     }
-
+    /// <summary>
+    /// Unfaults the instance, allowing it to be retried.
+    /// Changes the status from Faulted to Active and clears completion time.
+    /// </summary>
+    /// <returns>True if the instance was successfully unfaulted, false if it was not in Faulted state.</returns>
+    public bool Unfault()
+    {
+        if (!Status.Equals(InstanceStatus.Faulted))
+            return false;
+ 
+        Status = InstanceStatus.Active;
+        CompletedAt = null;
+        Duration = null;
+        return true;
+    }
     /// <summary>
     /// Cancels the instance and publishes a cancellation event.
     /// Sets the instance status to Canceled and records the completion time.

--- a/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
@@ -1296,6 +1296,56 @@ public static partial class WorkflowLogs
 
     #endregion
 
+    #region Instance Retry
+ 
+    /// <summary>
+    /// Logs when an instance retry is requested.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 20050,
+        Level = LogLevel.Information,
+        Message = "Instance retry requested for {InstanceId} in workflow {WorkflowKey}")]
+    public static partial void InstanceRetryRequested(
+        this ILogger logger,
+        string instanceId,
+        string workflowKey);
+ 
+    /// <summary>
+    /// Logs when an instance is successfully unfaulted.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 20051,
+        Level = LogLevel.Information,
+        Message = "Instance {InstanceId} unfaulted, ready for retry")]
+    public static partial void InstanceUnfaulted(
+        this ILogger logger,
+        Guid instanceId);
+ 
+    /// <summary>
+    /// Logs when an instance retry succeeds.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 20052,
+        Level = LogLevel.Information,
+        Message = "Instance {InstanceId} retry succeeded")]
+    public static partial void InstanceRetrySucceeded(
+        this ILogger logger,
+        Guid instanceId);
+ 
+    /// <summary>
+    /// Logs when an instance retry fails.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 20053,
+        Level = LogLevel.Warning,
+        Message = "Instance {InstanceId} retry failed: {Reason}")]
+    public static partial void InstanceRetryFailed(
+        this ILogger logger,
+        Guid instanceId,
+        string reason);
+ 
+    #endregion
+
     #region Service Discovery
 
     /// <summary>

--- a/src/BBT.Workflow.Domain/WorkflowErrorCodes.cs
+++ b/src/BBT.Workflow.Domain/WorkflowErrorCodes.cs
@@ -41,6 +41,8 @@ public static class WorkflowErrorCodes
     public const string UpdateDataNotConfiguredForWorkflow = "Instance:100024";
     public const string ActiveInstanceAlreadyExists = "Instance:100025";
     public const string ExitNotConfiguredForWorkflow = "Instance:100026";
+    public const string InstanceNotFaulted = "Instance:100027";
+    public const string NoIncompleteTransitionFound = "Instance:100028";
     
     #endregion
     

--- a/src/BBT.Workflow.Infrastructure/DataSink/DataSinkServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Infrastructure/DataSink/DataSinkServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using BBT.Workflow.ClickHouse;
 using BBT.Workflow.DataSink;
+using BBT.Workflow.Instances;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -85,9 +86,9 @@ public static class DataSinkServiceCollectionExtensions
         });
 
         // Register ClickHouse DataSink implementations
-        services.AddSingleton<IDataSink<Instances.Instance>, ClickHouseInstanceDataSink>();
-        services.AddSingleton<IDataSink<Instances.InstanceTransition>, ClickHouseInstanceTransitionDataSink>();
-        services.AddSingleton<IDataSink<Instances.InstanceTask>, ClickHouseInstanceTaskDataSink>();
+        services.AddSingleton<IDataSink<Instance>, ClickHouseInstanceDataSink>();
+        services.AddSingleton<IDataSink<InstanceTransition>, ClickHouseInstanceTransitionDataSink>();
+        services.AddSingleton<IDataSink<InstanceTask>, ClickHouseInstanceTaskDataSink>();
 
         return services;
     }

--- a/src/BBT.Workflow.Infrastructure/Gateway/LocalInstanceRetryGateway.cs
+++ b/src/BBT.Workflow.Infrastructure/Gateway/LocalInstanceRetryGateway.cs
@@ -1,0 +1,41 @@
+using BBT.Aether.MultiSchema;
+using BBT.Aether.Results;
+using BBT.Workflow.Gateway;
+using BBT.Workflow.Instances;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BBT.Workflow.Infrastructure.Gateway;
+
+/// <summary>
+/// Local implementation of instance retry gateway.
+/// Executes retry locally with proper schema context.
+/// Uses IServiceScopeFactory to create fresh scope for each operation ensuring clean transaction state.
+/// </summary>
+public sealed class LocalInstanceRetryGateway : IInstanceRetryGateway
+{
+    private readonly IServiceScopeFactory _serviceScopeFactory;
+
+    /// <summary>
+    /// Initializes a new instance of LocalInstanceRetryGateway.
+    /// </summary>
+    /// <param name="serviceScopeFactory">Factory for creating service scopes.</param>
+    public LocalInstanceRetryGateway(IServiceScopeFactory serviceScopeFactory)
+    {
+        _serviceScopeFactory = serviceScopeFactory;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<RetryInstanceOutput>> RetryAsync(
+        RetryInstanceInput input,
+        CancellationToken cancellationToken = default)
+    {
+        await using var scope = _serviceScopeFactory.CreateAsyncScope();
+        var currentSchema = scope.ServiceProvider.GetRequiredService<ICurrentSchema>();
+        var retryService = scope.ServiceProvider.GetRequiredService<IInstanceRetryAppService>();
+
+        using (currentSchema.Use(input.Workflow))
+        {
+            return await retryService.RetryAsync(input, cancellationToken);
+        }
+    }
+}

--- a/src/BBT.Workflow.Infrastructure/Gateway/RemoteInstanceRetryGateway.cs
+++ b/src/BBT.Workflow.Infrastructure/Gateway/RemoteInstanceRetryGateway.cs
@@ -1,0 +1,33 @@
+using BBT.Aether.Results;
+using BBT.Workflow.Gateway;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Instances.Remote;
+
+namespace BBT.Workflow.Infrastructure.Gateway;
+
+/// <summary>
+/// Remote implementation of instance retry gateway.
+/// Delegates all operations to IRemoteInstanceRetryAppService for HTTP-based execution.
+/// Used when target domain differs from the current runtime domain.
+/// </summary>
+public sealed class RemoteInstanceRetryGateway : IInstanceRetryGateway
+{
+    private readonly IRemoteInstanceRetryAppService _remoteService;
+
+    /// <summary>
+    /// Initializes a new instance of RemoteInstanceRetryGateway.
+    /// </summary>
+    /// <param name="remoteService">The remote instance retry service for HTTP calls.</param>
+    public RemoteInstanceRetryGateway(IRemoteInstanceRetryAppService remoteService)
+    {
+        _remoteService = remoteService;
+    }
+
+    /// <inheritdoc />
+    public Task<Result<RetryInstanceOutput>> RetryAsync(
+        RetryInstanceInput input,
+        CancellationToken cancellationToken = default)
+    {
+        return _remoteService.RetryAsync(input, cancellationToken);
+    }
+}

--- a/src/BBT.Workflow.Infrastructure/Gateway/RoutedInstanceRetryGateway.cs
+++ b/src/BBT.Workflow.Infrastructure/Gateway/RoutedInstanceRetryGateway.cs
@@ -1,0 +1,44 @@
+using BBT.Aether.Results;
+using BBT.Workflow.Gateway;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Runtime;
+
+namespace BBT.Workflow.Infrastructure.Gateway;
+
+/// <summary>
+/// Routed implementation of instance retry gateway.
+/// Routes between local and remote execution based on target domain.
+/// Uses IRuntimeInfoProvider.IsDomainMatch() to determine if target domain is local.
+/// </summary>
+public sealed class RoutedInstanceRetryGateway : IInstanceRetryGateway
+{
+    private readonly LocalInstanceRetryGateway _local;
+    private readonly RemoteInstanceRetryGateway _remote;
+    private readonly IRuntimeInfoProvider _runtimeInfoProvider;
+
+    /// <summary>
+    /// Initializes a new instance of RoutedInstanceRetryGateway.
+    /// </summary>
+    /// <param name="local">The local gateway for same-domain execution.</param>
+    /// <param name="remote">The remote gateway for cross-domain execution.</param>
+    /// <param name="runtimeInfoProvider">Provider for runtime domain information.</param>
+    public RoutedInstanceRetryGateway(
+        LocalInstanceRetryGateway local,
+        RemoteInstanceRetryGateway remote,
+        IRuntimeInfoProvider runtimeInfoProvider)
+    {
+        _local = local;
+        _remote = remote;
+        _runtimeInfoProvider = runtimeInfoProvider;
+    }
+
+    /// <inheritdoc />
+    public Task<Result<RetryInstanceOutput>> RetryAsync(
+        RetryInstanceInput input,
+        CancellationToken cancellationToken = default)
+    {
+        return _runtimeInfoProvider.IsDomainMatch(input.Domain)
+            ? _local.RetryAsync(input, cancellationToken)
+            : _remote.RetryAsync(input, cancellationToken);
+    }
+}

--- a/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceTransitionRepository.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceTransitionRepository.cs
@@ -68,4 +68,14 @@ public class EfCoreInstanceTransitionRepository(
                 cancellationToken
             );
     }
+
+    /// <inheritdoc />
+    public async Task<InstanceTransition?> GetLatestIncompleteAsync(Guid instanceId, CancellationToken cancellationToken = default)
+    {
+        var context = await GetDbContextAsync();
+        return await context.InstanceTransitions
+            .Where(p => p.InstanceId == instanceId && p.FinishedAt == null)
+            .OrderByDescending(p => p.StartedAt)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
 }

--- a/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceRetryAppService.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceRetryAppService.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Text;
+using System.Text.Json;
+using BBT.Aether.Results;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Discovery;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Instances.Remote;
+using BBT.Workflow.Remote.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace BBT.Workflow.Infrastructure.Instances.Remote;
+
+/// <summary>
+/// Remote implementation of instance retry operations using HTTP client calls to InstanceController.
+/// Uses IDomainDiscoveryResolver to dynamically resolve endpoint URLs based on target domain.
+/// </summary>
+public sealed class RemoteInstanceRetryAppService(
+    HttpClient httpClient,
+    IOptions<RemoteOptions> options,
+    IDomainDiscoveryResolver endpointResolver)
+    : IRemoteInstanceRetryAppService
+{
+    private readonly RemoteOptions _options = options.Value;
+
+    private string ApiVersionPrefix => InstanceUrlTemplates.GetApiVersionPrefix(_options.ApiVersion);
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
+
+    /// <summary>
+    /// Retries a faulted workflow instance by calling the remote API
+    /// POST {baseUrl}/api/v{version}/{domain}/workflows/{workflow}/instances/{instance}/retry
+    /// </summary>
+    public async Task<Result<RetryInstanceOutput>> RetryAsync(
+        RetryInstanceInput input,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            // Resolve endpoint dynamically based on target domain
+            var endpointResult = await endpointResolver.GetEndpointAsync(input.Domain, EndpointKind.Url, cancellationToken);
+
+            if (!endpointResult.IsSuccess)
+            {
+                return Result<RetryInstanceOutput>.Fail(endpointResult.Error);
+            }
+
+            var endpoint = endpointResult.Value!;
+
+            var relativePath = InstanceUrlTemplates.Retry(input.Domain, input.Workflow, input.Instance, ApiVersionPrefix);
+
+            var queryParams = new List<string>();
+            if (!string.IsNullOrEmpty(input.Version))
+                queryParams.Add($"version={Uri.EscapeDataString(input.Version)}");
+            if (input.Sync)
+                queryParams.Add("sync=true");
+
+            if (queryParams.Count > 0)
+                relativePath += "?" + string.Join("&", queryParams);
+
+            var requestUri = new Uri(endpoint.BaseUrl, relativePath.TrimStart('/'));
+
+            // Build request body from data if provided
+            var content = input.Data != null
+                ? new StringContent(JsonSerializer.Serialize(input.Data, JsonOptions), Encoding.UTF8, "application/json")
+                : new StringContent("{}", Encoding.UTF8, "application/json");
+
+            var requestMessage = new HttpRequestMessage(HttpMethod.Post, requestUri)
+            {
+                Content = content
+            };
+
+            // Forward headers
+            foreach (var header in input.Headers)
+            {
+                if (!IsRestrictedHeader(header.Key))
+                {
+                    requestMessage.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                }
+            }
+
+            var response = await httpClient.SendAsync(requestMessage, cancellationToken);
+
+            // Status code → Result.Fail (per Railway Pattern)
+            return await HandleResponseAsync<RetryInstanceOutput>(response, cancellationToken);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or OperationCanceledException)
+        {
+            // Network errors → Transient error (per Railway Pattern)
+            return Result<RetryInstanceOutput>.Fail(Error.Transient("remote_network_error", ex.Message));
+        }
+    }
+
+    /// <summary>
+    /// Handles HTTP response by mapping status codes to appropriate Result types.
+    /// Follows Railway Pattern: Status code → Result.Fail (not exceptions).
+    /// </summary>
+    private static async Task<Result<T>> HandleResponseAsync<T>(HttpResponseMessage response,
+        CancellationToken cancellationToken)
+    {
+        // Success case
+        if (response.IsSuccessStatusCode)
+        {
+            var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+            var result = JsonSerializer.Deserialize<T>(responseContent, JsonOptions);
+            return Result<T>.Ok(result!);
+        }
+
+        // Map status codes to appropriate Error types (per Railway Pattern)
+        return await MapStatusCodeToError<T>(response, cancellationToken);
+    }
+
+    /// <summary>
+    /// Maps HTTP status codes to appropriate Error types following Railway Pattern guidelines.
+    /// </summary>
+    private static async Task<Result<T>> MapStatusCodeToError<T>(HttpResponseMessage response,
+        CancellationToken cancellationToken)
+    {
+        var errorContent = await response.Content.ReadAsStringAsync(cancellationToken);
+        var statusCode = response.StatusCode;
+
+        // Check if response has Aether error format header
+        if (response.Headers.TryGetValues("_bbt_error_format", out var values) &&
+            values.Any(v => v.Equals("true", StringComparison.OrdinalIgnoreCase)))
+        {
+            try
+            {
+                var errorResponse = JsonSerializer.Deserialize<ServiceErrorResponse>(errorContent, JsonOptions);
+                if (errorResponse?.Error != null)
+                {
+                    // Use the prefix from remote service if available, otherwise infer from status code
+                    var prefix = errorResponse.Error.Prefix ?? InferPrefixFromStatusCode(statusCode);
+                    var code = errorResponse.Error.Code ?? "remote_error";
+
+                    // Map to appropriate Error type based on prefix
+                    var error = prefix switch
+                    {
+                        ErrorCodes.Prefixes.Validation => Error.Validation(code, errorResponse.Error.Message,
+                            errorResponse.Error.Target),
+                        ErrorCodes.Prefixes.NotFound => Error.NotFound(code, errorResponse.Error.Message,
+                            errorResponse.Error.Target),
+                        ErrorCodes.Prefixes.Conflict => Error.Conflict(code, errorResponse.Error.Message,
+                            errorResponse.Error.Target),
+                        ErrorCodes.Prefixes.Unauthorized => Error.Unauthorized(code, errorResponse.Error.Message),
+                        ErrorCodes.Prefixes.Forbidden => Error.Forbidden(code, errorResponse.Error.Message),
+                        ErrorCodes.Prefixes.Dependency => Error.Dependency(code, errorResponse.Error.Message,
+                            errorResponse.Error.Target),
+                        ErrorCodes.Prefixes.Transient => Error.Transient(code, errorResponse.Error.Message,
+                            errorResponse.Error.Target),
+                        _ => Error.Failure(code, errorResponse.Error.Message, errorResponse.Error.Details)
+                    };
+                    return Result<T>.Fail(error);
+                }
+            }
+            catch (JsonException)
+            {
+                // If JSON deserialization fails, fall back to status code mapping
+            }
+        }
+
+        // Map status code to appropriate Error type (Railway Pattern best practice)
+        var mappedError = statusCode switch
+        {
+            System.Net.HttpStatusCode.BadRequest => Error.Validation(
+                "remote_bad_request",
+                $"Remote API validation error: {errorContent}"),
+
+            System.Net.HttpStatusCode.NotFound => Error.NotFound(
+                "remote_not_found",
+                "Requested resource not found on remote API",
+                errorContent),
+
+            System.Net.HttpStatusCode.Conflict => Error.Conflict(
+                "remote_conflict",
+                $"Remote API conflict: {errorContent}"),
+
+            System.Net.HttpStatusCode.Unauthorized => Error.Unauthorized(
+                "remote_unauthorized",
+                "Unauthorized access to remote API"),
+
+            System.Net.HttpStatusCode.Forbidden => Error.Forbidden(
+                "remote_forbidden",
+                "Forbidden access to remote API"),
+
+            System.Net.HttpStatusCode.InternalServerError or
+                System.Net.HttpStatusCode.BadGateway or
+                System.Net.HttpStatusCode.ServiceUnavailable or
+                System.Net.HttpStatusCode.GatewayTimeout => Error.Dependency(
+                    "remote_service_error",
+                    $"Remote API service error: {response.ReasonPhrase}",
+                    ((int)statusCode).ToString()),
+
+            _ => Error.Dependency(
+                "remote_http_error",
+                $"Remote API returned HTTP {(int)statusCode}: {response.ReasonPhrase}",
+                ((int)statusCode).ToString())
+        };
+
+        return Result<T>.Fail(mappedError);
+    }
+
+    /// <summary>
+    /// Infers error prefix from HTTP status code for Aether error format
+    /// </summary>
+    private static string InferPrefixFromStatusCode(System.Net.HttpStatusCode statusCode)
+    {
+        return statusCode switch
+        {
+            System.Net.HttpStatusCode.BadRequest => ErrorCodes.Prefixes.Validation,
+            System.Net.HttpStatusCode.NotFound => ErrorCodes.Prefixes.NotFound,
+            System.Net.HttpStatusCode.Conflict => ErrorCodes.Prefixes.Conflict,
+            System.Net.HttpStatusCode.Unauthorized => ErrorCodes.Prefixes.Unauthorized,
+            System.Net.HttpStatusCode.Forbidden => ErrorCodes.Prefixes.Forbidden,
+            _ => ErrorCodes.Prefixes.Dependency
+        };
+    }
+
+    /// <summary>
+    /// Checks if a header is restricted and cannot be set manually
+    /// </summary>
+    private static bool IsRestrictedHeader(string headerName)
+    {
+        return headerName.Equals("Content-Type", StringComparison.OrdinalIgnoreCase) ||
+               headerName.Equals("Content-Length", StringComparison.OrdinalIgnoreCase) ||
+               headerName.Equals("Host", StringComparison.OrdinalIgnoreCase) ||
+               headerName.Equals("Connection", StringComparison.OrdinalIgnoreCase);
+    }
+}
+
+/// <summary>
+/// DTO for deserializing error responses from remote services
+/// </summary>
+internal sealed class ServiceErrorResponse
+{
+    public ServiceError? Error { get; set; }
+}
+
+/// <summary>
+/// DTO for service error details
+/// </summary>
+internal sealed class ServiceError
+{
+    public string? Code { get; set; }
+    public string? Message { get; set; }
+    public string? Prefix { get; set; }
+    public string? Target { get; set; }
+    public string? Details { get; set; }
+}

--- a/src/BBT.Workflow.Infrastructure/Microsoft/Extensions/DependencyInjection/GatewayServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Infrastructure/Microsoft/Extensions/DependencyInjection/GatewayServiceCollectionExtensions.cs
@@ -24,9 +24,13 @@ public static class GatewayServiceCollectionExtensions
         services.AddScoped<RemoteInstanceCommandGateway>();
         services.AddScoped<RemoteInstanceQueryGateway>();
 
+        services.AddScoped<LocalInstanceRetryGateway>();
+        services.AddScoped<RemoteInstanceRetryGateway>();
+
         // Routed gateways - route based on IRuntimeInfoProvider.IsDomainMatch()
         // These are registered as the interface implementations
         services.AddScoped<IInstanceCommandGateway, RoutedInstanceCommandGateway>();
+        services.AddScoped<IInstanceRetryGateway, RoutedInstanceRetryGateway>();
         services.AddScoped<IInstanceQueryGateway, RoutedInstanceQueryGateway>();
 
         return services;

--- a/src/BBT.Workflow.Infrastructure/Remote/Extensions/RemoteServiceExtensions.cs
+++ b/src/BBT.Workflow.Infrastructure/Remote/Extensions/RemoteServiceExtensions.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Options;
 using Polly;
 using Polly.Extensions.Http;
 using Polly.Timeout;
+using BBT.Workflow.Infrastructure.Instances.Remote;
 
 namespace BBT.Workflow.Remote.Extensions;
 
@@ -41,6 +42,38 @@ public static class RemoteServiceExtensions
         var options = optionsSection.Get<RemoteOptions>() ?? new RemoteOptions();
 
         services.AddHttpClient<IRemoteInstanceCommandAppService, RemoteInstanceCommandAppService>((sp, client) =>
+            {
+                var runtimeInfoProvider = sp.GetRequiredService<IRuntimeInfoProvider>();
+                var clientOptions = sp.GetRequiredService<IOptions<RemoteOptions>>().Value;
+
+                // Note: BaseAddress is no longer set here - it's resolved dynamically per request
+                // using IDomainDiscoveryResolver based on the target domain
+                client.Timeout = TimeSpan.FromSeconds(clientOptions.TimeoutSeconds);
+                client.DefaultRequestHeaders.Add("Accept", "application/json");
+                client.DefaultRequestHeaders.Add("User-Agent",
+                    $"vnext-runtime/{runtimeInfoProvider.Version} ({runtimeInfoProvider.Domain})");
+
+                // Add internal operation header for circuit breaker context
+                if (clientOptions.EnableCircuitBreakerBypass)
+                {
+                    client.DefaultRequestHeaders.Add(clientOptions.InternalOperationHeader, "true");
+                }
+                
+                // Increase buffer size limits to handle large responses
+                client.MaxResponseContentBufferSize = int.MaxValue;
+            })
+            .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler()
+            {
+                AutomaticDecompression = System.Net.DecompressionMethods.GZip | System.Net.DecompressionMethods.Deflate,
+                // Increase response headers length limit (default is 64KB)
+                MaxResponseHeadersLength = 1024 * 1024, // 1MB
+                // Increase request content buffer size limit (default is 2GB)
+                MaxRequestContentBufferSize = int.MaxValue
+            })
+            .AddPolicyHandler(GetTimeoutPolicy(options))
+            .AddPolicyHandler(GetRetryPolicy(options))
+            .AddPolicyHandler(GetCircuitBreakerPolicy(options));
+        services.AddHttpClient<IRemoteInstanceRetryAppService, RemoteInstanceRetryAppService>((sp, client) =>
             {
                 var runtimeInfoProvider = sp.GetRequiredService<IRuntimeInfoProvider>();
                 var clientOptions = sp.GetRequiredService<IOptions<RemoteOptions>>().Value;

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceRetryAppServiceTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceRetryAppServiceTests.cs
@@ -1,0 +1,219 @@
+using System;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.Results;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Gateway;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Instances;
+
+/// <summary>
+/// Unit tests for IInstanceRetryGateway interface behavior.
+/// Tests verify correct gateway routing and result handling.
+/// Note: Full integration tests for InstanceRetryAppService should use ApplicationTestBase infrastructure.
+/// </summary>
+public class InstanceRetryGatewayTests
+{
+    private readonly IInstanceRetryGateway _retryGateway;
+    private readonly IInstanceQueryGateway _queryGateway;
+
+    public InstanceRetryGatewayTests()
+    {
+        _retryGateway = Substitute.For<IInstanceRetryGateway>();
+        _queryGateway = Substitute.For<IInstanceQueryGateway>();
+    }
+
+    [Fact]
+    public async Task RetryGateway_WhenCalled_ShouldReturnSuccessfulResult()
+    {
+        // Arrange
+        var input = CreateRetryInput("test-instance");
+        var expectedOutput = new RetryInstanceOutput
+        {
+            Id = Guid.NewGuid(),
+            Status = InstanceStatus.Active,
+            RetriedTransitionId = Guid.NewGuid()
+        };
+
+        _retryGateway.RetryAsync(input, Arg.Any<CancellationToken>())
+            .Returns(Result<RetryInstanceOutput>.Ok(expectedOutput));
+
+        // Act
+        var result = await _retryGateway.RetryAsync(input);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.Id.ShouldBe(expectedOutput.Id);
+        result.Value.Status.ShouldBe(InstanceStatus.Active);
+    }
+
+    [Fact]
+    public async Task RetryGateway_WhenInstanceNotFound_ShouldReturnNotFoundError()
+    {
+        // Arrange
+        var input = CreateRetryInput("non-existent");
+        _retryGateway.RetryAsync(input, Arg.Any<CancellationToken>())
+            .Returns(Result<RetryInstanceOutput>.Fail(Error.NotFound(
+                WorkflowErrorCodes.InstanceNotFound,
+                "Instance not found")));
+
+        // Act
+        var result = await _retryGateway.RetryAsync(input);
+
+        // Assert
+        result.IsSuccess.ShouldBeFalse();
+        result.Error.Code.ShouldBe(WorkflowErrorCodes.InstanceNotFound);
+    }
+
+    [Fact]
+    public async Task RetryGateway_WhenInstanceNotFaulted_ShouldReturnValidationError()
+    {
+        // Arrange
+        var input = CreateRetryInput("active-instance");
+        _retryGateway.RetryAsync(input, Arg.Any<CancellationToken>())
+            .Returns(Result<RetryInstanceOutput>.Fail(Error.Validation(
+                WorkflowErrorCodes.InstanceNotFaulted,
+                "Instance is not in faulted state")));
+
+        // Act
+        var result = await _retryGateway.RetryAsync(input);
+
+        // Assert
+        result.IsSuccess.ShouldBeFalse();
+        result.Error.Code.ShouldBe(WorkflowErrorCodes.InstanceNotFaulted);
+    }
+
+    [Fact]
+    public async Task RetryGateway_WhenRetryFaultsAgain_ShouldReturnFaultedStatus()
+    {
+        // Arrange
+        var input = CreateRetryInput("failing-instance");
+        var expectedOutput = new RetryInstanceOutput
+        {
+            Id = Guid.NewGuid(),
+            Status = InstanceStatus.Faulted,
+            RetriedTransitionId = Guid.NewGuid()
+        };
+
+        _retryGateway.RetryAsync(input, Arg.Any<CancellationToken>())
+            .Returns(Result<RetryInstanceOutput>.Ok(expectedOutput));
+
+        // Act
+        var result = await _retryGateway.RetryAsync(input);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.Status.ShouldBe(InstanceStatus.Faulted);
+    }
+
+    [Fact]
+    public async Task RetryGateway_WithCrossDomainSubflow_ShouldRouteToRemote()
+    {
+        // Arrange
+        var input = new RetryInstanceInput
+        {
+            Domain = "remote-domain",
+            Workflow = "subflow-workflow",
+            Instance = Guid.NewGuid().ToString(),
+            Sync = false
+        };
+        var expectedOutput = new RetryInstanceOutput
+        {
+            Id = Guid.Parse(input.Instance),
+            Status = InstanceStatus.Active,
+            RetriedTransitionId = Guid.NewGuid()
+        };
+
+        _retryGateway.RetryAsync(
+            Arg.Is<RetryInstanceInput>(r => r.Domain == "remote-domain"),
+            Arg.Any<CancellationToken>())
+            .Returns(Result<RetryInstanceOutput>.Ok(expectedOutput));
+
+        // Act
+        var result = await _retryGateway.RetryAsync(input);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.Id.ShouldBe(expectedOutput.Id);
+
+        await _retryGateway.Received(1).RetryAsync(
+            Arg.Is<RetryInstanceInput>(r => r.Domain == "remote-domain"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task QueryGateway_WhenQueryingSubflowState_ShouldReturnFaultedStatus()
+    {
+        // Arrange
+        var input = new GetFunctionWithInstanceInput
+        {
+            Domain = "subflow-domain",
+            Workflow = "subflow-workflow",
+            Instance = Guid.NewGuid().ToString()
+        };
+        var expectedOutput = new GetInstanceStateOutput
+        {
+            Status = InstanceStatus.Faulted,
+            State = "faulted-state"
+        };
+
+        _queryGateway.GetFunctionWithStateAsync(input, Arg.Any<CancellationToken>())
+            .Returns(Result<GetInstanceStateOutput>.Ok(expectedOutput));
+
+        // Act
+        var result = await _queryGateway.GetFunctionWithStateAsync(input);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.Status.ShouldBe(InstanceStatus.Faulted);
+    }
+
+    [Fact]
+    public async Task RetryGateway_WithTransitionData_ShouldPassDataToRetry()
+    {
+        // Arrange
+        var input = new RetryInstanceInput
+        {
+            Domain = "test-domain",
+            Workflow = "test-workflow",
+            Instance = Guid.NewGuid().ToString(),
+            Sync = true,
+            Data = new TransitionDataInput
+            {
+                Key = "retry-key"
+            }
+        };
+        var expectedOutput = new RetryInstanceOutput
+        {
+            Id = Guid.Parse(input.Instance),
+            Status = InstanceStatus.Active,
+            RetriedTransitionId = Guid.NewGuid()
+        };
+
+        _retryGateway.RetryAsync(
+            Arg.Is<RetryInstanceInput>(r => r.Data != null && r.Data.Key == "retry-key"),
+            Arg.Any<CancellationToken>())
+            .Returns(Result<RetryInstanceOutput>.Ok(expectedOutput));
+
+        // Act
+        var result = await _retryGateway.RetryAsync(input);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        await _retryGateway.Received(1).RetryAsync(
+            Arg.Is<RetryInstanceInput>(r => r.Data != null && r.Data.Key == "retry-key"),
+            Arg.Any<CancellationToken>());
+    }
+
+    private static RetryInstanceInput CreateRetryInput(string instanceId, string? domain = null) => new()
+    {
+        Domain = domain ?? "test-domain",
+        Workflow = "test-workflow",
+        Instance = instanceId,
+        Sync = false
+    };
+}


### PR DESCRIPTION
## Summary by Sourcery

Add end-to-end support for retrying faulted workflow instances, including HTTP API, domain services, and gateway routing.

New Features:
- Expose an HTTP endpoint to retry workflow instances or their faulted subflows with optional data and sync execution mode.
- Introduce application and gateway services to orchestrate local and cross-domain instance retry operations, including remote HTTP-based execution.

Enhancements:
- Extend workflow instance and transition domain model and repositories to support unfaulting instances and retrieving the latest incomplete transition for retry.
- Add structured logging and error codes around instance retry operations for better observability and validation.
- Register new retry-related services and HTTP clients in dependency injection and remote service configuration.
- Add URL templates and execution context metadata to support instance retry routing and execution.

Tests:
- Add unit tests covering gateway behavior and result handling for instance retry, including cross-domain and error scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can now retry faulted workflow instances via a new retry endpoint. Retries resume incomplete transitions, accept optional data/version/sync parameters, return retry outcome (instance id, status, retried transition id), and support cross-domain subflow retries.

* **Tests**
  * Added comprehensive test coverage for retry operations, including success, failure, validation, and cross-domain scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->