### PR TITLE
feat(auth): Instance/transition audit fields and predefined roles (#396)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
     <PropertyGroup>
 
         <!-- All Prism packages -->
-        <AetherPackageVersion>1.0.17</AetherPackageVersion>
+        <AetherPackageVersion>1.0.18</AetherPackageVersion>
         <!-- Elastic Apm packages -->
         <ElasticApmPackageVersion>1.31.0</ElasticApmPackageVersion>
         <!-- Microsoft packages -->

--- a/execution/BBT.Workflow.Execution.HttpApi.Host/Microsoft/Extensions/DependencyInjection/ExecutionApiServiceCollectionExtensions.cs
+++ b/execution/BBT.Workflow.Execution.HttpApi.Host/Microsoft/Extensions/DependencyInjection/ExecutionApiServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using BBT.Workflow.Runtime;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Prometheus;
 
@@ -18,7 +19,7 @@ public static class ExecutionApiServiceCollectionExtensions
     {
         var configuration = services.GetConfiguration();
         services
-            .AddDomainModule()
+            .AddAetherDomain()
             .AddAetherApplication()
             .AddAetherInfrastructure()
             .AddAspNetCoreModules(configuration)
@@ -39,6 +40,9 @@ public static class ExecutionApiServiceCollectionExtensions
             .AddExecutionHealthChecks()
             .AddDaprNotification(configuration)
             .AddTaskInvokers(configuration);
+        
+        services.AddSingleton<IRuntimeInfoProvider, RuntimeInfoProvider>();
+        
         return services;
     }
     

--- a/src/BBT.Workflow.Application/Authorization/AuthorizeAppService.cs
+++ b/src/BBT.Workflow.Application/Authorization/AuthorizeAppService.cs
@@ -1,5 +1,6 @@
 using BBT.Aether.Application.Services;
 using BBT.Aether.Results;
+using BBT.Aether.Users;
 using BBT.Workflow.Caching;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Gateway;
@@ -14,12 +15,15 @@ namespace BBT.Workflow.Authorization;
 /// Application service for authorize and authorization matrix system functions.
 /// Evaluates role grants: DENY always wins; if no DENY match, any ALLOW match yields allowed.
 /// When instance has active subflow, forwards authorize request to subflow via IAuthorizeGateway.
+/// For predefined roles ($InstanceStarter, $PreviousUser), matching is done against ICurrentUser.ActorUserName.
 /// </summary>
 public sealed class AuthorizeAppService(
     IServiceProvider serviceProvider,
     IRuntimeInfoProvider runtimeInfoProvider,
     IComponentCacheStore componentCacheStore,
     IInstanceRepository instanceRepository,
+    IInstanceTransitionRepository instanceTransitionRepository,
+    ICurrentUser currentUser,
     IAuthorizeGateway authorizeGateway,
     ILogger<AuthorizeAppService> logger) : ApplicationService(serviceProvider), IAuthorizeAppService
 {
@@ -45,7 +49,7 @@ public sealed class AuthorizeAppService(
             return Result<AuthorizeOutput>.Fail(workflowResult.Error);
 
         var wf = workflowResult.Value!;
-        var allowed = await EvaluateAuthorizeAsync(wf, role, transitionKey, functionKey, null, checkQueryRoles, componentCacheStore, domain, workflowVersion, cancellationToken);
+        var allowed = await EvaluateAuthorizeAsync(wf, role, transitionKey, functionKey, null, checkQueryRoles, domain, workflowVersion, cancellationToken);
         logger.AuthorizeRequest(domain, workflow, role, allowed);
         return Result<AuthorizeOutput>.Ok(new AuthorizeOutput { Allowed = allowed });
     }
@@ -95,7 +99,7 @@ public sealed class AuthorizeAppService(
                 cancellationToken);
         }
 
-        var allowed = await EvaluateAuthorizeAsync(wf, role, transitionKey, functionKey, instance, checkQueryRoles, componentCacheStore, domain, workflowVersion, cancellationToken);
+        var allowed = await EvaluateAuthorizeAsync(wf, role, transitionKey, functionKey, instance, checkQueryRoles, domain, workflowVersion, cancellationToken);
         logger.AuthorizeRequest(domain, workflow, role, allowed);
         return Result<AuthorizeOutput>.Ok(new AuthorizeOutput { Allowed = allowed });
     }
@@ -248,15 +252,15 @@ public sealed class AuthorizeAppService(
     /// <summary>
     /// Evaluates authorize for a single target: transition, function, or state-based query roles.
     /// Caller validates exactly one target is specified.
+    /// Resolves predefined instance roles ($InstanceStarter, $PreviousUser) when instance is present.
     /// </summary>
-    private static async Task<bool> EvaluateAuthorizeAsync(
+    private async Task<bool> EvaluateAuthorizeAsync(
         Definitions.Workflow workflow,
         string role,
         string? transitionKey,
         string? functionKey,
         Instance? instance,
         bool checkQueryRoles,
-        IComponentCacheStore componentCacheStore,
         string domain,
         string? workflowVersion,
         CancellationToken cancellationToken)
@@ -265,36 +269,109 @@ public sealed class AuthorizeAppService(
             return false;
 
         if (checkQueryRoles)
-            return EvaluateQueryRoles(workflow, role, instance);
+            return await EvaluateQueryRolesAsync(workflow, role, instance, cancellationToken);
 
+        IReadOnlyCollection<RoleGrant>? roleGrants = null;
         if (!string.IsNullOrWhiteSpace(transitionKey))
         {
             var transition = workflow.FindTransitionInContext(transitionKey);
-            return transition != null && EvaluateRoles(role, transition.Roles);
+            if (transition != null)
+                roleGrants = transition.Roles;
         }
-
-        if (!string.IsNullOrWhiteSpace(functionKey))
+        else if (!string.IsNullOrWhiteSpace(functionKey))
         {
             var fnResult = await componentCacheStore.GetFunctionAsync(domain, functionKey, workflowVersion, cancellationToken);
-            return fnResult.IsSuccess && EvaluateRoles(role, fnResult.Value!.Roles);
+            if (fnResult.IsSuccess)
+                roleGrants = fnResult.Value!.Roles;
+        }
+
+        if (roleGrants == null || roleGrants.Count == 0)
+            return false;
+
+        if (instance != null)
+            return await EvaluateRolesWithPredefinedAsync(role, roleGrants, instance, cancellationToken);
+
+        return EvaluateRoles(role, roleGrants);
+    }
+
+    /// <summary>
+    /// Evaluates role grants with resolution of predefined instance roles ($InstanceStarter, $PreviousUser).
+    /// For predefined roles, matching is against CurrentUser.ActorUserName (instance starter or previous transition creator).
+    /// DENY always wins; then any ALLOW match (including resolved predefined) yields true.
+    /// </summary>
+    private async Task<bool> EvaluateRolesWithPredefinedAsync(
+        string role,
+        IReadOnlyCollection<RoleGrant> roleGrants,
+        Instance instance,
+        CancellationToken cancellationToken)
+    {
+        var normalizedRole = role.Trim();
+        var currentActorUserName = currentUser.ActorUserName?.Trim();
+
+        string? previousUserCreatedBy = null;
+        if (roleGrants.Any(g => string.Equals(g.Role, PredefinedInstanceRoles.PreviousUser, StringComparison.Ordinal)))
+            previousUserCreatedBy = (await instanceTransitionRepository.GetLastCompletedManualTransitionAsync(instance.Id, cancellationToken))?.CreatedBy;
+
+        foreach (var g in roleGrants)
+        {
+            if (g.IsDeny)
+            {
+                var resolvedValue = ResolvePredefinedRole(g.Role, instance, previousUserCreatedBy);
+                if (resolvedValue != null && !string.IsNullOrEmpty(currentActorUserName) && string.Equals(currentActorUserName, resolvedValue, StringComparison.Ordinal))
+                    return false;
+                if (resolvedValue == null && string.Equals(g.Role, normalizedRole, StringComparison.OrdinalIgnoreCase))
+                    return false;
+            }
+        }
+
+        foreach (var g in roleGrants)
+        {
+            if (!g.IsAllow)
+                continue;
+            var resolvedValue = ResolvePredefinedRole(g.Role, instance, previousUserCreatedBy);
+            if (resolvedValue != null && !string.IsNullOrEmpty(currentActorUserName) && string.Equals(currentActorUserName, resolvedValue, StringComparison.Ordinal))
+                return true;
+            if (resolvedValue == null && string.Equals(g.Role, normalizedRole, StringComparison.OrdinalIgnoreCase))
+                return true;
         }
 
         return false;
     }
 
     /// <summary>
-    /// Evaluates state-based query roles: instance current state → state queryRoles or workflow root queryRoles; DENY wins, else ALLOW.
+    /// Resolves predefined role to the effective user identifier (CreatedBy) for comparison with CurrentUser.ActorUserName.
     /// </summary>
-    private static bool EvaluateQueryRoles(Definitions.Workflow workflow, string role, Instance? instance)
+    private static string? ResolvePredefinedRole(string? grantRole, Instance instance, string? previousUserCreatedBy)
+    {
+        if (string.IsNullOrWhiteSpace(grantRole))
+            return null;
+        if (string.Equals(grantRole, PredefinedInstanceRoles.InstanceStarter, StringComparison.Ordinal))
+            return instance.CreatedBy;
+        if (string.Equals(grantRole, PredefinedInstanceRoles.PreviousUser, StringComparison.Ordinal))
+            return previousUserCreatedBy;
+        return null;
+    }
+
+    /// <summary>
+    /// Evaluates state-based query roles: instance effective state → state queryRoles or workflow root queryRoles.
+    /// Resolves predefined instance roles ($InstanceStarter, $PreviousUser) when instance is present. DENY wins, else ALLOW.
+    /// </summary>
+    private async Task<bool> EvaluateQueryRolesAsync(
+        Definitions.Workflow workflow,
+        string role,
+        Instance? instance,
+        CancellationToken cancellationToken)
     {
         if (instance == null)
             return false;
-        var currentStateKey = instance.GetCurrentState;
+        var currentStateKey = instance.GetEffectiveState;
         if (string.IsNullOrWhiteSpace(currentStateKey))
             return false;
         var state = workflow.FindState(currentStateKey);
-        var queryRoles = state != null && state.QueryRoles.Count > 0 ? state.QueryRoles : workflow.QueryRoles;
-        return EvaluateRoles(role, queryRoles);
+        var queryRoles = state is { QueryRoles.Count: > 0 } ? state.QueryRoles : workflow.QueryRoles;
+        if (queryRoles.Count == 0)
+            return false;
+        return await EvaluateRolesWithPredefinedAsync(role, queryRoles, instance, cancellationToken);
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Application/Authorization/AuthorizeAppService.cs
+++ b/src/BBT.Workflow.Application/Authorization/AuthorizeAppService.cs
@@ -312,28 +312,19 @@ public sealed class AuthorizeAppService(
         if (roleGrants.Any(g => string.Equals(g.Role, PredefinedInstanceRoles.PreviousUser, StringComparison.Ordinal)))
             previousUserCreatedBy = (await instanceTransitionRepository.GetLastCompletedManualTransitionAsync(instance.Id, cancellationToken))?.CreatedBy;
 
-        foreach (var g in roleGrants)
+        bool IsMatch(RoleGrant g)
         {
-            if (g.IsDeny)
-            {
-                var resolvedValue = ResolvePredefinedRole(g.Role, instance, previousUserCreatedBy);
-                if (resolvedValue != null && !string.IsNullOrEmpty(currentActorUserName) && string.Equals(currentActorUserName, resolvedValue, StringComparison.Ordinal))
-                    return false;
-                if (resolvedValue == null && string.Equals(g.Role, normalizedRole, StringComparison.OrdinalIgnoreCase))
-                    return false;
-            }
+            var resolvedValue = ResolvePredefinedRole(g.Role, instance, previousUserCreatedBy);
+            if (resolvedValue != null)
+                return !string.IsNullOrEmpty(currentActorUserName) && string.Equals(currentActorUserName, resolvedValue, StringComparison.Ordinal);
+            return string.Equals(g.Role, normalizedRole, StringComparison.OrdinalIgnoreCase);
         }
 
-        foreach (var g in roleGrants)
-        {
-            if (!g.IsAllow)
-                continue;
-            var resolvedValue = ResolvePredefinedRole(g.Role, instance, previousUserCreatedBy);
-            if (resolvedValue != null && !string.IsNullOrEmpty(currentActorUserName) && string.Equals(currentActorUserName, resolvedValue, StringComparison.Ordinal))
-                return true;
-            if (resolvedValue == null && string.Equals(g.Role, normalizedRole, StringComparison.OrdinalIgnoreCase))
-                return true;
-        }
+        if (roleGrants.Any(g => g.IsDeny && IsMatch(g)))
+            return false;
+
+        if (roleGrants.Any(g => g.IsAllow && IsMatch(g)))
+            return true;
 
         return false;
     }

--- a/src/BBT.Workflow.Application/Execution/Services/TransitionRunner.cs
+++ b/src/BBT.Workflow.Application/Execution/Services/TransitionRunner.cs
@@ -1,6 +1,7 @@
-using BBT.Aether.Aspects;
 using BBT.Aether.Results;
 using BBT.Aether.Uow;
+using BBT.Aether.Users;
+using BBT.Workflow.CurrentUser;
 using BBT.Workflow.Instances;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -46,19 +47,23 @@ public sealed class TransitionRunner(
         {
             var uowManager = sp.GetRequiredService<IUnitOfWorkManager>();
             var core = sp.GetRequiredService<IWorkflowExecutionCore>();
+            var currentUser = sp.GetRequiredService<ICurrentUser>();
 
-            await using var uow = await uowManager.BeginAsync(
-                new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew },
-                cancellationToken);
+            using (currentUser.ChangeFromHeaders(context.Headers))
+            {
+                await using var uow = await uowManager.BeginAsync(
+                    new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew },
+                    cancellationToken);
 
-            var coreResult = await core.ExecuteTransitionCoreAsync(context, cancellationToken);
-            if (!coreResult.IsSuccess)
-                return Result<TransitionCoreOutput>.Fail(coreResult.Error);
+                var coreResult = await core.ExecuteTransitionCoreAsync(context, cancellationToken);
+                if (!coreResult.IsSuccess)
+                    return Result<TransitionCoreOutput>.Fail(coreResult.Error);
 
-            // Commit is THE boundary
-            await uow.CommitAsync(cancellationToken);
+                // Commit is THE boundary
+                await uow.CommitAsync(cancellationToken);
 
-            return coreResult;
+                return coreResult;
+            }
         }, cancellationToken);
     }
 }

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/CreateTransitionRecordStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/CreateTransitionRecordStep.cs
@@ -76,6 +76,7 @@ public sealed class CreateTransitionRecordStep(
             context.InstanceId,
             transitionKey,
             context.Instance.GetCurrentState,
+            context.Trigger,
             new JsonData(context.Data),
             new JsonData(JsonSerializer.Serialize(context.Headers)));
 

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/HandleUpdateDataPreflightStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/HandleUpdateDataPreflightStep.cs
@@ -112,6 +112,7 @@ public sealed class HandleUpdateDataPreflightStep(
             context.InstanceId,
             transitionKey,
             context.Instance.GetCurrentState,
+            context.Trigger,
             new JsonData(context.Data),
             new JsonData(JsonSerializer.Serialize(context.Headers)));
 

--- a/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
@@ -49,7 +49,6 @@ public sealed class InstanceCommandAppService(
         CancellationToken cancellationToken = default)
     {
         runtimeInfoProvider.Check(input.Domain);
-
         // Step 1: Load workflow
         var workflowResult = await LoadWorkflowAsync(input.Domain, input.Workflow, input.Version, cancellationToken);
         if (!workflowResult.IsSuccess)

--- a/src/BBT.Workflow.Domain/CurrentUser/CurrentUserHeaderExtensions.cs
+++ b/src/BBT.Workflow.Domain/CurrentUser/CurrentUserHeaderExtensions.cs
@@ -1,0 +1,77 @@
+using BBT.Aether.Users;
+
+namespace BBT.Workflow.CurrentUser;
+
+/// <summary>
+/// Header key constants aligned with Aether claim types used by HeaderCurrentUserResolver.
+/// Used when building ICurrentUser from a request headers dictionary (e.g. in background job execution scope).
+/// </summary>
+internal static class CurrentUserHeaderKeys
+{
+    public const string UserId = "userId";
+    public const string UserName = "sub";
+    public const string Name = "given_name";
+    public const string SurName = "family_name";
+    public const string Role = "role";
+    public const string ActorSub = "act_sub";
+    public const string ActorUserId = "act_uid";
+    public const string ConsentId = "consent_id";
+}
+
+/// <summary>
+/// Extensions for setting ICurrentUser from a headers dictionary within a scope (e.g. workflow execution).
+/// Enables correct user context when execution runs outside HTTP (e.g. sync=false background jobs).
+/// </summary>
+public static class CurrentUserHeaderExtensions
+{
+    /// <summary>
+    /// Changes the current user from the given headers for the lifetime of the returned disposable.
+    /// When disposed, the previous user is restored. If headers are null or empty, returns a no-op disposable.
+    /// </summary>
+    /// <param name="currentUser">The current user service.</param>
+    /// <param name="headers">Request headers (e.g. from WorkflowExecutionContext.Headers or job payload).</param>
+    /// <returns>An IDisposable that restores the previous user when disposed; or a no-op if no headers.</returns>
+    public static IDisposable ChangeFromHeaders(
+        this ICurrentUser currentUser,
+        IReadOnlyDictionary<string, string?>? headers)
+    {
+        if (headers is null || headers.Count == 0)
+            return EmptyDisposable.Instance;
+
+        var userId = GetHeader(headers, CurrentUserHeaderKeys.UserId);
+        var userName = GetHeader(headers, CurrentUserHeaderKeys.UserName);
+        var name = GetHeader(headers, CurrentUserHeaderKeys.Name);
+        var surname = GetHeader(headers, CurrentUserHeaderKeys.SurName);
+        var rolesHeader = GetHeader(headers, CurrentUserHeaderKeys.Role);
+        var roles = string.IsNullOrEmpty(rolesHeader)
+            ? null
+            : rolesHeader.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var actorUserId = GetHeader(headers, CurrentUserHeaderKeys.ActorUserId);
+        var actorUserName = GetHeader(headers, CurrentUserHeaderKeys.ActorSub);
+        var consentId = GetHeader(headers, CurrentUserHeaderKeys.ConsentId);
+
+        return currentUser.Change(
+            userId,
+            userName,
+            name,
+            surname,
+            roles,
+            actorUserId,
+            actorUserName,
+            consentId);
+    }
+
+    private static string? GetHeader(IReadOnlyDictionary<string, string?> headers, string key)
+    {
+        return headers.TryGetValue(key, out var value) ? value : null;
+    }
+
+    private sealed class EmptyDisposable : IDisposable
+    {
+        public static readonly EmptyDisposable Instance = new();
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/BBT.Workflow.Domain/Definitions/Authorization/PredefinedInstanceRoles.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Authorization/PredefinedInstanceRoles.cs
@@ -1,0 +1,37 @@
+namespace BBT.Workflow.Definitions;
+
+/// <summary>
+/// Predefined system role names for instance-level authorization.
+/// These roles are resolved from instance/transition audit data; matching is done against CurrentUser.ActorUserName.
+/// </summary>
+public static class PredefinedInstanceRoles
+{
+    /// <summary>
+    /// Role resolved to the user who started the instance (Instance.CreatedBy).
+    /// When this role is in a grant: the same user who started the instance may perform the operation.
+    /// Matching: CurrentUser.ActorUserName is compared to Instance.CreatedBy.
+    /// </summary>
+    public const string InstanceStarter = "$InstanceStarter";
+
+    /// <summary>
+    /// Role resolved to the user who created the last completed manual transition (InstanceTransition.CreatedBy).
+    /// When this role is in a grant: the user who performed the previous manual transition may perform the operation.
+    /// Matching: CurrentUser.ActorUserName is compared to the last manual transition's CreatedBy.
+    /// Only manual transitions are considered; automatic/scheduled/event transitions are ignored.
+    /// </summary>
+    public const string PreviousUser = "$PreviousUser";
+
+    /// <summary>
+    /// Determines whether the given role is a predefined instance role.
+    /// </summary>
+    /// <param name="role">Role identifier to check.</param>
+    /// <returns>True if the role is InstanceStarter or PreviousUser.</returns>
+    public static bool IsPredefinedRole(string? role)
+    {
+        if (string.IsNullOrWhiteSpace(role))
+            return false;
+        var normalized = role.Trim();
+        return string.Equals(normalized, InstanceStarter, StringComparison.Ordinal)
+            || string.Equals(normalized, PreviousUser, StringComparison.Ordinal);
+    }
+}

--- a/src/BBT.Workflow.Domain/Instances/IInstanceTransitionRepository.cs
+++ b/src/BBT.Workflow.Domain/Instances/IInstanceTransitionRepository.cs
@@ -20,4 +20,13 @@ public interface IInstanceTransitionRepository : IRepository<InstanceTransition,
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The latest incomplete transition, or null if none found.</returns>
     Task<InstanceTransition?> GetLatestIncompleteAsync(Guid instanceId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the most recent completed manual transition for an instance.
+    /// Used to resolve $PreviousUser for instance authorization (CreatedBy of that transition).
+    /// </summary>
+    /// <param name="instanceId">The instance ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The last completed manual transition, or null if none found.</returns>
+    Task<InstanceTransition?> GetLastCompletedManualTransitionAsync(Guid instanceId, CancellationToken cancellationToken = default);
 }

--- a/src/BBT.Workflow.Domain/Instances/Instance.cs
+++ b/src/BBT.Workflow.Domain/Instances/Instance.cs
@@ -10,7 +10,7 @@ namespace BBT.Workflow.Instances;
 /// <summary>
 /// Instance
 /// </summary>
-public sealed class Instance : AggregateRoot<Guid>, IHasCreatedAt, IHasModifyTime, IHasExtraProperties
+public sealed class Instance : AggregateRoot<Guid>, ICreationAuditedObject, IModifyAuditedObject, IHasExtraProperties
 {  
     private Instance()
     {
@@ -125,6 +125,26 @@ public sealed class Instance : AggregateRoot<Guid>, IHasCreatedAt, IHasModifyTim
     /// Modified at
     /// </summary>
     public DateTime? ModifiedAt { get; set; }
+    
+    /// <summary>
+    /// Creator user identifier.
+    /// </summary>
+    public string? CreatedBy { get; set; }
+    
+    /// <summary>
+    /// Creator behalf-of user identifier.
+    /// </summary>
+    public string? CreatedByBehalfOf { get; set; }
+    
+    /// <summary>
+    /// Modifier user identifier.
+    /// </summary>
+    public string? ModifiedBy { get; set; }
+    
+    /// <summary>
+    /// Modifier behalf-of user identifier.
+    /// </summary>
+    public string? ModifiedByBehalfOf { get; set; }
 
     public bool IsTransient { get; private set; }
 

--- a/src/BBT.Workflow.Domain/Instances/Instance.cs
+++ b/src/BBT.Workflow.Domain/Instances/Instance.cs
@@ -238,6 +238,10 @@ public sealed class Instance : AggregateRoot<Guid>, ICreationAuditedObject, IMod
             EffectiveState = EffectiveState,
             Duration = Duration,
             Tags = [.. Tags],
+            CreatedBy = CreatedBy,
+            CreatedByBehalfOf = CreatedByBehalfOf,
+            ModifiedBy = ModifiedBy,
+            ModifiedByBehalfOf = ModifiedByBehalfOf,
             ExtraProperties = new ExtraPropertyDictionary(ExtraProperties)
         };
 

--- a/src/BBT.Workflow.Domain/Instances/InstanceTransition.cs
+++ b/src/BBT.Workflow.Domain/Instances/InstanceTransition.cs
@@ -1,8 +1,10 @@
+using BBT.Aether.Auditing;
 using BBT.Aether.Domain.Entities;
+using BBT.Workflow.Definitions;
 
 namespace BBT.Workflow.Instances;
 
-public sealed class InstanceTransition : Entity<Guid>
+public sealed class InstanceTransition : Entity<Guid>, ICreationAuditedObject
 {
     private InstanceTransition()
     {
@@ -13,6 +15,7 @@ public sealed class InstanceTransition : Entity<Guid>
         Guid instanceId,
         string transitionId,
         string fromState,
+        TriggerType triggerType,
         JsonData body,
         JsonData header
     ) : base(id)
@@ -20,7 +23,9 @@ public sealed class InstanceTransition : Entity<Guid>
         InstanceId = instanceId;
         TransitionId = transitionId;
         FromState = fromState;
+        TriggerType = triggerType;
         StartedAt = DateTime.UtcNow;
+        CreatedAt = DateTime.UtcNow;
         Body = body;
         Header = header;
     }
@@ -32,6 +37,26 @@ public sealed class InstanceTransition : Entity<Guid>
     public DateTime StartedAt { get; private set; }
     public DateTime? FinishedAt { get; private set; }
     public TimeSpan? Duration { get; private set; }
+
+    /// <summary>
+    /// Trigger type that initiated this transition. Used to resolve $PreviousUser (manual only).
+    /// </summary>
+    public TriggerType TriggerType { get; private set; }
+
+    /// <summary>
+    /// Created at
+    /// </summary>
+    public DateTime CreatedAt { get; set; }
+    
+    /// <summary>
+    /// Creator user identifier.
+    /// </summary>
+    public string? CreatedBy { get; set; }
+
+    /// <summary>
+    /// Creator behalf-of user identifier.
+    /// </summary>
+    public string? CreatedByBehalfOf { get; set; }
 
     /// <summary>
     /// Body
@@ -57,9 +82,10 @@ public sealed class InstanceTransition : Entity<Guid>
         Guid instanceId,
         string transitionId,
         string fromState,
+        TriggerType triggerType,
         JsonData body,
         JsonData header)
     {
-        return new InstanceTransition(id, instanceId, transitionId, fromState, body, header);
+        return new InstanceTransition(id, instanceId, transitionId, fromState, triggerType, body, header);
     }
 }

--- a/src/BBT.Workflow.Infrastructure/Data/InstancesModelCreatingExtensions.cs
+++ b/src/BBT.Workflow.Infrastructure/Data/InstancesModelCreatingExtensions.cs
@@ -162,6 +162,11 @@ public static class InstancesModelCreatingExtensions
             b.Property(p => p.ToState)
                 .HasMaxLength(StateConstants.MaxKeyLength);
 
+            b.Property(p => p.TriggerType)
+                .IsRequired()
+                .HasConversion<int>()
+                .HasDefaultValue(TriggerType.Manual);
+
             b.OwnsOne(p => p.Body, d =>
             {
                 d.Ignore(g => g.JsonElement);

--- a/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceTransitionRepository.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceTransitionRepository.cs
@@ -3,6 +3,7 @@ using BBT.Aether.Domain.Services;
 using BBT.Aether.Uow;
 using BBT.Workflow.Data;
 using BBT.Workflow.DataSink;
+using BBT.Workflow.Definitions;
 using Microsoft.EntityFrameworkCore;
 
 namespace BBT.Workflow.Instances;
@@ -76,6 +77,16 @@ public class EfCoreInstanceTransitionRepository(
         return await context.InstanceTransitions
             .Where(p => p.InstanceId == instanceId && p.FinishedAt == null)
             .OrderByDescending(p => p.StartedAt)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<InstanceTransition?> GetLastCompletedManualTransitionAsync(Guid instanceId, CancellationToken cancellationToken = default)
+    {
+        var context = await GetDbContextAsync();
+        return await context.InstanceTransitions
+            .Where(p => p.InstanceId == instanceId && p.FinishedAt != null && p.TriggerType == TriggerType.Manual)
+            .OrderByDescending(p => p.FinishedAt)
             .FirstOrDefaultAsync(cancellationToken);
     }
 }

--- a/src/BBT.Workflow.Infrastructure/Migrations/20260223195408_AddInstanceAndTransitionAuditFields.Designer.cs
+++ b/src/BBT.Workflow.Infrastructure/Migrations/20260223195408_AddInstanceAndTransitionAuditFields.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using BBT.Workflow.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BBT.Workflow.Migrations
 {
     [DbContext(typeof(WorkflowDbContext))]
-    partial class WorkflowDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260223195408_AddInstanceAndTransitionAuditFields")]
+    partial class AddInstanceAndTransitionAuditFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/BBT.Workflow.Infrastructure/Migrations/20260223195408_AddInstanceAndTransitionAuditFields.cs
+++ b/src/BBT.Workflow.Infrastructure/Migrations/20260223195408_AddInstanceAndTransitionAuditFields.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BBT.Workflow.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInstanceAndTransitionAuditFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "CreatedAt",
+                table: "InstanceTransitions",
+                type: "timestamp without time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<string>(
+                name: "CreatedBy",
+                table: "InstanceTransitions",
+                type: "character varying(36)",
+                maxLength: 36,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CreatedByBehalfOf",
+                table: "InstanceTransitions",
+                type: "character varying(36)",
+                maxLength: 36,
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "TriggerType",
+                table: "InstanceTransitions",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CreatedBy",
+                table: "Instances",
+                type: "character varying(36)",
+                maxLength: 36,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CreatedByBehalfOf",
+                table: "Instances",
+                type: "character varying(36)",
+                maxLength: 36,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ModifiedBy",
+                table: "Instances",
+                type: "character varying(36)",
+                maxLength: 36,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ModifiedByBehalfOf",
+                table: "Instances",
+                type: "character varying(36)",
+                maxLength: 36,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CreatedAt",
+                table: "InstanceTransitions");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedBy",
+                table: "InstanceTransitions");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedByBehalfOf",
+                table: "InstanceTransitions");
+
+            migrationBuilder.DropColumn(
+                name: "TriggerType",
+                table: "InstanceTransitions");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedBy",
+                table: "Instances");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedByBehalfOf",
+                table: "Instances");
+
+            migrationBuilder.DropColumn(
+                name: "ModifiedBy",
+                table: "Instances");
+
+            migrationBuilder.DropColumn(
+                name: "ModifiedByBehalfOf",
+                table: "Instances");
+        }
+    }
+}

--- a/test/BBT.Workflow.Domain.Tests/CurrentUser/CurrentUserHeaderExtensionsTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/CurrentUser/CurrentUserHeaderExtensionsTests.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Collections.Generic;
+using BBT.Aether.Users;
+using BBT.Workflow.CurrentUser;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.CurrentUser;
+
+public sealed class CurrentUserHeaderExtensionsTests
+{
+    [Fact]
+    public void ChangeFromHeaders_WhenHeadersIsNull_ReturnsNoOpDisposable_AndDoesNotCallChange()
+    {
+        var currentUser = Substitute.For<ICurrentUser>();
+
+        using (currentUser.ChangeFromHeaders(null))
+        {
+            // Scope active; dispose should not throw
+        }
+
+        currentUser.DidNotReceive().Change(
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string[]?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>());
+    }
+
+    [Fact]
+    public void ChangeFromHeaders_WhenHeadersIsEmpty_ReturnsNoOpDisposable_AndDoesNotCallChange()
+    {
+        var currentUser = Substitute.For<ICurrentUser>();
+        var headers = new Dictionary<string, string?>();
+
+        using (currentUser.ChangeFromHeaders(headers))
+        {
+        }
+
+        currentUser.DidNotReceive().Change(
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string[]?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>());
+    }
+
+    [Fact]
+    public void ChangeFromHeaders_WhenHeadersContainClaimValues_CallsChangeWithMappedValues()
+    {
+        var currentUser = Substitute.For<ICurrentUser>();
+        var disposable = Substitute.For<IDisposable>();
+        currentUser
+            .Change(
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string[]?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>())
+            .Returns(disposable);
+
+        var headers = new Dictionary<string, string?>
+        {
+            ["userId"] = "uid-1",
+            ["sub"] = "user1",
+            ["given_name"] = "Given",
+            ["family_name"] = "Family",
+            ["role"] = "Admin,User",
+            ["act_uid"] = "actor-uid",
+            ["act_sub"] = "actor1",
+            ["consent_id"] = "consent-1"
+        };
+
+        using (currentUser.ChangeFromHeaders(headers))
+        {
+        }
+
+        currentUser.Received(1).Change(
+            "uid-1",
+            "user1",
+            "Given",
+            "Family",
+            Arg.Is<string[]>(r => r.Length == 2 && r[0] == "Admin" && r[1] == "User"),
+            "actor-uid",
+            "actor1",
+            "consent-1");
+        disposable.Received(1).Dispose();
+    }
+
+    [Fact]
+    public void ChangeFromHeaders_WhenOnlySubAndActSubPresent_CallsChangeWithNullsForMissingKeys()
+    {
+        var currentUser = Substitute.For<ICurrentUser>();
+        var disposable = Substitute.For<IDisposable>();
+        currentUser
+            .Change(
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string[]?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>())
+            .Returns(disposable);
+
+        var headers = new Dictionary<string, string?>
+        {
+            ["sub"] = "user1",
+            ["act_sub"] = "actor1"
+        };
+
+        using (currentUser.ChangeFromHeaders(headers))
+        {
+        }
+
+        currentUser.Received(1).Change(
+            null,
+            "user1",
+            null,
+            null,
+            null,
+            null,
+            "actor1",
+            null);
+    }
+
+    [Fact]
+    public void ChangeFromHeaders_WhenRoleHeaderEmpty_SendsNullRoles()
+    {
+        var currentUser = Substitute.For<ICurrentUser>();
+        var disposable = Substitute.For<IDisposable>();
+        currentUser
+            .Change(
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string[]?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>())
+            .Returns(disposable);
+
+        var headers = new Dictionary<string, string?>
+        {
+            ["sub"] = "user1",
+            ["role"] = ""
+        };
+
+        using (currentUser.ChangeFromHeaders(headers))
+        {
+        }
+
+        currentUser.Received(1).Change(
+            null,
+            "user1",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+    }
+}

--- a/test/BBT.Workflow.Domain.Tests/Definitions/Authorization/PredefinedInstanceRolesTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Definitions/Authorization/PredefinedInstanceRolesTests.cs
@@ -1,0 +1,36 @@
+using BBT.Workflow.Definitions;
+using Xunit;
+
+namespace BBT.Workflow.Definitions;
+
+/// <summary>
+/// Unit tests for PredefinedInstanceRoles.
+/// </summary>
+public class PredefinedInstanceRolesTests
+{
+    [Fact]
+    public void InstanceStarter_ShouldBeDollarInstanceStarter()
+    {
+        Assert.Equal("$InstanceStarter", PredefinedInstanceRoles.InstanceStarter);
+    }
+
+    [Fact]
+    public void PreviousUser_ShouldBeDollarPreviousUser()
+    {
+        Assert.Equal("$PreviousUser", PredefinedInstanceRoles.PreviousUser);
+    }
+
+    [Theory]
+    [InlineData("$InstanceStarter", true)]
+    [InlineData("$PreviousUser", true)]
+    [InlineData("$instancestarter", false)]
+    [InlineData("$previoususer", false)]
+    [InlineData("role.maker", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    [InlineData("  $InstanceStarter  ", true)]
+    public void IsPredefinedRole_ShouldReturnExpected(string? role, bool expected)
+    {
+        Assert.Equal(expected, PredefinedInstanceRoles.IsPredefinedRole(role));
+    }
+}

--- a/test/BBT.Workflow.Domain.Tests/Instances/InstanceTransitionRepositoryTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Instances/InstanceTransitionRepositoryTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using BBT.Aether.Testing;
+using BBT.Workflow.Definitions;
 using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
 using Xunit;
@@ -31,6 +32,7 @@ public abstract class InstanceTransitionRepositoryTests<TEntry> : DomainTestBase
             instance.Id,
             "test-transition",
             "InitialState",
+            TriggerType.Manual,
             JsonData.CreateFrom("{}"),
             JsonData.CreateFrom("{}")
         );
@@ -58,6 +60,7 @@ public abstract class InstanceTransitionRepositoryTests<TEntry> : DomainTestBase
             instance.Id,
             "test-transition",
             "InitialState",
+            TriggerType.Manual,
             JsonData.CreateFrom("{}"),
             JsonData.CreateFrom("{}")
         );
@@ -86,6 +89,7 @@ public abstract class InstanceTransitionRepositoryTests<TEntry> : DomainTestBase
             instance.Id,
             "test-transition",
             "InitialState",
+            TriggerType.Manual,
             JsonData.CreateFrom("{}"),
             JsonData.CreateFrom("{}")
         );
@@ -116,6 +120,7 @@ public abstract class InstanceTransitionRepositoryTests<TEntry> : DomainTestBase
             instance.Id,
             "test-transition",
             "InitialState",
+            TriggerType.Manual,
             JsonData.CreateFrom("{}"),
             JsonData.CreateFrom("{}")
         );

--- a/test/BBT.Workflow.Domain.Tests/Instances/InstanceTransitionTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Instances/InstanceTransitionTests.cs
@@ -1,4 +1,5 @@
 using System;
+using BBT.Workflow.Definitions;
 using Xunit;
 
 namespace BBT.Workflow.Instances;
@@ -25,6 +26,7 @@ public class InstanceTransitionTests : DomainTestBase<DomainEntryPoint>
             instanceId,
             transitionId,
             fromState,
+            TriggerType.Manual,
             body,
             header
         );
@@ -36,6 +38,7 @@ public class InstanceTransitionTests : DomainTestBase<DomainEntryPoint>
         Assert.Equal(fromState, instanceTransition.FromState);
         Assert.Equal(body, instanceTransition.Body);
         Assert.Equal(header, instanceTransition.Header);
+        Assert.Equal(TriggerType.Manual, instanceTransition.TriggerType);
         Assert.Null(instanceTransition.ToState);
         Assert.Null(instanceTransition.FinishedAt);
         Assert.Null(instanceTransition.Duration);
@@ -53,6 +56,7 @@ public class InstanceTransitionTests : DomainTestBase<DomainEntryPoint>
             Guid.NewGuid(),
             "transition",
             "state",
+            TriggerType.Manual,
             JsonData.CreateFrom("{}"),
             JsonData.CreateFrom("{}")
         );
@@ -71,6 +75,7 @@ public class InstanceTransitionTests : DomainTestBase<DomainEntryPoint>
             Guid.NewGuid(),
             "transition",
             "from-state",
+            TriggerType.Manual,
             JsonData.CreateFrom("{}"),
             JsonData.CreateFrom("{}")
         );
@@ -96,6 +101,7 @@ public class InstanceTransitionTests : DomainTestBase<DomainEntryPoint>
             Guid.NewGuid(),
             "transition",
             "from-state",
+            TriggerType.Manual,
             JsonData.CreateFrom("{}"),
             JsonData.CreateFrom("{}")
         );
@@ -119,6 +125,7 @@ public class InstanceTransitionTests : DomainTestBase<DomainEntryPoint>
             Guid.NewGuid(),
             "transition",
             "from-state",
+            TriggerType.Manual,
             JsonData.CreateFrom("{}"),
             JsonData.CreateFrom("{}")
         );
@@ -143,6 +150,7 @@ public class InstanceTransitionTests : DomainTestBase<DomainEntryPoint>
             Guid.NewGuid(),
             "transition",
             "state",
+            TriggerType.Manual,
             bodyData,
             JsonData.CreateFrom("{}")
         );
@@ -165,6 +173,7 @@ public class InstanceTransitionTests : DomainTestBase<DomainEntryPoint>
             Guid.NewGuid(),
             "transition",
             "state",
+            TriggerType.Manual,
             JsonData.CreateFrom("{}"),
             headerData
         );
@@ -186,6 +195,7 @@ public class InstanceTransitionTests : DomainTestBase<DomainEntryPoint>
             Guid.NewGuid(),
             "transition",
             "from-state",
+            TriggerType.Manual,
             JsonData.CreateFrom("{}"),
             JsonData.CreateFrom("{}")
         );
@@ -222,6 +232,7 @@ public class InstanceTransitionTests : DomainTestBase<DomainEntryPoint>
             Guid.NewGuid(),
             "transition",
             "state",
+            TriggerType.Manual,
             body,
             header
         );
@@ -246,6 +257,7 @@ public class InstanceTransitionTests : DomainTestBase<DomainEntryPoint>
             Guid.NewGuid(),
             "transition",
             "state",
+            TriggerType.Manual,
             body,
             header
         );
@@ -266,6 +278,7 @@ public class InstanceTransitionTests : DomainTestBase<DomainEntryPoint>
             Guid.NewGuid(),
             "transition",
             "state",
+            TriggerType.Manual,
             JsonData.CreateFrom("{}"),
             JsonData.CreateFrom("{}")
         );
@@ -285,6 +298,7 @@ public class InstanceTransitionTests : DomainTestBase<DomainEntryPoint>
             Guid.NewGuid(),
             "transition1",
             "state",
+            TriggerType.Manual,
             JsonData.CreateFrom("{}"),
             JsonData.CreateFrom("{}")
         );
@@ -296,6 +310,7 @@ public class InstanceTransitionTests : DomainTestBase<DomainEntryPoint>
             Guid.NewGuid(),
             "transition2",
             "state",
+            TriggerType.Manual,
             JsonData.CreateFrom("{}"),
             JsonData.CreateFrom("{}")
         );


### PR DESCRIPTION
## Summary

Implements **Issue #396**: instance audit fields, transition audit/trigger type, and predefined system roles for instance authorization.

## Changes

### Instance & InstanceTransition audit
- **Instance** and **InstanceTransition** now use Aether-style audit interfaces (`CreatedBy`, `CreatedByBehalfOf`, `ModifiedBy`, `ModifiedByBehalfOf`). EF interceptor fills these via `ICurrentUser`.
- EF migration: `AddInstanceAndTransitionAuditFields`.
- **InstanceTransition** gains `TriggerType` to distinguish manual vs automatic transitions (used for $PreviousUser).

### Predefined system roles
- **PredefinedInstanceRoles**: `$InstanceStarter` and `$PreviousUser` as constants.
- **$InstanceStarter**: Granted when `Instance.CreatedBy` matches `CurrentUser.ActorUserName`.
- **$PreviousUser**: Granted when the last **manual** transition's `CreatedBy` matches `CurrentUser.ActorUserName`.
- `AuthorizeAppService` evaluates these roles also when `queryRoles == true`; refactored to use constructor-injected dependencies instead of passing them as parameters.

### CurrentUser from headers in execution
- **CurrentUserHeaderExtensions** (in Domain) sets `ICurrentUser` from request headers (`sub`, `act_sub`) so that sync=false (background job) transitions run with the original caller's user context for authorization.
- Used in execution API and `TransitionRunner` when running transitions from stored headers.

### Tests
- Unit tests for `PredefinedInstanceRoles` and `CurrentUserHeaderExtensions`.
- Updated `InstanceTransition` and `InstanceTransitionRepository` tests for new audit and trigger type behavior.

Closes #396

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Add auditing metadata to workflow instances and transitions, introduce predefined instance-level roles, and propagate current user context from headers into background transition execution for accurate authorization.

New Features:
- Support predefined instance-level roles ($InstanceStarter and $PreviousUser) that are resolved from instance and transition audit data during authorization checks.
- Derive current user context from request headers so background and asynchronous transition executions run under the original caller's identity.

Enhancements:
- Extend instance and instance transition models and persistence with creation and modification audit fields, including trigger type on transitions, and wire them into EF Core mappings and migrations.
- Update authorization logic to resolve predefined roles against the current actor and the last manual transition, including for state query roles, while simplifying dependency injection in the authorization service.
- Expose runtime information and domain wiring updates in the execution API module to align with Aether domain configuration.

Tests:
- Add unit tests covering predefined instance role helpers and current-user-from-headers behavior, and update existing transition domain and repository tests for the new trigger and audit fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audit tracking added to instances and transitions (created/modified metadata)
  * Transition records now include trigger type
  * Predefined instance roles ($InstanceStarter, $PreviousUser) for authorization
  * Header-based current-user context applied during execution for request-scoped identity

* **Chores**
  * Updated Aether package to version 1.0.18

* **Tests**
  * Added unit tests for header-to-current-user mapping and predefined-role detection
<!-- end of auto-generated comment: release notes by coderabbit.ai -->