### PR TITLE
v0.0.35

### DIFF
--- a/etc/orchestration/dapr/components/definition-cache-invalidation-subscription.yaml
+++ b/etc/orchestration/dapr/components/definition-cache-invalidation-subscription.yaml
@@ -1,0 +1,8 @@
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+  name: vnext-definition-cache-invalidation-subscription
+spec:
+  topic: definition.cache.invalidate
+  route: /api/v1/utilities/cache/invalidate
+  pubsubname: vnext-pubsub-broadcast

--- a/etc/workers/inbox/dapr/components/definition-cache-invalidation-subscription.yaml
+++ b/etc/workers/inbox/dapr/components/definition-cache-invalidation-subscription.yaml
@@ -1,0 +1,8 @@
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+  name: vnext-inbox-definition-cache-invalidation-subscription
+spec:
+  topic: definition.cache.invalidate
+  route: /api/v1/utilities/cache/invalidate
+  pubsubname: vnext-pubsub-broadcast

--- a/etc/workers/inbox/dapr/components/pubsub-broadcast.yaml
+++ b/etc/workers/inbox/dapr/components/pubsub-broadcast.yaml
@@ -1,0 +1,11 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: vnext-pubsub-broadcast
+spec:
+  type: pubsub.redis
+  metadata:
+  - name: redisHost
+    value: vnext-redis:6379
+  - name: redisPassword
+    value: ""

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Definitions/DefinitionController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Definitions/DefinitionController.cs
@@ -1,5 +1,8 @@
 using BBT.Aether.AspNetCore.Controllers;
 using BBT.Workflow.Definitions;
+using BBT.Workflow.Definitions.Events;
+using BBT.Workflow.Runtime;
+using Dapr.Client;
 using Microsoft.AspNetCore.Mvc;
 
 namespace BBT.Workflow.Orchestration.Controllers.Definitions;
@@ -7,7 +10,11 @@ namespace BBT.Workflow.Orchestration.Controllers.Definitions;
 [ApiController]
 [ApiVersion("1.0")]
 [Route("api/v{version:apiVersion}/definitions")]
-public sealed class DefinitionController(IDefinitionAppService appService) : AetherControllerBase
+public sealed class DefinitionController(
+    IDefinitionAppService appService,
+    DaprClient daprClient,
+    IRuntimeInfoProvider runtimeInfoProvider,
+    IConfiguration configuration) : AetherControllerBase
 {
     [HttpPost("publish")]
     public async Task<IActionResult> PublishAsync(
@@ -18,12 +25,33 @@ public sealed class DefinitionController(IDefinitionAppService appService) : Aet
         return FromResult(result);
     }
 
+    /// <summary>
+    /// Re-initializes the workflow system cache by broadcasting invalidation event to all pods.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token for the operation.</param>
+    /// <returns>Accepted response indicating broadcast initiated.</returns>
+    /// <response code="202">Cache invalidation broadcast initiated successfully.</response>
     [ApiExplorerSettings(IgnoreApi = true)]
     [HttpGet("re-initialize")]
+    [ProducesResponseType(StatusCodes.Status202Accepted)]
     public async Task<IActionResult> ReInitializeAsync(
         CancellationToken cancellationToken = default)
     {
-        var result = await appService.ReInitializeAsync(cancellationToken);
-        return FromResult(result);
+        // Publish broadcast event to all pods using Dapr client directly
+        var cacheInvalidationEvent = new DefinitionCacheInvalidationEvent
+        {
+            Domain = runtimeInfoProvider.Domain,
+            RequestedBy = "Manual",
+            RequestedAt = DateTime.UtcNow,
+            Environment = configuration["ASPNETCORE_ENVIRONMENT"]!
+        };
+        
+        await daprClient.PublishEventAsync(
+            pubsubName: configuration["DAPR_PUBSUB_BROADCAST_STORE_NAME"]!,
+            topicName: DefinitionCacheInvalidationEvent.TopicName,
+            data: cacheInvalidationEvent,
+            cancellationToken: cancellationToken);
+        
+        return Accepted(new { message = "Cache invalidation broadcast initiated" });
     }
 } 

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Utilities/UtilityController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Utilities/UtilityController.cs
@@ -1,6 +1,8 @@
 using BBT.Aether.AspNetCore.Controllers;
 using BBT.Workflow.Definitions;
+using BBT.Workflow.Definitions.Events;
 using BBT.Workflow.Discovery;
+using BBT.Workflow.Logging;
 using BBT.Workflow.Runtime;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
@@ -19,7 +21,9 @@ public sealed class UtilityController(
     IDefinitionAppService definitionAppService,
     IRuntimeInfoProvider runtimeInfoProvider,
     IOptions<RuntimeOptions> runtimeOptions,
-    IDomainDiscoveryResolver domainDiscoveryResolver) : AetherControllerBase
+    IDomainDiscoveryResolver domainDiscoveryResolver,
+    IConfiguration configuration,
+    ILogger<UtilityController> logger) : AetherControllerBase
 {
     /// <summary>
     /// Retrieves the current runtime configuration information.
@@ -71,5 +75,48 @@ public sealed class UtilityController(
     {
         await domainDiscoveryResolver.RefreshBulkCacheAsync(cancellationToken);
         return Ok(new { message = "Discovery cache refreshed successfully" });
+    }
+
+    /// <summary>
+    /// Handles broadcast cache invalidation requests from Dapr subscription.
+    /// All pods receive this message via vnext-pubsub-broadcast.
+    /// </summary>
+    /// <param name="eventData">Cache invalidation event data.</param>
+    /// <param name="cancellationToken">Cancellation token for the operation.</param>
+    /// <returns>Result of the cache invalidation operation.</returns>
+    /// <response code="200">Returns result of cache invalidation.</response>
+    [ApiExplorerSettings(IgnoreApi = true)]
+    [HttpPost("utilities/cache/invalidate")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<IActionResult> InvalidateCacheViaBroadcastAsync(
+        [FromBody] DefinitionCacheInvalidationEvent eventData,
+        CancellationToken cancellationToken = default)
+    {
+        var podInstance = Environment.GetEnvironmentVariable("HOSTNAME") 
+            ?? Environment.GetEnvironmentVariable("POD_NAME") 
+            ?? Environment.MachineName;
+        var hostEnvironment = configuration["ASPNETCORE_ENVIRONMENT"];
+        // Environment match validation
+        if (!string.Equals(eventData.Environment, hostEnvironment, StringComparison.OrdinalIgnoreCase))
+        {
+            logger.LogDebug(
+                "Definition cache invalidation ignored - environment mismatch. PodInstance: {PodInstance}, EventEnvironment: {EventEnvironment}, CurrentEnvironment: {CurrentEnvironment}",
+                podInstance, eventData.Environment, hostEnvironment);
+            return Ok();
+        }
+        
+        logger.DefinitionCacheInvalidationReceived(
+            podInstance,
+            eventData.Domain, 
+            eventData.RequestedBy);
+        
+        var result = await definitionAppService.ReInitializeAsync(cancellationToken);
+        
+        if (result.IsSuccess)
+            logger.DefinitionCacheInvalidationSucceeded(podInstance);
+        else
+            logger.DefinitionCacheInvalidationFailed(podInstance, result.Error.Message);
+            
+        return FromResult(result);
     }
 } 

--- a/src/BBT.Workflow.Application/Definitions/DefinitionAppService.cs
+++ b/src/BBT.Workflow.Application/Definitions/DefinitionAppService.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using BBT.Aether.Application.Services;
+using BBT.Aether.Events;
 using BBT.Aether.MultiSchema;
 using BBT.Aether.Results;
 using BBT.Workflow.Caching;

--- a/src/BBT.Workflow.Application/Execution/ExecutionErrors.cs
+++ b/src/BBT.Workflow.Application/Execution/ExecutionErrors.cs
@@ -1,4 +1,5 @@
 using BBT.Aether.Results;
+using BBT.Workflow.Execution.Pipeline;
 
 namespace BBT.Workflow.Execution;
 
@@ -92,6 +93,51 @@ public static class ExecutionErrors
             WorkflowErrorCodes.DuplicateInstanceKey,
             $"An active instance with key '{key}' already exists. Instance {instanceId} cannot use this key.",
             target: key);
+
+    #endregion
+
+    #region Task / Pipeline Errors
+
+    /// <summary>
+    /// Creates an error when one or more tasks failed at business level without an ErrorBoundary,
+    /// and the workflow did not handle the failure via automatic transitions (or epilogue was skipped).
+    /// </summary>
+    /// <param name="transitionKey">The transition key being executed.</param>
+    /// <param name="stateKey">The state key where handling was expected (usually target state).</param>
+    /// <param name="failures">The non-blocking failures collected from task steps.</param>
+    /// <param name="reason">Optional reason for why handling didn't occur (e.g., EpilogueSkipped, NoAutoTransitions, NoAutoTransitionWinner).</param>
+    public static Error UnhandledNonBlockingTaskFailures(
+        string transitionKey,
+        string stateKey,
+        IReadOnlyList<NonBlockingTaskFailure> failures,
+        string? reason = null)
+    {
+        var failedKeys = failures
+            .SelectMany(f => f.FailedTaskKeys)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var firstMessage = failures
+            .Select(f => f.FirstErrorMessage)
+            .FirstOrDefault(m => !string.IsNullOrWhiteSpace(m));
+
+        var reasonPart = string.IsNullOrWhiteSpace(reason) ? "Unknown" : reason;
+        var keysPart = failedKeys.Count == 0 ? "Unknown" : string.Join(", ", failedKeys);
+
+        var message =
+            $"Unhandled task business failures without ErrorBoundary for transition '{transitionKey}' " +
+            $"(state: '{stateKey}', reason: '{reasonPart}'). Failed task keys: [{keysPart}].";
+
+        if (!string.IsNullOrWhiteSpace(firstMessage))
+        {
+            message = $"{message} First error: {firstMessage}";
+        }
+
+        return Error.Failure(
+            WorkflowErrorCodes.TaskExecutionFailed,
+            message,
+            detail: stateKey);
+    }
 
     #endregion
     

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/NonBlockingTaskFailures.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/NonBlockingTaskFailures.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BBT.Workflow.Tasks.Coordinator;
+
+namespace BBT.Workflow.Execution.Pipeline;
+
+/// <summary>
+/// Carries non-blocking task failures (business-level failures when no ErrorBoundary exists)
+/// through the pipeline so epilogue (AutoTransitions) can decide whether they were handled.
+/// </summary>
+public static class NonBlockingTaskFailures
+{
+    /// <summary>
+    /// The <see cref="TransitionExecutionContext.Items"/> key used to store the failures list.
+    /// </summary>
+    public const string ItemsKey = "NonBlockingTaskFailures";
+
+    /// <summary>
+    /// Adds the non-blocking failure information to the transition context.
+    /// </summary>
+    public static void Add(
+        TransitionExecutionContext context,
+        string trigger,
+        TasksExecutionResult tasksResult)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(tasksResult);
+
+        if (!tasksResult.HasFailedTasks)
+        {
+            return;
+        }
+
+        var firstErrorMessage = tasksResult.ExecutedTasks
+            .FirstOrDefault(t => !t.IsSuccess)
+            ?.ErrorMessage;
+
+        var failure = new NonBlockingTaskFailure(
+            trigger,
+            tasksResult.FailedTaskKeys,
+            firstErrorMessage);
+
+        if (context.Items.TryGetValue(ItemsKey, out var existing) &&
+            existing is List<NonBlockingTaskFailure> list)
+        {
+            list.Add(failure);
+            return;
+        }
+
+        context.Items[ItemsKey] = new List<NonBlockingTaskFailure> { failure };
+    }
+
+    /// <summary>
+    /// Gets the collected non-blocking failures, if any.
+    /// </summary>
+    public static IReadOnlyList<NonBlockingTaskFailure> Get(TransitionExecutionContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (context.Items.TryGetValue(ItemsKey, out var existing) &&
+            existing is List<NonBlockingTaskFailure> list)
+        {
+            return list;
+        }
+
+        return Array.Empty<NonBlockingTaskFailure>();
+    }
+}
+
+/// <summary>
+/// Represents a single non-blocking task failure batch produced by a lifecycle trigger.
+/// </summary>
+public sealed record NonBlockingTaskFailure(
+    string Trigger,
+    IReadOnlyList<string> FailedTaskKeys,
+    string? FirstErrorMessage);

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/RunAutomaticTransitionsStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/RunAutomaticTransitionsStep.cs
@@ -24,24 +24,42 @@ public sealed class RunAutomaticTransitionsStep(
     {
         Activity.Current?.SetDisplayName($"[{Order}] {nameof(RunAutomaticTransitionsStep)}");
 
+        var nonBlockingFailures = NonBlockingTaskFailures.Get(context);
+
         // Check if target state has any automatic transitions
         if (context.Target?.AutoTransitions == null || !context.Target.AutoTransitions.Any())
         {
+            if (nonBlockingFailures.Count > 0)
+            {
+                return Result<StepOutcome>.Fail(
+                    ExecutionErrors.UnhandledNonBlockingTaskFailures(
+                        context.TransitionKey,
+                        context.Target?.Key ?? context.Current.Key,
+                        nonBlockingFailures,
+                        reason: "NoAutoTransitions"));
+            }
+
             return Result<StepOutcome>.Ok(StepOutcome.Continue());
         }
 
         // Railway chain: Evaluate all transitions -> Process winner (if exists)
-        return await EvaluateAllTransitionsAsync(context, cancellationToken)
-            .Map(evaluations => ProcessEvaluationResults(context, evaluations));
+        var evalResult = await EvaluateAllTransitionsAsync(context, cancellationToken);
+        if (!evalResult.IsSuccess)
+        {
+            return Result<StepOutcome>.Fail(evalResult.Error);
+        }
+
+        return ProcessEvaluationResults(context, evalResult.Value!, nonBlockingFailures);
     }
 
     /// <summary>
     /// Processes evaluation results and requests the winning transition for sync dispatch.
     /// If a winner is found, requests next transition and skips to Finalize step.
     /// </summary>
-    private StepOutcome ProcessEvaluationResults(
+    private Result<StepOutcome> ProcessEvaluationResults(
         TransitionExecutionContext context,
-        List<AutoConditionEvaluation> evaluations)
+        List<AutoConditionEvaluation> evaluations,
+        IReadOnlyList<NonBlockingTaskFailure> nonBlockingFailures)
     {
         var winner = evaluations.FirstOrDefault(e => e.Status == AutoConditionStatus.Satisfied);
 
@@ -52,8 +70,18 @@ public sealed class RunAutomaticTransitionsStep(
                 context.InstanceId,
                 string.Join(", ", evaluations.Select(e => e.TransitionKey)));
 
+            if (nonBlockingFailures.Count > 0)
+            {
+                return Result<StepOutcome>.Fail(
+                    ExecutionErrors.UnhandledNonBlockingTaskFailures(
+                        context.TransitionKey,
+                        context.Target!.Key,
+                        nonBlockingFailures,
+                        reason: "NoAutoTransitionWinner"));
+            }
+
             // No winner found - continue pipeline, stay in current state
-            return StepOutcome.Continue();
+            return Result<StepOutcome>.Ok(StepOutcome.Continue());
         }
 
         logger.AutoTransitionSelected(winner.TransitionKey, context.Target!.Key, context.InstanceId);
@@ -64,7 +92,7 @@ public sealed class RunAutomaticTransitionsStep(
 
         // Skip to Finalize to complete current transition, then pipeline will chain to next
         // return StepOutcome.SkipTo(LifecycleOrder.Finalize);
-        return StepOutcome.Continue();
+        return Result<StepOutcome>.Ok(StepOutcome.Continue());
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/RunOnEntryTasksStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/RunOnEntryTasksStep.cs
@@ -87,6 +87,33 @@ public sealed class RunOnEntryTasksStep(
             
             return Result<StepOutcome>.Fail(tasksResult.TaskError.ToError());
         }
+
+        // Non-blocking business failures (no ErrorBoundary) are expected to be routed by AutoTransitions.
+        // If epilogue is skipped, they become unhandled and must fault the transition.
+        if (tasksResult is { IsSuccess: true, HasFailedTasks: true })
+        {
+            NonBlockingTaskFailures.Add(context, trigger: "OnEntry", tasksResult);
+
+            if (context.Target?.AutoTransitions == null || !context.Target.AutoTransitions.Any())
+            {
+                return Result<StepOutcome>.Fail(
+                    ExecutionErrors.UnhandledNonBlockingTaskFailures(
+                        context.TransitionKey,
+                        context.Target?.Key ?? context.Current.Key,
+                        NonBlockingTaskFailures.Get(context),
+                        reason: "NoAutoTransitions"));
+            }
+
+            if (context.Directives.Epilogue == EpilogueMode.Skip)
+            {
+                return Result<StepOutcome>.Fail(
+                    ExecutionErrors.UnhandledNonBlockingTaskFailures(
+                        context.TransitionKey,
+                        context.Target?.Key ?? context.Current.Key,
+                        NonBlockingTaskFailures.Get(context),
+                        reason: "EpilogueSkipped"));
+            }
+        }
         
         context.ApplyScriptContextChanges(scriptContext);
         await instanceRepository.UpdateAsync(context.Instance, true, cancellationToken);

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/RunOnExecuteTasksStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/RunOnExecuteTasksStep.cs
@@ -81,12 +81,39 @@ public sealed class RunOnExecuteTasksStep(
         }
 
         // Unhandled failure - this will cause fault
-        if (!tasksResult.IsSuccess && tasksResult.TaskError != null)
+        if (tasksResult is { IsSuccess: false, TaskError: not null })
         {
             context.Items[FailedOnExecuteTaskKey] = tasksResult.FailedTask;
             context.Items[TaskExecutionErrorKey] = tasksResult.TaskError;
             
             return Result<StepOutcome>.Fail(tasksResult.TaskError.ToError());
+        }
+
+        // Non-blocking business failures (no ErrorBoundary) are expected to be routed by AutoTransitions.
+        // If epilogue is skipped, they become unhandled and must fault the transition.
+        if (tasksResult is { IsSuccess: true, HasFailedTasks: true })
+        {
+            NonBlockingTaskFailures.Add(context, trigger: "OnExecute", tasksResult);
+
+            if (context.Target?.AutoTransitions == null || !context.Target.AutoTransitions.Any())
+            {
+                return Result<StepOutcome>.Fail(
+                    ExecutionErrors.UnhandledNonBlockingTaskFailures(
+                        context.TransitionKey,
+                        context.Target?.Key ?? context.Current.Key,
+                        NonBlockingTaskFailures.Get(context),
+                        reason: "NoAutoTransitions"));
+            }
+
+            if (context.Directives.Epilogue == EpilogueMode.Skip)
+            {
+                return Result<StepOutcome>.Fail(
+                    ExecutionErrors.UnhandledNonBlockingTaskFailures(
+                        context.TransitionKey,
+                        context.Target?.Key ?? context.Current.Key,
+                        NonBlockingTaskFailures.Get(context),
+                        reason: "EpilogueSkipped"));
+            }
         }
         
         context.ApplyScriptContextChanges(scriptContext);

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/RunOnExitTasksStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/RunOnExitTasksStep.cs
@@ -89,6 +89,33 @@ public sealed class RunOnExitTasksStep(
             
             return Result<StepOutcome>.Fail(tasksResult.TaskError.ToError());
         }
+
+        // Non-blocking business failures (no ErrorBoundary) are expected to be routed by AutoTransitions.
+        // If epilogue is skipped, they become unhandled and must fault the transition.
+        if (tasksResult is { IsSuccess: true, HasFailedTasks: true })
+        {
+            NonBlockingTaskFailures.Add(context, trigger: "OnExit", tasksResult);
+
+            if (context.Target?.AutoTransitions == null || !context.Target.AutoTransitions.Any())
+            {
+                return Result<StepOutcome>.Fail(
+                    ExecutionErrors.UnhandledNonBlockingTaskFailures(
+                        context.TransitionKey,
+                        context.Target?.Key ?? context.Current.Key,
+                        NonBlockingTaskFailures.Get(context),
+                        reason: "NoAutoTransitions"));
+            }
+
+            if (context.Directives.Epilogue == EpilogueMode.Skip)
+            {
+                return Result<StepOutcome>.Fail(
+                    ExecutionErrors.UnhandledNonBlockingTaskFailures(
+                        context.TransitionKey,
+                        context.Target?.Key ?? context.Current.Key,
+                        NonBlockingTaskFailures.Get(context),
+                        reason: "EpilogueSkipped"));
+            }
+        }
         
         context.ApplyScriptContextChanges(scriptContext);
         await instanceRepository.UpdateAsync(context.Instance, true, cancellationToken);

--- a/src/BBT.Workflow.Application/Instances/DTOs/StartInstanceInput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/StartInstanceInput.cs
@@ -42,7 +42,7 @@ public sealed class StartInstanceInput(
             WorkflowKey = Workflow,
             WorkflowVersion = Version,
             TransitionKey = startTransitionKey,
-            TriggerType = TriggerType.Manual, // Start transitions are always manual
+            TriggerType = TriggerType.Manual, // Start transitions are always manual,
             Mode = Sync ? ExecMode.Sync : ExecMode.Async,
             CorrelationId = Guid.NewGuid().ToString("N"),
             RequestedAt = DateTimeOffset.UtcNow,

--- a/src/BBT.Workflow.Application/Tasks/Coordinator/TaskCoordinator.cs
+++ b/src/BBT.Workflow.Application/Tasks/Coordinator/TaskCoordinator.cs
@@ -200,9 +200,11 @@ public sealed class TaskCoordinator : ITaskCoordinatorExtended
                 executedTasks.Count, skippedCount);
         }
 
-        return Result<TasksExecutionResult>.Ok(TasksExecutionResult.Success(
-            executedTasks,
-            totalStopwatch.ElapsedMilliseconds));
+        var hasBusinessFailures = executedTasks.Any(t => !t.IsSuccess);
+        return Result<TasksExecutionResult>.Ok(
+            hasBusinessFailures
+                ? TasksExecutionResult.SuccessWithFailedTasks(executedTasks, totalStopwatch.ElapsedMilliseconds)
+                : TasksExecutionResult.Success(executedTasks, totalStopwatch.ElapsedMilliseconds));
     }
 
     /// <summary>
@@ -352,8 +354,11 @@ public sealed class TaskCoordinator : ITaskCoordinatorExtended
                 }
             }
 
-            return Result<TasksExecutionResult>.Ok(TasksExecutionResult.Success(
-                executedTasks, stopwatch.ElapsedMilliseconds));
+            var hasBusinessFailures = executedTasks.Any(t => !t.IsSuccess);
+            return Result<TasksExecutionResult>.Ok(
+                hasBusinessFailures
+                    ? TasksExecutionResult.SuccessWithFailedTasks(executedTasks, stopwatch.ElapsedMilliseconds)
+                    : TasksExecutionResult.Success(executedTasks, stopwatch.ElapsedMilliseconds));
         }
         catch (Exception ex)
         {

--- a/src/BBT.Workflow.Application/Tasks/Coordinator/TasksExecutionResult.cs
+++ b/src/BBT.Workflow.Application/Tasks/Coordinator/TasksExecutionResult.cs
@@ -99,7 +99,7 @@ public sealed record TasksExecutionResult
 
         return new TasksExecutionResult
         {
-            IsSuccess = true,
+            IsSuccess = false,
             HasFailedTasks = failedKeys.Count > 0,
             FailedTaskKeys = failedKeys,
             FailedTask = null,

--- a/src/BBT.Workflow.Application/Tasks/Executors/Core/TaskExecutorBase.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Core/TaskExecutorBase.cs
@@ -54,7 +54,8 @@ public abstract class TaskExecutorBase<TTask>(ILogger logger) : ITaskExecutor
             stopwatch.Stop();
             Logger.LogError("Task {TaskKey} input preparation failed: {Error}",
                 taskKey, inputResult.Error.Message);
-            return CreateErrorResponse(inputResult.Error, stopwatch.ElapsedMilliseconds);
+            return Result<StandardTaskResponse>.Fail(validationResult.Error);
+            // return CreateErrorResponse(inputResult.Error, stopwatch.ElapsedMilliseconds);
         }
         
         context.InputResponse = inputResult.Value;
@@ -66,7 +67,8 @@ public abstract class TaskExecutorBase<TTask>(ILogger logger) : ITaskExecutor
             stopwatch.Stop();
             Logger.LogError("Task {TaskKey} pre-processing failed: {Error}",
                 taskKey, preProcessResult.Error.Message);
-            return CreateErrorResponse(preProcessResult.Error, stopwatch.ElapsedMilliseconds);
+            return Result<StandardTaskResponse>.Fail(validationResult.Error);
+            // return CreateErrorResponse(preProcessResult.Error, stopwatch.ElapsedMilliseconds);
         }
 
         // 4. Invoke (abstract or virtual)
@@ -91,7 +93,8 @@ public abstract class TaskExecutorBase<TTask>(ILogger logger) : ITaskExecutor
             stopwatch.Stop();
             Logger.LogError("Task {TaskKey} post-processing failed: {Error}",
                 taskKey, postProcessResult.Error.Message);
-            return CreateErrorResponse(postProcessResult.Error, stopwatch.ElapsedMilliseconds);
+            return Result<StandardTaskResponse>.Fail(validationResult.Error);
+            // return CreateErrorResponse(postProcessResult.Error, stopwatch.ElapsedMilliseconds);
         }
 
         // 6. ProcessOutput (virtual - custom per executor)
@@ -101,7 +104,8 @@ public abstract class TaskExecutorBase<TTask>(ILogger logger) : ITaskExecutor
             stopwatch.Stop();
             Logger.LogError("Task {TaskKey} output processing failed: {Error}",
                 taskKey, outputResult.Error.Message);
-            return CreateErrorResponse(outputResult.Error, stopwatch.ElapsedMilliseconds);
+            return Result<StandardTaskResponse>.Fail(validationResult.Error);
+            // return CreateErrorResponse(outputResult.Error, stopwatch.ElapsedMilliseconds);
         }
         
         if (context.TaskTrigger == TaskTrigger.Extension)

--- a/src/BBT.Workflow.Application/Tasks/Executors/Trigger/SubProcessTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Trigger/SubProcessTaskExecutor.cs
@@ -278,7 +278,7 @@ public sealed class SubProcessTaskExecutor : TriggerTaskExecutorBase<SubProcessT
                 domain: task.TriggerDomain,
                 workflow: task.TriggerFlow,
                 version: task.TriggerVersion,
-                sync: false) // Always async
+                sync: task.TriggerSync)
             {
                 Instance = new CreateInstanceInput
                 {
@@ -325,7 +325,7 @@ public sealed class SubProcessTaskExecutor : TriggerTaskExecutorBase<SubProcessT
             Tags = task.TriggerTags,
             Headers = headers != null ? JsonSerializer.Serialize(headers) : null,
             ExtraProperties = BuildExtraPropertiesAsDictionary(context, task),
-            Sync = false, // Always Async
+            Sync = task.TriggerSync,
             UseDapr = task.UseDapr,
             ValidateSSL = task.ValidateSSL,
             BaseUrl = endpoint.BaseUrl.ToString(),

--- a/src/BBT.Workflow.Domain/Definitions/Specifications/ActorAuthorizationSpecification.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Specifications/ActorAuthorizationSpecification.cs
@@ -36,30 +36,14 @@ public sealed class ActorAuthorizationSpecification : ITransitionSpecification
     {
         return context.Trigger switch
         {
-            TriggerType.Manual => ValidateManualActor(context),
+            TriggerType.Manual => Result.Ok(),
             TriggerType.Automatic => ValidateAutomaticActor(context),
             TriggerType.Scheduled => ValidateScheduledActor(context),
-            TriggerType.Event => ValidateEventActor(context),
+            TriggerType.Event => Result.Ok(),
             _ => Result.Fail(Error.NotSupported(
                 "UnsupportedTriggerType",
                 $"Trigger type {context.Trigger} is not supported"))
         };
-    }
-    
-    /// <summary>
-    /// Validates manual trigger execution rules.
-    /// Manual transitions must be initiated by User actors (external API/UI requests).
-    /// </summary>
-    private static Result ValidateManualActor(TransitionExecutionContext context)
-    {
-        if (context.Actor != ExecutionActor.User)
-        {
-            return Result.Fail(WorkflowErrors.InvalidActorForManualTransition(
-                context.InstanceId,
-                context.Actor));
-        }
-
-        return Result.Ok();
     }
 
     /// <summary>
@@ -98,23 +82,6 @@ public sealed class ActorAuthorizationSpecification : ITransitionSpecification
         if (context.Actor != ExecutionActor.System)
         {
             return Result.Fail(WorkflowErrors.InvalidActorForScheduledTransition(
-                context.InstanceId,
-                context.Actor));
-        }
-
-        return Result.Ok();
-    }
-
-    /// <summary>
-    /// Validates event trigger execution rules.
-    /// Event transitions must be initiated by User actors (external webhooks/events).
-    /// This allows event-driven transitions from external systems.
-    /// </summary>
-    private static Result ValidateEventActor(TransitionExecutionContext context)
-    {
-        if (context.Actor != ExecutionActor.User)
-        {
-            return Result.Fail(WorkflowErrors.InvalidActorForEventTransition(
                 context.InstanceId,
                 context.Actor));
         }

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/SubProcessTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/SubProcessTask.cs
@@ -37,6 +37,11 @@ public sealed class SubProcessTask : WorkflowTask
     /// SubFlow version (optional)
     /// </summary>
     public string? TriggerVersion { get; private set; }
+    
+    /// <summary>
+    /// Sync of the instance to start
+    /// </summary>
+    public bool TriggerSync { get; private set; } = false;
 
     /// <summary>
     /// Body data to send with the subprocess request
@@ -99,6 +104,11 @@ public sealed class SubProcessTask : WorkflowTask
     {
         ValidateSSL = validateSSL;
     }
+    
+    public void SetSync(bool sync)
+    {
+        TriggerSync = sync;
+    }
 
     /// <summary>
     /// Internal property setters for object pooling
@@ -108,6 +118,7 @@ public sealed class SubProcessTask : WorkflowTask
     internal void SetTriggerFlowInternal(string triggerFlow) => TriggerFlow = triggerFlow;
     internal void SetTriggerKeyInternal(string? triggerKey) => TriggerKey = triggerKey;
     internal void SetTriggerVersionInternal(string? triggerVersion) => TriggerVersion = triggerVersion;
+    internal void SetTriggerSyncInternal(bool sync) => TriggerSync = sync;
     internal void SetBodyInternal(JsonElement? body) => Body = body;
     internal void SetTriggerTagsInternal(string[]? tags) => TriggerTags = tags;
     internal void SetUseDaprInternal(bool useDapr) => UseDapr = useDapr;
@@ -128,6 +139,9 @@ public sealed class SubProcessTask : WorkflowTask
 
         if (config.TryGetProperty("version", out var versionElement))
             TriggerVersion = versionElement.GetString();
+        
+        if (config.TryGetProperty("sync", out var triggerSyncElement))
+            TriggerSync = triggerSyncElement.GetBoolean();
 
         if (config.TryGetProperty("body", out var bodyElement))
         {
@@ -172,6 +186,7 @@ public sealed class SubProcessTask : WorkflowTask
         cloned.TriggerFlow = TriggerFlow;
         cloned.TriggerKey = TriggerKey;
         cloned.TriggerVersion = TriggerVersion;
+        cloned.TriggerSync = TriggerSync;
         cloned.Body = Body;
         cloned.TriggerTags = TriggerTags;
         cloned.UseDapr = UseDapr;
@@ -190,6 +205,7 @@ public sealed class SubProcessTask : WorkflowTask
         SetTriggerFlowInternal(source.TriggerFlow);
         SetTriggerKeyInternal(source.TriggerKey);
         SetTriggerVersionInternal(source.TriggerVersion);
+        SetTriggerSyncInternal(source.TriggerSync);
         SetBodyInternal(source.Body);
         SetTriggerTagsInternal(source.TriggerTags);
         SetUseDaprInternal(source.UseDapr);
@@ -206,6 +222,7 @@ public sealed class SubProcessTask : WorkflowTask
         TriggerFlow = string.Empty;
         TriggerKey = null;
         TriggerVersion = null;
+        TriggerSync = false;
         Body = null;
         TriggerTags = null;
         UseDapr = false;

--- a/src/BBT.Workflow.Domain/Definitions/Views/ViewEnums.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Views/ViewEnums.cs
@@ -18,5 +18,10 @@ public enum ViewType
     /// <summary>
     /// Markdown
     /// </summary>
-    Markdown = 3
+    Markdown = 3,
+
+    /// <summary>
+    /// Deep link URL for navigation
+    /// </summary>
+    DeepLink = 4
 }

--- a/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
@@ -1406,4 +1406,56 @@ public static partial class WorkflowLogs
         string errorMessage);
 
     #endregion
+
+    #region Cache Invalidation
+
+    /// <summary>
+    /// Logs when a definition cache invalidation request is received via broadcast.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 50020,
+        Level = LogLevel.Information,
+        Message = "Definition cache invalidation received. PodInstance: {PodInstance}, Domain: {Domain}, RequestedBy: {RequestedBy}")]
+    public static partial void DefinitionCacheInvalidationReceived(
+        this ILogger logger,
+        string podInstance,
+        string domain,
+        string requestedBy);
+
+    /// <summary>
+    /// Logs when a definition cache invalidation request is ignored due to domain mismatch.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 50021,
+        Level = LogLevel.Debug,
+        Message = "Definition cache invalidation ignored - domain mismatch. PodInstance: {PodInstance}, Domain: {Domain}")]
+    public static partial void DefinitionCacheInvalidationIgnoredDomainMismatch(
+        this ILogger logger,
+        string podInstance,
+        string domain);
+
+    /// <summary>
+    /// Logs when definition cache invalidation succeeds.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 50022,
+        Level = LogLevel.Information,
+        Message = "Definition cache invalidation succeeded. PodInstance: {PodInstance}")]
+    public static partial void DefinitionCacheInvalidationSucceeded(
+        this ILogger logger,
+        string podInstance);
+
+    /// <summary>
+    /// Logs when definition cache invalidation fails.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 50023,
+        Level = LogLevel.Error,
+        Message = "Definition cache invalidation failed. PodInstance: {PodInstance}, Error: {Error}")]
+    public static partial void DefinitionCacheInvalidationFailed(
+        this ILogger logger,
+        string podInstance,
+        string error);
+
+    #endregion
 }

--- a/src/BBT.Workflow.Events.Contracts/Definitions/Events/DefinitionCacheInvalidationEvent.cs
+++ b/src/BBT.Workflow.Events.Contracts/Definitions/Events/DefinitionCacheInvalidationEvent.cs
@@ -1,0 +1,37 @@
+using BBT.Aether.Events;
+
+namespace BBT.Workflow.Definitions.Events;
+
+/// <summary>
+/// Broadcast event to invalidate definition cache across all pods.
+/// Published to vnext-pubsub-broadcast for multi-pod synchronization.
+/// </summary>
+/// <remarks>
+/// This event is broadcast to all pods in the cluster (Orchestration and Worker.Inbox)
+/// to ensure cache consistency across all instances. Unlike domain events, this event
+/// does NOT use hooks - it's handled directly via Dapr subscriptions.
+/// </remarks>
+public class DefinitionCacheInvalidationEvent : IDistributedEvent
+{
+    public const string TopicName = "definition.cache.invalidate";
+    /// <summary>
+    /// The domain requesting cache invalidation.
+    /// </summary>
+    public required string Domain { get; init; }
+
+    /// <summary>
+    /// The environment requesting cache invalidation (e.g., "Development", "Production").
+    /// Used to ensure cache invalidation only affects pods in the same environment.
+    /// </summary>
+    public required string Environment { get; init; }
+
+    /// <summary>
+    /// The source that requested the cache invalidation (e.g., "Manual", "System").
+    /// </summary>
+    public required string RequestedBy { get; init; }
+
+    /// <summary>
+    /// When the cache invalidation was requested.
+    /// </summary>
+    public required DateTime RequestedAt { get; init; }
+}

--- a/src/BBT.Workflow.Execution/Invokers/SubProcessRemoteInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/SubProcessRemoteInvoker.cs
@@ -223,6 +223,8 @@ public sealed class SubProcessRemoteInvoker : ITaskInvoker<SubProcessBinding>
             queryParams.Add($"version={Uri.EscapeDataString(binding.Version)}");
         if (binding.Sync)
             queryParams.Add("sync=true");
+        else
+            queryParams.Add("sync=false");
 
         queryParams.Add("strictIdempotency=true");
 

--- a/src/BBT.Workflow.Execution/Invokers/SubProcessRemoteInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/SubProcessRemoteInvoker.cs
@@ -216,7 +216,7 @@ public sealed class SubProcessRemoteInvoker : ITaskInvoker<SubProcessBinding>
 
     private static string BuildPath(SubProcessBinding binding)
     {
-        var path = $"/api/v1/{binding.Domain}/workflows/sub/{binding.Workflow}/instances/start";
+        var path = $"/api/v1/{binding.Domain}/workflows/{binding.Workflow}/sub/instances/start";
 
         var queryParams = new List<string>();
         if (!string.IsNullOrEmpty(binding.Version))

--- a/workers/BBT.Workflow.Workers.Inbox/Controllers/UtilityController.cs
+++ b/workers/BBT.Workflow.Workers.Inbox/Controllers/UtilityController.cs
@@ -1,0 +1,69 @@
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Definitions.Events;
+using BBT.Workflow.Logging;
+using BBT.Workflow.Runtime;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BBT.Workflow.Workers.Inbox.Controllers;
+
+/// <summary>
+/// Provides utility endpoints for cache management operations in Worker.Inbox.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/utilities")]
+public sealed class UtilityController(
+    IDefinitionAppService definitionAppService,
+    IRuntimeInfoProvider runtimeInfoProvider,
+    IConfiguration configuration,
+    ILogger<UtilityController> logger) : ControllerBase
+{
+    /// <summary>
+    /// Handles broadcast cache invalidation requests from Dapr subscription.
+    /// All Worker.Inbox pods receive this message via vnext-pubsub-broadcast.
+    /// </summary>
+    /// <param name="eventData">Cache invalidation event data.</param>
+    /// <param name="cancellationToken">Cancellation token for the operation.</param>
+    /// <returns>Result of the cache invalidation operation.</returns>
+    /// <response code="200">Returns result of cache invalidation.</response>
+    [ApiExplorerSettings(IgnoreApi = true)]
+    [HttpPost("cache/invalidate")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<IActionResult> InvalidateCacheViaBroadcastAsync(
+        [FromBody] DefinitionCacheInvalidationEvent eventData,
+        CancellationToken cancellationToken = default)
+    {
+        var podInstance = Environment.GetEnvironmentVariable("HOSTNAME") 
+            ?? Environment.GetEnvironmentVariable("POD_NAME") 
+            ?? Environment.MachineName;
+        
+        var hostEnvironment = configuration["ASPNETCORE_ENVIRONMENT"];
+        // Environment match validation
+        if (!string.Equals(eventData.Environment, hostEnvironment, StringComparison.OrdinalIgnoreCase))
+        {
+            logger.LogDebug(
+                "Definition cache invalidation ignored - environment mismatch. PodInstance: {PodInstance}, EventEnvironment: {EventEnvironment}, CurrentEnvironment: {CurrentEnvironment}",
+                podInstance, eventData.Environment, hostEnvironment);
+            return Ok();
+        }
+        
+        // Domain match validation (Worker.Inbox multi-tenant)
+        if (!runtimeInfoProvider.IsDomainMatch(eventData.Domain))
+        {
+            logger.DefinitionCacheInvalidationIgnoredDomainMismatch(podInstance, eventData.Domain);
+            return Ok();
+        }
+        
+        logger.DefinitionCacheInvalidationReceived(podInstance, eventData.Domain, eventData.RequestedBy);
+        
+        var result = await definitionAppService.ReInitializeAsync(cancellationToken);
+        
+        if (result.IsSuccess)
+            logger.DefinitionCacheInvalidationSucceeded(podInstance);
+        else
+            logger.DefinitionCacheInvalidationFailed(podInstance, result.Error.Message);
+            
+        return Ok();
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

Introduce distributed definition cache invalidation and improve handling of non-blocking task failures in workflow execution.

New Features:
- Add broadcast-based definition cache invalidation using Dapr pub/sub across orchestration and worker pods.
- Allow subprocess tasks to start child workflows synchronously or asynchronously via a new configuration flag.
- Introduce a new DeepLink view type for navigation-oriented views.

Bug Fixes:
- Treat task batches with business-level failures as unsuccessful to surface non-blocking failures through the pipeline.
- Ensure non-blocking task failures without ErrorBoundary cause transition faults when auto-transitions or epilogues cannot handle them.
- Relax actor authorization rules for manual and event-triggered transitions by no longer enforcing user-only actors.

Enhancements:
- Add structured logging for definition cache invalidation events, including environment and domain mismatch handling.
- Track non-blocking task failures in the transition pipeline so automatic transitions can decide if they were handled.
- Adjust automatic transition step processing to propagate evaluation errors and return typed results.
- Extend subprocess invocation paths and query parameters to support sync mode and updated routing.
- Refine task executor error handling to return standard failure results instead of wrapped error responses.

Build:
- Add Dapr pub/sub components and subscriptions for definition cache invalidation in orchestration and worker environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cache invalidation can now be broadcast across all pods
  * SubProcess execution can be configured to run synchronously
  * New DeepLink view type available

* **Improvements**
  * Enhanced handling of business-level task failures in transitions
  * Improved task coordination error reporting for failed tasks
  * Actor authorization streamlined for manual and event triggers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->