### PR TITLE
Handle non-blocking task failures + SubProcess sync

### DIFF
--- a/src/BBT.Workflow.Application/Execution/ExecutionErrors.cs
+++ b/src/BBT.Workflow.Application/Execution/ExecutionErrors.cs
@@ -1,4 +1,5 @@
 using BBT.Aether.Results;
+using BBT.Workflow.Execution.Pipeline;
 
 namespace BBT.Workflow.Execution;
 
@@ -92,6 +93,51 @@ public static class ExecutionErrors
             WorkflowErrorCodes.DuplicateInstanceKey,
             $"An active instance with key '{key}' already exists. Instance {instanceId} cannot use this key.",
             target: key);
+
+    #endregion
+
+    #region Task / Pipeline Errors
+
+    /// <summary>
+    /// Creates an error when one or more tasks failed at business level without an ErrorBoundary,
+    /// and the workflow did not handle the failure via automatic transitions (or epilogue was skipped).
+    /// </summary>
+    /// <param name="transitionKey">The transition key being executed.</param>
+    /// <param name="stateKey">The state key where handling was expected (usually target state).</param>
+    /// <param name="failures">The non-blocking failures collected from task steps.</param>
+    /// <param name="reason">Optional reason for why handling didn't occur (e.g., EpilogueSkipped, NoAutoTransitions, NoAutoTransitionWinner).</param>
+    public static Error UnhandledNonBlockingTaskFailures(
+        string transitionKey,
+        string stateKey,
+        IReadOnlyList<NonBlockingTaskFailure> failures,
+        string? reason = null)
+    {
+        var failedKeys = failures
+            .SelectMany(f => f.FailedTaskKeys)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var firstMessage = failures
+            .Select(f => f.FirstErrorMessage)
+            .FirstOrDefault(m => !string.IsNullOrWhiteSpace(m));
+
+        var reasonPart = string.IsNullOrWhiteSpace(reason) ? "Unknown" : reason;
+        var keysPart = failedKeys.Count == 0 ? "Unknown" : string.Join(", ", failedKeys);
+
+        var message =
+            $"Unhandled task business failures without ErrorBoundary for transition '{transitionKey}' " +
+            $"(state: '{stateKey}', reason: '{reasonPart}'). Failed task keys: [{keysPart}].";
+
+        if (!string.IsNullOrWhiteSpace(firstMessage))
+        {
+            message = $"{message} First error: {firstMessage}";
+        }
+
+        return Error.Failure(
+            WorkflowErrorCodes.TaskExecutionFailed,
+            message,
+            detail: stateKey);
+    }
 
     #endregion
     

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/NonBlockingTaskFailures.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/NonBlockingTaskFailures.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BBT.Workflow.Tasks.Coordinator;
+
+namespace BBT.Workflow.Execution.Pipeline;
+
+/// <summary>
+/// Carries non-blocking task failures (business-level failures when no ErrorBoundary exists)
+/// through the pipeline so epilogue (AutoTransitions) can decide whether they were handled.
+/// </summary>
+public static class NonBlockingTaskFailures
+{
+    /// <summary>
+    /// The <see cref="TransitionExecutionContext.Items"/> key used to store the failures list.
+    /// </summary>
+    public const string ItemsKey = "NonBlockingTaskFailures";
+
+    /// <summary>
+    /// Adds the non-blocking failure information to the transition context.
+    /// </summary>
+    public static void Add(
+        TransitionExecutionContext context,
+        string trigger,
+        TasksExecutionResult tasksResult)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(tasksResult);
+
+        if (!tasksResult.HasFailedTasks)
+        {
+            return;
+        }
+
+        var firstErrorMessage = tasksResult.ExecutedTasks
+            .FirstOrDefault(t => !t.IsSuccess)
+            ?.ErrorMessage;
+
+        var failure = new NonBlockingTaskFailure(
+            trigger,
+            tasksResult.FailedTaskKeys,
+            firstErrorMessage);
+
+        if (context.Items.TryGetValue(ItemsKey, out var existing) &&
+            existing is List<NonBlockingTaskFailure> list)
+        {
+            list.Add(failure);
+            return;
+        }
+
+        context.Items[ItemsKey] = new List<NonBlockingTaskFailure> { failure };
+    }
+
+    /// <summary>
+    /// Gets the collected non-blocking failures, if any.
+    /// </summary>
+    public static IReadOnlyList<NonBlockingTaskFailure> Get(TransitionExecutionContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (context.Items.TryGetValue(ItemsKey, out var existing) &&
+            existing is List<NonBlockingTaskFailure> list)
+        {
+            return list;
+        }
+
+        return Array.Empty<NonBlockingTaskFailure>();
+    }
+}
+
+/// <summary>
+/// Represents a single non-blocking task failure batch produced by a lifecycle trigger.
+/// </summary>
+public sealed record NonBlockingTaskFailure(
+    string Trigger,
+    IReadOnlyList<string> FailedTaskKeys,
+    string? FirstErrorMessage);

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/RunAutomaticTransitionsStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/RunAutomaticTransitionsStep.cs
@@ -24,24 +24,42 @@ public sealed class RunAutomaticTransitionsStep(
     {
         Activity.Current?.SetDisplayName($"[{Order}] {nameof(RunAutomaticTransitionsStep)}");
 
+        var nonBlockingFailures = NonBlockingTaskFailures.Get(context);
+
         // Check if target state has any automatic transitions
         if (context.Target?.AutoTransitions == null || !context.Target.AutoTransitions.Any())
         {
+            if (nonBlockingFailures.Count > 0)
+            {
+                return Result<StepOutcome>.Fail(
+                    ExecutionErrors.UnhandledNonBlockingTaskFailures(
+                        context.TransitionKey,
+                        context.Target?.Key ?? context.Current.Key,
+                        nonBlockingFailures,
+                        reason: "NoAutoTransitions"));
+            }
+
             return Result<StepOutcome>.Ok(StepOutcome.Continue());
         }
 
         // Railway chain: Evaluate all transitions -> Process winner (if exists)
-        return await EvaluateAllTransitionsAsync(context, cancellationToken)
-            .Map(evaluations => ProcessEvaluationResults(context, evaluations));
+        var evalResult = await EvaluateAllTransitionsAsync(context, cancellationToken);
+        if (!evalResult.IsSuccess)
+        {
+            return Result<StepOutcome>.Fail(evalResult.Error);
+        }
+
+        return ProcessEvaluationResults(context, evalResult.Value!, nonBlockingFailures);
     }
 
     /// <summary>
     /// Processes evaluation results and requests the winning transition for sync dispatch.
     /// If a winner is found, requests next transition and skips to Finalize step.
     /// </summary>
-    private StepOutcome ProcessEvaluationResults(
+    private Result<StepOutcome> ProcessEvaluationResults(
         TransitionExecutionContext context,
-        List<AutoConditionEvaluation> evaluations)
+        List<AutoConditionEvaluation> evaluations,
+        IReadOnlyList<NonBlockingTaskFailure> nonBlockingFailures)
     {
         var winner = evaluations.FirstOrDefault(e => e.Status == AutoConditionStatus.Satisfied);
 
@@ -52,8 +70,18 @@ public sealed class RunAutomaticTransitionsStep(
                 context.InstanceId,
                 string.Join(", ", evaluations.Select(e => e.TransitionKey)));
 
+            if (nonBlockingFailures.Count > 0)
+            {
+                return Result<StepOutcome>.Fail(
+                    ExecutionErrors.UnhandledNonBlockingTaskFailures(
+                        context.TransitionKey,
+                        context.Target!.Key,
+                        nonBlockingFailures,
+                        reason: "NoAutoTransitionWinner"));
+            }
+
             // No winner found - continue pipeline, stay in current state
-            return StepOutcome.Continue();
+            return Result<StepOutcome>.Ok(StepOutcome.Continue());
         }
 
         logger.AutoTransitionSelected(winner.TransitionKey, context.Target!.Key, context.InstanceId);
@@ -64,7 +92,7 @@ public sealed class RunAutomaticTransitionsStep(
 
         // Skip to Finalize to complete current transition, then pipeline will chain to next
         // return StepOutcome.SkipTo(LifecycleOrder.Finalize);
-        return StepOutcome.Continue();
+        return Result<StepOutcome>.Ok(StepOutcome.Continue());
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/RunOnEntryTasksStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/RunOnEntryTasksStep.cs
@@ -87,6 +87,33 @@ public sealed class RunOnEntryTasksStep(
             
             return Result<StepOutcome>.Fail(tasksResult.TaskError.ToError());
         }
+
+        // Non-blocking business failures (no ErrorBoundary) are expected to be routed by AutoTransitions.
+        // If epilogue is skipped, they become unhandled and must fault the transition.
+        if (tasksResult is { IsSuccess: true, HasFailedTasks: true })
+        {
+            NonBlockingTaskFailures.Add(context, trigger: "OnEntry", tasksResult);
+
+            if (context.Target?.AutoTransitions == null || !context.Target.AutoTransitions.Any())
+            {
+                return Result<StepOutcome>.Fail(
+                    ExecutionErrors.UnhandledNonBlockingTaskFailures(
+                        context.TransitionKey,
+                        context.Target?.Key ?? context.Current.Key,
+                        NonBlockingTaskFailures.Get(context),
+                        reason: "NoAutoTransitions"));
+            }
+
+            if (context.Directives.Epilogue == EpilogueMode.Skip)
+            {
+                return Result<StepOutcome>.Fail(
+                    ExecutionErrors.UnhandledNonBlockingTaskFailures(
+                        context.TransitionKey,
+                        context.Target?.Key ?? context.Current.Key,
+                        NonBlockingTaskFailures.Get(context),
+                        reason: "EpilogueSkipped"));
+            }
+        }
         
         context.ApplyScriptContextChanges(scriptContext);
         await instanceRepository.UpdateAsync(context.Instance, true, cancellationToken);

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/RunOnExecuteTasksStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/RunOnExecuteTasksStep.cs
@@ -81,12 +81,39 @@ public sealed class RunOnExecuteTasksStep(
         }
 
         // Unhandled failure - this will cause fault
-        if (!tasksResult.IsSuccess && tasksResult.TaskError != null)
+        if (tasksResult is { IsSuccess: false, TaskError: not null })
         {
             context.Items[FailedOnExecuteTaskKey] = tasksResult.FailedTask;
             context.Items[TaskExecutionErrorKey] = tasksResult.TaskError;
             
             return Result<StepOutcome>.Fail(tasksResult.TaskError.ToError());
+        }
+
+        // Non-blocking business failures (no ErrorBoundary) are expected to be routed by AutoTransitions.
+        // If epilogue is skipped, they become unhandled and must fault the transition.
+        if (tasksResult is { IsSuccess: true, HasFailedTasks: true })
+        {
+            NonBlockingTaskFailures.Add(context, trigger: "OnExecute", tasksResult);
+
+            if (context.Target?.AutoTransitions == null || !context.Target.AutoTransitions.Any())
+            {
+                return Result<StepOutcome>.Fail(
+                    ExecutionErrors.UnhandledNonBlockingTaskFailures(
+                        context.TransitionKey,
+                        context.Target?.Key ?? context.Current.Key,
+                        NonBlockingTaskFailures.Get(context),
+                        reason: "NoAutoTransitions"));
+            }
+
+            if (context.Directives.Epilogue == EpilogueMode.Skip)
+            {
+                return Result<StepOutcome>.Fail(
+                    ExecutionErrors.UnhandledNonBlockingTaskFailures(
+                        context.TransitionKey,
+                        context.Target?.Key ?? context.Current.Key,
+                        NonBlockingTaskFailures.Get(context),
+                        reason: "EpilogueSkipped"));
+            }
         }
         
         context.ApplyScriptContextChanges(scriptContext);

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/RunOnExitTasksStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/RunOnExitTasksStep.cs
@@ -89,6 +89,33 @@ public sealed class RunOnExitTasksStep(
             
             return Result<StepOutcome>.Fail(tasksResult.TaskError.ToError());
         }
+
+        // Non-blocking business failures (no ErrorBoundary) are expected to be routed by AutoTransitions.
+        // If epilogue is skipped, they become unhandled and must fault the transition.
+        if (tasksResult is { IsSuccess: true, HasFailedTasks: true })
+        {
+            NonBlockingTaskFailures.Add(context, trigger: "OnExit", tasksResult);
+
+            if (context.Target?.AutoTransitions == null || !context.Target.AutoTransitions.Any())
+            {
+                return Result<StepOutcome>.Fail(
+                    ExecutionErrors.UnhandledNonBlockingTaskFailures(
+                        context.TransitionKey,
+                        context.Target?.Key ?? context.Current.Key,
+                        NonBlockingTaskFailures.Get(context),
+                        reason: "NoAutoTransitions"));
+            }
+
+            if (context.Directives.Epilogue == EpilogueMode.Skip)
+            {
+                return Result<StepOutcome>.Fail(
+                    ExecutionErrors.UnhandledNonBlockingTaskFailures(
+                        context.TransitionKey,
+                        context.Target?.Key ?? context.Current.Key,
+                        NonBlockingTaskFailures.Get(context),
+                        reason: "EpilogueSkipped"));
+            }
+        }
         
         context.ApplyScriptContextChanges(scriptContext);
         await instanceRepository.UpdateAsync(context.Instance, true, cancellationToken);

--- a/src/BBT.Workflow.Application/Tasks/Coordinator/TaskCoordinator.cs
+++ b/src/BBT.Workflow.Application/Tasks/Coordinator/TaskCoordinator.cs
@@ -200,9 +200,11 @@ public sealed class TaskCoordinator : ITaskCoordinatorExtended
                 executedTasks.Count, skippedCount);
         }
 
-        return Result<TasksExecutionResult>.Ok(TasksExecutionResult.Success(
-            executedTasks,
-            totalStopwatch.ElapsedMilliseconds));
+        var hasBusinessFailures = executedTasks.Any(t => !t.IsSuccess);
+        return Result<TasksExecutionResult>.Ok(
+            hasBusinessFailures
+                ? TasksExecutionResult.SuccessWithFailedTasks(executedTasks, totalStopwatch.ElapsedMilliseconds)
+                : TasksExecutionResult.Success(executedTasks, totalStopwatch.ElapsedMilliseconds));
     }
 
     /// <summary>
@@ -352,8 +354,11 @@ public sealed class TaskCoordinator : ITaskCoordinatorExtended
                 }
             }
 
-            return Result<TasksExecutionResult>.Ok(TasksExecutionResult.Success(
-                executedTasks, stopwatch.ElapsedMilliseconds));
+            var hasBusinessFailures = executedTasks.Any(t => !t.IsSuccess);
+            return Result<TasksExecutionResult>.Ok(
+                hasBusinessFailures
+                    ? TasksExecutionResult.SuccessWithFailedTasks(executedTasks, stopwatch.ElapsedMilliseconds)
+                    : TasksExecutionResult.Success(executedTasks, stopwatch.ElapsedMilliseconds));
         }
         catch (Exception ex)
         {

--- a/src/BBT.Workflow.Application/Tasks/Coordinator/TasksExecutionResult.cs
+++ b/src/BBT.Workflow.Application/Tasks/Coordinator/TasksExecutionResult.cs
@@ -99,7 +99,7 @@ public sealed record TasksExecutionResult
 
         return new TasksExecutionResult
         {
-            IsSuccess = true,
+            IsSuccess = false,
             HasFailedTasks = failedKeys.Count > 0,
             FailedTaskKeys = failedKeys,
             FailedTask = null,

--- a/src/BBT.Workflow.Application/Tasks/Executors/Core/TaskExecutorBase.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Core/TaskExecutorBase.cs
@@ -54,7 +54,8 @@ public abstract class TaskExecutorBase<TTask>(ILogger logger) : ITaskExecutor
             stopwatch.Stop();
             Logger.LogError("Task {TaskKey} input preparation failed: {Error}",
                 taskKey, inputResult.Error.Message);
-            return CreateErrorResponse(inputResult.Error, stopwatch.ElapsedMilliseconds);
+            return Result<StandardTaskResponse>.Fail(validationResult.Error);
+            // return CreateErrorResponse(inputResult.Error, stopwatch.ElapsedMilliseconds);
         }
         
         context.InputResponse = inputResult.Value;
@@ -66,7 +67,8 @@ public abstract class TaskExecutorBase<TTask>(ILogger logger) : ITaskExecutor
             stopwatch.Stop();
             Logger.LogError("Task {TaskKey} pre-processing failed: {Error}",
                 taskKey, preProcessResult.Error.Message);
-            return CreateErrorResponse(preProcessResult.Error, stopwatch.ElapsedMilliseconds);
+            return Result<StandardTaskResponse>.Fail(validationResult.Error);
+            // return CreateErrorResponse(preProcessResult.Error, stopwatch.ElapsedMilliseconds);
         }
 
         // 4. Invoke (abstract or virtual)
@@ -91,7 +93,8 @@ public abstract class TaskExecutorBase<TTask>(ILogger logger) : ITaskExecutor
             stopwatch.Stop();
             Logger.LogError("Task {TaskKey} post-processing failed: {Error}",
                 taskKey, postProcessResult.Error.Message);
-            return CreateErrorResponse(postProcessResult.Error, stopwatch.ElapsedMilliseconds);
+            return Result<StandardTaskResponse>.Fail(validationResult.Error);
+            // return CreateErrorResponse(postProcessResult.Error, stopwatch.ElapsedMilliseconds);
         }
 
         // 6. ProcessOutput (virtual - custom per executor)
@@ -101,7 +104,8 @@ public abstract class TaskExecutorBase<TTask>(ILogger logger) : ITaskExecutor
             stopwatch.Stop();
             Logger.LogError("Task {TaskKey} output processing failed: {Error}",
                 taskKey, outputResult.Error.Message);
-            return CreateErrorResponse(outputResult.Error, stopwatch.ElapsedMilliseconds);
+            return Result<StandardTaskResponse>.Fail(validationResult.Error);
+            // return CreateErrorResponse(outputResult.Error, stopwatch.ElapsedMilliseconds);
         }
         
         if (context.TaskTrigger == TaskTrigger.Extension)

--- a/src/BBT.Workflow.Application/Tasks/Executors/Trigger/SubProcessTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Trigger/SubProcessTaskExecutor.cs
@@ -278,7 +278,7 @@ public sealed class SubProcessTaskExecutor : TriggerTaskExecutorBase<SubProcessT
                 domain: task.TriggerDomain,
                 workflow: task.TriggerFlow,
                 version: task.TriggerVersion,
-                sync: false) // Always async
+                sync: task.TriggerSync)
             {
                 Instance = new CreateInstanceInput
                 {
@@ -325,7 +325,7 @@ public sealed class SubProcessTaskExecutor : TriggerTaskExecutorBase<SubProcessT
             Tags = task.TriggerTags,
             Headers = headers != null ? JsonSerializer.Serialize(headers) : null,
             ExtraProperties = BuildExtraPropertiesAsDictionary(context, task),
-            Sync = false, // Always Async
+            Sync = task.TriggerSync,
             UseDapr = task.UseDapr,
             ValidateSSL = task.ValidateSSL,
             BaseUrl = endpoint.BaseUrl.ToString(),

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/SubProcessTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/SubProcessTask.cs
@@ -37,6 +37,11 @@ public sealed class SubProcessTask : WorkflowTask
     /// SubFlow version (optional)
     /// </summary>
     public string? TriggerVersion { get; private set; }
+    
+    /// <summary>
+    /// Sync of the instance to start
+    /// </summary>
+    public bool TriggerSync { get; private set; } = false;
 
     /// <summary>
     /// Body data to send with the subprocess request
@@ -99,6 +104,11 @@ public sealed class SubProcessTask : WorkflowTask
     {
         ValidateSSL = validateSSL;
     }
+    
+    public void SetSync(bool sync)
+    {
+        TriggerSync = sync;
+    }
 
     /// <summary>
     /// Internal property setters for object pooling
@@ -108,6 +118,7 @@ public sealed class SubProcessTask : WorkflowTask
     internal void SetTriggerFlowInternal(string triggerFlow) => TriggerFlow = triggerFlow;
     internal void SetTriggerKeyInternal(string? triggerKey) => TriggerKey = triggerKey;
     internal void SetTriggerVersionInternal(string? triggerVersion) => TriggerVersion = triggerVersion;
+    internal void SetTriggerSyncInternal(bool sync) => TriggerSync = sync;
     internal void SetBodyInternal(JsonElement? body) => Body = body;
     internal void SetTriggerTagsInternal(string[]? tags) => TriggerTags = tags;
     internal void SetUseDaprInternal(bool useDapr) => UseDapr = useDapr;
@@ -128,6 +139,9 @@ public sealed class SubProcessTask : WorkflowTask
 
         if (config.TryGetProperty("version", out var versionElement))
             TriggerVersion = versionElement.GetString();
+        
+        if (config.TryGetProperty("sync", out var triggerSyncElement))
+            TriggerSync = triggerSyncElement.GetBoolean();
 
         if (config.TryGetProperty("body", out var bodyElement))
         {
@@ -172,6 +186,7 @@ public sealed class SubProcessTask : WorkflowTask
         cloned.TriggerFlow = TriggerFlow;
         cloned.TriggerKey = TriggerKey;
         cloned.TriggerVersion = TriggerVersion;
+        cloned.TriggerSync = TriggerSync;
         cloned.Body = Body;
         cloned.TriggerTags = TriggerTags;
         cloned.UseDapr = UseDapr;
@@ -190,6 +205,7 @@ public sealed class SubProcessTask : WorkflowTask
         SetTriggerFlowInternal(source.TriggerFlow);
         SetTriggerKeyInternal(source.TriggerKey);
         SetTriggerVersionInternal(source.TriggerVersion);
+        SetTriggerSyncInternal(source.TriggerSync);
         SetBodyInternal(source.Body);
         SetTriggerTagsInternal(source.TriggerTags);
         SetUseDaprInternal(source.UseDapr);
@@ -206,6 +222,7 @@ public sealed class SubProcessTask : WorkflowTask
         TriggerFlow = string.Empty;
         TriggerKey = null;
         TriggerVersion = null;
+        TriggerSync = false;
         Body = null;
         TriggerTags = null;
         UseDapr = false;

--- a/src/BBT.Workflow.Execution/Invokers/SubProcessRemoteInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/SubProcessRemoteInvoker.cs
@@ -223,6 +223,8 @@ public sealed class SubProcessRemoteInvoker : ITaskInvoker<SubProcessBinding>
             queryParams.Add($"version={Uri.EscapeDataString(binding.Version)}");
         if (binding.Sync)
             queryParams.Add("sync=true");
+        else
+            queryParams.Add("sync=false");
 
         queryParams.Add("strictIdempotency=true");
 


### PR DESCRIPTION
## Summary
- Carry non-blocking (business-level) task failures through transition pipeline and fault the transition when they remain unhandled (e.g., no AutoTransitions, epilogue skipped, or no auto-transition winner).
- Add `sync` support to `SubProcessTask` and propagate it through executor/binding and remote invocation.

## Related
- Closes/addresses #369

## Test plan
- Run a transition where OnEntry/OnExecute/OnExit produce business failures without ErrorBoundary:
  - verify AutoTransition winner routes it
  - verify missing AutoTransitions or skipped epilogue faults with `UnhandledNonBlockingTaskFailures`
- Configure SubProcess task with `sync=true` and `sync=false` and verify orchestration receives correct query param.

## Summary by Sourcery

Propagate non-blocking task (business) failures through the transition pipeline and fault transitions when they remain unhandled, while adding sync configuration support to SubProcess tasks and propagating it through task execution and remote invocation.

New Features:
- Introduce tracking of non-blocking task failures across transition steps so epilogue and automatic transitions can assess and handle them.
- Add a sync flag to SubProcessTask definitions and propagate it through bindings and remote invocations, including explicit sync query parameters.

Bug Fixes:
- Treat task groups with business-level failures as unsuccessful so they can be surfaced and routed appropriately.

Enhancements:
- Add a structured UnhandledNonBlockingTaskFailures error with contextual information for transitions and states lacking appropriate handling.
- Extend automatic transition processing to fail transitions when non-blocking task failures are left unhandled due to missing or non-winning auto-transitions.
- Ensure SubProcess remote invocations always send an explicit sync query parameter based on task configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * SubProcess tasks can now be configured for synchronous or asynchronous execution.

* **Bug Fixes**
  * Task execution now correctly reports partial success when individual tasks fail.
  * Non-blocking task failures are now properly handled and surfaced when no automatic transitions are available.
  * Subprocess invocation requests now always explicitly include the sync parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->