### PR TITLE
Refactor: Task Execution Pipeline and Cache Synchronization Improvements

### DIFF
--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Definitions/DefinitionController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Definitions/DefinitionController.cs
@@ -1,8 +1,5 @@
 using BBT.Aether.AspNetCore.Controllers;
 using BBT.Workflow.Definitions;
-using BBT.Workflow.Definitions.Events;
-using BBT.Workflow.Runtime;
-using Dapr.Client;
 using Microsoft.AspNetCore.Mvc;
 
 namespace BBT.Workflow.Orchestration.Controllers.Definitions;
@@ -11,10 +8,7 @@ namespace BBT.Workflow.Orchestration.Controllers.Definitions;
 [ApiVersion("1.0")]
 [Route("api/v{version:apiVersion}/definitions")]
 public sealed class DefinitionController(
-    IDefinitionAppService appService,
-    DaprClient daprClient,
-    IRuntimeInfoProvider runtimeInfoProvider,
-    IConfiguration configuration) : AetherControllerBase
+    IDefinitionAppService appService) : AetherControllerBase
 {
     [HttpPost("publish")]
     public async Task<IActionResult> PublishAsync(
@@ -29,29 +23,15 @@ public sealed class DefinitionController(
     /// Re-initializes the workflow system cache by broadcasting invalidation event to all pods.
     /// </summary>
     /// <param name="cancellationToken">Cancellation token for the operation.</param>
-    /// <returns>Accepted response indicating broadcast initiated.</returns>
-    /// <response code="202">Cache invalidation broadcast initiated successfully.</response>
+    /// <returns>Result of the cache re-initialization operation.</returns>
+    /// <response code="200">Cache re-initialization completed successfully.</response>
     [ApiExplorerSettings(IgnoreApi = true)]
     [HttpGet("re-initialize")]
-    [ProducesResponseType(StatusCodes.Status202Accepted)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
     public async Task<IActionResult> ReInitializeAsync(
         CancellationToken cancellationToken = default)
     {
-        // Publish broadcast event to all pods using Dapr client directly
-        var cacheInvalidationEvent = new DefinitionCacheInvalidationEvent
-        {
-            Domain = runtimeInfoProvider.Domain,
-            RequestedBy = "Manual",
-            RequestedAt = DateTime.UtcNow,
-            Environment = configuration["ASPNETCORE_ENVIRONMENT"]!
-        };
-        
-        await daprClient.PublishEventAsync(
-            pubsubName: configuration["DAPR_PUBSUB_BROADCAST_STORE_NAME"]!,
-            topicName: DefinitionCacheInvalidationEvent.TopicName,
-            data: cacheInvalidationEvent,
-            cancellationToken: cancellationToken);
-        
-        return Accepted(new { message = "Cache invalidation broadcast initiated" });
+        var result = await appService.ReInitializeAsync(cancellationToken);
+        return FromResult(result);
     }
 } 

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
@@ -52,9 +52,9 @@ public sealed class InstanceController(
         {
             Instance = new CreateInstanceInput
             {
-                Key = request.Key,
-                Tags = request.Tags,
-                Attributes = request.Attributes
+                Key = request?.Key,
+                Tags = request?.Tags,
+                Attributes = request?.Attributes
             }
         };
         var httpContext = httpContextAccessor.HttpContext;

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Utilities/UtilityController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Utilities/UtilityController.cs
@@ -1,4 +1,5 @@
 using BBT.Aether.AspNetCore.Controllers;
+using BBT.Workflow.Caching;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Definitions.Events;
 using BBT.Workflow.Discovery;
@@ -19,6 +20,7 @@ namespace BBT.Workflow.Orchestration.Controllers.Utilities;
 [ServiceFilter(typeof(ResponseHeaderFilter))]
 public sealed class UtilityController(
     IDefinitionAppService definitionAppService,
+    IRuntimeCacheInitializer runtimeCacheInitializer,
     IRuntimeInfoProvider runtimeInfoProvider,
     IOptions<RuntimeOptions> runtimeOptions,
     IDomainDiscoveryResolver domainDiscoveryResolver,
@@ -80,6 +82,7 @@ public sealed class UtilityController(
     /// <summary>
     /// Handles broadcast cache invalidation requests from Dapr subscription.
     /// All pods receive this message via vnext-pubsub-broadcast.
+    /// Updates only in-memory cache since distributed cache is already updated by initiating pod.
     /// </summary>
     /// <param name="eventData">Cache invalidation event data.</param>
     /// <param name="cancellationToken">Cancellation token for the operation.</param>
@@ -110,13 +113,11 @@ public sealed class UtilityController(
             eventData.Domain, 
             eventData.RequestedBy);
         
-        var result = await definitionAppService.ReInitializeAsync(cancellationToken);
+        // Update only in-memory cache (distributed cache already updated by initiating pod)
+        await runtimeCacheInitializer.InitializeAsync(cancellationToken);
         
-        if (result.IsSuccess)
-            logger.DefinitionCacheInvalidationSucceeded(podInstance);
-        else
-            logger.DefinitionCacheInvalidationFailed(podInstance, result.Error.Message);
+        logger.DefinitionCacheInvalidationSucceeded(podInstance);
             
-        return FromResult(result);
+        return Ok();
     }
 } 

--- a/src/BBT.Workflow.Application/Caching/CacheSet.cs
+++ b/src/BBT.Workflow.Application/Caching/CacheSet.cs
@@ -335,6 +335,65 @@ public class CacheSet<T>(
         return Task.CompletedTask;
     }
 
+    public async Task LoadAllWithDistributedCacheAsync(object data, CancellationToken cancellationToken = default)
+    {
+        if (data is not IEnumerable<T> entities)
+            throw new ArgumentException($"Invalid data type for {typeof(T).Name}");
+
+        var entitiesList = entities.ToList();
+        var entries = new Dictionary<string, CacheItem<T>>();
+        var index = new Dictionary<string, SortedSet<string>>();
+
+        // First, update in-memory cache
+        foreach (var entity in entitiesList)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var cacheKey = CreateCacheKey(entity);
+            EnsureReferenceIsSet(entity, cacheKey);
+
+            var item = new CacheItem<T>(entity);
+            entries[cacheKey] = item;
+            UpdateIndex(index, entity);
+        }
+
+        var newSnapshot = new CacheSnapshot<T>(
+            entries.ToImmutableDictionary(),
+            index.ToImmutableDictionary(kvp => kvp.Key, kvp => new SortedSet<string>(kvp.Value)));
+
+        Interlocked.Exchange(ref _snapshot, newSnapshot);
+
+        _logger.LogInformation(
+            "CacheSet<{Type}> initialized with distributed cache. Items: {Count}",
+            typeof(T).Name, entries.Count);
+
+        // Second, write all entities to distributed cache
+        var writeErrors = 0;
+        foreach (var entity in entitiesList)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var cacheKey = CreateCacheKey(entity);
+            try
+            {
+                await distributedCache.SetAsync(cacheKey, entity, cancellationToken: cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                writeErrors++;
+                _logger.LogError(ex, "Error writing to distributed cache for {CacheKey}", cacheKey);
+                // Continue with remaining entities even if one fails
+            }
+        }
+
+        if (writeErrors > 0)
+        {
+            _logger.LogWarning(
+                "CacheSet<{Type}> distributed cache write completed with {ErrorCount} errors out of {TotalCount} items",
+                typeof(T).Name, writeErrors, entitiesList.Count);
+        }
+    }
+
     /// <summary>
     /// Performs cleanup of expired and least-used items based on TTL and capacity.
     /// </summary>

--- a/src/BBT.Workflow.Application/Caching/DomainCacheContext.cs
+++ b/src/BBT.Workflow.Application/Caching/DomainCacheContext.cs
@@ -79,6 +79,19 @@ public class DomainCacheContext : CacheContext, IDomainCacheContext, IDisposable
     public new Task InitializeAsync(Dictionary<Type, object> initialData, CancellationToken cancellationToken = default)
         => base.InitializeAsync(initialData, cancellationToken);
 
+    public async Task InitializeWithDistributedCacheAsync(Dictionary<Type, object> initialData, CancellationToken cancellationToken = default)
+    {
+        foreach (var cacheSet in CacheSets)
+        {
+            var cacheSetType = cacheSet.GetType().GetGenericArguments()[0];
+
+            if (initialData.TryGetValue(cacheSetType, out var data))
+            {
+                await cacheSet.LoadAllWithDistributedCacheAsync(data, cancellationToken);
+            }
+        }
+    }
+
     public int CleanupAll(
         TimeSpan? ttl = null,
         int? maxItemsPerSet = null,

--- a/src/BBT.Workflow.Application/Caching/ICacheSet.cs
+++ b/src/BBT.Workflow.Application/Caching/ICacheSet.cs
@@ -13,6 +13,12 @@ public interface ICacheSet : IDisposable
     Type EntityType { get; }
 
     Task LoadAllAsync(object data, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Loads all entities into both in-memory and distributed cache.
+    /// Used when initiating cache refresh that should propagate to all pods.
+    /// </summary>
+    Task LoadAllWithDistributedCacheAsync(object data, CancellationToken cancellationToken = default);
 }
 
 /// <summary>

--- a/src/BBT.Workflow.Application/Caching/IDomainCacheContext.cs
+++ b/src/BBT.Workflow.Application/Caching/IDomainCacheContext.cs
@@ -18,6 +18,16 @@ public interface IDomainCacheContext
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Initializes both in-memory and distributed cache from the provided data.
+    /// Use this when triggering cache refresh that should propagate to all pods.
+    /// </summary>
+    /// <param name="initialData">Dictionary mapping entity types to their data</param>
+    /// <param name="cancellationToken">Token to monitor for cancellation requests</param>
+    /// <returns>A task representing the asynchronous initialization operation</returns>
+    Task InitializeWithDistributedCacheAsync(Dictionary<Type, object> initialData,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets the cache set for the specified entity type.
     /// </summary>
     /// <typeparam name="T">The entity type</typeparam>

--- a/src/BBT.Workflow.Application/Caching/IRuntimeCacheInitializer.cs
+++ b/src/BBT.Workflow.Application/Caching/IRuntimeCacheInitializer.cs
@@ -10,9 +10,19 @@ public interface IRuntimeCacheInitializer
     /// <summary>
     /// Initializes the domain cache context by loading all workflow components from the database.
     /// This includes workflows, tasks, functions, views, schemas, and extensions.
+    /// Updates only in-memory cache (used by receiving pods).
     /// </summary>
     /// <param name="cancellationToken">Token to monitor for cancellation requests</param>
     /// <returns>A task representing the asynchronous initialization operation</returns>
     Task InitializeAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Initializes both in-memory and distributed cache by loading all workflow components from the database.
+    /// This includes workflows, tasks, functions, views, schemas, and extensions.
+    /// Use this when triggering cache refresh that should propagate to all pods.
+    /// </summary>
+    /// <param name="cancellationToken">Token to monitor for cancellation requests</param>
+    /// <returns>A task representing the asynchronous initialization operation</returns>
+    Task InitializeWithDistributedCacheAsync(CancellationToken cancellationToken = default);
 }
 

--- a/src/BBT.Workflow.Application/Caching/RuntimeCacheInitializer.cs
+++ b/src/BBT.Workflow.Application/Caching/RuntimeCacheInitializer.cs
@@ -16,6 +16,19 @@ public sealed class RuntimeCacheInitializer(
     /// <inheritdoc />
     public async Task InitializeAsync(CancellationToken cancellationToken = default)
     {
+        var initialData = await LoadAllEntitiesFromDatabaseAsync(cancellationToken);
+        await domainCacheContext.InitializeAsync(initialData, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task InitializeWithDistributedCacheAsync(CancellationToken cancellationToken = default)
+    {
+        var initialData = await LoadAllEntitiesFromDatabaseAsync(cancellationToken);
+        await domainCacheContext.InitializeWithDistributedCacheAsync(initialData, cancellationToken);
+    }
+
+    private async Task<Dictionary<Type, object>> LoadAllEntitiesFromDatabaseAsync(CancellationToken cancellationToken)
+    {
         async Task<IEnumerable<T?>> LoadAsync<T>(CancellationToken ct)
             where T : class, IDomainEntity, IReferenceSetter
         {
@@ -35,8 +48,8 @@ public sealed class RuntimeCacheInitializer(
         // Wait for all tasks to complete
         await Task.WhenAll(flowsTask, tasksTask, functionsTask, viewsTask, schemasTask, extensionsTask);
 
-        // Build the initial data dictionary
-        var initialData = new Dictionary<Type, object>
+        // Build and return the initial data dictionary
+        return new Dictionary<Type, object>
         {
             { typeof(Definitions.Workflow), flowsTask.Result ?? [] },
             { typeof(WorkflowTask), tasksTask.Result ?? [] },
@@ -45,8 +58,5 @@ public sealed class RuntimeCacheInitializer(
             { typeof(View), viewsTask.Result ?? [] },
             { typeof(Extension), extensionsTask.Result ?? [] }
         };
-
-        // Initialize the domain cache context
-        await domainCacheContext.InitializeAsync(initialData, cancellationToken);
     }
 }

--- a/src/BBT.Workflow.Application/Definitions/DefinitionAppService.cs
+++ b/src/BBT.Workflow.Application/Definitions/DefinitionAppService.cs
@@ -5,12 +5,15 @@ using BBT.Aether.MultiSchema;
 using BBT.Aether.Results;
 using BBT.Workflow.Caching;
 using BBT.Workflow.Definitions.CastHandlers;
+using BBT.Workflow.Definitions.Events;
 using BBT.Workflow.Definitions.Validators;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Logging;
 using BBT.Workflow.Monitoring;
 using BBT.Workflow.Runtime;
 using BBT.Workflow.Schemas;
+using Dapr.Client;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Nito.Disposables;
@@ -28,6 +31,8 @@ public sealed class DefinitionAppService(
     WorkflowCastProcessor castProcessor,
     IWorkflowMetrics workflowMetrics,
     IRuntimeCacheInitializer runtimeCacheInitializer,
+    DaprClient daprClient,
+    IConfiguration configuration,
     IServiceScopeFactory  scopeFactory,
     IServiceProvider serviceProvider)
     : ApplicationService(serviceProvider), IDefinitionAppService
@@ -349,7 +354,24 @@ public sealed class DefinitionAppService(
     /// <inheritdoc />
     public async Task<Result> ReInitializeAsync(CancellationToken cancellationToken = default)
     {
-        await runtimeCacheInitializer.InitializeAsync(cancellationToken);
+        // First, update both in-memory and distributed cache on this initiating pod
+        await runtimeCacheInitializer.InitializeWithDistributedCacheAsync(cancellationToken);
+        
+        // Then, publish broadcast event to all pods using Dapr client directly
+        var cacheInvalidationEvent = new DefinitionCacheInvalidationEvent
+        {
+            Domain = runtimeInfoProvider.Domain,
+            RequestedBy = "System",
+            RequestedAt = DateTime.UtcNow,
+            Environment = configuration["ASPNETCORE_ENVIRONMENT"]!
+        };
+        
+        await daprClient.PublishEventAsync(
+            pubsubName: configuration["DAPR_PUBSUB_BROADCAST_STORE_NAME"]!,
+            topicName: DefinitionCacheInvalidationEvent.TopicName,
+            data: cacheInvalidationEvent,
+            cancellationToken: cancellationToken);
+        
         return Result.Ok();
     }
 }

--- a/src/BBT.Workflow.Application/Tasks/Executors/Core/TaskExecutorBase.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Core/TaskExecutorBase.cs
@@ -54,7 +54,7 @@ public abstract class TaskExecutorBase<TTask>(ILogger logger) : ITaskExecutor
             stopwatch.Stop();
             Logger.LogError("Task {TaskKey} input preparation failed: {Error}",
                 taskKey, inputResult.Error.Message);
-            return Result<StandardTaskResponse>.Fail(validationResult.Error);
+            return Result<StandardTaskResponse>.Fail(inputResult.Error);
             // return CreateErrorResponse(inputResult.Error, stopwatch.ElapsedMilliseconds);
         }
         
@@ -67,7 +67,7 @@ public abstract class TaskExecutorBase<TTask>(ILogger logger) : ITaskExecutor
             stopwatch.Stop();
             Logger.LogError("Task {TaskKey} pre-processing failed: {Error}",
                 taskKey, preProcessResult.Error.Message);
-            return Result<StandardTaskResponse>.Fail(validationResult.Error);
+            return Result<StandardTaskResponse>.Fail(preProcessResult.Error);
             // return CreateErrorResponse(preProcessResult.Error, stopwatch.ElapsedMilliseconds);
         }
 
@@ -93,7 +93,7 @@ public abstract class TaskExecutorBase<TTask>(ILogger logger) : ITaskExecutor
             stopwatch.Stop();
             Logger.LogError("Task {TaskKey} post-processing failed: {Error}",
                 taskKey, postProcessResult.Error.Message);
-            return Result<StandardTaskResponse>.Fail(validationResult.Error);
+            return Result<StandardTaskResponse>.Fail(postProcessResult.Error);
             // return CreateErrorResponse(postProcessResult.Error, stopwatch.ElapsedMilliseconds);
         }
 
@@ -104,7 +104,7 @@ public abstract class TaskExecutorBase<TTask>(ILogger logger) : ITaskExecutor
             stopwatch.Stop();
             Logger.LogError("Task {TaskKey} output processing failed: {Error}",
                 taskKey, outputResult.Error.Message);
-            return Result<StandardTaskResponse>.Fail(validationResult.Error);
+            return Result<StandardTaskResponse>.Fail(outputResult.Error);
             // return CreateErrorResponse(outputResult.Error, stopwatch.ElapsedMilliseconds);
         }
         

--- a/src/BBT.Workflow.Application/Tasks/Executors/Trigger/DirectTriggerTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Trigger/DirectTriggerTaskExecutor.cs
@@ -10,6 +10,7 @@ using BBT.Workflow.Logging;
 using BBT.Workflow.Resilience;
 using BBT.Workflow.Runtime;
 using BBT.Workflow.Scripting;
+using BBT.Workflow.Tasks.Mapping;
 using Microsoft.Extensions.Logging;
 using Polly;
 
@@ -123,9 +124,9 @@ public sealed class DirectTriggerTaskExecutor : TriggerTaskExecutorBase<DirectTr
                 statusCode: 404,
                 taskType: TaskType.ToString()));
         }
-
-        var headers = ExtractHeaders(context.ScriptContext);
-
+        
+        var headers = ConvertTaskHeadersToDictionary(task.Headers);
+        
         var transitionData = task.Body.HasValue
             ? new TransitionDataInput(task.Body)
             {
@@ -254,31 +255,41 @@ public sealed class DirectTriggerTaskExecutor : TriggerTaskExecutorBase<DirectTr
     {
         Logger.LogDebug("Using RemoteInvokerService for DirectTrigger task {TaskKey}", task.Key);
 
-        var bindingResult = await BuildDirectTriggerBindingAsync(task, context, cancellationToken);
-        
-        if (!bindingResult.IsSuccess)
+        // Create envelope from task using TaskBindingMapper
+        var envelopeResult = TaskBindingMapper.CreateEnvelope(task);
+        if (!envelopeResult.IsSuccess)
+        {
+            Logger.TaskEnvelopeCreationFailed(
+                task.Key,
+                TaskType.ToString(),
+                context.ScriptContext.Instance.Id,
+                envelopeResult.Error.Message ?? "Failed to create envelope");
+            return Result<TaskInvocationResult>.Fail(envelopeResult.Error);
+        }
+
+        // Enrich binding with runtime context (endpoint, headers)
+        var enrichResult = await EnrichBindingAsync<DirectTriggerBinding>(
+            envelopeResult.Value!,
+            task.TriggerDomain,
+            task.UseDapr,
+            context,
+            cancellationToken);
+
+        if (!enrichResult.IsSuccess)
         {
             Logger.TaskRemoteExecutionFailed(
                 task.Key,
                 TaskType.ToString(),
                 context.ScriptContext.Instance.Id,
-                bindingResult.Error.Message ?? "Failed to resolve endpoint");
-            return Result<TaskInvocationResult>.Fail(bindingResult.Error);
+                enrichResult.Error.Message ?? "Failed to resolve endpoint");
+            return Result<TaskInvocationResult>.Fail(enrichResult.Error);
         }
-
-        var binding = bindingResult.Value!;
-        var envelope = new TaskEnvelope
-        {
-            TaskType = TaskTypes.DirectTrigger,
-            TaskKey = task.Key,
-            Binding = JsonSerializer.SerializeToElement(binding)
-        };
 
         var traceContext = RemoteInvoker.CreateTraceContext(context.ScriptContext);
         var result = await RemoteInvoker.InvokeAsync(
             TaskTypes.DirectTrigger,
             task.Key,
-            envelope,
+            enrichResult.Value!,
             traceContext,
             cancellationToken);
 
@@ -294,40 +305,59 @@ public sealed class DirectTriggerTaskExecutor : TriggerTaskExecutorBase<DirectTr
         return result;
     }
 
-    private async Task<Result<DirectTriggerBinding>> BuildDirectTriggerBindingAsync(
-        DirectTriggerTask task,
+    private async Task<Result<TaskEnvelope>> EnrichBindingAsync<TBinding>(
+        TaskEnvelope envelope,
+        string targetDomain,
+        bool useDapr,
         TaskExecutorContext context,
         CancellationToken cancellationToken)
     {
-        var headers = ExtractHeaders(context.ScriptContext);
+        // Deserialize binding
+        var binding = envelope.Binding.Deserialize<DirectTriggerBinding>();
+        if (binding == null)
+        {
+            return Result<TaskEnvelope>.Fail(Error.Failure(
+                WorkflowErrorCodes.TaskBindingMappingFailed,
+                "Failed to deserialize binding"));
+        }
 
-        var preferredKind = task.UseDapr ? EndpointKind.Dapr : EndpointKind.Url;
+        // Resolve endpoint
+        var preferredKind = useDapr ? EndpointKind.Dapr : EndpointKind.Url;
         var endpointResult = await _endpointResolver.GetEndpointAsync(
-            task.TriggerDomain, preferredKind, cancellationToken);
+            targetDomain, preferredKind, cancellationToken);
 
         if (!endpointResult.IsSuccess)
         {
-            return Result<DirectTriggerBinding>.Fail(endpointResult.Error);
+            return Result<TaskEnvelope>.Fail(endpointResult.Error);
         }
 
         var endpoint = endpointResult.Value!;
 
-        return Result.Ok(new DirectTriggerBinding
+        // Create enriched binding with runtime context
+        var enrichedBinding = new DirectTriggerBinding
         {
-            Domain = task.TriggerDomain,
-            Workflow = task.TriggerFlow,
-            InstanceId = task.TriggerInstanceId,
-            Key = task.TriggerKey,
-            TransitionName = task.TransitionName,
-            Tags = task.TriggerTags,
-            Version = task.TriggerVersion,
-            Body = task.Body,
-            Headers = headers != null ? JsonSerializer.Serialize(headers) : null,
-            Sync = task.TriggerSync,
-            UseDapr = task.UseDapr,
-            ValidateSSL = task.ValidateSSL,
+            Domain = binding.Domain,
+            Workflow = binding.Workflow,
+            TransitionName = binding.TransitionName,
+            InstanceId = binding.InstanceId,
+            Key = binding.Key,
+            Version = binding.Version,
+            Tags = binding.Tags,
+            Body = binding.Body,
+            Sync = binding.Sync,
+            UseDapr = binding.UseDapr,
+            ValidateSSL = binding.ValidateSSL,
+            TimeoutSeconds = binding.TimeoutSeconds,
+            Headers = binding.Headers,
             BaseUrl = endpoint.BaseUrl.ToString(),
             DaprAppId = endpoint.DaprAppId
+        };
+
+        return Result.Ok(new TaskEnvelope
+        {
+            TaskType = envelope.TaskType,
+            TaskKey = envelope.TaskKey,
+            Binding = JsonSerializer.SerializeToElement(enrichedBinding)
         });
     }
 }

--- a/src/BBT.Workflow.Application/Tasks/Executors/Trigger/GetInstanceDataTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Trigger/GetInstanceDataTaskExecutor.cs
@@ -9,6 +9,7 @@ using BBT.Workflow.Instances;
 using BBT.Workflow.Logging;
 using BBT.Workflow.Runtime;
 using BBT.Workflow.Scripting;
+using BBT.Workflow.Tasks.Mapping;
 using Microsoft.Extensions.Logging;
 
 namespace BBT.Workflow.Tasks.Executors;
@@ -101,12 +102,15 @@ public sealed class GetInstanceDataTaskExecutor : TriggerTaskExecutorBase<GetIns
 
         try
         {
+            var headers = ConvertTaskHeadersToDictionary(task.Headers);
+
             var input = new GetInstanceDataInput
             {
                 Domain = task.TriggerDomain,
                 Workflow = task.TriggerFlow,
                 Instance = instanceIdentifier,
-                Extensions = task.Extensions
+                Extensions = task.Extensions,
+                Headers = headers
             };
 
             var result = await _instanceQueryGateway.GetInstanceDataAsync(input, cancellationToken);
@@ -165,31 +169,42 @@ public sealed class GetInstanceDataTaskExecutor : TriggerTaskExecutorBase<GetIns
     {
         Logger.LogDebug("Using RemoteInvokerService for GetInstanceData task {TaskKey}", task.Key);
 
-        var bindingResult = await BuildGetInstanceDataBindingAsync(task, instanceIdentifier, cancellationToken);
-        
-        if (!bindingResult.IsSuccess)
+        // Create envelope from task using TaskBindingMapper
+        var envelopeResult = TaskBindingMapper.CreateEnvelope(task);
+        if (!envelopeResult.IsSuccess)
+        {
+            Logger.TaskEnvelopeCreationFailed(
+                task.Key,
+                TaskType.ToString(),
+                context.ScriptContext.Instance.Id,
+                envelopeResult.Error.Message ?? "Failed to create envelope");
+            return Result<TaskInvocationResult>.Fail(envelopeResult.Error);
+        }
+
+        // Enrich binding with runtime context (endpoint, headers, resolved instance)
+        var enrichResult = await EnrichBindingAsync(
+            envelopeResult.Value!,
+            task.TriggerDomain,
+            task.UseDapr,
+            instanceIdentifier,
+            context,
+            cancellationToken);
+
+        if (!enrichResult.IsSuccess)
         {
             Logger.TaskRemoteExecutionFailed(
                 task.Key,
                 TaskType.ToString(),
                 context.ScriptContext.Instance.Id,
-                bindingResult.Error.Message ?? "Failed to resolve endpoint");
-            return Result<TaskInvocationResult>.Fail(bindingResult.Error);
+                enrichResult.Error.Message ?? "Failed to resolve endpoint");
+            return Result<TaskInvocationResult>.Fail(enrichResult.Error);
         }
-
-        var binding = bindingResult.Value!;
-        var envelope = new TaskEnvelope
-        {
-            TaskType = TaskTypes.GetInstanceData,
-            TaskKey = task.Key,
-            Binding = JsonSerializer.SerializeToElement(binding)
-        };
 
         var traceContext = RemoteInvoker.CreateTraceContext(context.ScriptContext);
         var result = await RemoteInvoker.InvokeAsync(
             TaskTypes.GetInstanceData,
             task.Key,
-            envelope,
+            enrichResult.Value!,
             traceContext,
             cancellationToken);
 
@@ -205,33 +220,56 @@ public sealed class GetInstanceDataTaskExecutor : TriggerTaskExecutorBase<GetIns
         return result;
     }
 
-    private async Task<Result<GetInstanceDataBinding>> BuildGetInstanceDataBindingAsync(
-        GetInstanceDataTask task,
+    private async Task<Result<TaskEnvelope>> EnrichBindingAsync(
+        TaskEnvelope envelope,
+        string targetDomain,
+        bool useDapr,
         string instanceIdentifier,
+        TaskExecutorContext context,
         CancellationToken cancellationToken)
     {
-        var preferredKind = task.UseDapr ? EndpointKind.Dapr : EndpointKind.Url;
+        // Deserialize binding
+        var binding = envelope.Binding.Deserialize<GetInstanceDataBinding>();
+        if (binding == null)
+        {
+            return Result<TaskEnvelope>.Fail(Error.Failure(
+                WorkflowErrorCodes.TaskBindingMappingFailed,
+                "Failed to deserialize GetInstanceDataBinding"));
+        }
+
+        // Resolve endpoint
+        var preferredKind = useDapr ? EndpointKind.Dapr : EndpointKind.Url;
         var endpointResult = await _endpointResolver.GetEndpointAsync(
-            task.TriggerDomain, preferredKind, cancellationToken);
+            targetDomain, preferredKind, cancellationToken);
 
         if (!endpointResult.IsSuccess)
         {
-            return Result<GetInstanceDataBinding>.Fail(endpointResult.Error);
+            return Result<TaskEnvelope>.Fail(endpointResult.Error);
         }
 
         var endpoint = endpointResult.Value!;
 
-        return Result.Ok(new GetInstanceDataBinding
+        // Create enriched binding with runtime context
+        var enrichedBinding = new GetInstanceDataBinding
         {
-            Domain = task.TriggerDomain,
-            Workflow = task.TriggerFlow,
+            Domain = binding.Domain,
+            Workflow = binding.Workflow,
             Instance = instanceIdentifier,
-            Extensions = task.Extensions,
-            ETag = null,
-            UseDapr = task.UseDapr,
-            ValidateSSL = task.ValidateSSL,
+            Extensions = binding.Extensions,
+            ETag = binding.ETag,
+            UseDapr = binding.UseDapr,
+            ValidateSSL = binding.ValidateSSL,
+            TimeoutSeconds = binding.TimeoutSeconds,
+            Headers = binding.Headers,
             BaseUrl = endpoint.BaseUrl.ToString(),
             DaprAppId = endpoint.DaprAppId
+        };
+
+        return Result.Ok(new TaskEnvelope
+        {
+            TaskType = envelope.TaskType,
+            TaskKey = envelope.TaskKey,
+            Binding = JsonSerializer.SerializeToElement(enrichedBinding)
         });
     }
 }

--- a/src/BBT.Workflow.Application/Tasks/Executors/Trigger/GetInstancesTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Trigger/GetInstancesTaskExecutor.cs
@@ -10,6 +10,7 @@ using BBT.Workflow.Instances;
 using BBT.Workflow.Logging;
 using BBT.Workflow.Runtime;
 using BBT.Workflow.Scripting;
+using BBT.Workflow.Tasks.Mapping;
 using Microsoft.Extensions.Logging;
 
 namespace BBT.Workflow.Tasks.Executors;
@@ -78,6 +79,8 @@ public sealed class GetInstancesTaskExecutor : TriggerTaskExecutorBase<GetInstan
 
         try
         {
+            var headers = ConvertTaskHeadersToDictionary(task.Headers);
+
             // Step 1: Get list of instances
             var listInput = new GetInstanceListInput
             {
@@ -86,7 +89,8 @@ public sealed class GetInstancesTaskExecutor : TriggerTaskExecutorBase<GetInstan
                 Page = task.Page,
                 PageSize = task.PageSize,
                 Sort = task.Sort,
-                Filter = task.Filter
+                Filter = task.Filter,
+                Headers = headers ?? new Dictionary<string, string?>()
             };
 
             var instanceListResult = await _instanceQueryGateway.GetInstanceListAsync(listInput, cancellationToken);
@@ -197,31 +201,41 @@ public sealed class GetInstancesTaskExecutor : TriggerTaskExecutorBase<GetInstan
     {
         Logger.LogDebug("Using RemoteInvokerService for GetInstances task {TaskKey}", task.Key);
 
-        var bindingResult = await BuildGetInstancesBindingAsync(task, cancellationToken);
-        
-        if (!bindingResult.IsSuccess)
+        // Create envelope from task using TaskBindingMapper
+        var envelopeResult = TaskBindingMapper.CreateEnvelope(task);
+        if (!envelopeResult.IsSuccess)
+        {
+            Logger.TaskEnvelopeCreationFailed(
+                task.Key,
+                TaskType.ToString(),
+                context.ScriptContext.Instance.Id,
+                envelopeResult.Error.Message ?? "Failed to create envelope");
+            return Result<TaskInvocationResult>.Fail(envelopeResult.Error);
+        }
+
+        // Enrich binding with runtime context (endpoint, headers)
+        var enrichResult = await EnrichBindingAsync<GetInstancesBinding>(
+            envelopeResult.Value!,
+            task.TriggerDomain,
+            task.UseDapr,
+            context,
+            cancellationToken);
+
+        if (!enrichResult.IsSuccess)
         {
             Logger.TaskRemoteExecutionFailed(
                 task.Key,
                 TaskType.ToString(),
                 context.ScriptContext.Instance.Id,
-                bindingResult.Error.Message ?? "Failed to resolve endpoint");
-            return Result<TaskInvocationResult>.Fail(bindingResult.Error);
+                enrichResult.Error.Message ?? "Failed to resolve endpoint");
+            return Result<TaskInvocationResult>.Fail(enrichResult.Error);
         }
-
-        var binding = bindingResult.Value!;
-        var envelope = new TaskEnvelope
-        {
-            TaskType = TaskTypes.GetInstances,
-            TaskKey = task.Key,
-            Binding = JsonSerializer.SerializeToElement(binding)
-        };
 
         var traceContext = RemoteInvoker.CreateTraceContext(context.ScriptContext);
         var result = await RemoteInvoker.InvokeAsync(
             TaskTypes.GetInstances,
             task.Key,
-            envelope,
+            enrichResult.Value!,
             traceContext,
             cancellationToken);
 
@@ -237,33 +251,56 @@ public sealed class GetInstancesTaskExecutor : TriggerTaskExecutorBase<GetInstan
         return result;
     }
 
-    private async Task<Result<GetInstancesBinding>> BuildGetInstancesBindingAsync(
-        GetInstancesTask task,
+    private async Task<Result<TaskEnvelope>> EnrichBindingAsync<TBinding>(
+        TaskEnvelope envelope,
+        string targetDomain,
+        bool useDapr,
+        TaskExecutorContext context,
         CancellationToken cancellationToken)
     {
-        var preferredKind = task.UseDapr ? EndpointKind.Dapr : EndpointKind.Url;
+        // Deserialize binding
+        var binding = envelope.Binding.Deserialize<GetInstancesBinding>();
+        if (binding == null)
+        {
+            return Result<TaskEnvelope>.Fail(Error.Failure(
+                WorkflowErrorCodes.TaskBindingMappingFailed,
+                "Failed to deserialize binding"));
+        }
+
+        // Resolve endpoint
+        var preferredKind = useDapr ? EndpointKind.Dapr : EndpointKind.Url;
         var endpointResult = await _endpointResolver.GetEndpointAsync(
-            task.TriggerDomain, preferredKind, cancellationToken);
+            targetDomain, preferredKind, cancellationToken);
 
         if (!endpointResult.IsSuccess)
         {
-            return Result<GetInstancesBinding>.Fail(endpointResult.Error);
+            return Result<TaskEnvelope>.Fail(endpointResult.Error);
         }
 
         var endpoint = endpointResult.Value!;
 
-        return Result.Ok(new GetInstancesBinding
+        // Create enriched binding with runtime context
+        var enrichedBinding = new GetInstancesBinding
         {
-            Domain = task.TriggerDomain,
-            Workflow = task.TriggerFlow,
-            Page = task.Page,
-            PageSize = task.PageSize,
-            Sort = task.Sort,
-            Filter = task.Filter,
-            UseDapr = task.UseDapr,
-            ValidateSSL = task.ValidateSSL,
+            Domain = binding.Domain,
+            Workflow = binding.Workflow,
+            Page = binding.Page,
+            PageSize = binding.PageSize,
+            Sort = binding.Sort,
+            Filter = binding.Filter,
+            UseDapr = binding.UseDapr,
+            ValidateSSL = binding.ValidateSSL,
+            TimeoutSeconds = binding.TimeoutSeconds,
+            Headers = binding.Headers,
             BaseUrl = endpoint.BaseUrl.ToString(),
             DaprAppId = endpoint.DaprAppId
+        };
+
+        return Result.Ok(new TaskEnvelope
+        {
+            TaskType = envelope.TaskType,
+            TaskKey = envelope.TaskKey,
+            Binding = JsonSerializer.SerializeToElement(enrichedBinding)
         });
     }
 }

--- a/src/BBT.Workflow.Application/Tasks/Executors/Trigger/StartTriggerTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Trigger/StartTriggerTaskExecutor.cs
@@ -9,6 +9,7 @@ using BBT.Workflow.Instances;
 using BBT.Workflow.Logging;
 using BBT.Workflow.Runtime;
 using BBT.Workflow.Scripting;
+using BBT.Workflow.Tasks.Mapping;
 using Microsoft.Extensions.Logging;
 
 namespace BBT.Workflow.Tasks.Executors;
@@ -121,31 +122,41 @@ public sealed class StartTriggerTaskExecutor : TriggerTaskExecutorBase<StartTask
     {
         Logger.LogDebug("Using RemoteInvokerService for StartTrigger task {TaskKey}", task.Key);
 
-        var bindingResult = await BuildStartTriggerBindingAsync(task, context, cancellationToken);
-        
-        if (!bindingResult.IsSuccess)
+        // Create envelope from task using TaskBindingMapper
+        var envelopeResult = TaskBindingMapper.CreateEnvelope(task);
+        if (!envelopeResult.IsSuccess)
+        {
+            Logger.TaskEnvelopeCreationFailed(
+                task.Key,
+                TaskType.ToString(),
+                context.ScriptContext.Instance.Id,
+                envelopeResult.Error.Message ?? "Failed to create envelope");
+            return Result<TaskInvocationResult>.Fail(envelopeResult.Error);
+        }
+
+        // Enrich binding with runtime context (endpoint, headers)
+        var enrichResult = await EnrichBindingAsync<StartTriggerBinding>(
+            envelopeResult.Value!,
+            task.TriggerDomain,
+            task.UseDapr,
+            context,
+            cancellationToken);
+
+        if (!enrichResult.IsSuccess)
         {
             Logger.TaskRemoteExecutionFailed(
                 task.Key,
                 TaskType.ToString(),
                 context.ScriptContext.Instance.Id,
-                bindingResult.Error.Message ?? "Failed to resolve endpoint");
-            return Result<TaskInvocationResult>.Fail(bindingResult.Error);
+                enrichResult.Error.Message ?? "Failed to resolve endpoint");
+            return Result<TaskInvocationResult>.Fail(enrichResult.Error);
         }
-
-        var binding = bindingResult.Value!;
-        var envelope = new TaskEnvelope
-        {
-            TaskType = TaskTypes.StartTrigger,
-            TaskKey = task.Key,
-            Binding = JsonSerializer.SerializeToElement(binding)
-        };
 
         var traceContext = RemoteInvoker.CreateTraceContext(context.ScriptContext);
         var result = await RemoteInvoker.InvokeAsync(
             TaskTypes.StartTrigger,
             task.Key,
-            envelope,
+            enrichResult.Value!,
             traceContext,
             cancellationToken);
 
@@ -161,9 +172,63 @@ public sealed class StartTriggerTaskExecutor : TriggerTaskExecutorBase<StartTask
         return result;
     }
 
+    private async Task<Result<TaskEnvelope>> EnrichBindingAsync<TBinding>(
+        TaskEnvelope envelope,
+        string targetDomain,
+        bool useDapr,
+        TaskExecutorContext context,
+        CancellationToken cancellationToken)
+    {
+        // Deserialize binding
+        var binding = envelope.Binding.Deserialize<StartTriggerBinding>();
+        if (binding == null)
+        {
+            return Result<TaskEnvelope>.Fail(Error.Failure(
+                WorkflowErrorCodes.TaskBindingMappingFailed,
+                "Failed to deserialize binding"));
+        }
+
+        // Resolve endpoint
+        var preferredKind = useDapr ? EndpointKind.Dapr : EndpointKind.Url;
+        var endpointResult = await _endpointResolver.GetEndpointAsync(
+            targetDomain, preferredKind, cancellationToken);
+
+        if (!endpointResult.IsSuccess)
+        {
+            return Result<TaskEnvelope>.Fail(endpointResult.Error);
+        }
+
+        var endpoint = endpointResult.Value!;
+
+        // Create enriched binding with runtime context
+        var enrichedBinding = new StartTriggerBinding
+        {
+            Domain = binding.Domain,
+            Workflow = binding.Workflow,
+            Version = binding.Version,
+            Key = binding.Key,
+            Body = binding.Body,
+            Tags = binding.Tags,
+            Sync = binding.Sync,
+            UseDapr = binding.UseDapr,
+            ValidateSSL = binding.ValidateSSL,
+            TimeoutSeconds = binding.TimeoutSeconds,
+            Headers = binding.Headers,
+            BaseUrl = endpoint.BaseUrl.ToString(),
+            DaprAppId = endpoint.DaprAppId
+        };
+
+        return Result.Ok(new TaskEnvelope
+        {
+            TaskType = envelope.TaskType,
+            TaskKey = envelope.TaskKey,
+            Binding = JsonSerializer.SerializeToElement(enrichedBinding)
+        });
+    }
+
     private StartInstanceInput BuildStartInstanceInput(StartTask task, TaskExecutorContext context)
     {
-        var headers = ExtractHeaders(context.ScriptContext);
+        var headers = ConvertTaskHeadersToDictionary(task.Headers);
 
         return new StartInstanceInput(
             domain: task.TriggerDomain,
@@ -179,40 +244,5 @@ public sealed class StartTriggerTaskExecutor : TriggerTaskExecutorBase<StartTask
             },
             Headers = headers ?? new Dictionary<string, string?>()
         };
-    }
-
-    private async Task<Result<StartTriggerBinding>> BuildStartTriggerBindingAsync(
-        StartTask task,
-        TaskExecutorContext context,
-        CancellationToken cancellationToken)
-    {
-        var headers = ExtractHeaders(context.ScriptContext);
-
-        var preferredKind = task.UseDapr ? EndpointKind.Dapr : EndpointKind.Url;
-        var endpointResult = await _endpointResolver.GetEndpointAsync(
-            task.TriggerDomain, preferredKind, cancellationToken);
-
-        if (!endpointResult.IsSuccess)
-        {
-            return Result<StartTriggerBinding>.Fail(endpointResult.Error);
-        }
-
-        var endpoint = endpointResult.Value!;
-
-        return Result.Ok(new StartTriggerBinding
-        {
-            Domain = task.TriggerDomain,
-            Workflow = task.TriggerFlow,
-            Version = task.TriggerVersion,
-            Key = task.TriggerKey,
-            Tags = task.TriggerTags,
-            Body = task.Body,
-            Headers = headers != null ? JsonSerializer.Serialize(headers) : null,
-            Sync = task.TriggerSync,
-            UseDapr = task.UseDapr,
-            ValidateSSL = task.ValidateSSL,
-            BaseUrl = endpoint.BaseUrl.ToString(),
-            DaprAppId = endpoint.DaprAppId
-        });
     }
 }

--- a/src/BBT.Workflow.Application/Tasks/Executors/Trigger/SubProcessTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Trigger/SubProcessTaskExecutor.cs
@@ -11,6 +11,7 @@ using BBT.Workflow.Instances;
 using BBT.Workflow.Logging;
 using BBT.Workflow.Runtime;
 using BBT.Workflow.Scripting;
+using BBT.Workflow.Tasks.Mapping;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
@@ -193,17 +194,17 @@ public sealed class SubProcessTaskExecutor : TriggerTaskExecutorBase<SubProcessT
     {
         Logger.LogDebug("Using RemoteInvokerService for SubProcess task {TaskKey}", task.Key);
 
-        var bindingResult = await BuildSubProcessBindingAsync(task, context.ScriptContext, subFlowInstanceId, cancellationToken);
-        
-        if (!bindingResult.IsSuccess)
+        // Create envelope from task using TaskBindingMapper
+        var envelopeResult = TaskBindingMapper.CreateEnvelope(task);
+        if (!envelopeResult.IsSuccess)
         {
-            Logger.TaskRemoteExecutionFailed(
+            Logger.TaskEnvelopeCreationFailed(
                 task.Key,
                 TaskType.ToString(),
                 context.ScriptContext.Instance.Id,
-                bindingResult.Error.Message ?? "Failed to resolve endpoint");
+                envelopeResult.Error.Message ?? "Failed to create envelope");
             return TaskInvocationResult.Failure(
-                error: bindingResult.Error.Message ?? "Failed to resolve endpoint",
+                error: envelopeResult.Error.Message ?? "Failed to create envelope",
                 statusCode: 500,
                 taskType: TaskType.ToString(),
                 metadata: new Dictionary<string, object>
@@ -213,19 +214,37 @@ public sealed class SubProcessTaskExecutor : TriggerTaskExecutorBase<SubProcessT
                 });
         }
 
-        var binding = bindingResult.Value!;
-        var envelope = new TaskEnvelope
+        // Enrich binding with runtime context (endpoint, headers, callback, instanceId, extraProperties)
+        var enrichResult = await EnrichSubProcessBindingAsync(
+            envelopeResult.Value!,
+            task,
+            context,
+            subFlowInstanceId,
+            cancellationToken);
+
+        if (!enrichResult.IsSuccess)
         {
-            TaskType = TaskTypes.SubProcess,
-            TaskKey = task.Key,
-            Binding = JsonSerializer.SerializeToElement(binding)
-        };
+            Logger.TaskRemoteExecutionFailed(
+                task.Key,
+                TaskType.ToString(),
+                context.ScriptContext.Instance.Id,
+                enrichResult.Error.Message ?? "Failed to resolve endpoint");
+            return TaskInvocationResult.Failure(
+                error: enrichResult.Error.Message ?? "Failed to resolve endpoint",
+                statusCode: 500,
+                taskType: TaskType.ToString(),
+                metadata: new Dictionary<string, object>
+                {
+                    ["SubFlowInstanceId"] = subFlowInstanceId,
+                    ["CorrelationId"] = correlationId
+                });
+        }
 
         var traceContext = RemoteInvoker.CreateTraceContext(context.ScriptContext);
         var result = await RemoteInvoker.InvokeAsync(
             TaskTypes.SubProcess,
             task.Key,
-            envelope,
+            enrichResult.Value!,
             traceContext,
             cancellationToken);
 
@@ -271,9 +290,68 @@ public sealed class SubProcessTaskExecutor : TriggerTaskExecutorBase<SubProcessT
         };
     }
 
+    private async Task<Result<TaskEnvelope>> EnrichSubProcessBindingAsync(
+        TaskEnvelope envelope,
+        SubProcessTask task,
+        TaskExecutorContext context,
+        Guid subFlowInstanceId,
+        CancellationToken cancellationToken)
+    {
+        // Deserialize binding
+        var binding = envelope.Binding.Deserialize<SubProcessBinding>();
+        if (binding == null)
+        {
+            return Result<TaskEnvelope>.Fail(Error.Failure(
+                WorkflowErrorCodes.TaskBindingMappingFailed,
+                "Failed to deserialize SubProcessBinding"));
+        }
+
+        // Resolve endpoint
+        var preferredKind = task.UseDapr ? EndpointKind.Dapr : EndpointKind.Url;
+        var endpointResult = await _endpointResolver.GetEndpointAsync(
+            task.TriggerDomain, preferredKind, cancellationToken);
+
+        if (!endpointResult.IsSuccess)
+        {
+            return Result<TaskEnvelope>.Fail(endpointResult.Error);
+        }
+
+        var endpoint = endpointResult.Value!;
+
+        // Create enriched binding with runtime context
+        var enrichedBinding = new SubProcessBinding
+        {
+            Domain = binding.Domain,
+            Workflow = binding.Workflow,
+            Version = binding.Version,
+            Key = binding.Key,
+            Body = binding.Body,
+            Tags = binding.Tags,
+            Sync = binding.Sync,
+            UseDapr = binding.UseDapr,
+            ValidateSSL = binding.ValidateSSL,
+            TimeoutSeconds = binding.TimeoutSeconds,
+            InstanceId = subFlowInstanceId,
+            Callback = GetCallbackAppId(),
+            ExtraProperties = BuildExtraPropertiesAsDictionary(context.ScriptContext, task),
+            Headers = binding.Headers,
+            BaseUrl = endpoint.BaseUrl.ToString(),
+            DaprAppId = endpoint.DaprAppId
+        };
+
+        return Result.Ok(new TaskEnvelope
+        {
+            TaskType = envelope.TaskType,
+            TaskKey = envelope.TaskKey,
+            Binding = JsonSerializer.SerializeToElement(enrichedBinding)
+        });
+    }
+
     private StartInstanceInput BuildStartInstanceInput(SubProcessTask task, ScriptContext context,
         Guid subFlowInstanceId)
     {
+        var headers = ConvertTaskHeadersToDictionary(task.Headers);
+
         return new StartInstanceInput(
                 domain: task.TriggerDomain,
                 workflow: task.TriggerFlow,
@@ -289,48 +367,9 @@ public sealed class SubProcessTaskExecutor : TriggerTaskExecutorBase<SubProcessT
                     Callback = GetCallbackAppId(),
                     ExtraProperties = BuildExtraProperties(context, task)
                 },
-                Headers = ExtractHeaders(context) ?? new Dictionary<string, string?>(),
+                Headers = headers ?? new Dictionary<string, string?>(),
                 StrictIdempotency = true // Service-to-service call: return 409 if active instance exists
             };
-    }
-
-    private async Task<Result<SubProcessBinding>> BuildSubProcessBindingAsync(
-        SubProcessTask task,
-        ScriptContext context,
-        Guid subFlowInstanceId,
-        CancellationToken cancellationToken)
-    {
-        var headers = ExtractHeaders(context);
-
-        var preferredKind = task.UseDapr ? EndpointKind.Dapr : EndpointKind.Url;
-        var endpointResult = await _endpointResolver.GetEndpointAsync(
-            task.TriggerDomain, preferredKind, cancellationToken);
-
-        if (!endpointResult.IsSuccess)
-        {
-            return Result<SubProcessBinding>.Fail(endpointResult.Error);
-        }
-
-        var endpoint = endpointResult.Value!;
-
-        return Result.Ok(new SubProcessBinding
-        {
-            Domain = task.TriggerDomain,
-            Workflow = task.TriggerFlow,
-            Version = task.TriggerVersion,
-            InstanceId = subFlowInstanceId,
-            Key = task.TriggerKey,
-            Callback = GetCallbackAppId(),
-            Body = task.Body,
-            Tags = task.TriggerTags,
-            Headers = headers != null ? JsonSerializer.Serialize(headers) : null,
-            ExtraProperties = BuildExtraPropertiesAsDictionary(context, task),
-            Sync = task.TriggerSync,
-            UseDapr = task.UseDapr,
-            ValidateSSL = task.ValidateSSL,
-            BaseUrl = endpoint.BaseUrl.ToString(),
-            DaprAppId = endpoint.DaprAppId
-        });
     }
 
     private async Task<Result> CreateCorrelationAsync(

--- a/src/BBT.Workflow.Application/Tasks/Executors/Trigger/TriggerTaskExecutorBase.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Trigger/TriggerTaskExecutorBase.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Text.Json;
 using BBT.Aether.Results;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Logging;
@@ -118,24 +119,23 @@ public abstract class TriggerTaskExecutorBase<TTask>(
     }
 
     /// <summary>
-    /// Extracts headers from the script context for HTTP calls.
+    /// Converts task headers (JsonElement?) to Dictionary for local Input objects.
     /// </summary>
-    protected static Dictionary<string, string?>? ExtractHeaders(ScriptContext context)
+    protected static Dictionary<string, string?>? ConvertTaskHeadersToDictionary(JsonElement? taskHeaders)
     {
-        if (context.Headers == null || context.Headers?.Count == 0)
+        if (!taskHeaders.HasValue || taskHeaders.Value.ValueKind != JsonValueKind.Object)
+        {
             return null;
+        }
 
-        var headers = new Dictionary<string, string?>();
-        if (context.Headers != null)
-            foreach (var header in context.Headers)
-            {
-                if (header.Value != null)
-                {
-                    headers[header.Key] = header.Value.ToString() ?? string.Empty;
-                }
-            }
-
-        return headers.Count > 0 ? headers : null;
+        try
+        {
+            return taskHeaders.Value.Deserialize<Dictionary<string, string?>>();
+        }
+        catch
+        {
+            return null;
+        }
     }
 }
 

--- a/src/BBT.Workflow.Application/Tasks/Mapping/TaskBindingMapper.cs
+++ b/src/BBT.Workflow.Application/Tasks/Mapping/TaskBindingMapper.cs
@@ -48,6 +48,9 @@ public static class TaskBindingMapper
                 
                 // Trigger tasks (basic mapping - runtime context handled by invokers)
                 StartTask startTask => (TaskTypes.StartTrigger, (object)MapStartTask(startTask)),
+                DirectTriggerTask directTriggerTask => (TaskTypes.DirectTrigger, (object)MapDirectTriggerTask(directTriggerTask)),
+                SubProcessTask subProcessTask => (TaskTypes.SubProcess, (object)MapSubProcessTask(subProcessTask)),
+                GetInstancesTask getInstancesTask => (TaskTypes.GetInstances, (object)MapGetInstancesTask(getInstancesTask)),
                 GetInstanceDataTask getDataTask => (TaskTypes.GetInstanceData, (object)MapGetInstanceDataTask(getDataTask)),
                 
                 // Note: DirectTriggerTask and SubProcessTask require runtime context (InstanceId, Correlation)
@@ -84,10 +87,71 @@ public static class TaskBindingMapper
     {
         Domain = task.TriggerDomain,
         Workflow = task.TriggerFlow,
-        Version = null, // StartTask doesn't have version
+        Version = task.TriggerVersion,
         Body = task.Body,
-        Headers = null, // Headers extracted from context at runtime
-        Sync = true
+        Tags = task.TriggerTags,
+        Sync = task.TriggerSync,
+        UseDapr = task.UseDapr,
+        ValidateSSL = task.ValidateSSL,
+        Headers = task.Headers?.GetRawText(),
+        TimeoutSeconds = task.TimeoutSeconds,
+    };
+    
+    /// <summary>
+    /// Maps DirectTriggerTask to DirectTriggerBinding.
+    /// </summary>
+    private static DirectTriggerBinding MapDirectTriggerTask(DirectTriggerTask task) => new()
+    {
+        Domain = task.TriggerDomain,
+        Workflow = task.TriggerFlow,
+        Version = task.TriggerVersion,
+        InstanceId = task.TriggerInstanceId,
+        Key = task.TriggerKey,
+        TransitionName =  task.TransitionName,
+        Body = task.Body,
+        Tags = task.TriggerTags,
+        Sync = task.TriggerSync,
+        UseDapr = task.UseDapr,
+        ValidateSSL = task.ValidateSSL,
+        Headers = task.Headers?.GetRawText(),
+        TimeoutSeconds = task.TimeoutSeconds
+    };
+    
+    /// <summary>
+    /// Maps SubProcessTask to SubProcessBinding.
+    /// </summary>
+    private static SubProcessBinding MapSubProcessTask(SubProcessTask task) => new()
+    {
+        Domain = task.TriggerDomain,
+        Workflow = task.TriggerFlow,
+        Version = task.TriggerVersion,
+        Tags = task.TriggerTags,
+        Key = task.TriggerKey,
+        InstanceId = Guid.Empty,
+        Body = task.Body,
+        ExtraProperties = new Dictionary<string, object>(),
+        Sync = task.TriggerSync,
+        UseDapr = task.UseDapr,
+        ValidateSSL = task.ValidateSSL,
+        Headers = task.Headers?.GetRawText(),
+        TimeoutSeconds = task.TimeoutSeconds
+    };
+    
+    /// <summary>
+    /// Maps GetInstancesTask to GetInstancesBinding.
+    /// Note: Instance is resolved at runtime, this provides a basic mapping.
+    /// </summary>
+    private static GetInstancesBinding MapGetInstancesTask(GetInstancesTask task) => new()
+    {
+        Domain = task.TriggerDomain,
+        Workflow = task.TriggerFlow,
+        Filter = task.Filter,
+        Page = task.Page,
+        PageSize = task.PageSize,
+        ValidateSSL = task.ValidateSSL,
+        UseDapr = task.UseDapr,
+        Headers = task.Headers?.GetRawText(),
+        TimeoutSeconds = task.TimeoutSeconds
     };
 
     /// <summary>
@@ -100,6 +164,10 @@ public static class TaskBindingMapper
         Workflow = task.TriggerFlow,
         Instance = task.Identifier ?? string.Empty,
         Extensions = task.Extensions,
+        ValidateSSL = task.ValidateSSL,
+        UseDapr = task.UseDapr,
+        Headers = task.Headers?.GetRawText(),
+        TimeoutSeconds = task.TimeoutSeconds,
         ETag = null
     };
 

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/DirectTriggerTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/DirectTriggerTask.cs
@@ -73,6 +73,16 @@ public sealed class DirectTriggerTask : WorkflowTask
     /// </summary>
     public bool ValidateSSL { get; private set; } = true;
 
+    /// <summary>
+    /// Headers
+    /// </summary>
+    public JsonElement? Headers { get; private set; }
+
+    /// <summary>
+    /// Timeout seconds
+    /// </summary>
+    public int TimeoutSeconds { get; private set; } = 30;
+
     public string? Identifier => TriggerInstanceId.HasValue ? TriggerInstanceId.Value.ToString() : TriggerKey;
 
     public void SetTags(string[] tags)
@@ -140,6 +150,11 @@ public sealed class DirectTriggerTask : WorkflowTask
         ValidateSSL = validateSSL;
     }
 
+    public void SetHeaders(Dictionary<string, string?> headers)
+    {
+        Headers = JsonSerializer.SerializeToElement(headers);
+    }
+
     /// <summary>
     /// Internal property setters for object pooling
     /// </summary>
@@ -154,6 +169,8 @@ public sealed class DirectTriggerTask : WorkflowTask
     internal void SetTriggerVersionInternal(string? version) => TriggerVersion = version;
     internal void SetUseDaprInternal(bool useDapr) => UseDapr = useDapr;
     internal void SetValidateSSLInternal(bool validateSSL) => ValidateSSL = validateSSL;
+    internal void SetHeadersInternal(JsonElement? headers) => Headers = headers;
+    internal void SetTimeoutSecondsInternal(int timeoutSeconds) => TimeoutSeconds = timeoutSeconds;
 
     protected override void Configure(JsonElement config)
     {
@@ -194,6 +211,15 @@ public sealed class DirectTriggerTask : WorkflowTask
 
         if (config.TryGetProperty("validateSsl", out var validateSslElement))
             ValidateSSL = validateSslElement.GetBoolean();
+
+        if (config.TryGetProperty("headers", out var headersElement))
+        {
+            var headers = headersElement.GetRawText();
+            Headers = string.IsNullOrWhiteSpace(headers) ? null : headersElement;
+        }
+
+        if (config.TryGetProperty("timeoutSeconds", out var timeoutSeconds))
+            TimeoutSeconds = timeoutSeconds.GetInt32();
     }
 
     public static DirectTriggerTask Create(JsonElement config)
@@ -228,6 +254,8 @@ public sealed class DirectTriggerTask : WorkflowTask
         cloned.TriggerTags = TriggerTags;
         cloned.UseDapr = UseDapr;
         cloned.ValidateSSL = ValidateSSL;
+        cloned.Headers = Headers;
+        cloned.TimeoutSeconds = TimeoutSeconds;
         return cloned;
     }
 
@@ -249,6 +277,8 @@ public sealed class DirectTriggerTask : WorkflowTask
         SetTriggerTagsInternal(source.TriggerTags);
         SetUseDaprInternal(source.UseDapr);
         SetValidateSSLInternal(source.ValidateSSL);
+        SetHeadersInternal(source.Headers);
+        SetTimeoutSecondsInternal(source.TimeoutSeconds);
     }
 
     /// <summary>
@@ -268,6 +298,8 @@ public sealed class DirectTriggerTask : WorkflowTask
         TriggerTags = null;
         UseDapr = false;
         ValidateSSL = true;
+        Headers = null;
+        TimeoutSeconds = 30;
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/GetInstanceDataTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/GetInstanceDataTask.cs
@@ -53,6 +53,16 @@ public sealed class GetInstanceDataTask : WorkflowTask
     /// </summary>
     public bool ValidateSSL { get; private set; } = true;
 
+    /// <summary>
+    /// Headers
+    /// </summary>
+    public JsonElement? Headers { get; private set; }
+
+    /// <summary>
+    /// Timeout seconds
+    /// </summary>
+    public int TimeoutSeconds { get; private set; } = 30;
+
     public string? Identifier => TriggerInstanceId.HasValue ? TriggerInstanceId.Value.ToString() : TriggerKey;
 
     public void SetInstance(string? instanceId)
@@ -99,6 +109,11 @@ public sealed class GetInstanceDataTask : WorkflowTask
         ValidateSSL = validateSSL;
     }
 
+    public void SetHeaders(Dictionary<string, string?> headers)
+    {
+        Headers = JsonSerializer.SerializeToElement(headers);
+    }
+
     /// <summary>
     /// Internal property setters for object pooling
     /// </summary>
@@ -109,6 +124,8 @@ public sealed class GetInstanceDataTask : WorkflowTask
     internal void SetExtensionsInternal(string[]? extensions) => Extensions = extensions;
     internal void SetUseDaprInternal(bool useDapr) => UseDapr = useDapr;
     internal void SetValidateSSLInternal(bool validateSSL) => ValidateSSL = validateSSL;
+    internal void SetHeadersInternal(JsonElement? headers) => Headers = headers;
+    internal void SetTimeoutSecondsInternal(int timeoutSeconds) => TimeoutSeconds = timeoutSeconds;
 
     protected override void Configure(JsonElement config)
     {
@@ -143,6 +160,15 @@ public sealed class GetInstanceDataTask : WorkflowTask
 
         if (config.TryGetProperty("validateSsl", out var validateSslElement))
             ValidateSSL = validateSslElement.GetBoolean();
+
+        if (config.TryGetProperty("headers", out var headersElement))
+        {
+            var headers = headersElement.GetRawText();
+            Headers = string.IsNullOrWhiteSpace(headers) ? null : headersElement;
+        }
+
+        if (config.TryGetProperty("timeoutSeconds", out var timeoutSeconds))
+            TimeoutSeconds = timeoutSeconds.GetInt32();
     }
 
     public static GetInstanceDataTask Create(JsonElement config)
@@ -173,6 +199,8 @@ public sealed class GetInstanceDataTask : WorkflowTask
         cloned.Extensions = Extensions;
         cloned.UseDapr = UseDapr;
         cloned.ValidateSSL = ValidateSSL;
+        cloned.Headers = Headers;
+        cloned.TimeoutSeconds = TimeoutSeconds;
 
         return cloned;
     }
@@ -191,6 +219,8 @@ public sealed class GetInstanceDataTask : WorkflowTask
         SetExtensionsInternal(source.Extensions);
         SetUseDaprInternal(source.UseDapr);
         SetValidateSSLInternal(source.ValidateSSL);
+        SetHeadersInternal(source.Headers);
+        SetTimeoutSecondsInternal(source.TimeoutSeconds);
     }
 
     /// <summary>
@@ -206,6 +236,8 @@ public sealed class GetInstanceDataTask : WorkflowTask
         Extensions = null;
         UseDapr = false;
         ValidateSSL = true;
+        Headers = null;
+        TimeoutSeconds = 30;
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/GetInstancesTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/GetInstancesTask.cs
@@ -59,6 +59,16 @@ public sealed class GetInstancesTask : WorkflowTask
     /// </summary>
     public bool ValidateSSL { get; private set; } = true;
 
+    /// <summary>
+    /// Headers
+    /// </summary>
+    public JsonElement? Headers { get; private set; }
+
+    /// <summary>
+    /// Timeout seconds
+    /// </summary>
+    public int TimeoutSeconds { get; private set; } = 30;
+
     public void SetDomain(string domain)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(domain, nameof(domain));
@@ -101,6 +111,11 @@ public sealed class GetInstancesTask : WorkflowTask
         ValidateSSL = validateSSL;
     }
 
+    public void SetHeaders(Dictionary<string, string?> headers)
+    {
+        Headers = JsonSerializer.SerializeToElement(headers);
+    }
+
     /// <summary>
     /// Internal property setters for object pooling
     /// </summary>
@@ -112,6 +127,8 @@ public sealed class GetInstancesTask : WorkflowTask
     internal void SetFilterInternal(string[]? filter) => Filter = filter;
     internal void SetUseDaprInternal(bool useDapr) => UseDapr = useDapr;
     internal void SetValidateSSLInternal(bool validateSSL) => ValidateSSL = validateSSL;
+    internal void SetHeadersInternal(JsonElement? headers) => Headers = headers;
+    internal void SetTimeoutSecondsInternal(int timeoutSeconds) => TimeoutSeconds = timeoutSeconds;
 
     protected override void Configure(JsonElement config)
     {
@@ -149,6 +166,15 @@ public sealed class GetInstancesTask : WorkflowTask
 
         if (config.TryGetProperty("validateSsl", out var validateSslElement))
             ValidateSSL = validateSslElement.GetBoolean();
+
+        if (config.TryGetProperty("headers", out var headersElement))
+        {
+            var headers = headersElement.GetRawText();
+            Headers = string.IsNullOrWhiteSpace(headers) ? null : headersElement;
+        }
+
+        if (config.TryGetProperty("timeoutSeconds", out var timeoutSeconds))
+            TimeoutSeconds = timeoutSeconds.GetInt32();
     }
 
     public static GetInstancesTask Create(JsonElement config)
@@ -180,6 +206,8 @@ public sealed class GetInstancesTask : WorkflowTask
         cloned.Filter = Filter;
         cloned.UseDapr = UseDapr;
         cloned.ValidateSSL = ValidateSSL;
+        cloned.Headers = Headers;
+        cloned.TimeoutSeconds = TimeoutSeconds;
 
         return cloned;
     }
@@ -199,6 +227,8 @@ public sealed class GetInstancesTask : WorkflowTask
         SetFilterInternal(source.Filter);
         SetUseDaprInternal(source.UseDapr);
         SetValidateSSLInternal(source.ValidateSSL);
+        SetHeadersInternal(source.Headers);
+        SetTimeoutSecondsInternal(source.TimeoutSeconds);
     }
 
     /// <summary>
@@ -215,6 +245,8 @@ public sealed class GetInstancesTask : WorkflowTask
         Filter = null;
         UseDapr = false;
         ValidateSSL = true;
+        Headers = null;
+        TimeoutSeconds = 30;
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/StartTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/StartTask.cs
@@ -64,6 +64,16 @@ public sealed class StartTask : WorkflowTask
     /// </summary>
     public bool ValidateSSL { get; private set; } = true;
 
+    /// <summary>
+    /// Headers
+    /// </summary>
+    public JsonElement? Headers { get; private set; }
+
+    /// <summary>
+    /// Timeout seconds
+    /// </summary>
+    public int TimeoutSeconds { get; private set; } = 30;
+
     public void SetTags(string[] tags)
     {
         TriggerTags = tags;
@@ -111,6 +121,11 @@ public sealed class StartTask : WorkflowTask
         ValidateSSL = validateSSL;
     }
 
+    public void SetHeaders(Dictionary<string, string?> headers)
+    {
+        Headers = JsonSerializer.SerializeToElement(headers);
+    }
+
     /// <summary>
     /// Internal property setters for object pooling
     /// </summary>
@@ -124,6 +139,8 @@ public sealed class StartTask : WorkflowTask
     internal void SetTriggerTagsInternal(string[]? tags) => TriggerTags = tags;
     internal void SetUseDaprInternal(bool useDapr) => UseDapr = useDapr;
     internal void SetValidateSSLInternal(bool validateSSL) => ValidateSSL = validateSSL;
+    internal void SetHeadersInternal(JsonElement? headers) => Headers = headers;
+    internal void SetTimeoutSecondsInternal(int timeoutSeconds) => TimeoutSeconds = timeoutSeconds;
 
     protected override void Configure(JsonElement config)
     {
@@ -158,6 +175,15 @@ public sealed class StartTask : WorkflowTask
 
         if (config.TryGetProperty("validateSsl", out var validateSslElement))
             ValidateSSL = validateSslElement.GetBoolean();
+
+        if (config.TryGetProperty("headers", out var headersElement))
+        {
+            var headers = headersElement.GetRawText();
+            Headers = string.IsNullOrWhiteSpace(headers) ? null : headersElement;
+        }
+
+        if (config.TryGetProperty("timeoutSeconds", out var timeoutSeconds))
+            TimeoutSeconds = timeoutSeconds.GetInt32();
     }
 
     public static StartTask Create(JsonElement config)
@@ -190,6 +216,8 @@ public sealed class StartTask : WorkflowTask
         cloned.TriggerTags = TriggerTags;
         cloned.UseDapr = UseDapr;
         cloned.ValidateSSL = ValidateSSL;
+        cloned.Headers = Headers;
+        cloned.TimeoutSeconds = TimeoutSeconds;
         return cloned;
     }
 
@@ -209,6 +237,8 @@ public sealed class StartTask : WorkflowTask
         SetTriggerTagsInternal(source.TriggerTags);
         SetUseDaprInternal(source.UseDapr);
         SetValidateSSLInternal(source.ValidateSSL);
+        SetHeadersInternal(source.Headers);
+        SetTimeoutSecondsInternal(source.TimeoutSeconds);
     }
 
     /// <summary>
@@ -226,6 +256,8 @@ public sealed class StartTask : WorkflowTask
         TriggerTags = null;
         UseDapr = false;
         ValidateSSL = true;
+        Headers = null;
+        TimeoutSeconds = 30;
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/SubProcessTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/SubProcessTask.cs
@@ -63,6 +63,16 @@ public sealed class SubProcessTask : WorkflowTask
     /// </summary>
     public bool ValidateSSL { get; private set; } = true;
 
+    /// <summary>
+    /// Headers
+    /// </summary>
+    public JsonElement? Headers { get; private set; }
+
+    /// <summary>
+    /// Timeout seconds
+    /// </summary>
+    public int TimeoutSeconds { get; private set; } = 30;
+
     public void SetBody(dynamic body)
     {
         Body = JsonSerializer.SerializeToElement(body);
@@ -110,6 +120,11 @@ public sealed class SubProcessTask : WorkflowTask
         TriggerSync = sync;
     }
 
+    public void SetHeaders(Dictionary<string, string?> headers)
+    {
+        Headers = JsonSerializer.SerializeToElement(headers);
+    }
+
     /// <summary>
     /// Internal property setters for object pooling
     /// </summary>
@@ -123,6 +138,8 @@ public sealed class SubProcessTask : WorkflowTask
     internal void SetTriggerTagsInternal(string[]? tags) => TriggerTags = tags;
     internal void SetUseDaprInternal(bool useDapr) => UseDapr = useDapr;
     internal void SetValidateSSLInternal(bool validateSSL) => ValidateSSL = validateSSL;
+    internal void SetHeadersInternal(JsonElement? headers) => Headers = headers;
+    internal void SetTimeoutSecondsInternal(int timeoutSeconds) => TimeoutSeconds = timeoutSeconds;
 
     protected override void Configure(JsonElement config)
     {
@@ -159,6 +176,15 @@ public sealed class SubProcessTask : WorkflowTask
 
         if (config.TryGetProperty("validateSsl", out var validateSslElement))
             ValidateSSL = validateSslElement.GetBoolean();
+
+        if (config.TryGetProperty("headers", out var headersElement))
+        {
+            var headers = headersElement.GetRawText();
+            Headers = string.IsNullOrWhiteSpace(headers) ? null : headersElement;
+        }
+
+        if (config.TryGetProperty("timeoutSeconds", out var timeoutSeconds))
+            TimeoutSeconds = timeoutSeconds.GetInt32();
     }
 
     public static SubProcessTask Create(JsonElement config)
@@ -191,6 +217,8 @@ public sealed class SubProcessTask : WorkflowTask
         cloned.TriggerTags = TriggerTags;
         cloned.UseDapr = UseDapr;
         cloned.ValidateSSL = ValidateSSL;
+        cloned.Headers = Headers;
+        cloned.TimeoutSeconds = TimeoutSeconds;
         return cloned;
     }
 
@@ -210,6 +238,8 @@ public sealed class SubProcessTask : WorkflowTask
         SetTriggerTagsInternal(source.TriggerTags);
         SetUseDaprInternal(source.UseDapr);
         SetValidateSSLInternal(source.ValidateSSL);
+        SetHeadersInternal(source.Headers);
+        SetTimeoutSecondsInternal(source.TimeoutSeconds);
     }
 
     /// <summary>
@@ -227,6 +257,8 @@ public sealed class SubProcessTask : WorkflowTask
         TriggerTags = null;
         UseDapr = false;
         ValidateSSL = true;
+        Headers = null;
+        TimeoutSeconds = 30;
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Execution.Abstractions/Bindings/DirectTriggerBinding.cs
+++ b/src/BBT.Workflow.Execution.Abstractions/Bindings/DirectTriggerBinding.cs
@@ -69,6 +69,11 @@ public sealed class DirectTriggerBinding
     public bool ValidateSSL { get; init; } = true;
 
     /// <summary>
+    /// Timeout seconds for HTTP requests.
+    /// </summary>
+    public int TimeoutSeconds { get; init; } = 30;
+
+    /// <summary>
     /// Resolved base URL for HTTP requests.
     /// </summary>
     public string? BaseUrl { get; init; }

--- a/src/BBT.Workflow.Execution.Abstractions/Bindings/GetInstanceDataBinding.cs
+++ b/src/BBT.Workflow.Execution.Abstractions/Bindings/GetInstanceDataBinding.cs
@@ -42,6 +42,16 @@ public sealed class GetInstanceDataBinding
     public bool ValidateSSL { get; init; } = true;
 
     /// <summary>
+    /// Request headers as JSON string.
+    /// </summary>
+    public string? Headers { get; init; }
+
+    /// <summary>
+    /// Timeout seconds for HTTP requests.
+    /// </summary>
+    public int TimeoutSeconds { get; init; } = 30;
+
+    /// <summary>
     /// Resolved base URL for HTTP requests.
     /// </summary>
     public string? BaseUrl { get; init; }

--- a/src/BBT.Workflow.Execution.Abstractions/Bindings/GetInstancesBinding.cs
+++ b/src/BBT.Workflow.Execution.Abstractions/Bindings/GetInstancesBinding.cs
@@ -47,6 +47,16 @@ public sealed class GetInstancesBinding
     public bool ValidateSSL { get; init; } = true;
 
     /// <summary>
+    /// Request headers as JSON string.
+    /// </summary>
+    public string? Headers { get; init; }
+
+    /// <summary>
+    /// Timeout seconds for HTTP requests.
+    /// </summary>
+    public int TimeoutSeconds { get; init; } = 30;
+
+    /// <summary>
     /// Resolved base URL for HTTP requests.
     /// </summary>
     public string? BaseUrl { get; init; }

--- a/src/BBT.Workflow.Execution.Abstractions/Bindings/StartTriggerBinding.cs
+++ b/src/BBT.Workflow.Execution.Abstractions/Bindings/StartTriggerBinding.cs
@@ -59,6 +59,11 @@ public sealed class StartTriggerBinding
     public bool ValidateSSL { get; init; } = true;
 
     /// <summary>
+    /// Timeout seconds for HTTP requests.
+    /// </summary>
+    public int TimeoutSeconds { get; init; } = 30;
+
+    /// <summary>
     /// Resolved base URL for HTTP requests.
     /// </summary>
     public string? BaseUrl { get; init; }

--- a/src/BBT.Workflow.Execution.Abstractions/Bindings/SubProcessBinding.cs
+++ b/src/BBT.Workflow.Execution.Abstractions/Bindings/SubProcessBinding.cs
@@ -75,6 +75,11 @@ public sealed class SubProcessBinding
     public bool ValidateSSL { get; init; } = true;
 
     /// <summary>
+    /// Timeout seconds for HTTP requests.
+    /// </summary>
+    public int TimeoutSeconds { get; init; } = 30;
+
+    /// <summary>
     /// Resolved base URL for HTTP requests.
     /// </summary>
     public string? BaseUrl { get; init; }

--- a/src/BBT.Workflow.Execution/Invokers/DirectTriggerRemoteInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/DirectTriggerRemoteInvoker.cs
@@ -412,6 +412,9 @@ public sealed class DirectTriggerRemoteInvoker : ITaskInvoker<DirectTriggerBindi
                 TaskType, taskKey);
         }
 
-        return _httpClientFactory.CreateClient(clientName);
+        var client = _httpClientFactory.CreateClient(clientName);
+        client.Timeout = TimeSpan.FromSeconds(binding.TimeoutSeconds);
+        
+        return client;
     }
 }

--- a/src/BBT.Workflow.Execution/Invokers/GetInstanceDataRemoteInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/GetInstanceDataRemoteInvoker.cs
@@ -300,6 +300,9 @@ public sealed class GetInstanceDataRemoteInvoker : ITaskInvoker<GetInstanceDataB
                 TaskType, taskKey);
         }
 
-        return _httpClientFactory.CreateClient(clientName);
+        var client = _httpClientFactory.CreateClient(clientName);
+        client.Timeout = TimeSpan.FromSeconds(binding.TimeoutSeconds);
+        
+        return client;
     }
 }

--- a/src/BBT.Workflow.Execution/Invokers/GetInstancesRemoteInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/GetInstancesRemoteInvoker.cs
@@ -308,6 +308,9 @@ public sealed class GetInstancesRemoteInvoker : ITaskInvoker<GetInstancesBinding
                 TaskType, taskKey);
         }
 
-        return _httpClientFactory.CreateClient(clientName);
+        var client = _httpClientFactory.CreateClient(clientName);
+        client.Timeout = TimeSpan.FromSeconds(binding.TimeoutSeconds);
+        
+        return client;
     }
 }

--- a/src/BBT.Workflow.Execution/Invokers/StartTriggerRemoteInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/StartTriggerRemoteInvoker.cs
@@ -335,6 +335,9 @@ public sealed class StartTriggerRemoteInvoker : ITaskInvoker<StartTriggerBinding
                 TaskType, taskKey);
         }
 
-        return _httpClientFactory.CreateClient(clientName);
+        var client = _httpClientFactory.CreateClient(clientName);
+        client.Timeout = TimeSpan.FromSeconds(binding.TimeoutSeconds);
+        
+        return client;
     }
 }

--- a/src/BBT.Workflow.Execution/Invokers/SubProcessRemoteInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/SubProcessRemoteInvoker.cs
@@ -186,7 +186,7 @@ public sealed class SubProcessRemoteInvoker : ITaskInvoker<SubProcessBinding>
         HttpResponseMessage response,
         long executionDurationMs,
         CancellationToken cancellationToken)
-    {
+        {
         var responseHeaders = InvokerHelpers.MergeHeaders(response.Headers, response.Content.Headers);
         var content = await response.Content.ReadAsStringAsync(cancellationToken);
         var responseData = InvokerHelpers.TryParseJson(content);
@@ -343,6 +343,9 @@ public sealed class SubProcessRemoteInvoker : ITaskInvoker<SubProcessBinding>
                 TaskType, taskKey);
         }
 
-        return _httpClientFactory.CreateClient(clientName);
+        var client = _httpClientFactory.CreateClient(clientName);
+        client.Timeout = TimeSpan.FromSeconds(binding.TimeoutSeconds);
+        
+        return client;
     }
 }

--- a/src/BBT.Workflow.Execution/Microsoft/Extensions/DependencyInjection/ExecutionServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Execution/Microsoft/Extensions/DependencyInjection/ExecutionServiceCollectionExtensions.cs
@@ -86,6 +86,8 @@ public static class ExecutionServiceCollectionExtensions
         services.AddHttpClient(WorkflowHttpClientNames.Default, client =>
             {
                 client.Timeout = TimeSpan.FromSeconds(30);
+                client.MaxResponseContentBufferSize = int.MaxValue;
+                client.DefaultRequestHeaders.Add("Accept", "application/json");
             })
             .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
             {
@@ -97,6 +99,8 @@ public static class ExecutionServiceCollectionExtensions
         services.AddHttpClient(WorkflowHttpClientNames.NoSslValidation, client =>
             {
                 client.Timeout = TimeSpan.FromSeconds(30);
+                client.MaxResponseContentBufferSize = int.MaxValue;
+                client.DefaultRequestHeaders.Add("Accept", "application/json");
             })
             .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
             {

--- a/src/BBT.Workflow.HttpApi.Shared/Microsoft/Extensions/DependencyInjection/WorkflowApiBaseServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.HttpApi.Shared/Microsoft/Extensions/DependencyInjection/WorkflowApiBaseServiceCollectionExtensions.cs
@@ -8,7 +8,6 @@ using BBT.Aether.MultiSchema.EntityFrameworkCore.Interceptors;
 using BBT.Workflow;
 using BBT.Workflow.BackgroundJobs.Handlers;
 using BBT.Workflow.Data;
-using BBT.Workflow.Definitions;
 using BBT.Workflow.Headers;
 using BBT.Workflow.Monitoring;
 using BBT.Workflow.Runtime;

--- a/workers/BBT.Workflow.Workers.Inbox/Controllers/UtilityController.cs
+++ b/workers/BBT.Workflow.Workers.Inbox/Controllers/UtilityController.cs
@@ -1,4 +1,4 @@
-using BBT.Workflow.Definitions;
+using BBT.Workflow.Caching;
 using BBT.Workflow.Definitions.Events;
 using BBT.Workflow.Logging;
 using BBT.Workflow.Runtime;
@@ -14,7 +14,7 @@ namespace BBT.Workflow.Workers.Inbox.Controllers;
 [ApiVersion("1.0")]
 [Route("api/v{version:apiVersion}/utilities")]
 public sealed class UtilityController(
-    IDefinitionAppService definitionAppService,
+    IRuntimeCacheInitializer runtimeCacheInitializer,
     IRuntimeInfoProvider runtimeInfoProvider,
     IConfiguration configuration,
     ILogger<UtilityController> logger) : ControllerBase
@@ -22,6 +22,7 @@ public sealed class UtilityController(
     /// <summary>
     /// Handles broadcast cache invalidation requests from Dapr subscription.
     /// All Worker.Inbox pods receive this message via vnext-pubsub-broadcast.
+    /// Updates only in-memory cache since distributed cache is already updated by initiating pod.
     /// </summary>
     /// <param name="eventData">Cache invalidation event data.</param>
     /// <param name="cancellationToken">Cancellation token for the operation.</param>
@@ -57,13 +58,11 @@ public sealed class UtilityController(
         
         logger.DefinitionCacheInvalidationReceived(podInstance, eventData.Domain, eventData.RequestedBy);
         
-        var result = await definitionAppService.ReInitializeAsync(cancellationToken);
+        // Update only in-memory cache (distributed cache already updated by initiating pod)
+        await runtimeCacheInitializer.InitializeAsync(cancellationToken);
         
-        if (result.IsSuccess)
-            logger.DefinitionCacheInvalidationSucceeded(podInstance);
-        else
-            logger.DefinitionCacheInvalidationFailed(podInstance, result.Error.Message);
-            
+        logger.DefinitionCacheInvalidationSucceeded(podInstance);
+                
         return Ok();
     }
 }

--- a/workers/BBT.Workflow.Workers.Inbox/appsettings.json
+++ b/workers/BBT.Workflow.Workers.Inbox/appsettings.json
@@ -11,7 +11,7 @@
       "Microsoft.AspNetCore.Routing.EndpointMiddleware": "Information",
       "System.Net.Http.HttpClient.Default.LogicalHandler": "Warning",
       "Microsoft.EntityFrameworkCore.Database.Command": "Warning",
-      "BBT.Workflow.Workers.Outbox": "Debug"
+      "BBT.Workflow.Workers.Inbox": "Debug"
     }
   },
   "vNextApi": {


### PR DESCRIPTION
## Summary

This PR implements comprehensive refactoring focused on cache management, task execution pipeline, and binding mechanisms in the workflow runtime system.

Fixes #377

## Key Changes

### 🚀 Cache Synchronization Optimization
- Implemented dual-mode cache initialization
- Initiating pod updates both distributed and in-memory cache
- Receiving pods update only in-memory cache
- Prevents unnecessary distributed cache writes during broadcast

### 🔧 Task Execution Pipeline Refactoring
- Separated task-to-binding mapping from runtime context enrichment
- Introduced `EnrichBindingAsync` pattern for endpoint resolution
- Standardized header handling across all trigger executors
- Fixed error handling in `TaskExecutorBase` (correct error objects)
- Centralized binding creation in `TaskBindingMapper`

### ✨ Domain Model Enhancements
- Added `Headers` and `TimeoutSeconds` properties to all trigger tasks
- Applied task-level timeout to HttpClient instances
- Configured HttpClient with proper buffer size and headers
- Enabled custom headers in remote task invocation

### 🎯 Additional Improvements
- Moved re-initialize logic from controller to application service
- Added null-safe operators in InstanceController
- Cleaned up unnecessary dependencies
- Fixed logging namespace in Worker.Inbox

## Impact

- **Files Changed:** 37
- **Lines Added:** ~833
- **Lines Deleted:** ~268
- **Net Increase:** ~565 lines

## Benefits

✅ **Performance** - Reduced unnecessary distributed cache operations  
✅ **Maintainability** - Centralized binding logic, reduced duplication  
✅ **Reliability** - Fixed error handling, improved timeout control  
✅ **Flexibility** - Custom headers and timeout support  
✅ **Architecture** - Better separation of concerns  

## Backward Compatibility

✅ All changes are backward compatible
- Existing task definitions work without headers/timeout (defaults applied)
- Cache invalidation uses same broadcast pattern
- API contracts preserved

## Test Plan

- [ ] Cache invalidation (single & multi-pod scenarios)
- [ ] Task executor error handling (all stages)
- [ ] Trigger tasks with custom headers/timeout
- [ ] Remote invoker timeout behavior
- [ ] Re-initialize endpoint functionality

## Summary by Sourcery

Refactor trigger task execution and cache initialization to centralize binding mapping, support richer HTTP options, and optimize distributed cache usage across pods.

New Features:
- Allow all trigger tasks to define custom HTTP headers and per-task timeout settings that flow through bindings to remote invokers.
- Introduce dual-mode runtime cache initialization that can update both in-memory and distributed caches for initiating pods.

Bug Fixes:
- Correct TaskExecutorBase error propagation so each execution stage returns its own error instead of validation errors.
- Fix logging category configuration for the Worker.Inbox service.

Enhancements:
- Centralize trigger task-to-binding mapping via TaskBindingMapper and new EnrichBindingAsync patterns in trigger executors.
- Standardize HttpClient configuration and apply binding-level timeouts for all remote trigger invokers.
- Change definition re-initialize endpoint to delegate cache refresh to the application service and return a concrete result.
- Handle cache invalidation broadcasts by updating only in-memory caches on receiving pods, avoiding redundant distributed cache writes.
- Add null-safe handling of instance start requests in InstanceController and simplify DI dependencies on controllers.
- Extend domain task models and bindings to carry headers and timeout metadata for remote calls.