### PR TITLE
feat(scripting): add CurrentTransition to ScriptContext for original request data and headers

### DIFF
--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/CreateTransitionRecordStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/CreateTransitionRecordStep.cs
@@ -48,7 +48,7 @@ public sealed class CreateTransitionRecordStep(
             .TapAsync(_ => instanceRepository.UpdateAsync(context.Instance, true, cancellationToken))
             .TapAsync(_ =>
                 instanceTransitionRepository.InsertAsync(instanceTransition, saveChanges: true, cancellationToken))
-            .Tap(_ => UpdateContextItems(context, instanceTransition.Id))
+            .Tap(_ => UpdateContextItems(context, instanceTransition))
             .Map(_ => StepOutcome.Continue());
     }
 
@@ -159,11 +159,12 @@ public sealed class CreateTransitionRecordStep(
     }
 
     /// <summary>
-    /// Updates context items with transition record ID.
+    /// Updates context items with transition record ID and the InstanceTransition for ScriptContext.CurrentTransition.
     /// </summary>
-    private static void UpdateContextItems(TransitionExecutionContext context, Guid transitionId)
+    private static void UpdateContextItems(TransitionExecutionContext context, InstanceTransition instanceTransition)
     {
-        context.Items["TransitionRecordId"] = transitionId;
+        context.Items["TransitionRecordId"] = instanceTransition.Id;
+        context.Items["InstanceTransition"] = instanceTransition;
         context.Items.Remove("NextTransitionKey");
     }
 }

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/RunOnEntryTasksStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/RunOnEntryTasksStep.cs
@@ -191,16 +191,21 @@ public sealed class RunOnEntryTasksStep(
         TransitionExecutionContext context,
         CancellationToken cancellationToken)
     {
+        var instanceTransition = context.Items.TryGetValue("InstanceTransition", out var it) && it is InstanceTransition inst
+            ? inst
+            : null;
+
         var builder = scriptContextFactory.NewBuilder(instanceRepository)
             .WithWorkflow(context.Workflow)
             .WithInstance(context.Instance)
             .WithBody(context.Data)
             .WithRuntime(runtimeInfoProvider)
-            .WithHeaders(context.Headers.ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
-        
+            .WithHeaders(context.Headers.ToDictionary(kvp => kvp.Key, kvp => kvp.Value))
+            .WithCurrentTransition(instanceTransition);
+
         if (context.Transition != null)
-            builder.WithTransition(context.Transition);
-        
+            builder = builder.WithTransition(context.Transition);
+
         return await builder.BuildAsync(cancellationToken);
     }
 }

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/RunOnExecuteTasksStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/RunOnExecuteTasksStep.cs
@@ -192,6 +192,10 @@ public sealed class RunOnExecuteTasksStep(
         TransitionExecutionContext context,
         CancellationToken cancellationToken)
     {
+        var instanceTransition = context.Items.TryGetValue("InstanceTransition", out var it) && it is InstanceTransition inst
+            ? inst
+            : null;
+
         return await scriptContextFactory.NewBuilder(instanceRepository)
             .WithWorkflow(context.Workflow)
             .WithInstance(context.Instance)
@@ -199,6 +203,7 @@ public sealed class RunOnExecuteTasksStep(
             .WithBody(context.Data)
             .WithRuntime(runtimeInfoProvider)
             .WithHeaders(context.Headers.ToDictionary(kvp => kvp.Key, kvp => kvp.Value))
+            .WithCurrentTransition(instanceTransition)
             .BuildAsync(cancellationToken);
     }
 }

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/RunOnExitTasksStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/RunOnExitTasksStep.cs
@@ -193,16 +193,21 @@ public sealed class RunOnExitTasksStep(
         TransitionExecutionContext context,
         CancellationToken cancellationToken)
     {
+        var instanceTransition = context.Items.TryGetValue("InstanceTransition", out var it) && it is InstanceTransition inst
+            ? inst
+            : null;
+
         var builder = scriptContextFactory.NewBuilder(instanceRepository)
             .WithWorkflow(context.Workflow)
             .WithInstance(context.Instance)
             .WithBody(context.Data)
             .WithRuntime(runtimeInfoProvider)
-            .WithHeaders(context.Headers.ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
-        
+            .WithHeaders(context.Headers.ToDictionary(kvp => kvp.Key, kvp => kvp.Value))
+            .WithCurrentTransition(instanceTransition);
+
         if (context.Transition != null)
-            builder.WithTransition(context.Transition);
-        
+            builder = builder.WithTransition(context.Transition);
+
         return await builder.BuildAsync(cancellationToken);
     }
 }

--- a/src/BBT.Workflow.Domain/Scripting/Factory/Contracts/IScriptContextBuilder.cs
+++ b/src/BBT.Workflow.Domain/Scripting/Factory/Contracts/IScriptContextBuilder.cs
@@ -94,7 +94,13 @@ public interface IScriptContextBuilder
     /// Sets the definitions for the ScriptContext.
     /// </summary>
     IScriptContextBuilder WithDefinitions(Dictionary<string, object> definitions);
-    
+
+    /// <summary>
+    /// Sets the original transition request (body and headers) from the persisted InstanceTransition.
+    /// When set, ScriptContext.CurrentTransition will expose this data with header keys normalized to lowercase.
+    /// </summary>
+    IScriptContextBuilder WithCurrentTransition(InstanceTransition? instanceTransition);
+
     /// <summary>
     /// Builds the ScriptContext asynchronously with all configured properties.
     /// This method retrieves any data that needs to be fetched asynchronously and constructs the final ScriptContext.

--- a/src/BBT.Workflow.Domain/Scripting/Factory/Services/ScriptContextBuilder.cs
+++ b/src/BBT.Workflow.Domain/Scripting/Factory/Services/ScriptContextBuilder.cs
@@ -1,3 +1,5 @@
+using System.Dynamic;
+using System.Text.Json;
 using BBT.Aether.Results;
 using BBT.Workflow.Caching;
 using BBT.Workflow.Definitions;
@@ -37,6 +39,7 @@ internal sealed class ScriptContextBuilder(
     private Guid? _instanceId;
     private bool _noTracking;
     private string? _transitionKey;
+    private InstanceTransition? _instanceTransition;
 
     public IScriptContextBuilder WithRuntime(IRuntimeInfoProvider runtimeInfoProvider)
     {
@@ -171,6 +174,12 @@ internal sealed class ScriptContextBuilder(
         return this;
     }
 
+    public IScriptContextBuilder WithCurrentTransition(InstanceTransition? instanceTransition)
+    {
+        _instanceTransition = instanceTransition;
+        return this;
+    }
+
     public async Task<ScriptContext> BuildAsync(CancellationToken cancellationToken = default)
     {
         // Resolve workflow if needed
@@ -181,6 +190,8 @@ internal sealed class ScriptContextBuilder(
 
         // Resolve transition if needed
         var transition = ResolveTransition(workflow);
+
+        var scriptTransitionRequest = BuildScriptTransitionRequest();
 
         // Build the ScriptContext using the domain builder
         return new ScriptContext.Builder(logger)
@@ -196,7 +207,36 @@ internal sealed class ScriptContextBuilder(
             .SetOutputResponse(_outputResponse)
             .SetMetadata(_metadata)
             .SetDefinitions(_definitions)
+            .SetCurrentTransition(scriptTransitionRequest)
             .Build();
+    }
+
+    /// <summary>
+    /// Builds ScriptTransitionRequest from persisted InstanceTransition when available.
+    /// Header keys are normalized to lowercase.
+    /// </summary>
+    private ScriptTransitionRequest? BuildScriptTransitionRequest()
+    {
+        if (_instanceTransition == null)
+            return null;
+
+        var data = _instanceTransition.Body.JsonElement.ToDynamic();
+        var header = ToHeaderDynamic(_instanceTransition.Header.JsonElement);
+        return new ScriptTransitionRequest(data, header);
+    }
+
+    /// <summary>
+    /// Converts header JsonElement to dynamic (ExpandoObject) with all keys normalized to lowercase.
+    /// </summary>
+    private static dynamic? ToHeaderDynamic(JsonElement headerElement)
+    {
+        if (headerElement.ValueKind != JsonValueKind.Object)
+            return headerElement.ToDynamic();
+
+        var headerExpando = new ExpandoObject() as IDictionary<string, object?>;
+        foreach (var property in headerElement.EnumerateObject())
+            headerExpando[property.Name.ToLowerInvariant()] = property.Value.ToDynamic();
+        return headerExpando;
     }
 
     private async Task<Definitions.Workflow> ResolveWorkflowAsync(CancellationToken cancellationToken)

--- a/src/BBT.Workflow.Domain/Scripting/Models.cs
+++ b/src/BBT.Workflow.Domain/Scripting/Models.cs
@@ -110,6 +110,36 @@ public sealed class StandardTaskResponse
     public string? TaskType { get; set; }
 }
 
+/// <summary>
+/// Represents the original transition request data and headers persisted at transition record creation.
+/// Exposed on <see cref="ScriptContext.CurrentTransition"/> so mapping scripts can access the initial
+/// request payload regardless of later Body merges from task responses.
+/// </summary>
+/// <remarks>
+/// Header keys are normalized to lowercase for consistent access (e.g. context.CurrentTransition.Header.authorization).
+/// </remarks>
+public sealed class ScriptTransitionRequest
+{
+    /// <summary>
+    /// Original transition request body (dynamic, typically ExpandoObject from JSON).
+    /// </summary>
+    public dynamic? Data { get; }
+
+    /// <summary>
+    /// Original transition request headers with all keys normalized to lowercase.
+    /// </summary>
+    public dynamic? Header { get; }
+
+    /// <summary>
+    /// Creates a new instance with the given data and header.
+    /// </summary>
+    public ScriptTransitionRequest(dynamic? data, dynamic? header)
+    {
+        Data = data;
+        Header = header;
+    }
+}
+
 public class ScriptContext(ILogger<ScriptContext> logger) : IDisposable, IAsyncDisposable
 {
     public static readonly JsonSerializerOptions JsonScriptBodyOptions = new()
@@ -137,6 +167,7 @@ public class ScriptContext(ILogger<ScriptContext> logger) : IDisposable, IAsyncD
                 Body = null;
                 Headers = null;
                 RouteValues = null;
+                CurrentTransition = null;
             }
             catch (InvalidOperationException ex)
             {
@@ -314,6 +345,19 @@ public class ScriptContext(ILogger<ScriptContext> logger) : IDisposable, IAsyncD
     /// This is particularly useful for transition-specific logic and task processing.
     /// </remarks>
     public Transition Transition { get; private set; }
+
+    /// <summary>
+    /// The original transition request data and headers that initiated this transition.
+    /// Populated from the persisted <see cref="Instances.InstanceTransition"/> when ScriptContext is built
+    /// during the transition pipeline (OnExecute, OnExit, OnEntry). Null when no transition record exists
+    /// (e.g. initial creation, queries, scheduled/auto transitions).
+    /// </summary>
+    /// <value>
+    /// - Data: Original request body (dynamic)
+    /// - Header: Original request headers with lowercase keys (dynamic)
+    /// - Null when ScriptContext is built outside transition task steps
+    /// </value>
+    public ScriptTransitionRequest? CurrentTransition { get; private set; }
 
     /// <summary>
     /// Contains workflow and component definitions available in the current execution context.
@@ -544,6 +588,15 @@ public class ScriptContext(ILogger<ScriptContext> logger) : IDisposable, IAsyncD
         public Builder SetMetadata(Dictionary<string, object> metadata)
         {
             _context.MetaData = metadata;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the current transition request (original body and headers) on the script context.
+        /// </summary>
+        public Builder SetCurrentTransition(ScriptTransitionRequest? value)
+        {
+            _context.CurrentTransition = value;
             return this;
         }
 


### PR DESCRIPTION
## Summary

When mapping scripts run in the transition pipeline (OnExecute, OnExit, OnEntry), `ScriptContext.Body` is merged/overwritten by task responses (`SetBody`, `SetStandardResponse`). Scripts running later in the pipeline lose access to the **original transition request** body and headers.

`InstanceTransition` already persists the original request `Body` and `Header` (as `JsonData`) in `CreateTransitionRecordStep` (order 20). This change exposes that data on `ScriptContext` so mapping scripts can reference the original transition payload regardless of where they run in the pipeline.

Closes #385

## API

```csharp
// In script/mapping code:
context.CurrentTransition.Data   // dynamic - original transition request body
context.CurrentTransition.Header // dynamic - original transition request headers (lowercase keys)
```

## Changes

- **Domain (Models.cs):** `ScriptTransitionRequest` with `Data` and `Header` (dynamic); `ScriptContext.CurrentTransition`; `Builder.SetCurrentTransition`; cleanup in `Dispose`.
- **IScriptContextBuilder / ScriptContextBuilder:** `WithCurrentTransition(InstanceTransition?)`; build `ScriptTransitionRequest` from persisted transition (Header keys normalized to lowercase via `ToHeaderDynamic`).
- **CreateTransitionRecordStep:** Store `InstanceTransition` in `context.Items["InstanceTransition"]` (and keep `TransitionRecordId`).
- **RunOnExecuteTasksStep, RunOnExitTasksStep, RunOnEntryTasksStep:** Read `InstanceTransition` from `context.Items` and pass to builder when building ScriptContext.

## Acceptance criteria

- [x] `ScriptTransitionRequest` with `Data` (dynamic) and `Header` (dynamic, lowercase keys)
- [x] `ScriptContext.CurrentTransition` populated via Builder
- [x] Pipeline steps pass `InstanceTransition` through `context.Items` and into ScriptContext builder
- [x] `CurrentTransition` is `null` when no transition record exists (e.g. SubFlow resume, queries)
- [x] Cleanup in `ScriptContext.Dispose` sets `CurrentTransition = null`
- [x] No breaking changes to existing `ScriptContext` properties (`Body`, `Headers`, etc.)

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Expose the original transition request body and headers on ScriptContext so scripts can reliably access the initial transition payload throughout the transition pipeline.

New Features:
- Add ScriptTransitionRequest model and ScriptContext.CurrentTransition property to surface the original transition request data and headers to scripts.

Enhancements:
- Extend ScriptContext builder and IScriptContextBuilder to accept an InstanceTransition and construct a ScriptTransitionRequest with normalized (lowercase) header keys.
- Propagate the created InstanceTransition through TransitionExecutionContext.Items and into ScriptContext creation in OnExecute, OnExit, and OnEntry pipeline steps.
- Ensure ScriptContext.Dispose clears the CurrentTransition reference to avoid retaining transition data beyond the context lifetime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scripts executing within workflow transitions can now access transition request data and headers during execution, enabling more dynamic workflow behavior based on transition-specific information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->