### PR TITLE
Function Defined in Workflows

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,10 @@ The BBT Workflow Engine is a comprehensive, domain-driven workflow management sy
 ### Security
 - [QueryExtensions Security](./security/queryextensions-security.md)
 
+### Breaking Changes
+- [Function–Workflow Validation (EN)](./breaking-changes/function-workflow-validation-en.md) – Functions with scope `I` or `F` must be declared in the workflow’s `functions` array
+- [Function–Workflow Validation (TR)](./breaking-changes/function-workflow-validation-tr.md) – Scope `I` veya `F` olan fonksiyonlar workflow’un `functions` dizisinde tanımlı olmalıdır
+
 ## Key Features
 
 ### Core Capabilities

--- a/docs/breaking-changes/function-workflow-validation-en.md
+++ b/docs/breaking-changes/function-workflow-validation-en.md
@@ -1,0 +1,42 @@
+# Breaking Change: Function–Workflow Validation
+
+## Summary
+
+When invoking a **function** whose scope is **Instance (`"scope": "I"`)** or **Flow (`"scope": "F"`)**, the workflow’s **flow definition** must declare that function in its `functions` array. If it does not, the API returns a validation error instead of executing the function.
+
+## Error Response
+
+If the function is not declared for the workflow:
+
+- **Message:** `"Function '{functionKey}' is not defined for workflow '{workflowKey}'"`
+- **HTTP status:** 400 (Validation)
+- **Error code:** `Function:800001` (FunctionNotInWorkflow)
+
+## Required Configuration
+
+The **workflow (flow) definition** must reference the function in its `functions` list. Only functions listed there may be executed in the context of that workflow when their scope is `I` or `F`.
+
+**Example (workflow/flow definition):**
+
+```json
+{
+  "key": "parent-flow",
+  "domain": "local-test",
+  "version": "1.0.0",
+  "functions": [
+    {
+      "key": "function-get-instance-summary",
+      "domain": "local-test",
+      "flow": "sys-functions",
+      "version": "1.0.0"
+    }
+  ]
+}
+```
+
+If `function-get-instance-summary` has `"scope": "I"` or `"scope": "F"` but is **missing** from the flow’s `functions` array, calls to that function for this workflow will fail with the error above.
+
+## Scope Behaviour
+
+- **System / global functions** (e.g. from `sys-functions` flow) that are **not** scope `I` or `F` are not subject to this check.
+- For **Instance (`I`)** and **Flow (`F`)** scope, the function **must** be listed in the workflow’s `functions` array.

--- a/docs/breaking-changes/function-workflow-validation-tr.md
+++ b/docs/breaking-changes/function-workflow-validation-tr.md
@@ -1,0 +1,42 @@
+# Breaking Change: Function–Workflow Doğrulaması
+
+## Özet
+
+**Instance (`"scope": "I"`)** veya **Flow (`"scope": "F"`)** kapsamındaki bir **fonksiyon** çağrıldığında, ilgili **akış (flow) tanımında** bu fonksiyon `functions` dizisinde tanımlı olmalıdır. Tanımlı değilse API, fonksiyonu çalıştırmak yerine validasyon hatası döner.
+
+## Hata Yanıtı
+
+Fonksiyon, workflow için tanımlı değilse:
+
+- **Mesaj:** `"Function '{functionKey}' is not defined for workflow '{workflowKey}'"`
+- **HTTP durumu:** 400 (Validation)
+- **Hata kodu:** `Function:800001` (FunctionNotInWorkflow)
+
+## Gerekli Yapılandırma
+
+**Workflow (flow) tanımında** fonksiyon, `functions` listesinde referans verilmiş olmalıdır. Kapsamı `I` veya `F` olan fonksiyonlar yalnızca bu listede yer alıyorsa ilgili workflow bağlamında çalıştırılabilir.
+
+**Örnek (workflow/flow tanımı):**
+
+```json
+{
+  "key": "parent-flow",
+  "domain": "local-test",
+  "version": "1.0.0",
+  "functions": [
+    {
+      "key": "function-get-instance-summary",
+      "domain": "local-test",
+      "flow": "sys-functions",
+      "version": "1.0.0"
+    }
+  ]
+}
+```
+
+`function-get-instance-summary` fonksiyonu `"scope": "I"` veya `"scope": "F"` ise ve akışın `functions` dizisinde **yoksa**, bu workflow için yapılan ilgili fonksiyon çağrıları yukarıdaki hata ile başarısız olur.
+
+## Kapsam Davranışı
+
+- **Sistem / global** (ör. `sys-functions` flow’undan) ve `I`/`F` kapsamında olmayan fonksiyonlar bu kontrole tabi değildir.
+- **Instance (`I`)** ve **Flow (`F`)** kapsamı için fonksiyonun workflow’un `functions` dizisinde tanımlı olması **zorunludur**.

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs
@@ -478,20 +478,23 @@ public sealed class FunctionController(
         Dictionary<string, string?> queryParams,
         CancellationToken cancellationToken)
     {
-        var tasks = instanceListResult.Items.Select(async instance =>
+       var tasks = instanceListResult.Items.Select(async instance =>
         {
             await using var scope = serviceScopeFactory.CreateAsyncScope();
             var scopedFunctionService = scope.ServiceProvider.GetRequiredService<IFunctionAppService>();
             return await scopedFunctionService.GetFunctionByInstanceAsync(function, workflow, domain, instance.Key!, headers, queryParams, cancellationToken);
         });
-
+ 
         var results = await Task.WhenAll(tasks);
-        var list = results.Where(r => r.IsSuccess).Select(r => r.Value!).ToList();
-
-        var route = urlTemplateBuilder.BuildFunctionListUrl(domain, workflow, function,
+        if (results.Any(r => !r.IsSuccess))
+            return Result<HateoasPagedResultDto<Dictionary<string, dynamic?>>>.Fail(results.First(r => !r.IsSuccess).Error);
+ 
+        var list = results.Select(r => r.Value!).ToList();
+        var route = InstanceUrlTemplates.FunctionList(domain, workflow, function,
             InstanceUrlTemplates.GetApiVersionPrefix("1"));
         var output = linkGenerator.CreateHateoasResult(instanceListResult, list, route);
         return Result<HateoasPagedResultDto<Dictionary<string, dynamic?>>>.Ok(output);
+   
     }
 
     #endregion

--- a/src/BBT.Workflow.Application/Functions/FunctionAppService.cs
+++ b/src/BBT.Workflow.Application/Functions/FunctionAppService.cs
@@ -6,6 +6,7 @@ using BBT.Aether.Results;
 using BBT.Workflow.Caching;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Instances;
+using BBT.Workflow.Logging;
 using BBT.Workflow.Runtime;
 using BBT.Workflow.Scripting;
 using BBT.Workflow.Tasks;
@@ -100,6 +101,13 @@ public sealed class FunctionAppService(
         Dictionary<string, string?>? queryParameters = null,
         CancellationToken cancellationToken = default)
     {
+        if (workflow.Key != RuntimeSysSchemaInfo.Functions &&function.Scope!=TaskScope.Domain&&
+            !workflow.Functions.Any(f => f.Key == function.Key))
+        {
+            return Result<Dictionary<string, dynamic?>>.Fail(
+                WorkflowErrors.FunctionNotInWorkflow(function.Key, workflow.Key));
+        }
+
         var scriptContext = await scriptContextFactory.NewBuilder(instanceRepository)
             .WithWorkflow(workflow)
             .WithInstance(instance)

--- a/src/BBT.Workflow.Domain/Logging/WorkflowErrors.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowErrors.cs
@@ -369,6 +369,22 @@ public static class WorkflowErrors
 
     #endregion
 
+    #region Function Errors
+
+    /// <summary>
+    /// Function is not declared in the workflow's Functions list.
+    /// Used when executing a non-system function that is not referenced by the workflow.
+    /// </summary>
+    /// <param name="functionKey">The key of the function that was not found in the workflow.</param>
+    /// <param name="workflowKey">The key of the workflow.</param>
+    public static Error FunctionNotInWorkflow(string functionKey, string workflowKey)
+        => Error.Validation(
+            WorkflowErrorCodes.FunctionNotInWorkflow,
+            $"Function '{functionKey}' is not defined for workflow '{workflowKey}'",
+            target: functionKey);
+
+    #endregion
+
     #region Discovery Errors
 
     /// <summary>

--- a/src/BBT.Workflow.Domain/WorkflowErrorCodes.cs
+++ b/src/BBT.Workflow.Domain/WorkflowErrorCodes.cs
@@ -116,6 +116,11 @@ public static class WorkflowErrorCodes
     public const string ExtensionExecutionFailed = "Extension:600001";
     
     #endregion
+    #region Function Errors (800xxx)
+    
+    public const string FunctionNotInWorkflow = "Function:800001";
+    
+    #endregion
     
     #region Discovery Errors (700xxx)
     


### PR DESCRIPTION
## Summary by Sourcery

Enforce validation that instance- and flow-scoped functions must be explicitly declared on the workflow before invocation and surface a specific workflow error when they are not.

New Features:
- Add a workflow validation error and error code for functions that are not defined on a workflow when invoked.

Bug Fixes:
- Ensure function list retrieval for workflow instances fails fast and returns the first error result instead of partially successful data.

Documentation:
- Document the new function–workflow validation rule as a breaking change in both English and Turkish, including required workflow configuration and error details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added breaking change notice: Functions with Instance or Flow scope must be declared in the workflow's functions array (available in English and Turkish).

* **Bug Fixes**
  * Enhanced validation to return HTTP 400 error when functions are not properly defined in workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->