### PR TITLE
feat: Support gateway base URL in InstanceUrlTemplates for cross-domain routing

### DIFF
--- a/docs/implementation/remote-routing-and-discovery.md
+++ b/docs/implementation/remote-routing-and-discovery.md
@@ -40,9 +40,71 @@ Remote execution:
 Remote clients live in `BBT.Workflow.Infrastructure/Instances/Remote` and:
 
 - Resolve endpoints with `IDomainDiscoveryResolver`.
-- Build URLs using `InstanceUrlTemplates` and `RemoteOptions.ApiVersion`.
+- Build URLs using **static `InstanceUrlTemplates`** and `RemoteOptions.ApiVersion`.
 - Use `HttpClient` + resilient policies configured in `AddVNextApiServices`.
 - Return `Result` / `ConditionalResult` with error normalization for transport failures.
+
+**Note:** Remote clients use static URL templates because they call internal controller routes that must remain fixed.
+
+## Client-Facing URL Templates (HATEOAS)
+
+Controllers in the Orchestration API generate HATEOAS links using **configurable URL templates** to support gateway routing patterns.
+
+### URL Template Builder
+
+`IUrlTemplateBuilder` (implemented by `UrlTemplateBuilder`) generates client-facing URLs from configured templates:
+
+- Used by `InstanceController` and `FunctionController` for HATEOAS link generation
+- Configured via `UrlTemplateOptions` in `appsettings.json`
+- Supports gateway prefixes and custom routing patterns
+- Independent from internal service-to-service URLs
+
+### Configuration
+
+`UrlTemplateOptions` (`UrlTemplates` section) configures client-facing URL patterns:
+
+```json
+{
+  "UrlTemplates": {
+    "Start": "/{0}/workflows/{1}/instances/start",
+    "Transition": "/{0}/workflows/{1}/instances/{2}/transitions/{3}",
+    "FunctionList": "/{0}/workflows/{1}/functions/{2}",
+    "InstanceList": "/{0}/workflows/{1}/instances",
+    "Instance": "/{0}/workflows/{1}/instances/{2}",
+    "InstanceHistory": "/{0}/workflows/{1}/instances/{2}/transitions"
+  }
+}
+```
+
+Template parameters:
+- `{0}` = domain
+- `{1}` = workflow
+- `{2}` = instance/instanceId
+- `{3}` = transitionKey/function
+
+### Gateway Routing Example
+
+For API Gateway with `/api/gateway` prefix:
+
+```json
+{
+  "UrlTemplates": {
+    "Start": "/api/gateway/{0}/workflows/{1}/instances/start",
+    "Transition": "/api/gateway/{0}/workflows/{1}/instances/{2}/transitions/{3}",
+    "FunctionList": "/api/gateway/{0}/workflows/{1}/functions/{2}",
+    "InstanceList": "/api/gateway/{0}/workflows/{1}/instances",
+    "Instance": "/api/gateway/{0}/workflows/{1}/instances/{2}",
+    "InstanceHistory": "/api/gateway/{0}/workflows/{1}/instances/{2}/transitions"
+  }
+}
+```
+
+### URL Types Comparison
+
+| URL Type | Purpose | Configuration | Used By |
+|----------|---------|---------------|---------|
+| Client-facing | HATEOAS links in responses | `UrlTemplates` (configurable) | Controllers |
+| Internal | Service-to-service calls | `InstanceUrlTemplates` (static) | Remote infrastructure |
 
 ## Service Discovery
 
@@ -73,6 +135,12 @@ Configuration: `ServiceDiscoveryOptions` (`BaseUrl`, `Domain`, `RegistryFlow`).
 
 ## Configuration
 
+`UrlTemplateOptions` (`UrlTemplates` section) - **Orchestration API only**:
+
+- Configures client-facing URL patterns for HATEOAS responses
+- Supports gateway routing and custom URL patterns
+- See "Client-Facing URL Templates" section above for details
+
 `RemoteOptions` (`vNextApi` section):
 
 - `BaseUrl`, `ApiVersion`
@@ -96,6 +164,7 @@ Configuration: `ServiceDiscoveryOptions` (`BaseUrl`, `Domain`, `RegistryFlow`).
 
 ## Implementation References
 
+### Gateway Routing
 - `src/BBT.Workflow.Application/Gateway/IInstanceCommandGateway.cs`
 - `src/BBT.Workflow.Application/Gateway/IInstanceQueryGateway.cs`
 - `src/BBT.Workflow.Infrastructure/Gateway/RoutedInstanceCommandGateway.cs`
@@ -104,12 +173,22 @@ Configuration: `ServiceDiscoveryOptions` (`BaseUrl`, `Domain`, `RegistryFlow`).
 - `src/BBT.Workflow.Infrastructure/Gateway/LocalInstanceQueryGateway.cs`
 - `src/BBT.Workflow.Infrastructure/Gateway/RemoteInstanceCommandGateway.cs`
 - `src/BBT.Workflow.Infrastructure/Gateway/RemoteInstanceQueryGateway.cs`
+
+### Service Discovery
 - `src/BBT.Workflow.Application/Discovery/IDomainDiscoveryResolver.cs`
 - `src/BBT.Workflow.Infrastructure/Discovery/DomainDiscoveryResolver.cs`
 - `src/BBT.Workflow.Application/Discovery/IDomainRegistrationService.cs`
 - `src/BBT.Workflow.Infrastructure/Discovery/DomainRegistrationService.cs`
+- `src/BBT.Workflow.Application/Discovery/ServiceDiscoveryOptions.cs`
+
+### Remote Clients
 - `src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceCommandAppService.cs`
 - `src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceQueryAppService.cs`
 - `src/BBT.Workflow.Infrastructure/Remote/Extensions/RemoteServiceExtensions.cs`
 - `src/BBT.Workflow.Infrastructure/Remote/Configuration/RemoteOptions.cs`
-- `src/BBT.Workflow.Application/Discovery/ServiceDiscoveryOptions.cs`
+
+### URL Templates
+- `src/BBT.Workflow.Domain/Definitions/UrlTemplateOptions.cs` - Configuration model
+- `src/BBT.Workflow.Domain/Definitions/IUrlTemplateBuilder.cs` - Builder interface
+- `src/BBT.Workflow.Infrastructure/Definitions/UrlTemplateBuilder.cs` - Implementation
+- `src/BBT.Workflow.Domain/Definitions/InstanceUrlTemplates.cs` - Static templates for internal use

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs
@@ -27,7 +27,8 @@ public sealed class FunctionController(
     IFunctionAppService functionAppService,
     IInstanceQueryAppService queryAppService,
     IPaginationLinkGenerator linkGenerator,
-    IServiceScopeFactory serviceScopeFactory) : AetherControllerBase
+    IServiceScopeFactory serviceScopeFactory,
+    IUrlTemplateBuilder urlTemplateBuilder) : AetherControllerBase
 {
     [HttpPatch("{domain}/functions")]
     public async Task<IActionResult> GetDomainFunctionsAsync(
@@ -72,7 +73,7 @@ public sealed class FunctionController(
             Domain = domain,
             Page = parameters.Page,
             PageSize = parameters.PageSize,
-            PageUrl = InstanceUrlTemplates.FunctionList(domain, workflow, function),
+            PageUrl = urlTemplateBuilder.BuildFunctionListUrl(domain, workflow, function),
             Sort = parameters.Sort,
             Workflow = workflow,
             Filter = function.ToLowerInvariant() == Definitions.Functions.FunctionTypeConst.Data
@@ -88,7 +89,8 @@ public sealed class FunctionController(
         {
             return FromResult(instanceListResult);
         }
-         var pagedList = instanceListResult.Value!.ToPagedList(parameters.PageSize);
+        
+        var pagedList = instanceListResult.Value!.ToPagedList(parameters.PageSize);
         // Process based on function type
         var functionType = function.ToLowerInvariant();
 
@@ -231,7 +233,7 @@ public sealed class FunctionController(
         var results = await Task.WhenAll(tasks);
         var list = results.Where(r => r.IsSuccess).Select(r => r.Value!).ToList();
 
-        var route = InstanceUrlTemplates.FunctionList(domain, workflow,
+        var route = urlTemplateBuilder.BuildFunctionListUrl(domain, workflow,
             Definitions.Functions.FunctionTypeConst.Longpooling, InstanceUrlTemplates.GetApiVersionPrefix("1"));
         var output = linkGenerator.CreateHateoasResult(instanceListResult, list, route);
 
@@ -337,7 +339,7 @@ public sealed class FunctionController(
         var results = await Task.WhenAll(tasks);
         var list = results.Where(r => r.IsSuccess).Select(r => r.Value!).ToList();
 
-        var route = InstanceUrlTemplates.FunctionList(domain, workflow,
+        var route = urlTemplateBuilder.BuildFunctionListUrl(domain, workflow,
             Definitions.Functions.FunctionTypeConst.Extensions, InstanceUrlTemplates.GetApiVersionPrefix("1"));
         var output = linkGenerator.CreateHateoasResult(instanceListResult, list, route);
 
@@ -367,7 +369,7 @@ public sealed class FunctionController(
         var results = await Task.WhenAll(tasks);
         var list = results.Where(r => r.IsSuccess).Select(r => r.Value!).ToList();
 
-        var route = InstanceUrlTemplates.FunctionList(domain, workflow,
+        var route = urlTemplateBuilder.BuildFunctionListUrl(domain, workflow,
             Definitions.Functions.FunctionTypeConst.Schema, InstanceUrlTemplates.GetApiVersionPrefix("1"));
         var output = linkGenerator.CreateHateoasResult(instanceListResult, list, route);
 
@@ -397,7 +399,7 @@ public sealed class FunctionController(
         var results = await Task.WhenAll(tasks);
         var list = results.Where(r => r.IsSuccess).Select(r => r.Value!).ToList();
 
-        var route = InstanceUrlTemplates.FunctionList(domain, workflow,
+        var route = urlTemplateBuilder.BuildFunctionListUrl(domain, workflow,
             Definitions.Functions.FunctionTypeConst.View, InstanceUrlTemplates.GetApiVersionPrefix("1"));
         var output = linkGenerator.CreateHateoasResult(instanceListResult, list, route);
 
@@ -461,7 +463,7 @@ public sealed class FunctionController(
         var results = await Task.WhenAll(tasks);
         var list = results.Where(r => r.Result.IsSuccess).Select(r => r.Result.Value!).ToList();
 
-        var route = InstanceUrlTemplates.FunctionList(domain, workflow,
+        var route = urlTemplateBuilder.BuildFunctionListUrl(domain, workflow,
             Definitions.Functions.FunctionTypeConst.Data, InstanceUrlTemplates.GetApiVersionPrefix("1"));
         var output = linkGenerator.CreateHateoasResult(instanceListResult, list, route);
         return Result<HateoasPagedResultDto<GetInstanceDataOutput>>.Ok(output);
@@ -486,7 +488,7 @@ public sealed class FunctionController(
         var results = await Task.WhenAll(tasks);
         var list = results.Where(r => r.IsSuccess).Select(r => r.Value!).ToList();
 
-        var route = InstanceUrlTemplates.FunctionList(domain, workflow, function,
+        var route = urlTemplateBuilder.BuildFunctionListUrl(domain, workflow, function,
             InstanceUrlTemplates.GetApiVersionPrefix("1"));
         var output = linkGenerator.CreateHateoasResult(instanceListResult, list, route);
         return Result<HateoasPagedResultDto<Dictionary<string, dynamic?>>>.Ok(output);

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
@@ -23,7 +23,8 @@ public sealed class InstanceController(
     IHttpContextAccessor httpContextAccessor,
     ISubflowCompletionService subflowCompletionService,
     ISubflowStateService subflowStateService,
-    IPaginationLinkGenerator linkGenerator) : AetherControllerBase
+    IPaginationLinkGenerator linkGenerator,
+    IUrlTemplateBuilder urlTemplateBuilder) : AetherControllerBase
 {
     /// <summary>
     /// Starts a new workflow instance.
@@ -244,7 +245,7 @@ public sealed class InstanceController(
             Extension = extension,
             Page = page,
             PageSize = pageSize,
-            PageUrl = InstanceUrlTemplates.InstanceList(domain, workflow),
+            PageUrl = urlTemplateBuilder.BuildInstanceListUrl(domain, workflow),
             Filter = filter,
             Sort = sort,
             Headers = requestContext.Headers,
@@ -254,7 +255,7 @@ public sealed class InstanceController(
         var response = await queryAppService.GetInstanceListAsync(input, cancellationToken);
         if (response.IsSuccess)
         {
-            var route = InstanceUrlTemplates.InstanceList(domain, workflow, InstanceUrlTemplates.GetApiVersionPrefix("1"));
+            var route = urlTemplateBuilder.BuildInstanceListUrl(domain, workflow);
 
             // Check if items contain GroupSummary objects (groupBy case) or GetInstanceOutput objects (normal case)
             var firstItem = response.Value!.Items.FirstOrDefault();

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Microsoft/Extensions/DependencyInjection/OrchestrationApiServiceCollectionExtensions.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Microsoft/Extensions/DependencyInjection/OrchestrationApiServiceCollectionExtensions.cs
@@ -17,10 +17,11 @@ public static class OrchestrationApiServiceCollectionExtensions
     public static IServiceCollection AddOrchestrationApiModule(this IServiceCollection services)
     {
         var configuration = services.GetConfiguration();
+        
         services
             .AddDomainModule()
             .AddApplicationModule()
-            .AddInfrastructureModule() // Infrastructure manages its own dependencies
+            .AddInfrastructureModule(configuration) // Infrastructure manages its own dependencies including URL templates
             .AddAspNetCoreModules(configuration)
             .AddResultResilience(configuration)
             .AddDaprClients()

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/appsettings.json
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/appsettings.json
@@ -24,6 +24,17 @@
     "EnableCircuitBreakerBypass": true,
     "InternalOperationHeader": "X-Internal-Operation"
   },
+  "UrlTemplates": {
+    "Start": "/api/{0}/workflows/{1}/instances/start",
+    "Transition": "/api/{0}/workflows/{1}/instances/{2}/transitions/{3}",
+    "FunctionList": "/api/{0}/workflows/{1}/functions/{2}",
+    "InstanceList": "/api/{0}/workflows/{1}/instances",
+    "Instance": "/api/{0}/workflows/{1}/instances/{2}",
+    "InstanceHistory": "/api/{0}/workflows/{1}/instances/{2}/transitions",
+    "Data": "/api/{0}/workflows/{1}/instances/{2}/functions/data",
+    "View": "/api/{0}/workflows/{1}/instances/{2}/functions/view",
+    "Schema": "/api/{0}/workflows/{1}/instances/{2}/functions/schema?transitionKey={3}"
+  },
   "ResponseCompression": {
     "Enable": true,
     "Providers": ["gzip"],

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -26,6 +26,7 @@ public sealed class InstanceQueryAppService(
     IScriptContextFactory scriptContextFactory,
     IInstanceQueryGateway instanceQueryGateway,
     ITaskConditionService taskConditionService,
+    IUrlTemplateBuilder urlTemplateBuilder,
     ILogger<InstanceQueryAppService> logger)
     : ApplicationService(serviceProvider), IInstanceQueryAppService
 {
@@ -585,8 +586,8 @@ private async Task<Result<GetInstanceStateOutput>> BuildInstanceStateOutputAsync
         var transitionItems = subFlowStateInfo.AvailableTransitions.Select(transitionKey => new TransitionItem
         {
             Name = transitionKey,
-            Href = InstanceUrlTemplates.Transition(input.Domain, input.Workflow, instance.Id.ToString(), transitionKey),
-            Schema = new HrefBase { Href = InstanceUrlTemplates.Schema(input.Domain, input.Workflow, instance.Id.ToString(), transitionKey) }
+            Href = urlTemplateBuilder.BuildTransitionUrl(input.Domain, input.Workflow, instance.Id.ToString(), transitionKey),
+            Schema = new HrefBase { Href = urlTemplateBuilder.BuildSchemaUrl(input.Domain, input.Workflow, instance.Id.ToString(), transitionKey) }
         }).ToList();
 
         // Get current state using Railway pattern
@@ -614,15 +615,15 @@ private async Task<Result<GetInstanceStateOutput>> BuildInstanceStateOutputAsync
                 var dataHref = new DataHref
                 {
                     Href = allExtensions.Length > 0
-                        ? InstanceUrlTemplates.DataWithExtensions(input.Domain, input.Workflow, instance.Id.ToString(),
+                        ? urlTemplateBuilder.BuildDataWithExtensionsUrl(input.Domain, input.Workflow, instance.Id.ToString(),
                             allExtensions)
-                        : InstanceUrlTemplates.Data(input.Domain, input.Workflow, instance.Id.ToString())
+                        : urlTemplateBuilder.BuildDataUrl(input.Domain, input.Workflow, instance.Id.ToString())
                 };
 
                 // Build view href - use SubFlow view's LoadData if available, otherwise use main flow
                 var viewHref = new ViewHref
                 {
-                    Href = InstanceUrlTemplates.View(input.Domain, input.Workflow, instance.Id.ToString()),
+                    Href = urlTemplateBuilder.BuildViewUrl(input.Domain, input.Workflow, instance.Id.ToString()),
                     LoadData = subFlowStateInfo.SubFlowView?.LoadData ?? viewLoadData
                 };
 
@@ -639,10 +640,10 @@ private async Task<Result<GetInstanceStateOutput>> BuildInstanceStateOutputAsync
                         SubFlowVersion = correlation.SubFlowVersion,
                         IsCompleted = correlation.IsCompleted,
                         Href = allExtensions.Length > 0
-                            ? InstanceUrlTemplates.DataWithExtensions(correlation.SubFlowDomain, correlation.SubFlowName,
+                            ? urlTemplateBuilder.BuildDataWithExtensionsUrl(correlation.SubFlowDomain, correlation.SubFlowName,
                                 correlation.SubFlowInstanceId.ToString(),
                                 allExtensions)
-                            : InstanceUrlTemplates.Data(correlation.SubFlowDomain, correlation.SubFlowName,
+                            : urlTemplateBuilder.BuildDataUrl(correlation.SubFlowDomain, correlation.SubFlowName,
                                 correlation.SubFlowInstanceId.ToString())
                     }).ToList();
 

--- a/src/BBT.Workflow.Application/Tasks/Executors/Trigger/GetInstancesTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Trigger/GetInstancesTaskExecutor.cs
@@ -23,6 +23,7 @@ public sealed class GetInstancesTaskExecutor : TriggerTaskExecutorBase<GetInstan
 {
     private readonly IInstanceQueryGateway _instanceQueryGateway;
     private readonly IDomainDiscoveryResolver _endpointResolver;
+    private readonly IUrlTemplateBuilder _urlTemplateBuilder;
 
     /// <summary>
     /// Initializes a new instance of GetInstancesTaskExecutor.
@@ -33,11 +34,13 @@ public sealed class GetInstancesTaskExecutor : TriggerTaskExecutorBase<GetInstan
         IRemoteInvokerService remoteInvoker,
         IInstanceQueryGateway instanceQueryGateway,
         IDomainDiscoveryResolver endpointResolver,
+        IUrlTemplateBuilder urlTemplateBuilder,
         ILogger<GetInstancesTaskExecutor> logger)
         : base(scriptEngine, runtimeInfoProvider, remoteInvoker, logger)
     {
         _instanceQueryGateway = instanceQueryGateway;
         _endpointResolver = endpointResolver;
+        _urlTemplateBuilder = urlTemplateBuilder;
     }
 
     /// <inheritdoc />
@@ -111,7 +114,10 @@ public sealed class GetInstancesTaskExecutor : TriggerTaskExecutorBase<GetInstan
                 cancellationToken);
 
             // Build HATEOAS-like response structure for consistency with remote execution
-            var basePath = $"/api/v1/{task.TriggerDomain}/workflows/{task.TriggerFlow}/functions/data";
+            var basePath = _urlTemplateBuilder.BuildFunctionListUrl(
+                task.TriggerDomain, 
+                task.TriggerFlow, 
+                "data");
             var responseData = new
             {
                 links = new

--- a/src/BBT.Workflow.Domain/Definitions/IUrlTemplateBuilder.cs
+++ b/src/BBT.Workflow.Domain/Definitions/IUrlTemplateBuilder.cs
@@ -1,0 +1,110 @@
+namespace BBT.Workflow.Definitions;
+
+/// <summary>
+/// Builds client-facing URLs from configurable templates for HATEOAS responses.
+/// Internal service-to-service URLs use static InstanceUrlTemplates.
+/// </summary>
+public interface IUrlTemplateBuilder
+{
+    /// <summary>
+    /// Builds URL for instance start endpoint.
+    /// </summary>
+    /// <param name="domain">The domain name</param>
+    /// <param name="workflow">The workflow name</param>
+    /// <param name="apiVersionPrefix">Optional API version prefix (e.g., "api/v1")</param>
+    /// <returns>Generated client-facing URL</returns>
+    string BuildStartUrl(string domain, string workflow, string? apiVersionPrefix = null);
+    
+    /// <summary>
+    /// Builds URL for instance transition endpoint.
+    /// </summary>
+    /// <param name="domain">The domain name</param>
+    /// <param name="workflow">The workflow name</param>
+    /// <param name="instanceId">The instance ID</param>
+    /// <param name="transitionKey">The transition key</param>
+    /// <param name="apiVersionPrefix">Optional API version prefix (e.g., "api/v1")</param>
+    /// <returns>Generated client-facing URL</returns>
+    string BuildTransitionUrl(string domain, string workflow, string instanceId, string transitionKey, string? apiVersionPrefix = null);
+    
+    /// <summary>
+    /// Builds URL for function list endpoint.
+    /// </summary>
+    /// <param name="domain">The domain name</param>
+    /// <param name="workflow">The workflow name</param>
+    /// <param name="function">The function name</param>
+    /// <param name="apiVersionPrefix">Optional API version prefix (e.g., "api/v1")</param>
+    /// <returns>Generated client-facing URL</returns>
+    string BuildFunctionListUrl(string domain, string workflow, string function, string? apiVersionPrefix = null);
+    
+    /// <summary>
+    /// Builds URL for instance list endpoint.
+    /// </summary>
+    /// <param name="domain">The domain name</param>
+    /// <param name="workflow">The workflow name</param>
+    /// <param name="apiVersionPrefix">Optional API version prefix (e.g., "api/v1")</param>
+    /// <returns>Generated client-facing URL</returns>
+    string BuildInstanceListUrl(string domain, string workflow, string? apiVersionPrefix = null);
+    
+    /// <summary>
+    /// Builds URL for single instance endpoint.
+    /// </summary>
+    /// <param name="domain">The domain name</param>
+    /// <param name="workflow">The workflow name</param>
+    /// <param name="instance">The instance key or ID</param>
+    /// <param name="apiVersionPrefix">Optional API version prefix (e.g., "api/v1")</param>
+    /// <returns>Generated client-facing URL</returns>
+    string BuildInstanceUrl(string domain, string workflow, string instance, string? apiVersionPrefix = null);
+    
+    /// <summary>
+    /// Builds URL for instance history endpoint.
+    /// </summary>
+    /// <param name="domain">The domain name</param>
+    /// <param name="workflow">The workflow name</param>
+    /// <param name="instance">The instance key or ID</param>
+    /// <param name="apiVersionPrefix">Optional API version prefix (e.g., "api/v1")</param>
+    /// <returns>Generated client-facing URL</returns>
+    string BuildInstanceHistoryUrl(string domain, string workflow, string instance, string? apiVersionPrefix = null);
+    
+    /// <summary>
+    /// Builds URL for instance data endpoint.
+    /// </summary>
+    /// <param name="domain">The domain name</param>
+    /// <param name="workflow">The workflow name</param>
+    /// <param name="instance">The instance key or ID</param>
+    /// <param name="apiVersionPrefix">Optional API version prefix (e.g., "api/v1")</param>
+    /// <returns>Generated client-facing URL</returns>
+    string BuildDataUrl(string domain, string workflow, string instance, string? apiVersionPrefix = null);
+    
+    /// <summary>
+    /// Builds URL for instance data endpoint with extensions.
+    /// Each extension is added as a separate query parameter: ?extensions=ext1&extensions=ext2
+    /// </summary>
+    /// <param name="domain">The domain name</param>
+    /// <param name="workflow">The workflow name</param>
+    /// <param name="instance">The instance key or ID</param>
+    /// <param name="extensions">The collection of extension names</param>
+    /// <param name="apiVersionPrefix">Optional API version prefix (e.g., "api/v1")</param>
+    /// <returns>Generated client-facing URL with extensions as query parameters</returns>
+    string BuildDataWithExtensionsUrl(string domain, string workflow, string instance, IEnumerable<string> extensions, string? apiVersionPrefix = null);
+    
+    /// <summary>
+    /// Builds URL for instance view endpoint.
+    /// </summary>
+    /// <param name="domain">The domain name</param>
+    /// <param name="workflow">The workflow name</param>
+    /// <param name="instance">The instance key or ID</param>
+    /// <param name="apiVersionPrefix">Optional API version prefix (e.g., "api/v1")</param>
+    /// <returns>Generated client-facing URL</returns>
+    string BuildViewUrl(string domain, string workflow, string instance, string? apiVersionPrefix = null);
+    
+    /// <summary>
+    /// Builds URL for instance schema endpoint.
+    /// </summary>
+    /// <param name="domain">The domain name</param>
+    /// <param name="workflow">The workflow name</param>
+    /// <param name="instanceId">The instance ID</param>
+    /// <param name="transitionKey">The transition key</param>
+    /// <param name="apiVersionPrefix">Optional API version prefix (e.g., "api/v1")</param>
+    /// <returns>Generated client-facing URL</returns>
+    string BuildSchemaUrl(string domain, string workflow, string instanceId, string transitionKey, string? apiVersionPrefix = null);
+}

--- a/src/BBT.Workflow.Domain/Definitions/UrlTemplateOptions.cs
+++ b/src/BBT.Workflow.Domain/Definitions/UrlTemplateOptions.cs
@@ -1,0 +1,67 @@
+namespace BBT.Workflow.Definitions;
+
+/// <summary>
+/// Configuration for client-facing URL templates used in HATEOAS responses.
+/// Internal service-to-service URLs remain static in InstanceUrlTemplates as they map to controller routes.
+/// </summary>
+public sealed class UrlTemplateOptions
+{
+    /// <summary>
+    /// Configuration section name in appsettings.json
+    /// </summary>
+    public const string SectionName = "UrlTemplates";
+    
+    /// <summary>
+    /// Template for instance start endpoint (POST)
+    /// Parameters: {0}=domain, {1}=workflow
+    /// </summary>
+    public string Start { get; set; } = "/{0}/workflows/{1}/instances/start";
+    
+    /// <summary>
+    /// Template for instance transition endpoint (PATCH)
+    /// Parameters: {0}=domain, {1}=workflow, {2}=instanceId, {3}=transitionKey
+    /// </summary>
+    public string Transition { get; set; } = "/{0}/workflows/{1}/instances/{2}/transitions/{3}";
+    
+    /// <summary>
+    /// Template for function list endpoint (GET)
+    /// Parameters: {0}=domain, {1}=workflow, {2}=function
+    /// </summary>
+    public string FunctionList { get; set; } = "/{0}/workflows/{1}/functions/{2}";
+    
+    /// <summary>
+    /// Template for instance list endpoint (GET)
+    /// Parameters: {0}=domain, {1}=workflow
+    /// </summary>
+    public string InstanceList { get; set; } = "/{0}/workflows/{1}/instances";
+    
+    /// <summary>
+    /// Template for single instance endpoint (GET)
+    /// Parameters: {0}=domain, {1}=workflow, {2}=instance
+    /// </summary>
+    public string Instance { get; set; } = "/{0}/workflows/{1}/instances/{2}";
+    
+    /// <summary>
+    /// Template for instance history/transitions endpoint (GET)
+    /// Parameters: {0}=domain, {1}=workflow, {2}=instance
+    /// </summary>
+    public string InstanceHistory { get; set; } = "/{0}/workflows/{1}/instances/{2}/transitions";
+    
+    /// <summary>
+    /// Template for instance data endpoint (GET)
+    /// Parameters: {0}=domain, {1}=workflow, {2}=instance
+    /// </summary>
+    public string Data { get; set; } = "/{0}/workflows/{1}/instances/{2}/functions/data";
+    
+    /// <summary>
+    /// Template for instance view endpoint (GET)
+    /// Parameters: {0}=domain, {1}=workflow, {2}=instance
+    /// </summary>
+    public string View { get; set; } = "/{0}/workflows/{1}/instances/{2}/functions/view";
+    
+    /// <summary>
+    /// Template for instance schema endpoint (GET)
+    /// Parameters: {0}=domain, {1}=workflow, {2}=instanceId, {3}=transitionKey
+    /// </summary>
+    public string Schema { get; set; } = "/{0}/workflows/{1}/instances/{2}/functions/schema?transitionKey={3}";
+}

--- a/src/BBT.Workflow.Domain/Definitions/Views/ViewEnums.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Views/ViewEnums.cs
@@ -23,5 +23,15 @@ public enum ViewType
     /// <summary>
     /// Deep link URL for navigation
     /// </summary>
-    DeepLink = 4
+    DeepLink = 4,
+    
+    /// <summary>
+    /// Http
+    /// </summary>
+    Http = 5,
+    
+    /// <summary>
+    /// Urn
+    /// </summary>
+    URN = 6
 }

--- a/src/BBT.Workflow.Infrastructure/Definitions/UrlTemplateBuilder.cs
+++ b/src/BBT.Workflow.Infrastructure/Definitions/UrlTemplateBuilder.cs
@@ -1,0 +1,107 @@
+using BBT.Workflow.Definitions;
+using Microsoft.Extensions.Options;
+
+namespace BBT.Workflow.Infrastructure.Definitions;
+
+/// <summary>
+/// Builds client-facing URLs from configurable templates.
+/// Used by controllers to generate HATEOAS links with optional gateway routing.
+/// Lifecycle: Singleton - stateless service using configured templates.
+/// </summary>
+public sealed class UrlTemplateBuilder : IUrlTemplateBuilder
+{
+    private readonly UrlTemplateOptions _options;
+    
+    /// <summary>
+    /// Initializes a new instance of UrlTemplateBuilder with configured templates.
+    /// </summary>
+    /// <param name="options">URL template configuration options</param>
+    public UrlTemplateBuilder(IOptions<UrlTemplateOptions> options)
+    {
+        _options = options.Value;
+    }
+    
+    /// <inheritdoc />
+    public string BuildStartUrl(string domain, string workflow, string? apiVersionPrefix = null)
+    {
+        var path = string.Format(_options.Start, domain, workflow);
+        return BuildUrl(path, apiVersionPrefix);
+    }
+    
+    /// <inheritdoc />
+    public string BuildTransitionUrl(string domain, string workflow, string instanceId, string transitionKey, string? apiVersionPrefix = null)
+    {
+        var path = string.Format(_options.Transition, domain, workflow, instanceId, transitionKey);
+        return BuildUrl(path, apiVersionPrefix);
+    }
+    
+    /// <inheritdoc />
+    public string BuildFunctionListUrl(string domain, string workflow, string function, string? apiVersionPrefix = null)
+    {
+        var path = string.Format(_options.FunctionList, domain, workflow, function);
+        return BuildUrl(path, apiVersionPrefix);
+    }
+    
+    /// <inheritdoc />
+    public string BuildInstanceListUrl(string domain, string workflow, string? apiVersionPrefix = null)
+    {
+        var path = string.Format(_options.InstanceList, domain, workflow);
+        return BuildUrl(path, apiVersionPrefix);
+    }
+    
+    /// <inheritdoc />
+    public string BuildInstanceUrl(string domain, string workflow, string instance, string? apiVersionPrefix = null)
+    {
+        var path = string.Format(_options.Instance, domain, workflow, instance);
+        return BuildUrl(path, apiVersionPrefix);
+    }
+    
+    /// <inheritdoc />
+    public string BuildInstanceHistoryUrl(string domain, string workflow, string instance, string? apiVersionPrefix = null)
+    {
+        var path = string.Format(_options.InstanceHistory, domain, workflow, instance);
+        return BuildUrl(path, apiVersionPrefix);
+    }
+    
+    /// <inheritdoc />
+    public string BuildDataUrl(string domain, string workflow, string instance, string? apiVersionPrefix = null)
+    {
+        var path = string.Format(_options.Data, domain, workflow, instance);
+        return BuildUrl(path, apiVersionPrefix);
+    }
+    
+    /// <inheritdoc />
+    public string BuildDataWithExtensionsUrl(string domain, string workflow, string instance, IEnumerable<string> extensions, string? apiVersionPrefix = null)
+    {
+        var basePath = BuildDataUrl(domain, workflow, instance, apiVersionPrefix);
+        var extensionParams = string.Join("&", extensions.Where(e => !string.IsNullOrEmpty(e)).Select(e => $"extensions={Uri.EscapeDataString(e)}"));
+        return string.IsNullOrEmpty(extensionParams) ? basePath : $"{basePath}?{extensionParams}";
+    }
+    
+    /// <inheritdoc />
+    public string BuildViewUrl(string domain, string workflow, string instance, string? apiVersionPrefix = null)
+    {
+        var path = string.Format(_options.View, domain, workflow, instance);
+        return BuildUrl(path, apiVersionPrefix);
+    }
+    
+    /// <inheritdoc />
+    public string BuildSchemaUrl(string domain, string workflow, string instanceId, string transitionKey, string? apiVersionPrefix = null)
+    {
+        var path = string.Format(_options.Schema, domain, workflow, instanceId, transitionKey);
+        return BuildUrl(path, apiVersionPrefix);
+    }
+    
+    /// <summary>
+    /// Combines the relative path with optional API version prefix.
+    /// </summary>
+    /// <param name="path">The relative path generated from template</param>
+    /// <param name="apiVersionPrefix">Optional API version prefix (e.g., "api/v1")</param>
+    /// <returns>Final URL path</returns>
+    private static string BuildUrl(string path, string? apiVersionPrefix)
+    {
+        return string.IsNullOrEmpty(apiVersionPrefix) 
+            ? path 
+            : apiVersionPrefix + path;
+    }
+}

--- a/src/BBT.Workflow.Infrastructure/Microsoft/Extensions/DependencyInjection/UrlTemplateServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Infrastructure/Microsoft/Extensions/DependencyInjection/UrlTemplateServiceCollectionExtensions.cs
@@ -1,0 +1,35 @@
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Infrastructure.Definitions;
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Extension methods for configuring URL template services in an <see cref="IServiceCollection" />.
+/// </summary>
+public static class UrlTemplateServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds URL template services for generating client-facing HATEOAS URLs.
+    /// Configures UrlTemplateOptions from appsettings and registers IUrlTemplateBuilder.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
+    /// <param name="configuration">The configuration instance to bind UrlTemplateOptions from.</param>
+    /// <returns>The <see cref="IServiceCollection" /> so that additional calls can be chained.</returns>
+    /// <remarks>
+    /// URL templates are used by controllers to generate HATEOAS links in API responses.
+    /// Internal service-to-service URLs use static InstanceUrlTemplates and are not affected by this configuration.
+    /// </remarks>
+    public static IServiceCollection AddUrlTemplateServices(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        // Configure URL templates for client-facing HATEOAS responses
+        services.Configure<UrlTemplateOptions>(configuration.GetSection(UrlTemplateOptions.SectionName));
+        
+        // Register URL template builder as singleton (stateless service)
+        services.AddSingleton<IUrlTemplateBuilder, UrlTemplateBuilder>();
+        
+        return services;
+    }
+}

--- a/src/BBT.Workflow.Infrastructure/Microsoft/Extensions/DependencyInjection/WorkflowInfrastructureModuleServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Infrastructure/Microsoft/Extensions/DependencyInjection/WorkflowInfrastructureModuleServiceCollectionExtensions.cs
@@ -15,6 +15,7 @@ using BBT.Workflow.Schemas;
 using BBT.Workflow.Security;
 using BBT.Workflow.Scripting;
 using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.Extensions.DependencyInjection;
@@ -28,13 +29,39 @@ public static class WorkflowInfrastructureModuleServiceCollectionExtensions
     /// Adds the infrastructure module services to the specified <see cref="IServiceCollection" />.
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
+    /// <param name="configuration">The configuration instance for service configuration.</param>
     /// <returns>The <see cref="IServiceCollection" /> so that additional calls can be chained.</returns>
     /// <remarks>
     /// Infrastructure module manages its own dependencies.
     /// If IDistributedCache is not registered, a fallback in-memory cache will be used.
+    /// URL template services are configured for HATEOAS support.
+    /// </remarks>
+    public static IServiceCollection AddInfrastructureModule(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        return AddInfrastructureModuleCore(services, configuration);
+    }
+
+    /// <summary>
+    /// Adds the infrastructure module services to the specified <see cref="IServiceCollection" />.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
+    /// <returns>The <see cref="IServiceCollection" /> so that additional calls can be chained.</returns>
+    /// <remarks>
+    /// Infrastructure module manages its own dependencies.
+    /// If IDistributedCache is not registered, a fallback in-memory cache will be used.
+    /// This overload does not configure URL template services (used for testing).
     /// </remarks>
     public static IServiceCollection AddInfrastructureModule(
         this IServiceCollection services)
+    {
+        return AddInfrastructureModuleCore(services, configuration: null);
+    }
+
+    private static IServiceCollection AddInfrastructureModuleCore(
+        IServiceCollection services,
+        IConfiguration? configuration)
     {
         services.AddAetherInfrastructure();
         
@@ -43,6 +70,12 @@ public static class WorkflowInfrastructureModuleServiceCollectionExtensions
         if (!services.Any(sd => sd.ServiceType == typeof(IDistributedCache)))
         {
             services.AddDistributedMemoryCache();
+        }
+        
+        // URL Template Services for HATEOAS (only if configuration is provided)
+        if (configuration != null)
+        {
+            services.AddUrlTemplateServices(configuration);
         }
         
         // DbContext

--- a/workers/BBT.Workflow.Workers.Inbox/Microsoft/Extensions/DependencyInjection/InboxWorkerServiceCollectionExtensions.cs
+++ b/workers/BBT.Workflow.Workers.Inbox/Microsoft/Extensions/DependencyInjection/InboxWorkerServiceCollectionExtensions.cs
@@ -20,7 +20,7 @@ public static class InboxWorkerServiceCollectionExtensions
         services
             .AddDomainModule()
             .AddApplicationModule()
-            .AddInfrastructureModule()
+            .AddInfrastructureModule(configuration)
             .AddAspNetCoreModules(configuration)
             .AddResultResilience(configuration)
             .AddDaprClients()

--- a/workers/BBT.Workflow.Workers.Inbox/appsettings.json
+++ b/workers/BBT.Workflow.Workers.Inbox/appsettings.json
@@ -25,6 +25,17 @@
     "EnableCircuitBreakerBypass": true,
     "InternalOperationHeader": "X-Internal-Operation"
   },
+  "UrlTemplates": {
+    "Start": "/api/{0}/workflows/{1}/instances/start",
+    "Transition": "/api/{0}/workflows/{1}/instances/{2}/transitions/{3}",
+    "FunctionList": "/api/{0}/workflows/{1}/functions/{2}",
+    "InstanceList": "/api/{0}/workflows/{1}/instances",
+    "Instance": "/api/{0}/workflows/{1}/instances/{2}",
+    "InstanceHistory": "/api/{0}/workflows/{1}/instances/{2}/transitions",
+    "Data": "/api/{0}/workflows/{1}/instances/{2}/functions/data",
+    "View": "/api/{0}/workflows/{1}/instances/{2}/functions/view",
+    "Schema": "/api/{0}/workflows/{1}/instances/{2}/functions/schema?transitionKey={3}"
+  },
   "Redis": {
     "Mode": "Standalone",
     "InstanceName": "workflow-api",

--- a/workers/BBT.Workflow.Workers.Outbox/Microsoft/Extensions/DependencyInjection/OutboxWorkerServiceCollectionExtensions.cs
+++ b/workers/BBT.Workflow.Workers.Outbox/Microsoft/Extensions/DependencyInjection/OutboxWorkerServiceCollectionExtensions.cs
@@ -19,7 +19,7 @@ public static class OutboxWorkerServiceCollectionExtensions
         services
             .AddDomainModule()
             .AddApplicationModule()
-            .AddInfrastructureModule()
+            .AddInfrastructureModule(configuration)
             .AddAspNetCoreModules(configuration)
             .AddResultResilience(configuration)
             .AddDaprClients()


### PR DESCRIPTION
## Summary
Resolves #327

Implements configurable URL templates for client-facing HATEOAS links to support gateway routing patterns while keeping internal service-to-service URLs static.

## Changes

### New Features
- ✨ **IUrlTemplateBuilder interface** for generating client-facing URLs
- ✨ **UrlTemplateBuilder implementation** using configured templates from `appsettings.json`
- ✨ **UrlTemplateOptions configuration model** for URL pattern customization
- ✨ Added support for `Http` and `URN` view types in `ViewEnums`

### Updated Components
- 🔄 **Controllers** (`InstanceController`, `FunctionController`) now use `IUrlTemplateBuilder` for HATEOAS links
- 🔄 **InstanceQueryAppService** generates HATEOAS links with configurable templates
- 🔄 **GetInstancesTaskExecutor** uses configurable templates for local execution HATEOAS links
- 🔄 **DI Registration** - Added `UrlTemplateServiceCollectionExtensions` for modular registration
- 🔄 **WorkflowInfrastructureModuleServiceCollectionExtensions** with configuration overloads

### Configuration
Added `UrlTemplates` section to all `appsettings.json` files:
- Orchestration API
- Inbox Worker
- Outbox Worker

### Documentation
- 📚 Updated `remote-routing-and-discovery.md` with detailed explanation of:
  - Client-facing vs. internal URL templates
  - Configuration examples
  - Gateway routing patterns

## Configuration Example

\`\`\`json
{
  "UrlTemplates": {
    "Start": "/{0}/workflows/{1}/instances/start",
    "Transition": "/{0}/workflows/{1}/instances/{2}/transitions/{3}",
    "FunctionList": "/{0}/workflows/{1}/functions/{2}",
    "InstanceList": "/{0}/workflows/{1}/instances",
    "Instance": "/{0}/workflows/{1}/instances/{2}",
    "InstanceHistory": "/{0}/workflows/{1}/instances/{2}/transitions",
    "Data": "/{0}/workflows/{1}/instances/{2}/functions/data",
    "View": "/{0}/workflows/{1}/instances/{2}/functions/view",
    "Schema": "/{0}/workflows/{1}/instances/{2}/functions/schema?transitionKey={3}"
  }
}
\`\`\`

For gateway routing with `/api/gateway` prefix:
\`\`\`json
{
  "UrlTemplates": {
    "Start": "/api/gateway/{0}/workflows/{1}/instances/start",
    ...
  }
}
\`\`\`

## Breaking Changes
⚠️ `AddInfrastructureModule` now has an overload that requires `IConfiguration` parameter
- Backward compatibility maintained with parameterless overload
- Tests continue to work without changes

## Implementation Details
- **Static templates** (`InstanceUrlTemplates`) remain unchanged for internal service-to-service communication
- **Configurable templates** (`IUrlTemplateBuilder`) used only for client-facing HATEOAS responses
- Clean separation of concerns between internal routing and external API contracts

## Test Plan
- [ ] Verify HATEOAS links in orchestration API responses use configured templates
- [ ] Test gateway routing with custom URL prefix
- [ ] Verify internal service-to-service calls still use static templates
- [ ] Confirm backward compatibility with existing tests
- [ ] Validate configuration in all environments (Orchestration, Inbox, Outbox workers)

## Files Changed
- 16 files changed
- 500 insertions(+), 26 deletions(-)
- 4 new files created

## Summary by Sourcery

Introduce configurable client-facing URL templates and builder services for HATEOAS links while keeping internal service URLs static, and wire them into orchestration API, workers, and dependency injection.

New Features:
- Add UrlTemplateOptions configuration model and IUrlTemplateBuilder abstraction with UrlTemplateBuilder implementation for generating client-facing HATEOAS URLs from appsettings-driven templates.
- Support additional Http and URN view types in ViewEnums for extended view URL semantics.

Enhancements:
- Refactor orchestration controllers, instance query services, and trigger executors to use the configurable URL template builder instead of static InstanceUrlTemplates for client-facing links.
- Extend WorkflowInfrastructureModule registration to optionally take IConfiguration and centralize URL template service wiring.
- Document the separation between client-facing and internal URL templates and gateway routing patterns in remote-routing-and-discovery.md.

Documentation:
- Expand remote-routing-and-discovery documentation with client-facing URL template configuration, gateway routing examples, and URL type comparison.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable URL templates for workflow API endpoints in application settings.
  * Added support for new view types: Http and URN.

* **Improvements**
  * Centralized URL template management for improved consistency across API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->