### PR TITLE
Preserve config and process objects during domain replacement in pack…

### DIFF
--- a/etc/orchestration/dapr/components/invalidate-cache-subscription.yaml
+++ b/etc/orchestration/dapr/components/invalidate-cache-subscription.yaml
@@ -1,8 +1,0 @@
-apiVersion: dapr.io/v1alpha1
-kind: Subscription
-metadata:
-  name: vnext-invalidate-cache-subscription
-spec:
-  topic: development.vnext.invalidate-cache
-  route: /api/v1/utilities/invalidate
-  pubsubname: vnext-pubsub-broadcast

--- a/init/VNext.Init.Host/package-api-server.js
+++ b/init/VNext.Init.Host/package-api-server.js
@@ -479,14 +479,15 @@ function replaceDomainInJson(obj, targetDomain) {
     }
     
     // Recursively process all properties to find nested domain fields
+    // BUT skip "config" and "process" keys - it should always remain unchanged
     for (const [key, value] of Object.entries(result)) {
-        if (key !== 'domain') { // Skip domain itself, already processed
-        result[key] = replaceDomainInJson(value, targetDomain);
+        if (key !== 'domain' && key !== 'config' && key !== "process") { // Skip domain (already processed) and attributes (always preserved)
+            result[key] = replaceDomainInJson(value, targetDomain);
         }
     }
     
     return result;
-}
+} 
 
 
 /**


### PR DESCRIPTION
…age-api-server

## Summary by Sourcery

Preserve configuration-related fields when replacing domains in package-api-server and remove the invalidate-cache Dapr subscription component.

Bug Fixes:
- Avoid altering values under config and process keys during domain replacement in JSON objects.

Deployment:
- Remove the Dapr invalidate-cache-subscription component configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Dapr Subscription component that managed cache invalidation messaging. This eliminates the automatic routing of cache clearing operations previously triggered through the event broker infrastructure.
  * Enhanced API server configuration processing by improving domain replacement handling. Configuration and process attributes are now explicitly preserved by excluding them from modification and traversal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->