### PR TITLE
Filter and group by bug fix

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -60,6 +60,8 @@ The BBT Workflow Engine is a comprehensive, domain-driven workflow management sy
 ### Breaking Changes
 - [Function–Workflow Validation (EN)](./breaking-changes/function-workflow-validation-en.md) – Functions with scope `I` or `F` must be declared in the workflow’s `functions` array
 - [Function–Workflow Validation (TR)](./breaking-changes/function-workflow-validation-tr.md) – Scope `I` veya `F` olan fonksiyonlar workflow’un `functions` dizisinde tanımlı olmalıdır
+- [Instance Filter Single String (EN)](./breaking-changes/instance-filter-single-string-en.md) – Instance list and GetInstances task accept a single filter string; `filter` is no longer an array; `SetFilter(string[]?)` is now `SetFilter(string?)`
+- [Instance Filter Tek String (TR)](./breaking-changes/instance-filter-single-string-tr.md) – Instance listesi ve GetInstances task tek filter string kabul eder; `filter` artık dizi değil; `SetFilter(string[]?)` yerine `SetFilter(string?)`
 
 ## Key Features
 

--- a/docs/breaking-changes/instance-filter-single-string-en.md
+++ b/docs/breaking-changes/instance-filter-single-string-en.md
@@ -1,0 +1,76 @@
+# Breaking Change: Instance Filter — Single String (No Array)
+
+## Summary
+
+Instance list and Data function APIs, as well as the **GetInstances** task and related bindings, now accept **a single filter string** instead of an array of filters. Multiple separate filter expressions are no longer supported in one request; complex conditions must be expressed in a single filter (e.g. one GraphQL-style JSON with `and`/`or`).
+
+## Affected Areas
+
+### 1. HTTP API
+
+| Endpoint / usage | Before | After |
+|------------------|--------|--------|
+| `GET .../instances` query param | `filter` as `string[]` (e.g. `?filter=x&filter=y`) | `filter` as single `string` (e.g. `?filter=<one value>`) |
+| Data function `GET .../functions/data` | `filter` in query/body as array | `filter` as single string |
+
+- **Controller:** `InstanceController.GetInstanceListAsync` — parameter changed from `[FromQuery] string[]? filter` to `[FromQuery] string? filter`.
+- **Query model:** `FunctionListQueryParameters.Filter` — type changed from `string[]?` to `string?`.
+
+### 2. Application / DTOs
+
+- **GetInstanceListInput.Filter** — type changed from `string[]?` to `string?`. Callers must pass one filter string or `null`.
+
+### 3. GetInstances Task (workflow definition)
+
+- **GetInstancesTask.Filter** — property type changed from `string[]?` to `string?`.
+- **SetFilter** — method signature changed from `SetFilter(string[]? filter)` to `SetFilter(string? filter)`.
+- **Task JSON config:**  
+  - **Before:** `"filter": ["expr1", "expr2"]`  
+  - **After:** `"filter": "expr"` (single string) or, for backward compatibility, a **single-element array** is still supported and is treated as that one filter string.  
+  - Multiple elements in an array are no longer supported; only the first element was previously used in practice; now the API is explicitly a single string.
+
+### 4. GetInstances Binding (execution)
+
+- **GetInstancesBinding.Filter** — type changed from `string[]?` to `string?`. Remote invokers and gateways build the query string with one `filter` parameter.
+
+### 5. Domain / infrastructure
+
+- **IInstanceRepository** — `GetPagedResultsAsync` and `GetPagedResultsWithGroupsAsync` (the overload that takes filters) now take `string? filter` instead of `string[]? filters`.
+- **FilterFormatDetector** — `DetectFormat(string[]?)` overload removed; `CombineFilters` and `ConvertLegacyToGraphQL` now take `string?` (single filter).
+- **UnifiedFilterService.ApplyFilters** — parameter changed from `string[]? filters` to `string? filter`.
+- **PostgreSqlJsonFilterService.ApplyJsonFilters** — parameter changed from `string[] filters` to `string? filter`.
+- **FilterSpecification&lt;T&gt;** — constructor changed from `(string[]? filters, ...)` to `(string? filter, ...)`.
+- **InstanceFilterSpecification** — constructor changed from `(string[]? filters)` to `(string? filter)`.
+- **InputValidator** — `ValidateFilters(string? filter)` overload added; the existing `ValidateFilters(string[]? filters)` remains for internal use.
+
+## Migration
+
+### Clients (HTTP)
+
+- If you sent multiple `filter` query parameters, combine the intended logic into **one** filter string (e.g. one GraphQL-style JSON with `and`/`or` nodes, or one legacy-style string if your backend supports it).
+- Example: instead of `?filter={"a":"eq:1"}&filter={"b":"eq:2"}`, send one filter such as  
+  `?filter={"and":[{"attributes":{"a":{"eq":"1"}}},{"attributes":{"b":{"eq":"2"}}}]}` (syntax may vary by your API contract).
+
+### Workflow / task definitions
+
+- Change task config from array to single string:
+  - **Before:** `"filter": ["status=Active", "flow=my-flow"]`
+  - **After:** `"filter": "status=Active"` (or a single combined expression).  
+  For multiple conditions, use one GraphQL-style JSON string that expresses the full condition (e.g. with `and`/`or`).
+- Update any code that calls **SetFilter** to pass a `string?` instead of `string[]?`.
+
+### Code using GetInstanceListInput / repository / filter services
+
+- Pass a single `string?` for the filter (or `null`) instead of `string[]?`.
+- Any logic that built or iterated over a filter array should be updated to build or pass one filter string.
+
+## Backward compatibility (task config only)
+
+- In **GetInstancesTask** JSON configuration, if `"filter"` is still an **array**, it is interpreted as follows for compatibility:
+  - One element: that element is used as the single filter string.
+  - Multiple elements: only the **first** element is used as the filter string.  
+  Prefer migrating to a single `"filter": "..."` string or one combined expression.
+
+## Version / date
+
+This change is effective as of the commit/version that introduces the single-string filter across the listed APIs and types. Check the repository history or release notes for the exact version.

--- a/docs/breaking-changes/instance-filter-single-string-tr.md
+++ b/docs/breaking-changes/instance-filter-single-string-tr.md
@@ -1,0 +1,76 @@
+# Breaking Change: Instance Filter — Tek String (Dizi Yok)
+
+## Özet
+
+Instance listesi ve Data function API’leri ile **GetInstances** task’ı ve ilgili binding’ler artık **tek bir filter string** kabul ediyor; filter dizisi kabul edilmiyor. Bir istekte birden fazla ayrı filter ifadesi desteklenmiyor; karmaşık koşullar tek bir filter içinde ifade edilmeli (ör. `and`/`or` içeren tek bir GraphQL tarzı JSON).
+
+## Etkilenen Alanlar
+
+### 1. HTTP API
+
+| Endpoint / kullanım | Önce | Sonra |
+|---------------------|------|--------|
+| `GET .../instances` query parametresi | `filter` → `string[]` (örn. `?filter=x&filter=y`) | `filter` → tek `string` (örn. `?filter=<tek değer>`) |
+| Data function `GET .../functions/data` | query/body’de `filter` dizi | `filter` tek string |
+
+- **Controller:** `InstanceController.GetInstanceListAsync` — parametre `[FromQuery] string[]? filter` iken artık `[FromQuery] string? filter`.
+- **Query model:** `FunctionListQueryParameters.Filter` — tip `string[]?` iken artık `string?`.
+
+### 2. Application / DTO’lar
+
+- **GetInstanceListInput.Filter** — tip `string[]?` iken artık `string?`. Çağıranlar tek filter string veya `null` geçmeli.
+
+### 3. GetInstances Task (workflow tanımı)
+
+- **GetInstancesTask.Filter** — property tipi `string[]?` iken artık `string?`.
+- **SetFilter** — imza `SetFilter(string[]? filter)` iken artık `SetFilter(string? filter)`.
+- **Task JSON config:**  
+  - **Önce:** `"filter": ["expr1", "expr2"]`  
+  - **Sonra:** `"filter": "expr"` (tek string). Geriye dönük uyumluluk için **tek elemanlı dizi** hâlâ desteklenir ve o tek filter string olarak işlenir.  
+  - Dizide birden fazla eleman artık desteklenmiyor; eskiden pratikte yalnızca ilk eleman kullanılıyordu; artık API açıkça tek string.
+
+### 4. GetInstances Binding (çalışma zamanı)
+
+- **GetInstancesBinding.Filter** — tip `string[]?` iken artık `string?`. Remote invoker’lar ve gateway’ler query string’i tek `filter` parametresi ile oluşturur.
+
+### 5. Domain / altyapı
+
+- **IInstanceRepository** — Filter alan overload’lar `GetPagedResultsAsync` ve `GetPagedResultsWithGroupsAsync` artık `string[]? filters` yerine `string? filter` alıyor.
+- **FilterFormatDetector** — `DetectFormat(string[]?)` overload’u kaldırıldı; `CombineFilters` ve `ConvertLegacyToGraphQL` artık `string?` (tek filter) alıyor.
+- **UnifiedFilterService.ApplyFilters** — parametre `string[]? filters` iken artık `string? filter`.
+- **PostgreSqlJsonFilterService.ApplyJsonFilters** — parametre `string[] filters` iken artık `string? filter`.
+- **FilterSpecification&lt;T&gt;** — constructor `(string[]? filters, ...)` iken artık `(string? filter, ...)`.
+- **InstanceFilterSpecification** — constructor `(string[]? filters)` iken artık `(string? filter)`.
+- **InputValidator** — `ValidateFilters(string? filter)` overload’u eklendi; mevcut `ValidateFilters(string[]? filters)` dahili kullanım için duruyor.
+
+## Geçiş
+
+### İstemciler (HTTP)
+
+- Birden fazla `filter` query parametresi gönderiyorsanız, mantığı **tek** bir filter string’te toplayın (ör. `and`/`or` düğümleri içeren tek GraphQL tarzı JSON veya backend’in desteklediği tek legacy string).
+- Örnek: `?filter={"a":"eq:1"}&filter={"b":"eq:2"}` yerine tek filter gönderin, örn.  
+  `?filter={"and":[{"attributes":{"a":{"eq":"1"}}},{"attributes":{"b":{"eq":"2"}}}]}` (sözdizimi API sözleşmenize göre değişebilir).
+
+### Workflow / task tanımları
+
+- Task config’te diziyi tek string’e geçirin:
+  - **Önce:** `"filter": ["status=Active", "flow=my-flow"]`
+  - **Sonra:** `"filter": "status=Active"` (veya tek birleşik ifade).  
+  Birden fazla koşul için tüm koşulu ifade eden tek bir GraphQL tarzı JSON string kullanın (örn. `and`/`or` ile).
+- **SetFilter** çağıran tüm kodları `string[]?` yerine `string?` geçecek şekilde güncelleyin.
+
+### GetInstanceListInput / repository / filter servislerini kullanan kod
+
+- Filter için tek bir `string?` (veya `null`) geçirin; `string[]?` kullanmayın.
+- Filter dizisi oluşturan veya üzerinde döngü kuran mantığı tek filter string oluşturacak / geçirecek şekilde güncelleyin.
+
+## Geriye dönük uyumluluk (yalnızca task config)
+
+- **GetInstancesTask** JSON yapılandırmasında `"filter"` hâlâ **dizi** verilmişse, uyumluluk için şöyle yorumlanır:
+  - Tek eleman: o eleman tek filter string olarak kullanılır.
+  - Birden fazla eleman: yalnızca **ilk** eleman filter string olarak kullanılır.  
+  Mümkünse tek `"filter": "..."` string’e veya tek birleşik ifadeye geçin.
+
+## Sürüm / tarih
+
+Bu değişiklik, listelenen API ve tiplerde tek-string filter’ı getiren commit/sürüm itibarıyla geçerlidir. Kesin sürüm için repository geçmişine veya release notlarına bakın.

--- a/docs/features/instance-filtering.md
+++ b/docs/features/instance-filtering.md
@@ -109,6 +109,41 @@ Any JSON field in `InstancesData.Data` can be queried using:
 
 GraphQL filters can also target Instance columns directly at the top level (e.g., `{"status":{"eq":"Active"}}`).
 
+## Instance list ordering (orderBy)
+
+Instance list results can be sorted via the `sort` or `orderBy` query parameter (same JSON format; `orderBy` wins if both are set).
+
+### OrderBy JSON format
+
+**Single field:**
+
+```
+?sort={"field":"createdAt","direction":"desc"}
+?orderBy={"field":"status","direction":"asc"}
+```
+
+**Multiple fields:**
+
+```
+?sort={"fields":[{"field":"status","direction":"asc"},{"field":"createdAt","direction":"desc"}]}
+```
+
+- `direction`: `"asc"` or `"desc"` (case-insensitive). Defaults to `"asc"` if omitted.
+
+### Sortable fields
+
+| Field | Notes |
+|-------|-------|
+| `createdAt` | Creation timestamp |
+| `modifiedAt` | Modification timestamp |
+| `completedAt` | Completion timestamp |
+| `status` | Instance status |
+| `key` | Instance key |
+| `currentState` / `state` | Current state (state is alias) |
+| `attributes.fieldName` | JSON attribute (path into `InstancesData.Data`); nested paths supported (e.g. `attributes.nested.path`) |
+
+Instance columns are applied in the database; `attributes.*` ordering uses the latest instance data JSON and is subject to the same schema/security as filtering.
+
 ## Supported Operators
 
 ### Equality Operators

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs
@@ -58,6 +58,11 @@ public sealed class FunctionController(
         return FromResult(response);
     }
 
+    /// <summary>
+    /// Gets a paged list of workflow instances for the given function (View, Data, Schema, etc.).
+    /// For function type Data: filter, sort and orderBy are applied. orderBy wins over sort when both provided.
+    /// </summary>
+    /// <param name="orderBy">OrderBy JSON (Data function only): {"field":"...","direction":"asc|desc"} or {"fields":[...]}. If provided with sort, orderBy wins.</param>
     [HttpGet("{domain}/workflows/{workflow}/functions/{function}")]
     public async Task<IActionResult> GetFunctionByKeyAsync(
         [FromRoute] string domain,
@@ -67,6 +72,8 @@ public sealed class FunctionController(
         CancellationToken cancellationToken = default)
     {
         var requestContext = HttpContext.GetRequestBindingContext();
+        var functionType = function.ToLowerInvariant();
+        var isDataFunction = functionType == Definitions.Functions.FunctionTypeConst.Data;
 
         var getInstanceListInput = new GetInstanceListInput
         {
@@ -74,11 +81,9 @@ public sealed class FunctionController(
             Page = parameters.Page,
             PageSize = parameters.PageSize,
             PageUrl = urlTemplateBuilder.BuildFunctionListUrl(domain, workflow, function),
-            Sort = parameters.Sort,
+            Sort = isDataFunction ? (parameters.OrderBy ?? parameters.Sort) : parameters.Sort,
             Workflow = workflow,
-            Filter = function.ToLowerInvariant() == Definitions.Functions.FunctionTypeConst.Data
-                ? parameters.Filter
-                : [],
+            Filter = isDataFunction ? parameters.Filter : null,
             Headers = requestContext.Headers,
             QueryParameters = requestContext.QueryParameters
         };
@@ -92,8 +97,6 @@ public sealed class FunctionController(
         
         var pagedList = instanceListResult.Value!.ToPagedList(parameters.PageSize);
         // Process based on function type
-        var functionType = function.ToLowerInvariant();
-
         if (functionType == Definitions.Functions.FunctionTypeConst.Longpooling)
         {
             return FromResult(await ProcessLongpoolingFunctionListAsync(domain, workflow, pagedList,

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
@@ -276,15 +276,21 @@ public sealed class InstanceController(
         return FromResult(result.Result);
     }
 
+    /// <summary>
+    /// Gets a paged list of workflow instances with optional filter, groupBy, aggregations and orderBy.
+    /// </summary>
+    /// <param name="sort">OrderBy JSON: single {"field":"createdAt","direction":"desc"} or multiple {"fields":[{"field":"status","direction":"asc"},{"field":"createdAt","direction":"desc"}]}. Also accepted as orderBy.</param>
+    /// <param name="orderBy">Alias for sort; same JSON format. If both provided, orderBy wins.</param>
     [HttpGet("{domain}/workflows/{workflow}/instances")]
     public async Task<IActionResult> GetInstanceListAsync(
         [FromRoute] string domain,
         [FromRoute] string workflow,
-        [FromQuery] string[]? filter = null,
+        [FromQuery] string? filter = null,
         [FromQuery] string[]? extension = null,
         [FromQuery][Range(1, 1000)] int page = 1,
         [FromQuery][Range(1, 100)] int pageSize = 10,
         [FromQuery] string? sort = null,
+        [FromQuery] string? orderBy = null,
         CancellationToken cancellationToken = default)
     {
         var requestContext = HttpContext.GetRequestBindingContext();
@@ -298,7 +304,7 @@ public sealed class InstanceController(
             PageSize = pageSize,
             PageUrl = urlTemplateBuilder.BuildInstanceListUrl(domain, workflow),
             Filter = filter,
-            Sort = sort,
+            Sort = orderBy ?? sort,
             Headers = requestContext.Headers,
             QueryParameters = requestContext.QueryParameters
         };

--- a/src/BBT.Workflow.Application/Instances/DTOs/FunctionListQueryParameters.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/FunctionListQueryParameters.cs
@@ -6,7 +6,7 @@ public class FunctionListQueryParameters
 {
 
     [JsonPropertyName("filter")]
-    public string[]? Filter { get; set; } =[];
+    public string? Filter { get; set; }
 
     [JsonPropertyName("page")]
     public int Page { get; set; } = 1;
@@ -16,4 +16,11 @@ public class FunctionListQueryParameters
     
     [JsonPropertyName("sort")]
     public string? Sort { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Alias for sort; same JSON format as sort. Only applied when function type is Data.
+    /// If both sort and orderBy provided, orderBy wins.
+    /// </summary>
+    [JsonPropertyName("orderBy")]
+    public string? OrderBy { get; set; }
 }

--- a/src/BBT.Workflow.Application/Instances/DTOs/GetInstanceInput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/GetInstanceInput.cs
@@ -60,9 +60,9 @@ public sealed class GetInstanceListInput : IHasDomain
     public string[]? Extension { get; set; }
 
     /// <summary>
-    /// Filters to apply to the query (format: JSON)
+    /// Filter to apply to the query (JSON format, e.g. GraphQL-style or legacy)
     /// </summary>
-    public string[]? Filter { get; set; }
+    public string? Filter { get; set; }
 
     /// <summary>
     /// Page number for pagination (1-based)
@@ -79,8 +79,9 @@ public sealed class GetInstanceListInput : IHasDomain
     public string PageUrl { get; set; } = string.Empty;
 
     /// <summary>
-    /// Field to sort by. Prefix with '-' for descending order.
-    /// Example: "CreatedAt" for ascending, "-CreatedAt" for descending
+    /// OrderBy JSON for sorting. Single: {"field":"createdAt","direction":"desc"}.
+    /// Multiple: {"fields":[{"field":"status","direction":"asc"},{"field":"createdAt","direction":"desc"}]}.
+    /// Instance columns: createdAt, modifiedAt, completedAt, status, key, currentState (or state). JSON: attributes.fieldName, attributes.nested.path.
     /// </summary>
     public string? Sort { get; set; }
 

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -80,26 +80,22 @@ public sealed class InstanceQueryAppService(
             async ct =>
             {
                 // Parse filter parameter - check if it's in GraphQLFilterRequest format
-                string[]? filters = input.Filter;
                 string? groupBy = input.GroupBy;
                 string? aggregations = input.Aggregations;
 
-                // If filter array has one element, check if it's GraphQLFilterRequest format
+                // If filter is provided, check if it's GraphQLFilterRequest format
                 Definitions.GraphQL.GraphQLFilterRequest? parsedRequest = null;
-                if (input.Filter != null && input.Filter.Length == 1 && string.IsNullOrWhiteSpace(groupBy))
+                if (!string.IsNullOrWhiteSpace(input.Filter) && string.IsNullOrWhiteSpace(groupBy))
                 {
-                    var filterString = input.Filter[0];
+                    var filterString = input.Filter;
                     if (GraphQLFilterParser.TryParseRequest(filterString, out var request) && request != null)
                     {
                         parsedRequest = request;
-                        // Extract filter and groupBy from GraphQLFilterRequest for backward compatibility path
-                        filters = request.Filter != null
-                            ? new[] { JsonSerializer.Serialize(request.Filter, new JsonSerializerOptions
-                            {
-                                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                                WriteIndented = false
-                            }) }
-                            : null;
+                        // Apply sort from query param (overrides envelope orderBy when provided)
+                        if (!string.IsNullOrWhiteSpace(input.Sort) && GraphQLFilterParser.ParseOrderBy(input.Sort) is { } orderBy)
+                        {
+                            parsedRequest.OrderBy = orderBy;
+                        }
 
                         if (request.GroupBy != null)
                         {
@@ -139,9 +135,10 @@ public sealed class InstanceQueryAppService(
                     var result = await instanceRepository.GetPagedResultsWithGroupsAsync(
                         input.Page,
                         input.PageSize,
-                        filters,
+                        input.Filter,
                         groupBy,
                         aggregations,
+                        input.Sort,
                         ct);
                     pagedList = result.PagedList;
                     groups = result.Groups;

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/GetInstancesTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/GetInstancesTask.cs
@@ -45,9 +45,9 @@ public sealed class GetInstancesTask : WorkflowTask
     public string? Sort { get; private set; }
 
     /// <summary>
-    /// Filter expressions to apply to the query
+    /// Filter expression to apply to the query (JSON format)
     /// </summary>
-    public string[]? Filter { get; private set; }
+    public string? Filter { get; private set; }
 
     /// <summary>
     /// Whether to use Dapr service invocation instead of direct HTTP
@@ -96,7 +96,7 @@ public sealed class GetInstancesTask : WorkflowTask
         Sort = sort;
     }
 
-    public void SetFilter(string[]? filter)
+    public void SetFilter(string? filter)
     {
         Filter = filter;
     }
@@ -124,7 +124,7 @@ public sealed class GetInstancesTask : WorkflowTask
     internal void SetPageInternal(int page) => Page = page;
     internal void SetPageSizeInternal(int pageSize) => PageSize = pageSize;
     internal void SetSortInternal(string? sort) => Sort = sort;
-    internal void SetFilterInternal(string[]? filter) => Filter = filter;
+    internal void SetFilterInternal(string? filter) => Filter = filter;
     internal void SetUseDaprInternal(bool useDapr) => UseDapr = useDapr;
     internal void SetValidateSSLInternal(bool validateSSL) => ValidateSSL = validateSSL;
     internal void SetHeadersInternal(JsonElement? headers) => Headers = headers;
@@ -149,16 +149,23 @@ public sealed class GetInstancesTask : WorkflowTask
         if (config.TryGetProperty("sort", out var sortElement))
             Sort = sortElement.GetString();
 
-        if (config.TryGetProperty("filter", out var filterElement) && filterElement.ValueKind == JsonValueKind.Array)
+        if (config.TryGetProperty("filter", out var filterElement))
         {
-            var filterList = new List<string>();
-            foreach (var item in filterElement.EnumerateArray())
+            if (filterElement.ValueKind == JsonValueKind.String)
             {
-                var filterValue = item.GetString();
-                if (!string.IsNullOrWhiteSpace(filterValue))
-                    filterList.Add(filterValue);
+                Filter = filterElement.GetString();
             }
-            Filter = filterList.Count > 0 ? filterList.ToArray() : null;
+            else if (filterElement.ValueKind == JsonValueKind.Array)
+            {
+                var filterList = new List<string>();
+                foreach (var item in filterElement.EnumerateArray())
+                {
+                    var filterValue = item.GetString();
+                    if (!string.IsNullOrWhiteSpace(filterValue))
+                        filterList.Add(filterValue);
+                }
+                Filter = filterList.Count > 0 ? filterList[0] : null;
+            }
         }
 
         if (config.TryGetProperty("useDapr", out var useDaprElement))

--- a/src/BBT.Workflow.Domain/Instances/IInstanceRepository.cs
+++ b/src/BBT.Workflow.Domain/Instances/IInstanceRepository.cs
@@ -23,7 +23,7 @@ public interface IInstanceRepository : IRepository<Instance, Guid>
     Task<HateoasPagedList<Instance>> GetPagedResultsAsync(
         int page, 
         int pageSize, 
-        string[]? filters,
+        string? filter,
         string? groupBy = null,
         string? aggregations = null,
         CancellationToken cancellationToken = default);
@@ -31,12 +31,14 @@ public interface IInstanceRepository : IRepository<Instance, Guid>
     /// <summary>
     /// Gets paged results with optional groups for groupBy queries
     /// </summary>
+    /// <param name="sort">Optional orderBy JSON (e.g. {"field":"createdAt","direction":"desc"} or {"fields":[...]})</param>
     Task<(HateoasPagedList<Instance> PagedList, List<GroupSummary>? Groups)> GetPagedResultsWithGroupsAsync(
         int page,
         int pageSize,
-        string[]? filters,
+        string? filter,
         string? groupBy = null,
         string? aggregations = null,
+        string? sort = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/BBT.Workflow.Domain/QueryExtensions/FilterSpecification.cs
+++ b/src/BBT.Workflow.Domain/QueryExtensions/FilterSpecification.cs
@@ -17,10 +17,10 @@ public class FilterSpecification<T> : IFilterSpecification<T>
     protected static readonly Regex KeyValueRegex = new(@"^\s*([^=]+?)\s*=\s*(.+?)\s*$", RegexOptions.Compiled);
 
     public FilterSpecification(
-        string[]? filters,
+        string? filter,
         Dictionary<string, Func<string, Expression<Func<T, bool>>>> filterMappings)
     {
-        _filters = filters;
+        _filters = string.IsNullOrWhiteSpace(filter) ? null : new[] { filter };
         _filterMappings = filterMappings;
     }
 

--- a/src/BBT.Workflow.Domain/QueryExtensions/GraphQL/FilterFormatDetector.cs
+++ b/src/BBT.Workflow.Domain/QueryExtensions/GraphQL/FilterFormatDetector.cs
@@ -62,40 +62,6 @@ public static class FilterFormatDetector
     }
 
     /// <summary>
-    /// Detects format for an array of filters
-    /// Returns the dominant format, with GraphQL taking precedence if any are GraphQL
-    /// </summary>
-    public static FilterFormat DetectFormat(string[]? filters)
-    {
-        if (filters == null || filters.Length == 0)
-            return FilterFormat.Empty;
-
-        var hasGraphQL = false;
-        var hasLegacy = false;
-
-        foreach (var filter in filters)
-        {
-            if (string.IsNullOrWhiteSpace(filter))
-                continue;
-
-            var format = DetectFormat(filter);
-            if (format == FilterFormat.GraphQL)
-                hasGraphQL = true;
-            else if (format == FilterFormat.Legacy)
-                hasLegacy = true;
-        }
-
-        // GraphQL takes precedence - if any filter is GraphQL, treat all as GraphQL
-        if (hasGraphQL)
-            return FilterFormat.GraphQL;
-        
-        if (hasLegacy)
-            return FilterFormat.Legacy;
-
-        return FilterFormat.Empty;
-    }
-
-    /// <summary>
     /// Checks if a filter string is in GraphQL-style JSON format
     /// </summary>
     public static bool IsGraphQLFormat(string? filter)
@@ -112,78 +78,45 @@ public static class FilterFormatDetector
     }
 
     /// <summary>
-    /// Combines multiple GraphQL filter nodes into a single AND node
+    /// Parses a single filter string into a GraphQL filter node
     /// </summary>
-    public static GraphQLFilterNode? CombineFilters(string[]? filters)
+    public static GraphQLFilterNode? CombineFilters(string? filter)
     {
-        if (filters == null || filters.Length == 0)
+        if (string.IsNullOrWhiteSpace(filter))
             return null;
 
-        var nodes = new List<GraphQLFilterNode>();
-
-        foreach (var filter in filters)
-        {
-            if (string.IsNullOrWhiteSpace(filter))
-                continue;
-
-            var node = GraphQLFilterParser.ParseFilter(filter);
-            if (node != null && node.NodeType != FilterNodeType.Empty)
-            {
-                nodes.Add(node);
-            }
-        }
-
-        if (nodes.Count == 0)
-            return null;
-
-        if (nodes.Count == 1)
-            return nodes[0];
-
-        // Combine multiple nodes with AND
-        return new GraphQLFilterNode
-        {
-            And = nodes
-        };
+        var node = GraphQLFilterParser.ParseFilter(filter);
+        return node != null && node.NodeType != FilterNodeType.Empty ? node : null;
     }
 
     /// <summary>
-    /// Converts legacy filter strings to GraphQL filter format
+    /// Converts a legacy filter string to GraphQL filter format
     /// </summary>
-    public static GraphQLFilterNode? ConvertLegacyToGraphQL(string[]? legacyFilters)
+    public static GraphQLFilterNode? ConvertLegacyToGraphQL(string? legacyFilter)
     {
-        if (legacyFilters == null || legacyFilters.Length == 0)
+        if (string.IsNullOrWhiteSpace(legacyFilter))
             return null;
 
         var attributes = new Dictionary<string, FieldCondition>();
 
-        foreach (var filter in legacyFilters)
+        try
         {
-            if (string.IsNullOrWhiteSpace(filter))
-                continue;
+            var (field, op, value) = FilterOperatorParser.ParseOperator(legacyFilter);
 
-            try
-            {
-                var (field, op, value) = FilterOperatorParser.ParseOperator(filter);
-                
-                if (string.IsNullOrWhiteSpace(field) || string.IsNullOrWhiteSpace(op))
-                    continue;
+            if (string.IsNullOrWhiteSpace(field) || string.IsNullOrWhiteSpace(op))
+                return null;
 
-                if (!attributes.TryGetValue(field, out var condition))
-                {
-                    condition = new FieldCondition();
-                    attributes[field] = condition;
-                }
-
-                SetOperatorValue(condition, op, value);
-            }
-            catch (ArgumentException)
-            {
-                // Skip invalid filters with argument errors
-            }
-            catch (FormatException)
-            {
-                // Skip invalid filters with format errors
-            }
+            var condition = new FieldCondition();
+            attributes[field] = condition;
+            SetOperatorValue(condition, op, value);
+        }
+        catch (ArgumentException)
+        {
+            return null;
+        }
+        catch (FormatException)
+        {
+            return null;
         }
 
         if (attributes.Count == 0)

--- a/src/BBT.Workflow.Domain/QueryExtensions/GraphQL/GraphQLFilterModels.cs
+++ b/src/BBT.Workflow.Domain/QueryExtensions/GraphQL/GraphQLFilterModels.cs
@@ -25,6 +25,81 @@ public sealed class GraphQLFilterRequest
     /// </summary>
     [JsonPropertyName("aggregations")]
     public AggregationRequest? Aggregations { get; set; }
+
+    /// <summary>
+    /// Sort order for results (instance columns and/or attributes JSON path).
+    /// </summary>
+    [JsonPropertyName("orderBy")]
+    public OrderByRequest? OrderBy { get; set; }
+}
+
+/// <summary>
+/// Single sort field with direction for orderBy
+/// </summary>
+public sealed class OrderByField
+{
+    /// <summary>
+    /// Field to sort by (e.g. "createdAt", "status", "attributes.clientId")
+    /// </summary>
+    [JsonPropertyName("field")]
+    public string? Field { get; set; }
+
+    /// <summary>
+    /// Sort direction: "asc" or "desc" (case-insensitive). Defaults to "asc" if missing.
+    /// </summary>
+    [JsonPropertyName("direction")]
+    public string? Direction { get; set; }
+}
+
+/// <summary>
+/// OrderBy request: single field or multiple fields.
+/// Supports {"field":"createdAt","direction":"desc"} or {"fields":[{"field":"status","direction":"asc"},...]}.
+/// </summary>
+public sealed class OrderByRequest
+{
+    /// <summary>
+    /// Single field (when not using fields array)
+    /// </summary>
+    [JsonPropertyName("field")]
+    public string? Field { get; set; }
+
+    /// <summary>
+    /// Direction for single field (when not using fields array)
+    /// </summary>
+    [JsonPropertyName("direction")]
+    public string? Direction { get; set; }
+
+    /// <summary>
+    /// Multiple sort fields
+    /// </summary>
+    [JsonPropertyName("fields")]
+    public List<OrderByField>? Fields { get; set; }
+
+    /// <summary>
+    /// Gets all order-by entries as a list for uniform handling (single or multi).
+    /// </summary>
+    public IReadOnlyList<(string Field, string Direction)> GetEntries()
+    {
+        if (Fields != null && Fields.Count > 0)
+        {
+            return Fields
+                .Where(f => !string.IsNullOrWhiteSpace(f.Field))
+                .Select(f => (f.Field!.Trim(), NormalizeDirection(f.Direction)))
+                .ToList();
+        }
+        if (!string.IsNullOrWhiteSpace(Field))
+        {
+            return new List<(string, string)> { (Field.Trim(), NormalizeDirection(Direction)) };
+        }
+        return Array.Empty<(string, string)>();
+    }
+
+    private static string NormalizeDirection(string? direction)
+    {
+        if (string.IsNullOrWhiteSpace(direction))
+            return "asc";
+        return direction!.Trim().Equals("desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc";
+    }
 }
 
 /// <summary>

--- a/src/BBT.Workflow.Domain/QueryExtensions/GraphQL/GraphQLFilterNodeConverter.cs
+++ b/src/BBT.Workflow.Domain/QueryExtensions/GraphQL/GraphQLFilterNodeConverter.cs
@@ -199,7 +199,7 @@ public sealed class GraphQLFilterNodeConverter : JsonConverter<GraphQLFilterNode
                     condition.NotIn = ReadValueArray(ref reader);
                     break;
                 case "isnull":
-                    condition.IsNull = reader.GetBoolean();
+                    condition.IsNull = reader.TokenType == JsonTokenType.Null ? null : reader.GetBoolean();
                     break;
                 default:
                     // This could be a nested field - handle as nested condition

--- a/src/BBT.Workflow.Domain/QueryExtensions/GraphQL/GraphQLFilterParser.cs
+++ b/src/BBT.Workflow.Domain/QueryExtensions/GraphQL/GraphQLFilterParser.cs
@@ -139,15 +139,44 @@ public static class GraphQLFilterParser
     /// <param name="filter">Filter JSON string</param>
     /// <param name="groupBy">GroupBy JSON string</param>
     /// <param name="aggregations">Aggregations JSON string</param>
+    /// <param name="orderBy">OrderBy JSON string (optional)</param>
     /// <returns>Complete filter request</returns>
-    public static GraphQLFilterRequest ParseRequest(string? filter, string? groupBy, string? aggregations)
+    public static GraphQLFilterRequest ParseRequest(string? filter, string? groupBy, string? aggregations, string? orderBy = null)
     {
         return new GraphQLFilterRequest
         {
             Filter = ParseFilter(filter),
             GroupBy = ParseGroupBy(groupBy),
-            Aggregations = ParseAggregations(aggregations)
+            Aggregations = ParseAggregations(aggregations),
+            OrderBy = ParseOrderBy(orderBy)
         };
+    }
+
+    /// <summary>
+    /// Parse an orderBy JSON string into an OrderByRequest.
+    /// Supports single: {"field":"createdAt","direction":"desc"}
+    /// or multiple: {"fields":[{"field":"status","direction":"asc"},{"field":"createdAt","direction":"desc"}]}.
+    /// </summary>
+    /// <param name="jsonOrderBy">OrderBy JSON string</param>
+    /// <returns>Parsed orderBy request, or null if empty/invalid</returns>
+    public static OrderByRequest? ParseOrderBy(string? jsonOrderBy)
+    {
+        if (string.IsNullOrWhiteSpace(jsonOrderBy))
+            return null;
+
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<OrderByRequest>(jsonOrderBy, JsonOptions);
+            if (parsed == null)
+                return null;
+            if (parsed.GetEntries().Count == 0)
+                return null;
+            return parsed;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Domain/QueryExtensions/GraphQL/GraphQLJsonFilterService.cs
+++ b/src/BBT.Workflow.Domain/QueryExtensions/GraphQL/GraphQLJsonFilterService.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Text.RegularExpressions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Npgsql;
@@ -48,6 +49,7 @@ public static class GraphQLJsonFilterService
     /// <summary>
     /// Apply GraphQL filter node using PostgreSQL native JSONB operators
     /// </summary>
+    /// <param name="orderByClause">Optional ORDER BY clause (e.g. from BuildOrderByClause). When null, defaults to s."CreatedAt" DESC.</param>
     public static IQueryable<T> ApplyGraphQLFilter<T>(
         this DbSet<T> dbSet,
         GraphQLFilterNode filterNode,
@@ -55,7 +57,8 @@ public static class GraphQLJsonFilterService
         string tableName = "",
         string schema = "public",
         ISchemaValidator? schemaValidator = null,
-        ILogger? logger = null) where T : class
+        ILogger? logger = null,
+        string? orderByClause = null) where T : class
     {
         // Validate schema and table names
         if (schemaValidator != null)
@@ -102,9 +105,71 @@ public static class GraphQLJsonFilterService
             FROM ""{schema}"".""Instances"" s
             JOIN FilteredData d ON s.""Id"" = d.""InstanceId""
             {(string.IsNullOrEmpty(instanceWhereClause) ? "" : $"WHERE {instanceWhereClause}")}
-            ORDER BY s.""CreatedAt"" DESC";
+            ORDER BY {(string.IsNullOrWhiteSpace(orderByClause) ? "s.\"CreatedAt\" DESC" : orderByClause)}";
 
         return dbSet.FromSqlRaw(rawSql, parameters.ToArray()).AsNoTracking();
+    }
+
+    /// <summary>
+    /// Builds ORDER BY clause SQL for instance list (instance columns and/or attributes JSON path).
+    /// </summary>
+    public static string? BuildOrderByClause(
+        OrderByRequest? orderBy,
+        string schema,
+        string instanceAlias = "s",
+        string dataTableName = "InstancesData")
+    {
+        if (orderBy == null)
+            return null;
+        var entries = orderBy.GetEntries();
+        if (entries.Count == 0)
+            return null;
+
+        var parts = new List<string>();
+        foreach (var (field, direction) in entries)
+        {
+            var dir = direction.Equals("desc", StringComparison.OrdinalIgnoreCase) ? "DESC" : "ASC";
+            var trimmed = field.Trim();
+            if (trimmed.StartsWith("attributes.", StringComparison.OrdinalIgnoreCase))
+            {
+                var jsonPath = trimmed.Substring("attributes.".Length).Trim();
+                if (string.IsNullOrEmpty(jsonPath) || !IsSafeJsonPath(jsonPath))
+                    continue;
+                var accessor = BuildJsonTextAccessorForOrderBy(jsonPath);
+                parts.Add($"(SELECT {accessor} FROM \"{schema}\".\"{dataTableName}\" _d WHERE _d.\"InstanceId\" = {instanceAlias}.\"Id\" AND _d.\"IsLatest\" = true LIMIT 1) {dir}");
+            }
+            else if (InstanceFieldDiscriminator.IsInstanceColumn(trimmed))
+            {
+                try
+                {
+                    var columnName = InstanceFieldDiscriminator.GetInstanceColumnName(trimmed);
+                    parts.Add($"{instanceAlias}.\"{columnName}\" {dir}");
+                }
+                catch (ArgumentException) { }
+            }
+        }
+        if (parts.Count == 0)
+            return null;
+        return string.Join(", ", parts);
+    }
+
+    private static bool IsSafeJsonPath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path)) return false;
+        var segments = path.Split('.');
+        var safeSegment = new Regex("^[a-zA-Z0-9_]+$");
+        return segments.All(seg => safeSegment.IsMatch(seg.Trim()));
+    }
+
+    private static string BuildJsonTextAccessorForOrderBy(string field)
+    {
+        if (field.Contains('.'))
+        {
+            var parts = field.Split('.');
+            var arrayElements = string.Join(",", parts.Select(p => $"'{p.Trim()}'"));
+            return "\"Data\" #>> ARRAY[" + arrayElements + "]";
+        }
+        return "\"Data\" ->> '" + field.Trim().Replace("'", "''") + "'";
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Domain/QueryExtensions/GraphQL/UnifiedFilterService.cs
+++ b/src/BBT.Workflow.Domain/QueryExtensions/GraphQL/UnifiedFilterService.cs
@@ -16,31 +16,31 @@ public static class UnifiedFilterService
     /// </summary>
     /// <typeparam name="T">Entity type</typeparam>
     /// <param name="dbSet">Entity DbSet</param>
-    /// <param name="filters">Array of filter strings (can be mixed formats)</param>
+    /// <param name="filter">Filter string (legacy or GraphQL-style JSON)</param>
     /// <param name="jsonColumnName">Name of the JSON column</param>
     /// <param name="tableName">Name of the database table</param>
     /// <param name="schema">Database schema name</param>
     /// <returns>Filtered queryable</returns>
     public static IQueryable<T> ApplyFilters<T>(
         this DbSet<T> dbSet,
-        string[]? filters,
+        string? filter,
         string jsonColumnName = "Data",
         string tableName = "",
         string schema = "public",
         ISchemaValidator? schemaValidator = null) where T : class
     {
-        if (filters == null || filters.Length == 0)
+        if (string.IsNullOrWhiteSpace(filter))
             return dbSet;
 
         // Validate inputs
-        InputValidator.ValidateFilters(filters);
+        InputValidator.ValidateFilters(filter);
 
-        var format = FilterFormatDetector.DetectFormat(filters);
+        var format = FilterFormatDetector.DetectFormat(filter);
 
         return format switch
         {
-            FilterFormat.GraphQL => ApplyGraphQLFilters(dbSet, filters, jsonColumnName, tableName, schema, schemaValidator),
-            FilterFormat.Legacy => PostgreSqlJsonFilterService.ApplyJsonFilters(dbSet, filters, jsonColumnName, tableName, schema, schemaValidator),
+            FilterFormat.GraphQL => ApplyGraphQLFilters(dbSet, filter, jsonColumnName, tableName, schema, schemaValidator),
+            FilterFormat.Legacy => PostgreSqlJsonFilterService.ApplyJsonFilters(dbSet, filter, jsonColumnName, tableName, schema, schemaValidator),
             _ => dbSet
         };
     }
@@ -50,14 +50,13 @@ public static class UnifiedFilterService
     /// </summary>
     private static IQueryable<T> ApplyGraphQLFilters<T>(
         DbSet<T> dbSet,
-        string[] filters,
+        string? filter,
         string jsonColumnName,
         string tableName,
         string schema,
         ISchemaValidator? schemaValidator) where T : class
     {
-        // Combine all filters into a single node
-        var combinedNode = FilterFormatDetector.CombineFilters(filters);
+        var combinedNode = FilterFormatDetector.CombineFilters(filter);
 
         if (combinedNode == null)
             return dbSet;
@@ -92,13 +91,15 @@ public static class UnifiedFilterService
         CancellationToken cancellationToken = default) where T : class
     {
         var request = GraphQLFilterParser.ParseRequest(filter, groupBy, aggregations);
-        return await ExecuteRequestAsync(dbContext, dbSet, request, jsonColumnName, schema, includeFunc, schemaValidator, cancellationToken);
+        return await ExecuteRequestAsync(dbContext, dbSet, request, jsonColumnName, schema, includeFunc, applyOrderBy: null, applyOrderByRaw: null, schemaValidator, cancellationToken);
     }
 
     /// <summary>
     /// Execute a complete GraphQL filter request
     /// </summary>
     /// <param name="includeFunc">Optional function to include navigation properties</param>
+    /// <param name="applyOrderBy">Optional function to apply request.OrderBy (instance columns only)</param>
+    /// <param name="applyOrderByRaw">Optional function to build ordered query when there is no filter but orderBy has attributes (e.g. raw SQL with ORDER BY subquery)</param>
     public static async Task<GraphQLFilterResponse<T>> ExecuteRequestAsync<T>(
         DbContext dbContext,
         DbSet<T> dbSet,
@@ -106,6 +107,8 @@ public static class UnifiedFilterService
         string jsonColumnName = "Data",
         string schema = "public",
         Func<IQueryable<T>, IQueryable<T>>? includeFunc = null,
+        Func<IQueryable<T>, OrderByRequest?, IQueryable<T>>? applyOrderBy = null,
+        Func<DbContext, string, OrderByRequest?, IQueryable<T>>? applyOrderByRaw = null,
         ISchemaValidator? schemaValidator = null,
         CancellationToken cancellationToken = default) where T : class
     {
@@ -142,14 +145,33 @@ public static class UnifiedFilterService
         }
 
         // Handle regular filter (no aggregations)
-        var query = request.Filter != null
-            ? dbSet.ApplyGraphQLFilter(request.Filter, jsonColumnName, "", schema, schemaValidator)
-            : dbSet;
+        var orderByClause = request.OrderBy != null ? GraphQLJsonFilterService.BuildOrderByClause(request.OrderBy, schema) : null;
+        var orderByHasAttributes = request.OrderBy != null && request.OrderBy.GetEntries().Any(e => e.Field.Trim().StartsWith("attributes.", StringComparison.OrdinalIgnoreCase));
+
+        IQueryable<T> query;
+        if (request.Filter != null)
+        {
+            query = dbSet.ApplyGraphQLFilter(request.Filter, jsonColumnName, "", schema, schemaValidator, orderByClause: orderByClause);
+        }
+        else if (orderByHasAttributes && orderByClause != null && applyOrderByRaw != null)
+        {
+            query = applyOrderByRaw(dbContext, schema, request.OrderBy!);
+        }
+        else
+        {
+            query = dbSet;
+        }
 
         // Apply include function if provided
         if (includeFunc != null)
         {
             query = includeFunc(query);
+        }
+
+        // Apply orderBy via applicator only when no filter and no attributes (filter/raw path already has ORDER BY)
+        if (request.Filter == null && !orderByHasAttributes && request.OrderBy != null && request.OrderBy.GetEntries().Count > 0 && applyOrderBy != null)
+        {
+            query = applyOrderBy(query, request.OrderBy);
         }
 
         response.Data = await query.ToListAsync(cancellationToken);

--- a/src/BBT.Workflow.Domain/QueryExtensions/InstanceFilterSpecification.cs
+++ b/src/BBT.Workflow.Domain/QueryExtensions/InstanceFilterSpecification.cs
@@ -8,8 +8,8 @@ namespace BBT.Workflow.Definitions;
 
 public class InstanceFilterSpecification : FilterSpecification<Instance>
 {
-    public InstanceFilterSpecification(string[]? filters) 
-        : base(filters, CreateFilterMappings())
+    public InstanceFilterSpecification(string? filter)
+        : base(filter, CreateFilterMappings())
     {
     }
 

--- a/src/BBT.Workflow.Domain/QueryExtensions/PostgreSqlJsonFilterService.cs
+++ b/src/BBT.Workflow.Domain/QueryExtensions/PostgreSqlJsonFilterService.cs
@@ -21,7 +21,7 @@ public static class PostgreSqlJsonFilterService
     /// </summary>
     /// <typeparam name="T">Entity type</typeparam>
     /// <param name="dbSet">Entity DbSet</param>
-    /// <param name="filters">Array of filter strings in format: "field=operator:value"</param>
+    /// <param name="filter">Filter string in format: "field=operator:value"</param>
     /// <param name="jsonColumnName">Name of the JSON column (e.g., "Data", "Json")</param>
     /// <param name="tableName">Name of the database table</param>
     /// <param name="schema">Database schema name</param>
@@ -30,18 +30,20 @@ public static class PostgreSqlJsonFilterService
     /// <returns>Filtered queryable</returns>
     public static IQueryable<T> ApplyJsonFilters<T>(
         this DbSet<T> dbSet,
-        string[] filters,
+        string? filter,
         string jsonColumnName = "Data",
         string tableName = "",
         string schema = "public",
         ISchemaValidator? schemaValidator = null,
         ILogger? logger = null) where T : class
     {
-        if (filters == null || !filters.Any())
+        if (string.IsNullOrWhiteSpace(filter))
             return dbSet;
 
         // Validate inputs
-        InputValidator.ValidateFilters(filters);
+        InputValidator.ValidateFilters(filter);
+
+        var filters = new[] { filter };
         
         // Validate schema and table names
         if (schemaValidator != null)
@@ -65,15 +67,15 @@ public static class PostgreSqlJsonFilterService
         var parameterIndex = 0;
 
         // Process JSON Data filters
-        foreach (var filter in jsonFilters)
+        foreach (var filterItem in jsonFilters)
         {
             try
             {
-                var (field, operatorType, operatorValue) = FilterOperatorParser.ParseOperator(filter);
-                
+                var (field, operatorType, operatorValue) = FilterOperatorParser.ParseOperator(filterItem);
+
                 var (condition, filterParameters) = BuildPostgreSqlCondition(
                     field, operatorType, operatorValue, jsonColumnName, ref parameterIndex);
-                
+
                 if (!string.IsNullOrEmpty(condition))
                 {
                     jsonWhereConditions.Add(condition);
@@ -82,26 +84,24 @@ public static class PostgreSqlJsonFilterService
             }
             catch (ArgumentException ex)
             {
-                // Log error but continue with other filters
-                logger?.LogWarning(ex, "Error parsing JSON filter: {Filter}", filter);
+                logger?.LogWarning(ex, "Error parsing JSON filter: {Filter}", filterItem);
             }
             catch (FormatException ex)
             {
-                // Log error but continue with other filters
-                logger?.LogWarning(ex, "Error parsing JSON filter: {Filter}", filter);
+                logger?.LogWarning(ex, "Error parsing JSON filter: {Filter}", filterItem);
             }
         }
 
         // Process Instance column filters
-        foreach (var filter in instanceFilters)
+        foreach (var filterItem in instanceFilters)
         {
             try
             {
-                var (field, operatorType, operatorValue) = FilterOperatorParser.ParseOperator(filter);
-                
+                var (field, operatorType, operatorValue) = FilterOperatorParser.ParseOperator(filterItem);
+
                 var (condition, filterParameters) = InstanceColumnConditionBuilder.BuildCondition(
                     field, operatorType, operatorValue, ref parameterIndex);
-                
+
                 if (!string.IsNullOrEmpty(condition))
                 {
                     instanceWhereConditions.Add(condition);
@@ -110,13 +110,11 @@ public static class PostgreSqlJsonFilterService
             }
             catch (ArgumentException ex)
             {
-                // Log error but continue with other filters
-                logger?.LogWarning(ex, "Error parsing Instance filter: {Filter}", filter);
+                logger?.LogWarning(ex, "Error parsing Instance filter: {Filter}", filterItem);
             }
             catch (FormatException ex)
             {
-                // Log error but continue with other filters
-                logger?.LogWarning(ex, "Error parsing Instance filter: {Filter}", filter);
+                logger?.LogWarning(ex, "Error parsing Instance filter: {Filter}", filterItem);
             }
         }
 
@@ -176,7 +174,7 @@ public static class PostgreSqlJsonFilterService
         string tableName = "") where T : class
     {
         return dbSet.ApplyJsonFilters(
-            new[] { $"{field}={operatorType}:{value}" },
+            $"{field}={operatorType}:{value}",
             jsonColumnName,
             tableName);
     }

--- a/src/BBT.Workflow.Domain/Security/InputValidator.cs
+++ b/src/BBT.Workflow.Domain/Security/InputValidator.cs
@@ -34,6 +34,18 @@ public static class InputValidator
     public const int MaxFieldDepth = 10;
 
     /// <summary>
+    /// Validates a single filter string
+    /// </summary>
+    /// <param name="filter">Filter to validate</param>
+    /// <exception cref="ArgumentException">Thrown when validation fails</exception>
+    public static void ValidateFilters(string? filter)
+    {
+        if (string.IsNullOrWhiteSpace(filter))
+            return;
+        ValidateFilters(new[] { filter });
+    }
+
+    /// <summary>
     /// Validates an array of filters
     /// </summary>
     /// <param name="filters">Filters to validate</param>
@@ -42,10 +54,10 @@ public static class InputValidator
     {
         if (filters == null || filters.Length == 0)
             return;
-        
+
         if (filters.Length > MaxFiltersCount)
             throw new ArgumentException($"Too many filters: {filters.Length}. Maximum allowed: {MaxFiltersCount}");
-        
+
         for (int i = 0; i < filters.Length; i++)
         {
             var filter = filters[i];

--- a/src/BBT.Workflow.Execution.Abstractions/Bindings/GetInstancesBinding.cs
+++ b/src/BBT.Workflow.Execution.Abstractions/Bindings/GetInstancesBinding.cs
@@ -32,9 +32,9 @@ public sealed class GetInstancesBinding
     public string? Sort { get; init; }
 
     /// <summary>
-    /// Filter expressions to apply to the query.
+    /// Filter expression to apply to the query (JSON format).
     /// </summary>
-    public string[]? Filter { get; init; }
+    public string? Filter { get; init; }
 
     /// <summary>
     /// Whether to use Dapr service invocation instead of direct HTTP.

--- a/src/BBT.Workflow.Execution/Invokers/GetInstancesRemoteInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/GetInstancesRemoteInvoker.cs
@@ -227,12 +227,9 @@ public sealed class GetInstancesRemoteInvoker : ITaskInvoker<GetInstancesBinding
         if (!string.IsNullOrEmpty(binding.Sort))
             queryParams.Add($"sort={Uri.EscapeDataString(binding.Sort)}");
 
-        if (binding.Filter is { Length: > 0 })
+        if (!string.IsNullOrWhiteSpace(binding.Filter))
         {
-            foreach (var filter in binding.Filter.Where(f => !string.IsNullOrEmpty(f)))
-            {
-                queryParams.Add($"filter={Uri.EscapeDataString(filter)}");
-            }
+            queryParams.Add($"filter={Uri.EscapeDataString(binding.Filter)}");
         }
 
         if (queryParams.Count > 0)

--- a/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceRepository.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceRepository.cs
@@ -212,23 +212,21 @@ public sealed class EfCoreInstanceRepository(
     }
 
     private async Task<IQueryable<Instance>> GetFilteredQueryAsync(
-        string[]? filters,
+        string? filter,
         CancellationToken cancellationToken = default)
     {
         // Apply PostgreSQL native JSON filters if provided
-        if (filters?.Any() == true)
+        if (!string.IsNullOrWhiteSpace(filter))
         {
             try
             {
-                // Use ApplyJsonFilters on Instance DbSet - this matches the working pattern
-                // The CTE inside ApplyJsonFilters will handle InstanceData filtering and return Instances
                 var filteredInstances = (await GetDbSetAsync())
                     .ApplyFilters(
-                        filters: filters,
-                        jsonColumnName: "Data", // InstanceData.Data is the JSON column
-                        tableName: "InstancesData", // Filter table name
-                        schema: currentSchema.Name ?? "public", // Default schema
-                        schemaValidator: schemaValidator // Security validation
+                        filter,
+                        jsonColumnName: "Data",
+                        tableName: "InstancesData",
+                        schema: currentSchema.Name ?? "public",
+                        schemaValidator: schemaValidator
                     );
 
                 return filteredInstances
@@ -236,34 +234,30 @@ public sealed class EfCoreInstanceRepository(
             }
             catch (ArgumentException)
             {
-                // Invalid filter format, fallback to specification-based filtering
                 var dbSet = await GetDbSetAsync();
                 var query = dbSet
                     .Include(i => i.DataList);
-                var filterSpec = new InstanceFilterSpecification(filters);
+                var filterSpec = new InstanceFilterSpecification(filter);
                 return filterSpec.Apply(query);
             }
             catch (FormatException)
             {
-                // Invalid filter format, fallback to specification-based filtering
                 var dbSet = await GetDbSetAsync();
                 var query = dbSet
                     .Include(i => i.DataList);
-                var filterSpec = new InstanceFilterSpecification(filters);
+                var filterSpec = new InstanceFilterSpecification(filter);
                 return filterSpec.Apply(query);
             }
             catch (Microsoft.EntityFrameworkCore.DbUpdateException)
             {
-                // Database error, fallback to specification-based filtering
                 var dbSet = await GetDbSetAsync();
                 var query = dbSet
                     .Include(i => i.DataList);
-                var filterSpec = new InstanceFilterSpecification(filters);
+                var filterSpec = new InstanceFilterSpecification(filter);
                 return filterSpec.Apply(query);
             }
         }
 
-        // If no filters, use the standard approach with includes
         var standardDbSet = await GetDbSetAsync();
         return standardDbSet
             .Include(i => i.DataList);
@@ -272,7 +266,7 @@ public sealed class EfCoreInstanceRepository(
     public async Task<HateoasPagedList<Instance>> GetPagedResultsAsync(
         int page,
         int pageSize,
-        string[]? filters,
+        string? filter,
         string? groupBy = null,
         string? aggregations = null,
         CancellationToken cancellationToken = default)
@@ -283,15 +277,12 @@ public sealed class EfCoreInstanceRepository(
             var context = await GetDbContextAsync();
             var dbSet = await GetDbSetAsync();
 
-            // Combine filters into a single JSON string if multiple filters exist
             string? combinedFilter = null;
-            if (filters != null && filters.Length > 0)
+            if (!string.IsNullOrWhiteSpace(filter))
             {
-                // If filters are in GraphQL format, combine them
-                if (FilterFormatDetector.DetectFormat(filters) == FilterFormat.GraphQL)
+                if (FilterFormatDetector.DetectFormat(filter) == FilterFormat.GraphQL)
                 {
-                    // Single element may be full request format (filter + groupBy); extract .Filter so query params win
-                    if (filters.Length == 1 && GraphQLFilterParser.TryParseRequest(filters[0], out var parsedRequest) && parsedRequest?.Filter != null)
+                    if (GraphQLFilterParser.TryParseRequest(filter, out var parsedRequest) && parsedRequest?.Filter != null)
                     {
                         combinedFilter = JsonSerializer.Serialize(parsedRequest.Filter, new JsonSerializerOptions
                         {
@@ -301,7 +292,7 @@ public sealed class EfCoreInstanceRepository(
                     }
                     else
                     {
-                        var combinedNode = FilterFormatDetector.CombineFilters(filters);
+                        var combinedNode = FilterFormatDetector.CombineFilters(filter);
                         if (combinedNode != null)
                         {
                             combinedFilter = JsonSerializer.Serialize(combinedNode, new JsonSerializerOptions
@@ -314,8 +305,7 @@ public sealed class EfCoreInstanceRepository(
                 }
                 else
                 {
-                    // For legacy format, convert to GraphQL filter node so ParseFilter receives valid JSON
-                    var legacyNode = FilterFormatDetector.ConvertLegacyToGraphQL(filters);
+                    var legacyNode = FilterFormatDetector.ConvertLegacyToGraphQL(filter);
                     if (legacyNode != null)
                     {
                         combinedFilter = JsonSerializer.Serialize(legacyNode, new JsonSerializerOptions
@@ -371,7 +361,7 @@ public sealed class EfCoreInstanceRepository(
 
         // Normal flow without groupBy/aggregations
         // GetFilteredQueryAsync already includes DataList, no need to include again
-        var query = await GetFilteredQueryAsync(filters, cancellationToken);
+        var query = await GetFilteredQueryAsync(filter, cancellationToken);
 
         // Manually materialize to ensure DataList is loaded
         var skipCount = (page - 1) * pageSize;
@@ -392,9 +382,10 @@ public sealed class EfCoreInstanceRepository(
     public async Task<(HateoasPagedList<Instance> PagedList, List<GroupSummary>? Groups)> GetPagedResultsWithGroupsAsync(
         int page,
         int pageSize,
-        string[]? filters,
+        string? filter,
         string? groupBy = null,
         string? aggregations = null,
+        string? sort = null,
         CancellationToken cancellationToken = default)
     {
         // If groupBy is provided, use ApplyFilterWithAggregationsAsync
@@ -403,15 +394,12 @@ public sealed class EfCoreInstanceRepository(
             var context = await GetDbContextAsync();
             var dbSet = await GetDbSetAsync();
 
-            // Combine filters into a single JSON string if multiple filters exist
             string? combinedFilter = null;
-            if (filters != null && filters.Length > 0)
+            if (!string.IsNullOrWhiteSpace(filter))
             {
-                // If filters are in GraphQL format, combine them
-                if (FilterFormatDetector.DetectFormat(filters) == FilterFormat.GraphQL)
+                if (FilterFormatDetector.DetectFormat(filter) == FilterFormat.GraphQL)
                 {
-                    // Single element may be full request format (filter + groupBy); extract .Filter so groupBy param wins
-                    if (filters.Length == 1 && GraphQLFilterParser.TryParseRequest(filters[0], out var parsedRequest) && parsedRequest?.Filter != null)
+                    if (GraphQLFilterParser.TryParseRequest(filter, out var parsedRequest) && parsedRequest?.Filter != null)
                     {
                         combinedFilter = JsonSerializer.Serialize(parsedRequest.Filter, new JsonSerializerOptions
                         {
@@ -421,7 +409,7 @@ public sealed class EfCoreInstanceRepository(
                     }
                     else
                     {
-                        var combinedNode = FilterFormatDetector.CombineFilters(filters);
+                        var combinedNode = FilterFormatDetector.CombineFilters(filter);
                         if (combinedNode != null)
                         {
                             combinedFilter = JsonSerializer.Serialize(combinedNode, new JsonSerializerOptions
@@ -434,8 +422,7 @@ public sealed class EfCoreInstanceRepository(
                 }
                 else
                 {
-                    // For legacy format, convert to GraphQL filter node so ParseFilter receives valid JSON
-                    var legacyNode = FilterFormatDetector.ConvertLegacyToGraphQL(filters);
+                    var legacyNode = FilterFormatDetector.ConvertLegacyToGraphQL(filter);
                     if (legacyNode != null)
                     {
                         combinedFilter = JsonSerializer.Serialize(legacyNode, new JsonSerializerOptions
@@ -514,13 +501,12 @@ public sealed class EfCoreInstanceRepository(
             var context = await GetDbContextAsync();
             var dbSet = await GetDbSetAsync();
 
-            // Combine filters
             string? combinedFilter = null;
-            if (filters != null && filters.Length > 0)
+            if (!string.IsNullOrWhiteSpace(filter))
             {
-                if (FilterFormatDetector.DetectFormat(filters) == FilterFormat.GraphQL)
+                if (FilterFormatDetector.DetectFormat(filter) == FilterFormat.GraphQL)
                 {
-                    var combinedNode = FilterFormatDetector.CombineFilters(filters);
+                    var combinedNode = FilterFormatDetector.CombineFilters(filter);
                     if (combinedNode != null)
                     {
                         combinedFilter = JsonSerializer.Serialize(combinedNode, new JsonSerializerOptions
@@ -532,7 +518,7 @@ public sealed class EfCoreInstanceRepository(
                 }
                 else
                 {
-                    combinedFilter = filters[0];
+                    combinedFilter = filter;
                 }
             }
 
@@ -572,20 +558,109 @@ public sealed class EfCoreInstanceRepository(
         }
 
         // Normal flow without groupBy/aggregations
-        // GetFilteredQueryAsync already includes DataList, no need to include again
-        var query = await GetFilteredQueryAsync(filters, cancellationToken);
+        var orderBy = GraphQLFilterParser.ParseOrderBy(sort);
+        var hasAttributesOrderBy = orderBy != null && orderBy.GetEntries().Any(e => e.Field.Trim().StartsWith("attributes.", StringComparison.OrdinalIgnoreCase));
+        var schema = currentSchema.Name ?? "public";
 
-        // Manually materialize to ensure DataList is loaded
         var skipCount = (page - 1) * pageSize;
-        var items = await query
-            .Skip(skipCount)
-            .Take(pageSize + 1) // Take one extra to check if there's a next page
-            .ToListAsync(cancellationToken);
+        List<Instance> items;
+        bool hasNextPage;
 
-        var hasNextPage = items.Count > pageSize;
-        if (hasNextPage)
+        if (string.IsNullOrWhiteSpace(filter) && hasAttributesOrderBy)
         {
-            items = items.Take(pageSize).ToList();
+            // No filter + attributes orderBy: raw SQL with ORDER BY, then load DataList by IDs
+            var orderByClause = GraphQLJsonFilterService.BuildOrderByClause(orderBy, schema);
+            if (!string.IsNullOrEmpty(orderByClause))
+            {
+                var dbSet = await GetDbSetAsync();
+                var rawSql = $"SELECT s.* FROM \"{schema}\".\"Instances\" s ORDER BY {orderByClause} OFFSET {skipCount} LIMIT {pageSize + 1}";
+                var orderedInstances = await dbSet
+                    .FromSqlRaw(rawSql)
+                    .AsNoTracking()
+                    .ToListAsync(cancellationToken);
+
+                hasNextPage = orderedInstances.Count > pageSize;
+                if (hasNextPage)
+                    orderedInstances = orderedInstances.Take(pageSize).ToList();
+
+                items = await LoadDataListAndPreserveOrderAsync(orderedInstances, cancellationToken);
+            }
+            else
+            {
+                var query = await GetFilteredQueryAsync(filter, cancellationToken);
+                if (orderBy != null)
+                    query = InstanceOrderByApplicator.Apply(query, orderBy);
+                items = await query
+                    .Skip(skipCount)
+                    .Take(pageSize + 1)
+                    .ToListAsync(cancellationToken);
+                hasNextPage = items.Count > pageSize;
+                if (hasNextPage)
+                    items = items.Take(pageSize).ToList();
+            }
+        }
+        else if (!string.IsNullOrWhiteSpace(filter) && hasAttributesOrderBy)
+        {
+            var combinedFilter = BuildCombinedFilterJson(filter);
+            var orderByClause = GraphQLJsonFilterService.BuildOrderByClause(orderBy, schema);
+            if (!string.IsNullOrEmpty(combinedFilter) && !string.IsNullOrEmpty(orderByClause))
+            {
+                var dbSet = await GetDbSetAsync();
+                var filterNode = GraphQLFilterParser.ParseFilter(combinedFilter);
+                if (filterNode != null && filterNode.NodeType != FilterNodeType.Empty)
+                {
+                    var query = dbSet.ApplyGraphQLFilter(filterNode, "Data", "InstancesData", schema, schemaValidator, null, orderByClause);
+                    var orderedInstances = await query
+                        .Skip(skipCount)
+                        .Take(pageSize + 1)
+                        .ToListAsync(cancellationToken);
+
+                    hasNextPage = orderedInstances.Count > pageSize;
+                    if (hasNextPage)
+                        orderedInstances = orderedInstances.Take(pageSize).ToList();
+
+                    items = await LoadDataListAndPreserveOrderAsync(orderedInstances, cancellationToken);
+                }
+                else
+                {
+                    var query = await GetFilteredQueryAsync(filter, cancellationToken);
+                    if (orderBy != null)
+                        query = InstanceOrderByApplicator.Apply(query, orderBy);
+                    items = await query
+                        .Skip(skipCount)
+                        .Take(pageSize + 1)
+                        .ToListAsync(cancellationToken);
+                    hasNextPage = items.Count > pageSize;
+                    if (hasNextPage)
+                        items = items.Take(pageSize).ToList();
+                }
+            }
+            else
+            {
+                var query = await GetFilteredQueryAsync(filter, cancellationToken);
+                if (orderBy != null)
+                    query = InstanceOrderByApplicator.Apply(query, orderBy);
+                items = await query
+                    .Skip(skipCount)
+                    .Take(pageSize + 1)
+                    .ToListAsync(cancellationToken);
+                hasNextPage = items.Count > pageSize;
+                if (hasNextPage)
+                    items = items.Take(pageSize).ToList();
+            }
+        }
+        else
+        {
+            var query = await GetFilteredQueryAsync(filter, cancellationToken);
+            if (orderBy != null)
+                query = InstanceOrderByApplicator.Apply(query, orderBy);
+            items = await query
+                .Skip(skipCount)
+                .Take(pageSize + 1)
+                .ToListAsync(cancellationToken);
+            hasNextPage = items.Count > pageSize;
+            if (hasNextPage)
+                items = items.Take(pageSize).ToList();
         }
 
         var normalPagedList = new HateoasPagedList<Instance>(items, page, pageSize, hasNextPage);
@@ -604,13 +679,24 @@ public sealed class EfCoreInstanceRepository(
         var context = await GetDbContextAsync();
         var dbSet = await GetDbSetAsync();
 
+        var schema = currentSchema.Name ?? "public";
         var response = await UnifiedFilterService.ExecuteRequestAsync(
             context,
             dbSet,
             request ?? new Definitions.GraphQL.GraphQLFilterRequest(),
             "Data",
-            currentSchema.Name ?? "public",
+            schema,
             query => query.Include(i => i.DataList).AsSplitQuery(),
+            applyOrderBy: (q, orderBy) => InstanceOrderByApplicator.Apply((IQueryable<Instance>)q, orderBy),
+            applyOrderByRaw: (ctx, sch, orderBy) =>
+            {
+                if (orderBy == null) return ((WorkflowDbContext)ctx).Instances.AsQueryable();
+                var clause = GraphQLJsonFilterService.BuildOrderByClause(orderBy, sch);
+                if (string.IsNullOrEmpty(clause)) return ((WorkflowDbContext)ctx).Instances.AsQueryable();
+                return ((WorkflowDbContext)ctx).Instances
+                    .FromSqlRaw($"SELECT s.* FROM \"{sch}\".\"Instances\" s ORDER BY {clause}")
+                    .AsNoTracking();
+            },
             schemaValidator,
             cancellationToken);
 
@@ -778,6 +864,66 @@ public sealed class EfCoreInstanceRepository(
                      && i.Id != excludeInstanceId
                      && i.Status == InstanceStatus.Active,
                 cancellationToken);
+    }
+
+    /// <summary>
+    /// Loads DataList for instances (ordered by id list) and returns list in the same order. Used when ORDER BY must be preserved (EF Include breaks order).
+    /// </summary>
+    private async Task<List<Instance>> LoadDataListAndPreserveOrderAsync(List<Instance> orderedInstances, CancellationToken cancellationToken)
+    {
+        if (orderedInstances.Count == 0)
+            return [];
+        var ids = orderedInstances.Select(i => i.Id).ToList();
+        var dbSet = await GetDbSetAsync();
+        var instancesWithData = await dbSet
+            .Where(i => ids.Contains(i.Id))
+            .Include(i => i.DataList)
+            .AsNoTracking()
+            .ToListAsync(cancellationToken);
+        var byId = instancesWithData.ToDictionary(i => i.Id);
+        return ids.Select(id => byId[id]).ToList();
+    }
+
+    /// <summary>
+    /// Builds a single GraphQL filter JSON from the filter string (same logic as groupBy/aggregations path).
+    /// </summary>
+    private static string? BuildCombinedFilterJson(string? filter)
+    {
+        if (string.IsNullOrWhiteSpace(filter))
+            return null;
+        if (FilterFormatDetector.DetectFormat(filter) == FilterFormat.GraphQL)
+        {
+            if (GraphQLFilterParser.TryParseRequest(filter, out var parsedRequest) && parsedRequest?.Filter != null)
+            {
+                return JsonSerializer.Serialize(parsedRequest.Filter, new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                    WriteIndented = false
+                });
+            }
+            var combinedNode = FilterFormatDetector.CombineFilters(filter);
+            if (combinedNode != null)
+            {
+                return JsonSerializer.Serialize(combinedNode, new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                    WriteIndented = false
+                });
+            }
+        }
+        else
+        {
+            var legacyNode = FilterFormatDetector.ConvertLegacyToGraphQL(filter);
+            if (legacyNode != null)
+            {
+                return JsonSerializer.Serialize(legacyNode, new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                    WriteIndented = false
+                });
+            }
+        }
+        return null;
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceRepository.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceRepository.cs
@@ -290,20 +290,40 @@ public sealed class EfCoreInstanceRepository(
                 // If filters are in GraphQL format, combine them
                 if (FilterFormatDetector.DetectFormat(filters) == FilterFormat.GraphQL)
                 {
-                    var combinedNode = FilterFormatDetector.CombineFilters(filters);
-                    if (combinedNode != null)
+                    // Single element may be full request format (filter + groupBy); extract .Filter so query params win
+                    if (filters.Length == 1 && GraphQLFilterParser.TryParseRequest(filters[0], out var parsedRequest) && parsedRequest?.Filter != null)
                     {
-                        combinedFilter = JsonSerializer.Serialize(combinedNode, new JsonSerializerOptions
+                        combinedFilter = JsonSerializer.Serialize(parsedRequest.Filter, new JsonSerializerOptions
                         {
                             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
                             WriteIndented = false
                         });
                     }
+                    else
+                    {
+                        var combinedNode = FilterFormatDetector.CombineFilters(filters);
+                        if (combinedNode != null)
+                        {
+                            combinedFilter = JsonSerializer.Serialize(combinedNode, new JsonSerializerOptions
+                            {
+                                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                                WriteIndented = false
+                            });
+                        }
+                    }
                 }
                 else
                 {
-                    // For legacy format, use first filter
-                    combinedFilter = filters[0];
+                    // For legacy format, convert to GraphQL filter node so ParseFilter receives valid JSON
+                    var legacyNode = FilterFormatDetector.ConvertLegacyToGraphQL(filters);
+                    if (legacyNode != null)
+                    {
+                        combinedFilter = JsonSerializer.Serialize(legacyNode, new JsonSerializerOptions
+                        {
+                            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                            WriteIndented = false
+                        });
+                    }
                 }
             }
 
@@ -390,20 +410,40 @@ public sealed class EfCoreInstanceRepository(
                 // If filters are in GraphQL format, combine them
                 if (FilterFormatDetector.DetectFormat(filters) == FilterFormat.GraphQL)
                 {
-                    var combinedNode = FilterFormatDetector.CombineFilters(filters);
-                    if (combinedNode != null)
+                    // Single element may be full request format (filter + groupBy); extract .Filter so groupBy param wins
+                    if (filters.Length == 1 && GraphQLFilterParser.TryParseRequest(filters[0], out var parsedRequest) && parsedRequest?.Filter != null)
                     {
-                        combinedFilter = JsonSerializer.Serialize(combinedNode, new JsonSerializerOptions
+                        combinedFilter = JsonSerializer.Serialize(parsedRequest.Filter, new JsonSerializerOptions
                         {
                             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
                             WriteIndented = false
                         });
                     }
+                    else
+                    {
+                        var combinedNode = FilterFormatDetector.CombineFilters(filters);
+                        if (combinedNode != null)
+                        {
+                            combinedFilter = JsonSerializer.Serialize(combinedNode, new JsonSerializerOptions
+                            {
+                                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                                WriteIndented = false
+                            });
+                        }
+                    }
                 }
                 else
                 {
-                    // For legacy format, use first filter
-                    combinedFilter = filters[0];
+                    // For legacy format, convert to GraphQL filter node so ParseFilter receives valid JSON
+                    var legacyNode = FilterFormatDetector.ConvertLegacyToGraphQL(filters);
+                    if (legacyNode != null)
+                    {
+                        combinedFilter = JsonSerializer.Serialize(legacyNode, new JsonSerializerOptions
+                        {
+                            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                            WriteIndented = false
+                        });
+                    }
                 }
             }
 

--- a/src/BBT.Workflow.Infrastructure/Instances/InstanceOrderByApplicator.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/InstanceOrderByApplicator.cs
@@ -1,0 +1,129 @@
+using System.Linq.Expressions;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Definitions.GraphQL;
+using BBT.Workflow.Instances;
+
+namespace BBT.Workflow.Instances;
+
+/// <summary>
+/// Applies OrderByRequest to IQueryable&lt;Instance&gt; for instance list sorting.
+/// Supports instance columns (createdAt, modifiedAt, status, key, currentState, etc.) and
+/// attributes JSON path (attributes.fieldName) when query allows it.
+/// </summary>
+public static class InstanceOrderByApplicator
+{
+    /// <summary>
+    /// Applies ordering to the instance query. Instance columns are applied via EF;
+    /// attributes.* sort keys are skipped (JSON ordering not yet implemented).
+    /// </summary>
+    public static IQueryable<Instance> Apply(IQueryable<Instance> query, OrderByRequest? orderBy)
+    {
+        if (orderBy == null)
+            return query;
+
+        var entries = orderBy.GetEntries();
+        if (entries.Count == 0)
+            return query;
+
+        var index = 0;
+        foreach (var (field, direction) in entries)
+        {
+            var isDesc = direction.Equals("desc", StringComparison.OrdinalIgnoreCase);
+            bool applied;
+            if (index == 0)
+            {
+                applied = ApplyFirstOrderBy(query, field, isDesc, out var ordered);
+                if (applied && ordered != null)
+                    query = ordered;
+            }
+            else if (query is IOrderedQueryable<Instance> orderedQuery)
+            {
+                applied = ApplyThenBy(orderedQuery, field, isDesc, out var nextOrdered);
+                if (applied && nextOrdered != null)
+                    query = nextOrdered;
+            }
+
+            index++;
+        }
+
+        return query;
+    }
+
+    private static bool ApplyFirstOrderBy(IQueryable<Instance> query, string field, bool descending, out IQueryable<Instance>? result)
+    {
+        result = null;
+        var lambda = GetTypedSelector(field);
+        if (lambda == null)
+            return false;
+
+        var ordered = CallOrderBy(query, lambda, descending, isThenBy: false);
+        if (ordered == null)
+            return false;
+
+        result = ordered;
+        return true;
+    }
+
+    private static bool ApplyThenBy(IOrderedQueryable<Instance> query, string field, bool descending, out IQueryable<Instance>? result)
+    {
+        result = null;
+        var lambda = GetTypedSelector(field);
+        if (lambda == null)
+            return false;
+
+        var ordered = CallOrderBy(query, lambda, descending, isThenBy: true);
+        if (ordered == null)
+            return false;
+
+        result = ordered;
+        return true;
+    }
+
+    private static IQueryable<Instance>? CallOrderBy(IQueryable<Instance> query, LambdaExpression keySelector, bool descending, bool isThenBy)
+    {
+        var keyType = keySelector.ReturnType;
+        var methodName = isThenBy
+            ? (descending ? "ThenByDescending" : "ThenBy")
+            : (descending ? "OrderByDescending" : "OrderBy");
+        var methods = typeof(Queryable).GetMethods()
+            .Where(m => m.Name == methodName && m.GetParameters().Length == 2)
+            .Where(m => m.GetParameters()[1].ParameterType.IsGenericType
+                && m.GetParameters()[1].ParameterType.GetGenericTypeDefinition() == typeof(Expression<>))
+            .ToList();
+        var method = methods.FirstOrDefault(m => m.GetGenericArguments().Length == 2);
+        if (method == null)
+            return null;
+        var genericMethod = method.MakeGenericMethod(typeof(Instance), keyType);
+        return genericMethod.Invoke(null, [query, keySelector]) as IQueryable<Instance>;
+    }
+
+    /// <summary>
+    /// Returns a typed LambdaExpression for the given instance column, or null if not supported.
+    /// </summary>
+    private static LambdaExpression? GetTypedSelector(string fieldName)
+    {
+        if (string.IsNullOrWhiteSpace(fieldName))
+            return null;
+
+        var trimmed = fieldName.Trim();
+        if (trimmed.StartsWith("attributes.", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        if (!InstanceFieldDiscriminator.IsInstanceColumn(trimmed))
+            return null;
+
+        string columnName;
+        try
+        {
+            columnName = InstanceFieldDiscriminator.GetInstanceColumnName(trimmed);
+        }
+        catch (ArgumentException)
+        {
+            return null;
+        }
+
+        var parameter = Expression.Parameter(typeof(Instance), "i");
+        var property = Expression.Property(parameter, columnName);
+        return Expression.Lambda(property, parameter);
+    }
+}

--- a/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceQueryAppService.cs
@@ -200,12 +200,9 @@ public sealed class RemoteInstanceQueryAppService(
                 queryParams.Add($"sort={Uri.EscapeDataString(input.Sort)}");
             }
 
-            if (input.Filter?.Length > 0)
+            if (!string.IsNullOrWhiteSpace(input.Filter))
             {
-                foreach (var filter in input.Filter)
-                {
-                    queryParams.Add($"filter={Uri.EscapeDataString(filter)}");
-                }
+                queryParams.Add($"filter={Uri.EscapeDataString(input.Filter)}");
             }
 
             if (!string.IsNullOrWhiteSpace(input.GroupBy))

--- a/test/BBT.Workflow.Domain.Tests/Definitions/GetInstancesTaskTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Definitions/GetInstancesTaskTests.cs
@@ -19,7 +19,7 @@ public class GetInstancesTaskTests
                 "page": 2,
                 "pageSize": 25,
                 "sort": "-CreatedAt",
-                "filter": ["status:active", "type:premium"],
+                "filter": "status:active",
                 "useDapr": true
             }
             """;
@@ -35,9 +35,7 @@ public class GetInstancesTaskTests
         Assert.Equal(25, task.PageSize);
         Assert.Equal("-CreatedAt", task.Sort);
         Assert.NotNull(task.Filter);
-        Assert.Equal(2, task.Filter.Length);
-        Assert.Contains("status:active", task.Filter);
-        Assert.Contains("type:premium", task.Filter);
+        Assert.Equal("status:active", task.Filter);
         Assert.True(task.UseDapr);
     }
 
@@ -340,30 +338,23 @@ public class GetInstancesTaskTests
     [Fact]
     public void SetFilter_ShouldUpdateFilter()
     {
-        // Arrange
         var task = GetInstancesTask.CreateEmpty();
-        var filters = new[] { "status:active", "type:premium" };
+        var filter = "status:active";
 
-        // Act
-        task.SetFilter(filters);
+        task.SetFilter(filter);
 
-        // Assert
         Assert.NotNull(task.Filter);
-        Assert.Equal(2, task.Filter.Length);
-        Assert.Equal(filters, task.Filter);
+        Assert.Equal(filter, task.Filter);
     }
 
     [Fact]
     public void SetFilter_ShouldAcceptNull()
     {
-        // Arrange
         var task = GetInstancesTask.CreateEmpty();
-        task.SetFilter(new[] { "test" });
+        task.SetFilter("test");
 
-        // Act
         task.SetFilter(null);
 
-        // Assert
         Assert.Null(task.Filter);
     }
 
@@ -469,14 +460,11 @@ public class GetInstancesTaskTests
             }
             """;
 
-        // Act
         var task = GetInstancesTask.Create(config.ToJsonElement());
 
-        // Assert
+        // Array: first element is used
         Assert.NotNull(task.Filter);
-        Assert.Equal(2, task.Filter.Length);
-        Assert.Contains("status:active", task.Filter);
-        Assert.Contains("type:premium", task.Filter);
+        Assert.Equal("status:active", task.Filter);
     }
 
     [Fact]

--- a/test/BBT.Workflow.Domain.Tests/Factories/WorkflowTaskFactory.cs
+++ b/test/BBT.Workflow.Domain.Tests/Factories/WorkflowTaskFactory.cs
@@ -31,11 +31,11 @@ public static class WorkflowTaskFactory
         int page = 1,
         int pageSize = 10,
         string? sort = null,
-        string[]? filter = null,
+        string? filter = null,
         bool useDapr = false)
     {
-        var filterJson = filter != null 
-            ? $@"""filter"": [{string.Join(", ", filter.Select(f => $@"""{f}"""))}],"
+        var filterJson = !string.IsNullOrWhiteSpace(filter)
+            ? $@"""filter"": ""{filter.Replace("\"", "\\\"")}"","
             : "";
         var sortJson = sort != null ? $@"""sort"": ""{sort}""," : "";
 

--- a/test/BBT.Workflow.Domain.Tests/QueryExtensions/FilterSpecificationTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/QueryExtensions/FilterSpecificationTests.cs
@@ -40,9 +40,8 @@ public class FilterSpecificationTests : DomainTestBase<DomainEntryPoint>
     [Fact]
     public void FilterSpecification_ShouldReturnTrueExpression_WhenEmptyFilters()
     {
-        // Arrange
         var filterMappings = CreateFilterMappings();
-        var spec = new FilterSpecification<TestEntity>(Array.Empty<string>(), filterMappings);
+        var spec = new FilterSpecification<TestEntity>("", filterMappings);
 
         // Act
         var expression = spec.ToExpression();
@@ -59,7 +58,7 @@ public class FilterSpecificationTests : DomainTestBase<DomainEntryPoint>
         // Arrange
         var filterMappings = CreateFilterMappings();
         var jsonFilter = JsonSerializer.Serialize(new { Name = "John" });
-        var spec = new FilterSpecification<TestEntity>(new[] { jsonFilter }, filterMappings);
+        var spec = new FilterSpecification<TestEntity>(jsonFilter, filterMappings);
 
         // Act
         var expression = spec.ToExpression();
@@ -75,7 +74,7 @@ public class FilterSpecificationTests : DomainTestBase<DomainEntryPoint>
     {
         // Arrange
         var filterMappings = CreateFilterMappings();
-        var spec = new FilterSpecification<TestEntity>(new[] { "Name=Jane" }, filterMappings);
+        var spec = new FilterSpecification<TestEntity>("Name=Jane", filterMappings);
 
         // Act
         var expression = spec.ToExpression();
@@ -89,11 +88,9 @@ public class FilterSpecificationTests : DomainTestBase<DomainEntryPoint>
     [Fact]
     public void FilterSpecification_ShouldCombineMultipleFiltersWithAnd()
     {
-        // Arrange
         var filterMappings = CreateFilterMappings();
-        var spec = new FilterSpecification<TestEntity>(
-            new[] { "Name=John", "Age=30" }, 
-            filterMappings);
+        var jsonFilter = JsonSerializer.Serialize(new { Name = "John", Age = 30 });
+        var spec = new FilterSpecification<TestEntity>(jsonFilter, filterMappings);
 
         // Act
         var expression = spec.ToExpression();
@@ -110,9 +107,7 @@ public class FilterSpecificationTests : DomainTestBase<DomainEntryPoint>
     {
         // Arrange
         var filterMappings = CreateFilterMappings();
-        var spec = new FilterSpecification<TestEntity>(
-            new[] { "InvalidFormat" }, 
-            filterMappings);
+        var spec = new FilterSpecification<TestEntity>("InvalidFormat", filterMappings);
 
         // Act
         var expression = spec.ToExpression();
@@ -127,9 +122,7 @@ public class FilterSpecificationTests : DomainTestBase<DomainEntryPoint>
     {
         // Arrange
         var filterMappings = CreateFilterMappings();
-        var spec = new FilterSpecification<TestEntity>(
-            new[] { "UnmappedProperty=value" }, 
-            filterMappings);
+        var spec = new FilterSpecification<TestEntity>("UnmappedProperty=value", filterMappings);
 
         // Act
         var expression = spec.ToExpression();
@@ -145,7 +138,7 @@ public class FilterSpecificationTests : DomainTestBase<DomainEntryPoint>
         // Arrange
         var filterMappings = CreateFilterMappings();
         var jsonFilter = JsonSerializer.Serialize(new { Name = "Alice", Age = 25 });
-        var spec = new FilterSpecification<TestEntity>(new[] { jsonFilter }, filterMappings);
+        var spec = new FilterSpecification<TestEntity>(jsonFilter, filterMappings);
 
         // Act
         var expression = spec.ToExpression();
@@ -162,7 +155,7 @@ public class FilterSpecificationTests : DomainTestBase<DomainEntryPoint>
     {
         // Arrange
         var filterMappings = CreateFilterMappings();
-        var spec = new FilterSpecification<TestEntity>(new[] { "name=John" }, filterMappings);
+        var spec = new FilterSpecification<TestEntity>("name=John", filterMappings);
 
         // Act
         var expression = spec.ToExpression();
@@ -178,7 +171,7 @@ public class FilterSpecificationTests : DomainTestBase<DomainEntryPoint>
     {
         // Arrange
         var filterMappings = CreateFilterMappings();
-        var spec = new FilterSpecification<TestEntity>(new[] { "  Name  =  Jane  " }, filterMappings);
+        var spec = new FilterSpecification<TestEntity>("  Name  =  Jane  ", filterMappings);
 
         // Act
         var expression = spec.ToExpression();
@@ -194,7 +187,7 @@ public class FilterSpecificationTests : DomainTestBase<DomainEntryPoint>
     {
         // Arrange
         var filterMappings = CreateFilterMappings();
-        var spec = new FilterSpecification<TestEntity>(new[] { "Name=John" }, filterMappings);
+        var spec = new FilterSpecification<TestEntity>("Name=John", filterMappings);
         var query = CreateTestEntities().AsQueryable();
 
         // Act
@@ -208,12 +201,9 @@ public class FilterSpecificationTests : DomainTestBase<DomainEntryPoint>
     [Fact]
     public void FilterSpecification_ShouldHandleMixedJsonAndKeyValueFilters()
     {
-        // Arrange
         var filterMappings = CreateFilterMappings();
-        var jsonFilter = JsonSerializer.Serialize(new { Name = "Alice" });
-        var spec = new FilterSpecification<TestEntity>(
-            new[] { jsonFilter, "Age=25" }, 
-            filterMappings);
+        var jsonFilter = JsonSerializer.Serialize(new { Name = "Alice", Age = 25 });
+        var spec = new FilterSpecification<TestEntity>(jsonFilter, filterMappings);
 
         // Act
         var expression = spec.ToExpression();
@@ -230,7 +220,7 @@ public class FilterSpecificationTests : DomainTestBase<DomainEntryPoint>
     {
         // Arrange
         var filterMappings = CreateFilterMappings();
-        var spec = new FilterSpecification<TestEntity>(new[] { "IsActive=true" }, filterMappings);
+        var spec = new FilterSpecification<TestEntity>("IsActive=true", filterMappings);
 
         // Act
         var expression = spec.ToExpression();
@@ -246,7 +236,7 @@ public class FilterSpecificationTests : DomainTestBase<DomainEntryPoint>
     {
         // Arrange
         var filterMappings = CreateFilterMappings();
-        var spec = new FilterSpecification<TestEntity>(new[] { "Age=30" }, filterMappings);
+        var spec = new FilterSpecification<TestEntity>("Age=30", filterMappings);
 
         // Act
         var expression = spec.ToExpression();

--- a/test/BBT.Workflow.Domain.Tests/QueryExtensions/GraphQL/GraphQLFilterParserTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/QueryExtensions/GraphQL/GraphQLFilterParserTests.cs
@@ -1,0 +1,614 @@
+using System;
+using System.Linq;
+using BBT.Workflow.Definitions.GraphQL;
+using Xunit;
+
+namespace BBT.Workflow.Domain.Tests.QueryExtensions.GraphQL;
+
+/// <summary>
+/// Unit tests for GraphQLFilterParser
+/// </summary>
+public class GraphQLFilterParserTests : DomainTestBase<DomainEntryPoint>
+{
+    #region ParseFilter Tests
+
+    [Fact]
+    public void ParseFilter_ShouldReturnNull_WhenNullInput()
+    {
+        // Act
+        var result = GraphQLFilterParser.ParseFilter(null);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ParseFilter_ShouldReturnNull_WhenEmptyInput()
+    {
+        // Act
+        var result = GraphQLFilterParser.ParseFilter("");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ParseFilter_ShouldReturnNull_WhenWhitespaceInput()
+    {
+        // Act
+        var result = GraphQLFilterParser.ParseFilter("   ");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ParseFilter_ShouldParseSimpleEquality()
+    {
+        // Arrange
+        var json = """{"attributes":{"clientId":{"eq":122}}}""";
+
+        // Act
+        var result = GraphQLFilterParser.ParseFilter(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(FilterNodeType.Condition, result.NodeType);
+        Assert.NotNull(result.Attributes);
+        Assert.True(result.Attributes.ContainsKey("clientId"));
+        Assert.Equal(122L, result.Attributes["clientId"].Eq);
+    }
+
+    [Fact]
+    public void ParseFilter_ShouldParseStringEquality()
+    {
+        // Arrange
+        var json = """{"attributes":{"status":{"eq":"active"}}}""";
+
+        // Act
+        var result = GraphQLFilterParser.ParseFilter(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(FilterNodeType.Condition, result.NodeType);
+        Assert.NotNull(result.Attributes);
+        Assert.Equal("active", result.Attributes["status"].Eq);
+    }
+
+    [Fact]
+    public void ParseFilter_ShouldParseMultipleConditions()
+    {
+        // Arrange
+        var json = """{"attributes":{"clientId":{"eq":122},"testValue":{"gt":2}}}""";
+
+        // Act
+        var result = GraphQLFilterParser.ParseFilter(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(FilterNodeType.Condition, result.NodeType);
+        Assert.NotNull(result.Attributes);
+        Assert.Equal(2, result.Attributes.Count);
+        Assert.Equal(122L, result.Attributes["clientId"].Eq);
+        Assert.Equal(2L, result.Attributes["testValue"].Gt);
+    }
+
+    [Fact]
+    public void ParseFilter_ShouldParseAndOperator()
+    {
+        // Arrange
+        var json = """
+        {
+            "and": [
+                {"attributes":{"status":{"eq":"active"}}},
+                {"attributes":{"amount":{"gt":100}}}
+            ]
+        }
+        """;
+
+        // Act
+        var result = GraphQLFilterParser.ParseFilter(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(FilterNodeType.And, result.NodeType);
+        Assert.NotNull(result.And);
+        Assert.Equal(2, result.And.Count);
+    }
+
+    [Fact]
+    public void ParseFilter_ShouldParseOrOperator()
+    {
+        // Arrange
+        var json = """
+        {
+            "or": [
+                {"attributes":{"status":{"eq":"active"}}},
+                {"attributes":{"status":{"eq":"pending"}}}
+            ]
+        }
+        """;
+
+        // Act
+        var result = GraphQLFilterParser.ParseFilter(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(FilterNodeType.Or, result.NodeType);
+        Assert.NotNull(result.Or);
+        Assert.Equal(2, result.Or.Count);
+    }
+
+    [Fact]
+    public void ParseFilter_ShouldParseNotOperator()
+    {
+        // Arrange
+        var json = """
+        {
+            "not": {"attributes":{"status":{"eq":"deleted"}}}
+        }
+        """;
+
+        // Act
+        var result = GraphQLFilterParser.ParseFilter(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(FilterNodeType.Not, result.NodeType);
+        Assert.NotNull(result.Not);
+        Assert.Equal(FilterNodeType.Condition, result.Not.NodeType);
+    }
+
+    [Fact]
+    public void ParseFilter_ShouldParseComplexNestedLogic()
+    {
+        // Arrange
+        var json = """
+        {
+            "and": [
+                {
+                    "or": [
+                        {"attributes":{"status":{"eq":"active"}}},
+                        {"attributes":{"status":{"eq":"pending"}}}
+                    ]
+                },
+                {"attributes":{"amount":{"gt":100}}}
+            ]
+        }
+        """;
+
+        // Act
+        var result = GraphQLFilterParser.ParseFilter(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(FilterNodeType.And, result.NodeType);
+        Assert.NotNull(result.And);
+        Assert.Equal(2, result.And.Count);
+        Assert.Equal(FilterNodeType.Or, result.And[0].NodeType);
+        Assert.Equal(FilterNodeType.Condition, result.And[1].NodeType);
+    }
+
+    [Fact]
+    public void ParseFilter_ShouldParseAllComparisonOperators()
+    {
+        // Arrange
+        var json = """
+        {
+            "attributes": {
+                "field1": {"eq": 1},
+                "field2": {"ne": 2},
+                "field3": {"gt": 3},
+                "field4": {"ge": 4},
+                "field5": {"lt": 5},
+                "field6": {"le": 6}
+            }
+        }
+        """;
+
+        // Act
+        var result = GraphQLFilterParser.ParseFilter(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotNull(result.Attributes);
+        Assert.Equal(6, result.Attributes.Count);
+        Assert.Equal(1L, result.Attributes["field1"].Eq);
+        Assert.Equal(2L, result.Attributes["field2"].Ne);
+        Assert.Equal(3L, result.Attributes["field3"].Gt);
+        Assert.Equal(4L, result.Attributes["field4"].Ge);
+        Assert.Equal(5L, result.Attributes["field5"].Lt);
+        Assert.Equal(6L, result.Attributes["field6"].Le);
+    }
+
+    [Fact]
+    public void ParseFilter_ShouldParseStringOperators()
+    {
+        // Arrange
+        var json = """
+        {
+            "attributes": {
+                "name": {"like": "John"},
+                "email": {"startswith": "test@"},
+                "domain": {"endswith": ".com"}
+            }
+        }
+        """;
+
+        // Act
+        var result = GraphQLFilterParser.ParseFilter(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotNull(result.Attributes);
+        Assert.Equal("John", result.Attributes["name"].Like);
+        Assert.Equal("test@", result.Attributes["email"].StartsWith);
+        Assert.Equal(".com", result.Attributes["domain"].EndsWith);
+    }
+
+    [Fact]
+    public void ParseFilter_ShouldParseBetweenOperator()
+    {
+        // Arrange
+        var json = """{"attributes":{"age":{"between":[18, 65]}}}""";
+
+        // Act
+        var result = GraphQLFilterParser.ParseFilter(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotNull(result.Attributes);
+        Assert.NotNull(result.Attributes["age"].Between);
+        Assert.Equal(2, result.Attributes["age"].Between!.Length);
+    }
+
+    [Fact]
+    public void ParseFilter_ShouldParseInOperator()
+    {
+        // Arrange
+        var json = """{"attributes":{"status":{"in":["active","pending","processing"]}}}""";
+
+        // Act
+        var result = GraphQLFilterParser.ParseFilter(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotNull(result.Attributes);
+        Assert.NotNull(result.Attributes["status"].In);
+        Assert.Equal(3, result.Attributes["status"].In!.Length);
+    }
+
+    [Fact]
+    public void ParseFilter_ShouldParseNotInOperator()
+    {
+        // Arrange
+        var json = """{"attributes":{"status":{"nin":["cancelled","deleted"]}}}""";
+
+        // Act
+        var result = GraphQLFilterParser.ParseFilter(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotNull(result.Attributes);
+        Assert.NotNull(result.Attributes["status"].NotIn);
+        Assert.Equal(2, result.Attributes["status"].NotIn!.Length);
+    }
+
+    [Fact]
+    public void ParseFilter_ShouldParseIsNullTrue()
+    {
+        // Arrange
+        var json = """{"attributes":{"optionalField":{"isNull":true}}}""";
+
+        // Act
+        var result = GraphQLFilterParser.ParseFilter(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotNull(result.Attributes);
+        Assert.True(result.Attributes["optionalField"].IsNull);
+    }
+
+    [Fact]
+    public void ParseFilter_ShouldParseIsNullFalse()
+    {
+        // Arrange
+        var json = """{"attributes":{"requiredField":{"isNull":false}}}""";
+
+        // Act
+        var result = GraphQLFilterParser.ParseFilter(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotNull(result.Attributes);
+        Assert.False(result.Attributes["requiredField"].IsNull);
+    }
+
+    [Fact]
+    public void ParseFilter_ShouldThrowOnInvalidJson()
+    {
+        // Arrange
+        var json = "not valid json {{{";
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => GraphQLFilterParser.ParseFilter(json));
+    }
+
+    #endregion
+
+    #region ParseGroupBy Tests
+
+    [Fact]
+    public void ParseGroupBy_ShouldReturnNull_WhenNullInput()
+    {
+        // Act
+        var result = GraphQLFilterParser.ParseGroupBy(null);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ParseGroupBy_ShouldParseSingleField()
+    {
+        // Arrange
+        var json = """{"field":"attributes.status"}""";
+
+        // Act
+        var result = GraphQLFilterParser.ParseGroupBy(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("attributes.status", result.Field);
+    }
+
+    [Fact]
+    public void ParseGroupBy_ShouldParseMultipleFields()
+    {
+        // Arrange
+        var json = """{"fields":["attributes.status","attributes.category"]}""";
+
+        // Act
+        var result = GraphQLFilterParser.ParseGroupBy(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotNull(result.Fields);
+        Assert.Equal(2, result.Fields.Count);
+    }
+
+    [Fact]
+    public void ParseGroupBy_ShouldParseWithAggregations()
+    {
+        // Arrange
+        var json = """
+        {
+            "field": "attributes.status",
+            "aggregations": {
+                "count": true,
+                "sum": "attributes.amount"
+            }
+        }
+        """;
+
+        // Act
+        var result = GraphQLFilterParser.ParseGroupBy(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotNull(result.Aggregations);
+        Assert.True(result.Aggregations.Count is bool b && b);
+        Assert.Equal("attributes.amount", result.Aggregations.Sum);
+    }
+
+    [Fact]
+    public void ParseGroupBy_GetFields_ShouldCombineSingleAndMultipleFields()
+    {
+        // Arrange
+        var json = """
+        {
+            "field": "attributes.status",
+            "fields": ["attributes.category", "attributes.type"]
+        }
+        """;
+
+        // Act
+        var result = GraphQLFilterParser.ParseGroupBy(json);
+        var fields = result!.GetFields();
+
+        // Assert
+        Assert.Equal(3, fields.Count);
+        Assert.Contains("attributes.status", fields);
+        Assert.Contains("attributes.category", fields);
+        Assert.Contains("attributes.type", fields);
+    }
+
+    #endregion
+
+    #region ParseAggregations Tests
+
+    [Fact]
+    public void ParseAggregations_ShouldReturnNull_WhenNullInput()
+    {
+        // Act
+        var result = GraphQLFilterParser.ParseAggregations(null);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ParseAggregations_ShouldParseCount()
+    {
+        // Arrange
+        var json = """{"count":true}""";
+
+        // Act
+        var result = GraphQLFilterParser.ParseAggregations(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.True(result.Count is bool b && b);
+    }
+
+    [Fact]
+    public void ParseAggregations_ShouldParseAllFunctions()
+    {
+        // Arrange
+        var json = """
+        {
+            "count": true,
+            "sum": "attributes.amount",
+            "avg": "attributes.amount",
+            "min": "attributes.amount",
+            "max": "attributes.amount"
+        }
+        """;
+
+        // Act
+        var result = GraphQLFilterParser.ParseAggregations(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.True(result.HasAggregations);
+        Assert.Equal("attributes.amount", result.Sum);
+        Assert.Equal("attributes.amount", result.Avg);
+        Assert.Equal("attributes.amount", result.Min);
+        Assert.Equal("attributes.amount", result.Max);
+    }
+
+    #endregion
+
+    #region FlattenToConditions Tests
+
+    [Fact]
+    public void FlattenToConditions_ShouldReturnEmpty_WhenNullNode()
+    {
+        // Act
+        var result = GraphQLFilterParser.FlattenToConditions(null);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void FlattenToConditions_ShouldFlattenSimpleCondition()
+    {
+        // Arrange
+        var json = """{"attributes":{"clientId":{"eq":"122"}}}""";
+        var node = GraphQLFilterParser.ParseFilter(json);
+
+        // Act
+        var result = GraphQLFilterParser.FlattenToConditions(node);
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal("clientId", result[0].Field);
+        Assert.Equal("eq", result[0].Operator);
+        Assert.Equal("122", result[0].Value);
+    }
+
+    [Fact]
+    public void FlattenToConditions_ShouldFlattenMultipleConditions()
+    {
+        // Arrange
+        var json = """{"attributes":{"clientId":{"eq":"122"},"status":{"ne":"deleted"}}}""";
+        var node = GraphQLFilterParser.ParseFilter(json);
+
+        // Act
+        var result = GraphQLFilterParser.FlattenToConditions(node);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public void FlattenToConditions_ShouldPreserveLegacyFormat()
+    {
+        // Arrange
+        var json = """{"attributes":{"clientId":{"eq":"122"}}}""";
+        var node = GraphQLFilterParser.ParseFilter(json);
+
+        // Act
+        var result = GraphQLFilterParser.FlattenToConditions(node);
+        var legacyFormat = result[0].ToLegacyFormat();
+
+        // Assert
+        Assert.Equal("attributes=clientId=eq:122", legacyFormat);
+    }
+
+    #endregion
+
+    #region ParseOrderBy Tests
+
+    [Fact]
+    public void ParseOrderBy_ShouldReturnNull_WhenNullInput()
+    {
+        var result = GraphQLFilterParser.ParseOrderBy(null);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ParseOrderBy_ShouldReturnNull_WhenEmptyInput()
+    {
+        var result = GraphQLFilterParser.ParseOrderBy("");
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ParseOrderBy_ShouldParseSingleField_WithDirection()
+    {
+        var json = """{"field":"createdAt","direction":"desc"}""";
+        var result = GraphQLFilterParser.ParseOrderBy(json);
+        Assert.NotNull(result);
+        var entries = result!.GetEntries();
+        Assert.Single(entries);
+        Assert.Equal("createdAt", entries[0].Field);
+        Assert.Equal("desc", entries[0].Direction);
+    }
+
+    [Fact]
+    public void ParseOrderBy_ShouldParseSingleField_DefaultAsc()
+    {
+        var json = """{"field":"status"}""";
+        var result = GraphQLFilterParser.ParseOrderBy(json);
+        Assert.NotNull(result);
+        var entries = result!.GetEntries();
+        Assert.Single(entries);
+        Assert.Equal("asc", entries[0].Direction);
+    }
+
+    [Fact]
+    public void ParseOrderBy_ShouldParseMultipleFields()
+    {
+        var json = """{"fields":[{"field":"status","direction":"asc"},{"field":"createdAt","direction":"desc"}]}""";
+        var result = GraphQLFilterParser.ParseOrderBy(json);
+        Assert.NotNull(result);
+        var entries = result!.GetEntries();
+        Assert.Equal(2, entries.Count);
+        Assert.Equal("status", entries[0].Field);
+        Assert.Equal("asc", entries[0].Direction);
+        Assert.Equal("createdAt", entries[1].Field);
+        Assert.Equal("desc", entries[1].Direction);
+    }
+
+    [Fact]
+    public void ParseOrderBy_ShouldReturnNull_WhenInvalidJson()
+    {
+        var result = GraphQLFilterParser.ParseOrderBy("not valid json");
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ParseOrderBy_ShouldReturnNull_WhenEmptyField()
+    {
+        var result = GraphQLFilterParser.ParseOrderBy("""{"field":"","direction":"asc"}""");
+        Assert.Null(result);
+    }
+
+    #endregion
+}
+
+
+
+

--- a/test/BBT.Workflow.Domain.Tests/QueryExtensions/GraphQLInstanceColumnFilterTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/QueryExtensions/GraphQLInstanceColumnFilterTests.cs
@@ -1,0 +1,208 @@
+using System;
+using System.Text.Json;
+using BBT.Workflow.Definitions.GraphQL;
+using Xunit;
+using Shouldly;
+
+namespace BBT.Workflow.Domain.Tests.QueryExtensions;
+
+/// <summary>
+/// Tests for GraphQL format with Instance columns at root level
+/// Validates that {"key":{"eq":"1111"}} format works correctly
+/// </summary>
+public class GraphQLInstanceColumnFilterTests
+{
+    [Fact]
+    public void ParseFilter_WithRootLevelKey_ShouldParseCorrectly()
+    {
+        // Arrange
+        var filterJson = @"{""key"":{""eq"":""1111""}}";
+
+        // Act
+        var filterNode = GraphQLFilterParser.ParseFilter(filterJson);
+
+        // Assert
+        filterNode.ShouldNotBeNull();
+        filterNode.NodeType.ShouldBe(FilterNodeType.Condition);
+        filterNode.Attributes.ShouldNotBeNull();
+        filterNode.Attributes.ShouldContainKey("key");
+        filterNode.Attributes["key"].Eq.ShouldBe("1111");
+    }
+
+    [Fact]
+    public void ParseFilter_WithRootLevelStatus_ShouldParseCorrectly()
+    {
+        // Arrange
+        var filterJson = @"{""status"":{""eq"":""Active""}}";
+
+        // Act
+        var filterNode = GraphQLFilterParser.ParseFilter(filterJson);
+
+        // Assert
+        filterNode.ShouldNotBeNull();
+        filterNode.NodeType.ShouldBe(FilterNodeType.Condition);
+        filterNode.Attributes.ShouldNotBeNull();
+        filterNode.Attributes.ShouldContainKey("status");
+        filterNode.Attributes["status"].Eq.ShouldBe("Active");
+    }
+
+    [Fact]
+    public void ParseFilter_WithMixedRootAndAttributes_ShouldParseCorrectly()
+    {
+        // Arrange
+        var filterJson = @"{
+            ""key"":{""eq"":""1111""},
+            ""status"":{""eq"":""Active""},
+            ""attributes"":{
+                ""triggerId"":{""eq"":""82111090771""}
+            }
+        }";
+
+        // Act
+        var filterNode = GraphQLFilterParser.ParseFilter(filterJson);
+
+        // Assert
+        filterNode.ShouldNotBeNull();
+        filterNode.NodeType.ShouldBe(FilterNodeType.Condition);
+        filterNode.Attributes.ShouldNotBeNull();
+        
+        // Root level fields
+        filterNode.Attributes.ShouldContainKey("key");
+        filterNode.Attributes["key"].Eq.ShouldBe("1111");
+        
+        filterNode.Attributes.ShouldContainKey("status");
+        filterNode.Attributes["status"].Eq.ShouldBe("Active");
+        
+        // Nested attributes field
+        filterNode.Attributes.ShouldContainKey("triggerId");
+        filterNode.Attributes["triggerId"].Eq.ShouldBe("82111090771");
+    }
+
+    [Fact]
+    public void ParseFilter_WithRootLevelCreatedAt_ShouldParseCorrectly()
+    {
+        // Arrange
+        var filterJson = @"{""createdAt"":{""gt"":""2024-01-01""}}";
+
+        // Act
+        var filterNode = GraphQLFilterParser.ParseFilter(filterJson);
+
+        // Assert
+        filterNode.ShouldNotBeNull();
+        filterNode.NodeType.ShouldBe(FilterNodeType.Condition);
+        filterNode.Attributes.ShouldNotBeNull();
+        filterNode.Attributes.ShouldContainKey("createdAt");
+        filterNode.Attributes["createdAt"].Gt.ShouldBe("2024-01-01");
+    }
+
+    [Fact]
+    public void ParseFilter_WithRootLevelFlow_ShouldParseCorrectly()
+    {
+        // Arrange
+        var filterJson = @"{""flow"":{""like"":""workflow""}}";
+
+        // Act
+        var filterNode = GraphQLFilterParser.ParseFilter(filterJson);
+
+        // Assert
+        filterNode.ShouldNotBeNull();
+        filterNode.NodeType.ShouldBe(FilterNodeType.Condition);
+        filterNode.Attributes.ShouldNotBeNull();
+        filterNode.Attributes.ShouldContainKey("flow");
+        filterNode.Attributes["flow"].Like.ShouldBe("workflow");
+    }
+
+    [Fact]
+    public void ParseFilter_WithMultipleRootLevelInstanceColumns_ShouldParseCorrectly()
+    {
+        // Arrange
+        var filterJson = @"{
+            ""key"":{""eq"":""1111""},
+            ""status"":{""in"":[""Active"",""Busy""]},
+            ""flow"":{""like"":""payment""},
+            ""createdAt"":{""between"":[""2024-01-01"",""2024-12-31""]}
+        }";
+
+        // Act
+        var filterNode = GraphQLFilterParser.ParseFilter(filterJson);
+
+        // Assert
+        filterNode.ShouldNotBeNull();
+        filterNode.NodeType.ShouldBe(FilterNodeType.Condition);
+        filterNode.Attributes.ShouldNotBeNull();
+        filterNode.Attributes.Count.ShouldBe(4);
+        
+        filterNode.Attributes["key"].Eq.ShouldBe("1111");
+        filterNode.Attributes["status"].In.ShouldNotBeNull();
+        filterNode.Attributes["flow"].Like.ShouldBe("payment");
+        filterNode.Attributes["createdAt"].Between.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void ParseFilter_WithAndOperatorAndRootLevelColumns_ShouldParseCorrectly()
+    {
+        // Arrange
+        var filterJson = @"{
+            ""and"":[
+                {""key"":{""eq"":""1111""}},
+                {""status"":{""eq"":""Active""}}
+            ]
+        }";
+
+        // Act
+        var filterNode = GraphQLFilterParser.ParseFilter(filterJson);
+
+        // Assert
+        filterNode.ShouldNotBeNull();
+        filterNode.NodeType.ShouldBe(FilterNodeType.And);
+        filterNode.And.ShouldNotBeNull();
+        filterNode.And.Count.ShouldBe(2);
+        
+        // First condition
+        filterNode.And[0].NodeType.ShouldBe(FilterNodeType.Condition);
+        filterNode.And[0].Attributes.ShouldContainKey("key");
+        
+        // Second condition
+        filterNode.And[1].NodeType.ShouldBe(FilterNodeType.Condition);
+        filterNode.And[1].Attributes.ShouldContainKey("status");
+    }
+
+    [Fact]
+    public void ParseFilter_WithOrOperatorAndRootLevelColumns_ShouldParseCorrectly()
+    {
+        // Arrange
+        var filterJson = @"{
+            ""or"":[
+                {""key"":{""eq"":""1111""}},
+                {""key"":{""eq"":""2222""}}
+            ]
+        }";
+
+        // Act
+        var filterNode = GraphQLFilterParser.ParseFilter(filterJson);
+
+        // Assert
+        filterNode.ShouldNotBeNull();
+        filterNode.NodeType.ShouldBe(FilterNodeType.Or);
+        filterNode.Or.ShouldNotBeNull();
+        filterNode.Or.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void ParseFilter_BackwardCompatibility_AttributesFormat_ShouldStillWork()
+    {
+        // Arrange - Old format should still work
+        var filterJson = @"{""attributes"":{""triggerId"":{""eq"":""82111090771""}}}";
+
+        // Act
+        var filterNode = GraphQLFilterParser.ParseFilter(filterJson);
+
+        // Assert
+        filterNode.ShouldNotBeNull();
+        filterNode.NodeType.ShouldBe(FilterNodeType.Condition);
+        filterNode.Attributes.ShouldNotBeNull();
+        filterNode.Attributes.ShouldContainKey("triggerId");
+        filterNode.Attributes["triggerId"].Eq.ShouldBe("82111090771");
+    }
+}
+

--- a/test/BBT.Workflow.Domain.Tests/QueryExtensions/InstanceColumnFilterTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/QueryExtensions/InstanceColumnFilterTests.cs
@@ -1,0 +1,507 @@
+using System;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Instances;
+using Xunit;
+using Shouldly;
+
+namespace BBT.Workflow.Domain.Tests.QueryExtensions;
+
+/// <summary>
+/// Unit tests for Instance column filtering functionality
+/// Tests InstanceFieldDiscriminator and InstanceColumnConditionBuilder
+/// </summary>
+public class InstanceColumnFilterTests
+{
+    #region InstanceFieldDiscriminator Tests
+
+    [Theory]
+    [InlineData("Key", true)]
+    [InlineData("key", true)]
+    [InlineData("Status", true)]
+    [InlineData("status", true)]
+    [InlineData("Flow", true)]
+    [InlineData("flow", true)]
+    [InlineData("CurrentState", true)]
+    [InlineData("State", true)] // Alias
+    [InlineData("CreatedAt", true)]
+    [InlineData("createdat", true)]
+    [InlineData("ModifiedAt", true)]
+    [InlineData("CompletedAt", true)]
+    [InlineData("IsTransient", true)]
+    [InlineData("attributes", false)]
+    [InlineData("triggerId", false)]
+    [InlineData("customField", false)]
+    [InlineData("", false)]
+    public void IsInstanceColumn_ShouldIdentifyColumnCorrectly(string fieldName, bool expectedResult)
+    {
+        // Act
+        var result = InstanceFieldDiscriminator.IsInstanceColumn(fieldName);
+
+        // Assert
+        result.ShouldBe(expectedResult);
+    }
+
+    [Theory]
+    [InlineData("Key", "Key")]
+    [InlineData("key", "Key")]
+    [InlineData("Status", "Status")]
+    [InlineData("status", "Status")]
+    [InlineData("State", "CurrentState")] // Alias mapping
+    [InlineData("state", "CurrentState")]
+    [InlineData("CreatedAt", "CreatedAt")]
+    [InlineData("createdat", "CreatedAt")]
+    public void GetInstanceColumnName_ShouldReturnProperCaseName(string input, string expected)
+    {
+        // Act
+        var result = InstanceFieldDiscriminator.GetInstanceColumnName(input);
+
+        // Assert
+        result.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void GetInstanceColumnName_ShouldThrowForInvalidColumn()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentException>(() => 
+            InstanceFieldDiscriminator.GetInstanceColumnName("invalidColumn"));
+    }
+
+    [Fact]
+    public void SeparateFilters_ShouldSeparateInstanceAndJsonFilters()
+    {
+        // Arrange
+        var filters = new[]
+        {
+            "key=eq:1111",
+            "status=eq:A",
+            "attributes=triggerId=eq:82111090771",
+            "createdAt=gt:2024-01-01"
+        };
+
+        // Act
+        var (instanceFilters, jsonFilters) = InstanceFieldDiscriminator.SeparateFilters(filters);
+
+        // Assert
+        instanceFilters.Length.ShouldBe(3);
+        instanceFilters.ShouldContain("key=eq:1111");
+        instanceFilters.ShouldContain("status=eq:A");
+        instanceFilters.ShouldContain("createdAt=gt:2024-01-01");
+
+        jsonFilters.Length.ShouldBe(1);
+        jsonFilters.ShouldContain("attributes=triggerId=eq:82111090771");
+    }
+
+    [Fact]
+    public void SeparateFilters_ShouldHandleEmptyArray()
+    {
+        // Arrange
+        var filters = Array.Empty<string>();
+
+        // Act
+        var (instanceFilters, jsonFilters) = InstanceFieldDiscriminator.SeparateFilters(filters);
+
+        // Assert
+        instanceFilters.ShouldBeEmpty();
+        jsonFilters.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("Active", "A")]
+    [InlineData("active", "A")]
+    [InlineData("Busy", "B")]
+    [InlineData("Completed", "C")]
+    [InlineData("Faulted", "F")]
+    [InlineData("Passive", "P")]
+    [InlineData("A", "A")] // Direct code
+    [InlineData("B", "B")]
+    public void ResolveStatusValue_ShouldMapStatusNamesToCodes(string input, string expected)
+    {
+        // Act
+        var result = InstanceFieldDiscriminator.ResolveStatusValue(input);
+
+        // Assert
+        result.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void ResolveStatusValues_ShouldMapMultipleValues()
+    {
+        // Arrange
+        var values = new[] { "Active", "Busy", "A" };
+
+        // Act
+        var result = InstanceFieldDiscriminator.ResolveStatusValues(values);
+
+        // Assert
+        result.Length.ShouldBe(3);
+        result[0].ShouldBe("A");
+        result[1].ShouldBe("B");
+        result[2].ShouldBe("A");
+    }
+
+    #endregion
+
+    #region InstanceColumnConditionBuilder Tests
+
+    [Fact]
+    public void BuildCondition_Equals_ShouldBuildCorrectCondition()
+    {
+        // Arrange
+        var parameterIndex = 0;
+
+        // Act
+        var (condition, parameters) = InstanceColumnConditionBuilder.BuildCondition(
+            "Key", "eq", "1111", ref parameterIndex);
+
+        // Assert
+        condition.ShouldBe("s.\"Key\" = {0}");
+        parameters.Count.ShouldBe(1);
+        parameters[0].Value.ShouldBe("1111");
+        parameterIndex.ShouldBe(1);
+    }
+
+    [Fact]
+    public void BuildCondition_NotEquals_ShouldBuildCorrectCondition()
+    {
+        // Arrange
+        var parameterIndex = 0;
+
+        // Act
+        var (condition, parameters) = InstanceColumnConditionBuilder.BuildCondition(
+            "Status", "ne", "Active", ref parameterIndex);
+
+        // Assert
+        condition.ShouldBe("s.\"Status\" != {0}");
+        parameters.Count.ShouldBe(1);
+        parameters[0].Value.ShouldBe("A"); // Should be resolved to code
+        parameterIndex.ShouldBe(1);
+    }
+
+    [Fact]
+    public void BuildCondition_GreaterThan_ShouldBuildCorrectCondition()
+    {
+        // Arrange
+        var parameterIndex = 0;
+
+        // Act
+        var (condition, parameters) = InstanceColumnConditionBuilder.BuildCondition(
+            "CreatedAt", "gt", "2024-01-01", ref parameterIndex);
+
+        // Assert
+        condition.ShouldBe("s.\"CreatedAt\" > {0}");
+        parameters.Count.ShouldBe(1);
+        parameterIndex.ShouldBe(1);
+    }
+
+    [Fact]
+    public void BuildCondition_Between_ShouldBuildCorrectCondition()
+    {
+        // Arrange
+        var parameterIndex = 0;
+
+        // Act
+        var (condition, parameters) = InstanceColumnConditionBuilder.BuildCondition(
+            "CreatedAt", "between", "2024-01-01,2024-12-31", ref parameterIndex);
+
+        // Assert
+        condition.ShouldBe("s.\"CreatedAt\" BETWEEN {0} AND {1}");
+        parameters.Count.ShouldBe(2);
+        parameterIndex.ShouldBe(2);
+    }
+
+    [Fact]
+    public void BuildCondition_Like_ShouldBuildCorrectCondition()
+    {
+        // Arrange
+        var parameterIndex = 0;
+
+        // Act
+        var (condition, parameters) = InstanceColumnConditionBuilder.BuildCondition(
+            "Key", "like", "test", ref parameterIndex);
+
+        // Assert
+        condition.ShouldBe("s.\"Key\" ILIKE {0}");
+        parameters.Count.ShouldBe(1);
+        parameters[0].Value.ShouldBe("%test%");
+        parameterIndex.ShouldBe(1);
+    }
+
+    [Fact]
+    public void BuildCondition_StartsWith_ShouldBuildCorrectCondition()
+    {
+        // Arrange
+        var parameterIndex = 0;
+
+        // Act
+        var (condition, parameters) = InstanceColumnConditionBuilder.BuildCondition(
+            "Flow", "startswith", "workflow", ref parameterIndex);
+
+        // Assert
+        condition.ShouldBe("s.\"Flow\" ILIKE {0}");
+        parameters.Count.ShouldBe(1);
+        parameters[0].Value.ShouldBe("workflow%");
+        parameterIndex.ShouldBe(1);
+    }
+
+    [Fact]
+    public void BuildCondition_EndsWith_ShouldBuildCorrectCondition()
+    {
+        // Arrange
+        var parameterIndex = 0;
+
+        // Act
+        var (condition, parameters) = InstanceColumnConditionBuilder.BuildCondition(
+            "Flow", "endswith", "flow", ref parameterIndex);
+
+        // Assert
+        condition.ShouldBe("s.\"Flow\" ILIKE {0}");
+        parameters.Count.ShouldBe(1);
+        parameters[0].Value.ShouldBe("%flow");
+        parameterIndex.ShouldBe(1);
+    }
+
+    [Fact]
+    public void BuildCondition_In_ShouldBuildCorrectCondition()
+    {
+        // Arrange
+        var parameterIndex = 0;
+
+        // Act
+        var (condition, parameters) = InstanceColumnConditionBuilder.BuildCondition(
+            "Status", "in", "Active,Busy,Completed", ref parameterIndex);
+
+        // Assert
+        condition.ShouldBe("s.\"Status\" IN ({0}, {1}, {2})");
+        parameters.Count.ShouldBe(3);
+        parameters[0].Value.ShouldBe("A"); // Resolved
+        parameters[1].Value.ShouldBe("B"); // Resolved
+        parameters[2].Value.ShouldBe("C"); // Resolved
+        parameterIndex.ShouldBe(3);
+    }
+
+    [Fact]
+    public void BuildCondition_NotIn_ShouldBuildCorrectCondition()
+    {
+        // Arrange
+        var parameterIndex = 0;
+
+        // Act
+        var (condition, parameters) = InstanceColumnConditionBuilder.BuildCondition(
+            "Key", "nin", "test1,test2", ref parameterIndex);
+
+        // Assert
+        condition.ShouldBe("s.\"Key\" NOT IN ({0}, {1})");
+        parameters.Count.ShouldBe(2);
+        parameters[0].Value.ShouldBe("test1");
+        parameters[1].Value.ShouldBe("test2");
+        parameterIndex.ShouldBe(2);
+    }
+
+    [Fact]
+    public void BuildCondition_Status_ShouldResolveStatusNames()
+    {
+        // Arrange
+        var parameterIndex = 0;
+
+        // Act
+        var (condition, parameters) = InstanceColumnConditionBuilder.BuildCondition(
+            "Status", "eq", "Active", ref parameterIndex);
+
+        // Assert
+        condition.ShouldBe("s.\"Status\" = {0}");
+        parameters.Count.ShouldBe(1);
+        parameters[0].Value.ShouldBe("A"); // Should be resolved from "Active" to "A"
+    }
+
+    [Fact]
+    public void BuildCondition_InvalidColumn_ShouldThrow()
+    {
+        // Arrange
+        var parameterIndex = 0;
+
+        // Act & Assert
+        Should.Throw<ArgumentException>(() =>
+            InstanceColumnConditionBuilder.BuildCondition(
+                "InvalidColumn", "eq", "value", ref parameterIndex));
+    }
+
+    [Fact]
+    public void BuildCondition_InvalidOperator_ShouldThrow()
+    {
+        // Arrange
+        var parameterIndex = 0;
+
+        // Act & Assert
+        Should.Throw<ArgumentException>(() =>
+            InstanceColumnConditionBuilder.BuildCondition(
+                "Key", "invalidop", "value", ref parameterIndex));
+    }
+
+    [Fact]
+    public void BuildCondition_ComparisonOnBoolean_ShouldThrow()
+    {
+        // Arrange
+        var parameterIndex = 0;
+
+        // Act & Assert
+        Should.Throw<ArgumentException>(() =>
+            InstanceColumnConditionBuilder.BuildCondition(
+                "IsTransient", "gt", "true", ref parameterIndex));
+    }
+
+    [Fact]
+    public void BuildCondition_BetweenOnBoolean_ShouldThrow()
+    {
+        // Arrange
+        var parameterIndex = 0;
+
+        // Act & Assert
+        Should.Throw<ArgumentException>(() =>
+            InstanceColumnConditionBuilder.BuildCondition(
+                "IsTransient", "between", "true,false", ref parameterIndex));
+    }
+
+    [Fact]
+    public void BuildCondition_InvalidBetweenFormat_ShouldThrow()
+    {
+        // Arrange
+        var parameterIndex = 0;
+
+        // Act & Assert
+        Should.Throw<ArgumentException>(() =>
+            InstanceColumnConditionBuilder.BuildCondition(
+                "CreatedAt", "between", "2024-01-01", ref parameterIndex));
+    }
+
+    [Fact]
+    public void BuildCondition_InvalidDateTimeValue_ShouldThrow()
+    {
+        // Arrange
+        var parameterIndex = 0;
+
+        // Act & Assert
+        Should.Throw<ArgumentException>(() =>
+            InstanceColumnConditionBuilder.BuildCondition(
+                "CreatedAt", "eq", "invalid-date", ref parameterIndex));
+    }
+
+    [Fact]
+    public void BuildCondition_InvalidBooleanValue_ShouldThrow()
+    {
+        // Arrange
+        var parameterIndex = 0;
+
+        // Act & Assert
+        Should.Throw<ArgumentException>(() =>
+            InstanceColumnConditionBuilder.BuildCondition(
+                "IsTransient", "eq", "not-a-boolean", ref parameterIndex));
+    }
+
+    [Fact]
+    public void BuildCondition_Status_InvalidOperator_ShouldThrow()
+    {
+        // Arrange
+        var parameterIndex = 0;
+
+        // Act & Assert - Status only supports eq, ne, in, nin
+        Should.Throw<ArgumentException>(() =>
+            InstanceColumnConditionBuilder.BuildCondition(
+                "Status", "gt", "Active", ref parameterIndex));
+    }
+
+    [Theory]
+    [InlineData("Key", "eq", "test-key")]
+    [InlineData("Flow", "like", "workflow")]
+    [InlineData("CurrentState", "startswith", "state")]
+    [InlineData("Status", "in", "Active,Busy")]
+    [InlineData("CreatedAt", "between", "2024-01-01,2024-12-31")]
+    [InlineData("ModifiedAt", "gt", "2024-06-01")]
+    [InlineData("CompletedAt", "le", "2024-12-31")]
+    [InlineData("IsTransient", "eq", "true")]
+    public void BuildCondition_AllColumns_ShouldWorkCorrectly(string column, string op, string value)
+    {
+        // Arrange
+        var parameterIndex = 0;
+
+        // Act
+        var (condition, parameters) = InstanceColumnConditionBuilder.BuildCondition(
+            column, op, value, ref parameterIndex);
+
+        // Assert
+        condition.ShouldNotBeNullOrEmpty();
+        parameters.ShouldNotBeEmpty();
+    }
+
+    #endregion
+
+    #region Integration Tests
+
+    [Fact]
+    public void MixedFilters_ShouldBeSeparatedCorrectly()
+    {
+        // Arrange - Mix of Instance and JSON filters
+        var filters = new[]
+        {
+            "key=eq:workflow-123",
+            "status=eq:Active",
+            "attributes=customerId=eq:12345",
+            "createdAt=gt:2024-01-01",
+            "attributes=amount=gt:1000",
+            "flow=like:payment"
+        };
+
+        // Act
+        var (instanceFilters, jsonFilters) = InstanceFieldDiscriminator.SeparateFilters(filters);
+
+        // Assert
+        instanceFilters.Length.ShouldBe(4);
+        instanceFilters.ShouldContain("key=eq:workflow-123");
+        instanceFilters.ShouldContain("status=eq:Active");
+        instanceFilters.ShouldContain("createdAt=gt:2024-01-01");
+        instanceFilters.ShouldContain("flow=like:payment");
+
+        jsonFilters.Length.ShouldBe(2);
+        jsonFilters.ShouldContain("attributes=customerId=eq:12345");
+        jsonFilters.ShouldContain("attributes=amount=gt:1000");
+    }
+
+    [Fact]
+    public void StatusFilter_WithMultipleValues_ShouldResolveAllValues()
+    {
+        // Arrange
+        var parameterIndex = 0;
+
+        // Act
+        var (condition, parameters) = InstanceColumnConditionBuilder.BuildCondition(
+            "Status", "in", "Active,Busy,F", ref parameterIndex);
+
+        // Assert
+        condition.ShouldBe("s.\"Status\" IN ({0}, {1}, {2})");
+        parameters.Count.ShouldBe(3);
+        parameters[0].Value.ShouldBe("A"); // Active -> A
+        parameters[1].Value.ShouldBe("B"); // Busy -> B
+        parameters[2].Value.ShouldBe("F"); // F -> F (already a code)
+    }
+
+    [Fact]
+    public void ParameterIndex_ShouldIncrementCorrectly()
+    {
+        // Arrange
+        var parameterIndex = 5; // Start from 5
+
+        // Act
+        var (condition1, parameters1) = InstanceColumnConditionBuilder.BuildCondition(
+            "Key", "eq", "test", ref parameterIndex);
+        var (condition2, parameters2) = InstanceColumnConditionBuilder.BuildCondition(
+            "Status", "eq", "Active", ref parameterIndex);
+
+        // Assert
+        condition1.ShouldBe("s.\"Key\" = {5}");
+        condition2.ShouldBe("s.\"Status\" = {6}");
+        parameterIndex.ShouldBe(7);
+    }
+
+    #endregion
+}
+

--- a/test/BBT.Workflow.Domain.Tests/QueryExtensions/InstanceFilterSpecificationTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/QueryExtensions/InstanceFilterSpecificationTests.cs
@@ -27,11 +27,8 @@ public class InstanceFilterSpecificationTests : DomainTestBase<DomainEntryPoint>
     [Fact]
     public void InstanceFilterSpecification_ShouldCreateWithEmptyFilters()
     {
-        // Act
-        var spec = new InstanceFilterSpecification(Array.Empty<string>());
+        var spec = new InstanceFilterSpecification("");
         var expression = spec.ToExpression();
-
-        // Assert
         Assert.NotNull(spec);
         Assert.NotNull(expression);
     }
@@ -39,11 +36,7 @@ public class InstanceFilterSpecificationTests : DomainTestBase<DomainEntryPoint>
     [Fact(Skip = "InstanceStatus is a class, not an enum. Status filter implementation needs to be fixed to use InstanceStatus.FromCode")]
     public void InstanceFilterSpecification_StatusFilter_ShouldCompile()
     {
-        // Arrange - Status values must match InstanceStatus enum values
-        var filters = new[] { "status=Active" };
-
-        // Act
-        var spec = new InstanceFilterSpecification(filters);
+        var spec = new InstanceFilterSpecification("status=Active");
         var expression = spec.ToExpression();
 
         // Assert
@@ -55,11 +48,7 @@ public class InstanceFilterSpecificationTests : DomainTestBase<DomainEntryPoint>
     [Fact]
     public void InstanceFilterSpecification_FlowFilter_ShouldCompile()
     {
-        // Arrange
-        var filters = new[] { "flow=test-workflow" };
-
-        // Act
-        var spec = new InstanceFilterSpecification(filters);
+        var spec = new InstanceFilterSpecification("flow=test-workflow");
         var expression = spec.ToExpression();
 
         // Assert
@@ -71,11 +60,7 @@ public class InstanceFilterSpecificationTests : DomainTestBase<DomainEntryPoint>
     [Fact]
     public void InstanceFilterSpecification_KeyFilter_ShouldCompile()
     {
-        // Arrange - Key filter uses KeyValueRegex which expects "property=value" format
-        var filters = new[] { "key=instance-key" };
-
-        // Act
-        var spec = new InstanceFilterSpecification(filters);
+        var spec = new InstanceFilterSpecification("key=instance-key");
         var expression = spec.ToExpression();
 
         // Assert
@@ -87,11 +72,7 @@ public class InstanceFilterSpecificationTests : DomainTestBase<DomainEntryPoint>
     [Fact]
     public void InstanceFilterSpecification_TagFilter_ShouldCompile()
     {
-        // Arrange - Tag filter uses KeyValueRegex which expects "property=value" format
-        var filters = new[] { "tag=important" };
-
-        // Act
-        var spec = new InstanceFilterSpecification(filters);
+        var spec = new InstanceFilterSpecification("tag=important");
         var expression = spec.ToExpression();
 
         // Assert
@@ -103,11 +84,7 @@ public class InstanceFilterSpecificationTests : DomainTestBase<DomainEntryPoint>
     [Fact]
     public void InstanceFilterSpecification_AttributesFilter_ShouldCompile()
     {
-        // Arrange
-        var filters = new[] { "attributes=clientId=12345" };
-
-        // Act
-        var spec = new InstanceFilterSpecification(filters);
+        var spec = new InstanceFilterSpecification("attributes=clientId=12345");
         var expression = spec.ToExpression();
 
         // Assert
@@ -119,15 +96,7 @@ public class InstanceFilterSpecificationTests : DomainTestBase<DomainEntryPoint>
     [Fact(Skip = "InstanceStatus is a class, not an enum. Status filter implementation needs to be fixed")]
     public void InstanceFilterSpecification_MultipleFilters_ShouldCombineWithAnd()
     {
-        // Arrange - Using valid enum values
-        var filters = new[] 
-        { 
-            "status=Active",
-            "flow=test-workflow"
-        };
-
-        // Act
-        var spec = new InstanceFilterSpecification(filters);
+        var spec = new InstanceFilterSpecification("status=Active");
         var expression = spec.ToExpression();
 
         // Assert
@@ -139,9 +108,7 @@ public class InstanceFilterSpecificationTests : DomainTestBase<DomainEntryPoint>
     [Fact]
     public void InstanceFilterSpecification_InvalidStatusFilter_ShouldThrow()
     {
-        // Arrange
-        var filters = new[] { "status=InvalidStatus" };
-        var spec = new InstanceFilterSpecification(filters);
+        var spec = new InstanceFilterSpecification("status=InvalidStatus");
 
         // Act & Assert - Invalid enum values should throw when creating expression
         Assert.Throws<ArgumentException>(() => spec.ToExpression());
@@ -150,9 +117,7 @@ public class InstanceFilterSpecificationTests : DomainTestBase<DomainEntryPoint>
     [Fact]
     public void InstanceFilterSpecification_Apply_ShouldReturnQueryable()
     {
-        // Arrange
-        var filters = new[] { "flow=test-workflow" };
-        var spec = new InstanceFilterSpecification(filters);
+        var spec = new InstanceFilterSpecification("flow=test-workflow");
         var instances = CreateTestInstances().AsQueryable();
 
         // Act
@@ -165,9 +130,7 @@ public class InstanceFilterSpecificationTests : DomainTestBase<DomainEntryPoint>
     [Fact]
     public void InstanceFilterSpecification_FlowFilter_ShouldFilterCorrectly()
     {
-        // Arrange
-        var filters = new[] { "flow=workflow-a" };
-        var spec = new InstanceFilterSpecification(filters);
+        var spec = new InstanceFilterSpecification("flow=workflow-a");
         var instances = CreateTestInstances().AsQueryable();
 
         // Act
@@ -181,9 +144,7 @@ public class InstanceFilterSpecificationTests : DomainTestBase<DomainEntryPoint>
     [Fact(Skip = "Key filter implementation incorrectly uses KeyValueRegex. FilterSpecification base class already parses the value.")]
     public void InstanceFilterSpecification_KeyFilter_ShouldFilterCorrectly()
     {
-        // Arrange - Key filter uses KeyValueRegex which expects "property=value" format
-        var filters = new[] { "key=key-1" };
-        var spec = new InstanceFilterSpecification(filters);
+        var spec = new InstanceFilterSpecification("key=key-1");
         var instances = CreateTestInstances().AsQueryable();
 
         // Act
@@ -197,9 +158,7 @@ public class InstanceFilterSpecificationTests : DomainTestBase<DomainEntryPoint>
     [Fact]
     public void InstanceFilterSpecification_InvalidKeyFormat_ShouldReturnEmpty()
     {
-        // Arrange - Key filter without proper format
-        var filters = new[] { "key" };
-        var spec = new InstanceFilterSpecification(filters);
+        var spec = new InstanceFilterSpecification("key");
         var instances = CreateTestInstances().AsQueryable();
 
         // Act
@@ -212,9 +171,7 @@ public class InstanceFilterSpecificationTests : DomainTestBase<DomainEntryPoint>
     [Fact]
     public void InstanceFilterSpecification_InvalidTagFormat_ShouldReturnEmpty()
     {
-        // Arrange - Tag filter without proper format
-        var filters = new[] { "tag" };
-        var spec = new InstanceFilterSpecification(filters);
+        var spec = new InstanceFilterSpecification("tag");
         var instances = CreateTestInstances().AsQueryable();
 
         // Act
@@ -227,13 +184,7 @@ public class InstanceFilterSpecificationTests : DomainTestBase<DomainEntryPoint>
     [Fact(Skip = "Key filter implementation incorrectly uses KeyValueRegex. FilterSpecification base class already parses the value.")]
     public void InstanceFilterSpecification_MultipleFilters_ShouldApplyAll()
     {
-        // Arrange - Key filter uses KeyValueRegex which expects "property=value" format
-        var filters = new[] 
-        { 
-            "flow=workflow-a",
-            "key=key-1"
-        };
-        var spec = new InstanceFilterSpecification(filters);
+        var spec = new InstanceFilterSpecification("flow=workflow-a");
         var instances = CreateTestInstances().AsQueryable();
 
         // Act

--- a/test/BBT.Workflow.Domain.Tests/QueryExtensions/Security/InputValidatorTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/QueryExtensions/Security/InputValidatorTests.cs
@@ -1,0 +1,116 @@
+using System;
+using BBT.Workflow.Security;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Domain.Tests.QueryExtensions.Security;
+
+public class InputValidatorTests
+{
+    [Fact]
+    public void ValidateFilters_NullOrEmpty_ShouldPass()
+    {
+        // Act & Assert - test both overloads
+        Should.NotThrow(() => InputValidator.ValidateFilters((string?)null));
+        Should.NotThrow(() => InputValidator.ValidateFilters((string[]?)null));
+        Should.NotThrow(() => InputValidator.ValidateFilters(Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void ValidateFilters_TooManyFilters_ShouldThrow()
+    {
+        // Arrange
+        var filters = new string[InputValidator.MaxFiltersCount + 1];
+        for (int i = 0; i < filters.Length; i++)
+        {
+            filters[i] = "test=eq:value";
+        }
+
+        // Act & Assert
+        Should.Throw<ArgumentException>(() => InputValidator.ValidateFilters(filters));
+    }
+
+    [Fact]
+    public void ValidateFilters_FilterTooLong_ShouldThrow()
+    {
+        // Arrange
+        var longFilter = new string('a', InputValidator.MaxFilterLength + 1);
+        var filters = new[] { longFilter };
+
+        // Act & Assert
+        Should.Throw<ArgumentException>(() => InputValidator.ValidateFilters(filters));
+    }
+
+    [Fact]
+    public void ValidateFieldName_ValidFieldName_ShouldPass()
+    {
+        // Act & Assert
+        Should.NotThrow(() => InputValidator.ValidateFieldName("fieldName"));
+        Should.NotThrow(() => InputValidator.ValidateFieldName("parent.child"));
+        Should.NotThrow(() => InputValidator.ValidateFieldName("a.b.c"));
+    }
+
+    [Fact]
+    public void ValidateFieldName_TooLong_ShouldThrow()
+    {
+        // Arrange
+        var longFieldName = new string('a', InputValidator.MaxFieldNameLength + 1);
+
+        // Act & Assert
+        Should.Throw<ArgumentException>(() => InputValidator.ValidateFieldName(longFieldName));
+    }
+
+    [Fact]
+    public void ValidateFieldName_TooDeep_ShouldThrow()
+    {
+        // Arrange
+        var deepFieldName = string.Join(".", new string[InputValidator.MaxFieldDepth + 1]);
+
+        // Act & Assert
+        Should.Throw<ArgumentException>(() => InputValidator.ValidateFieldName(deepFieldName));
+    }
+
+    [Fact]
+    public void ValidateFieldName_EmptyPart_ShouldThrow()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentException>(() => InputValidator.ValidateFieldName("parent..child"));
+    }
+
+    [Fact]
+    public void ValidateValue_ValidValue_ShouldPass()
+    {
+        // Act & Assert
+        Should.NotThrow(() => InputValidator.ValidateValue("test"));
+        Should.NotThrow(() => InputValidator.ValidateValue(null));
+    }
+
+    [Fact]
+    public void ValidateValue_TooLong_ShouldThrow()
+    {
+        // Arrange
+        var longValue = new string('a', InputValidator.MaxValueLength + 1);
+
+        // Act & Assert
+        Should.Throw<ArgumentException>(() => InputValidator.ValidateValue(longValue));
+    }
+
+    [Fact]
+    public void ValidateJsonLength_ValidJson_ShouldPass()
+    {
+        // Act & Assert
+        Should.NotThrow(() => InputValidator.ValidateJsonLength("{\"test\":\"value\"}"));
+        Should.NotThrow(() => InputValidator.ValidateJsonLength(null));
+    }
+
+    [Fact]
+    public void ValidateJsonLength_TooLong_ShouldThrow()
+    {
+        // Arrange
+        var longJson = new string('a', InputValidator.MaxFilterLength + 1);
+
+        // Act & Assert
+        Should.Throw<ArgumentException>(() => InputValidator.ValidateJsonLength(longJson));
+    }
+}
+


### PR DESCRIPTION
## Summary by Sourcery

Improve handling of GraphQL and legacy filters when querying instances and fix nullable handling in GraphQL filter condition parsing.

Bug Fixes:
- Ensure full GraphQL request payloads with both filter and groupBy are parsed so that query or groupBy parameters can correctly override embedded values.
- Convert legacy filter formats to GraphQL-compatible JSON before parsing to avoid invalid JSON being passed to the filter parser.
- Handle null values for the isNull GraphQL filter condition without throwing or misreading the token.

Enhancements:
- Unify filter combination logic to consistently serialize GraphQL filter nodes using camelCase JSON for instance queries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Instance filtering now accepts a single filter string (query/body/config) instead of an array of filters.

* **New Features**
  * JSON-based orderBy/sort support for instance listing (multi-field ordering, direction).
  * New workflow-aware function endpoint variant.

* **Bug Fixes**
  * isNull filter operator accepts explicit null values.

* **Improvements**
  * Unified parsing/serialization for GraphQL-style and legacy filters; preserved ordering when combining filters and sorting.

* **Documentation**
  * Added breaking-change and migration guidance.

* **Tests**
  * Expanded unit tests for parsing, filtering, ordering, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->