### PR TITLE
Added contains filter support for instance query.

### DIFF
--- a/docs/features/instance-filtering.md
+++ b/docs/features/instance-filtering.md
@@ -99,6 +99,7 @@ Filters can target these Instance columns:
 | `modifiedAt` | Modification timestamp |
 | `completedAt` | Completion timestamp |
 | `isTransient` | Boolean flag |
+| `tags` | Array |
 
 ### JSON Attributes
 
@@ -142,6 +143,7 @@ GraphQL filters can also target Instance columns directly at the top level (e.g.
 |----------|-------------|---------|----------------|
 | `in` | Value in list | `filter=attributes=clientId=in:122,177,83` | `(Data ->> 'clientId') IN ('122','177','83')` |
 | `nin` | Value not in list | `filter=attributes=clientId=nin:122,177` | `(Data ->> 'clientId') NOT IN ('122','177')` |
+| `contains` | List contains value | `filter=attributes=tags=contains:idm` | `(Data ->> ['idm','user']) contains 'idm'` |
 
 **GraphQL-only operator:** `isNull` (e.g., `{"attributes":{"field":{"isNull":true}}}`)
 

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
@@ -316,6 +316,46 @@ public sealed class InstanceController(
         var response = await queryAppService.GetInstanceHistoryAsync(input, cancellationToken);
         return response.ToActionResult(HttpContext);
     }
+
+    /// <summary>
+    /// Retrieves the list of transition execution records for an instance (by instance key or ID).
+    /// Response includes HATEOAS links (self, instance).
+    /// </summary>
+    /// <response code="200">Transition records returned successfully</response>
+    /// <response code="404">Instance not found</response>
+    [HttpGet("{domain}/workflows/{workflow}/instances/{instance}/transitions/history")]
+    [ProducesResponseType(typeof(GetInstanceTransitionsOutput), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetInstanceTransitionRecordsAsync(
+        [FromRoute] string domain,
+        [FromRoute] string workflow,
+        [FromRoute] string instance,
+        CancellationToken cancellationToken = default)
+    {
+        var input = new GetInstanceTransitionsInput
+        {
+            Domain = domain,
+            Workflow = workflow,
+            Instance = instance
+        };
+
+        var response = await queryAppService.GetInstanceTransitionsAsync(input, cancellationToken);
+        if (response.IsSuccess)
+        {
+            var route = InstanceUrlTemplates.InstanceTransitionRecords(domain, workflow, instance, InstanceUrlTemplates.GetApiVersionPrefix("1"));
+            var items = response.Value!.Items;
+            var tempPagedList = new HateoasPagedList<InstanceTransitionItemOutput>(
+                items,
+                1,
+                items.Count,
+                false);
+            var hateoasResult = linkGenerator.CreateHateoasResult(tempPagedList, items, route);
+            response.Value!.Links = hateoasResult.Links;
+            return Result.Ok(response.Value).ToAcceptedResult(HttpContext);
+        }
+
+        return response.ToActionResult(HttpContext);
+    }
     
     [ApiExplorerSettings(IgnoreApi = true)]
     [HttpGet("{domain}/workflows/{workflow}/instances/{instance}/data")]

--- a/src/BBT.Workflow.Application/Instances/DTOs/GetInstanceInput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/GetInstanceInput.cs
@@ -138,6 +138,23 @@ public sealed class GetInstanceHistoryInput : IHasDomain
 }
 
 /// <summary>
+/// Input for retrieving instance transition records (execution log) by instance key or ID.
+/// </summary>
+public sealed class GetInstanceTransitionsInput : IHasDomain
+{
+    [Required]
+    [StringLength(WorkflowConstants.MaxDomainLength)]
+    public string Domain { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(WorkflowConstants.MaxFlowLength)]
+    public string Workflow { get; set; } = string.Empty;
+
+    [Required]
+    public string Instance { get; set; } = string.Empty;
+}
+
+/// <summary>
 /// Input for retrieving instance data (attributes only)
 /// </summary>
 public sealed class GetInstanceDataInput : IHasDomain

--- a/src/BBT.Workflow.Application/Instances/IInstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/IInstanceQueryAppService.cs
@@ -29,6 +29,13 @@ public interface IInstanceQueryAppService : IApplicationService
     Task<Result<GetInstanceHistoryOutput>> GetInstanceHistoryAsync(
         GetInstanceHistoryInput input,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the list of transition execution records for an instance by instance key or ID.
+    /// </summary>
+    Task<Result<GetInstanceTransitionsOutput>> GetInstanceTransitionsAsync(
+        GetInstanceTransitionsInput input,
+        CancellationToken cancellationToken = default);
     
     /// <summary>
     /// Retrieves only the instance data (attributes) with optional ETag support

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -22,6 +22,7 @@ public sealed class InstanceQueryAppService(
     IRuntimeInfoProvider runtimeInfoProvider,
     IComponentCacheStore componentCacheStore,
     IInstanceRepository instanceRepository,
+    IInstanceTransitionRepository instanceTransitionRepository,
     IInstanceExtensionService instanceExtensionService,
     IScriptContextFactory scriptContextFactory,
     IInstanceQueryGateway instanceQueryGateway,
@@ -224,6 +225,53 @@ public sealed class InstanceQueryAppService(
                     Transitions = transitions
                 });
             });
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<GetInstanceTransitionsOutput>> GetInstanceTransitionsAsync(
+        GetInstanceTransitionsInput input,
+        CancellationToken cancellationToken = default)
+    {
+        runtimeInfoProvider.Check(input.Domain);
+
+        return await GetInstanceByIdOrKeyAsync(input.Instance, cancellationToken)
+            .ThenAsync(async instance =>
+            {
+                var transitions = await instanceTransitionRepository.GetListByInstanceIdAsync(instance.Id, cancellationToken);
+                var items = transitions.Select(MapToTransitionItemOutput).ToList();
+                return Result<GetInstanceTransitionsOutput>.Ok(new GetInstanceTransitionsOutput { Items = items });
+            });
+    }
+
+    private static InstanceTransitionItemOutput MapToTransitionItemOutput(InstanceTransition t)
+    {
+        return new InstanceTransitionItemOutput
+        {
+            Id = t.Id,
+            InstanceId = t.InstanceId,
+            TransitionId = t.TransitionId,
+            FromState = t.FromState,
+            ToState = t.ToState,
+            StartedAt = t.StartedAt,
+            FinishedAt = t.FinishedAt,
+            Duration = t.Duration,
+            Body = TryParseJsonElement(t.Body?.Json),
+            Header = TryParseJsonElement(t.Header?.Json)
+        };
+    }
+
+    private static JsonElement? TryParseJsonElement(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json) || json == "{}")
+            return null;
+        try
+        {
+            return JsonSerializer.Deserialize<JsonElement>(json);
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Domain/Definitions/InstanceUrlTemplates.cs
+++ b/src/BBT.Workflow.Domain/Definitions/InstanceUrlTemplates.cs
@@ -28,6 +28,12 @@ public static class InstanceUrlTemplates
     public const string InstanceHistoryTemplate = "/{0}/workflows/{1}/instances/{2}/transitions";
 
     /// <summary>
+    /// URL template for instance transition records (execution log) endpoints.
+    /// Format: /{domain}/workflows/{workflow}/instances/{instance}/transitions/history
+    /// </summary>
+    public const string InstanceTransitionRecordsTemplate = "/{0}/workflows/{1}/instances/{2}/transitions/history";
+
+    /// <summary>
     /// URL template for instance transition endpoints.
     /// Format: /{domain}/workflows/{workflow}/instances/{instanceId}/transitions/{transitionKey}
     /// </summary>
@@ -135,6 +141,17 @@ public static class InstanceUrlTemplates
     /// <returns>Generated URL</returns>
     public static string InstanceHistory(string domain, string workflow, string instance, string? apiVersionPrefix = null)
         => BuildUrl(InstanceHistoryTemplate, apiVersionPrefix, domain, workflow, instance);
+
+    /// <summary>
+    /// Generates URL for instance transition records (execution log) endpoint.
+    /// </summary>
+    /// <param name="domain">The domain name</param>
+    /// <param name="workflow">The workflow name</param>
+    /// <param name="instance">The instance key or ID</param>
+    /// <param name="apiVersionPrefix">Optional API version prefix (e.g., "api/v1")</param>
+    /// <returns>Generated URL</returns>
+    public static string InstanceTransitionRecords(string domain, string workflow, string instance, string? apiVersionPrefix = null)
+        => BuildUrl(InstanceTransitionRecordsTemplate, apiVersionPrefix, domain, workflow, instance);
 
     /// <summary>
     /// Generates URL for instance transition endpoint.

--- a/src/BBT.Workflow.Domain/Instances/DTOs/GetInstanceOutput.cs
+++ b/src/BBT.Workflow.Domain/Instances/DTOs/GetInstanceOutput.cs
@@ -42,6 +42,56 @@ public sealed class GetInstanceHistoryOutput
 }
 
 /// <summary>
+/// Single transition execution record for API response.
+/// </summary>
+public sealed class InstanceTransitionItemOutput
+{
+    /// <summary>Transition record ID.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Workflow instance ID.</summary>
+    public Guid InstanceId { get; set; }
+
+    /// <summary>Transition key (e.g. transition name).</summary>
+    public string TransitionId { get; set; } = string.Empty;
+
+    /// <summary>State before the transition.</summary>
+    public string FromState { get; set; } = string.Empty;
+
+    /// <summary>State after the transition (null if not yet completed).</summary>
+    public string? ToState { get; set; }
+
+    /// <summary>When the transition started (UTC).</summary>
+    public DateTime StartedAt { get; set; }
+
+    /// <summary>When the transition finished (UTC); null if not completed.</summary>
+    public DateTime? FinishedAt { get; set; }
+
+    /// <summary>Duration of the transition; null if not completed.</summary>
+    public TimeSpan? Duration { get; set; }
+
+    /// <summary>Transition body payload.</summary>
+    public JsonElement? Body { get; set; }
+
+    /// <summary>Transition header payload.</summary>
+    public JsonElement? Header { get; set; }
+}
+
+/// <summary>
+/// Output for instance transition records (execution log) by instance.
+/// </summary>
+public sealed class GetInstanceTransitionsOutput
+{
+    /// <summary>HATEOAS links (e.g. self, instance).</summary>
+    [System.Text.Json.Serialization.JsonPropertyName("links")]
+    public object? Links { get; set; }
+
+    /// <summary>List of transition records for the instance, ordered by StartedAt.</summary>
+    [System.Text.Json.Serialization.JsonPropertyName("items")]
+    public List<InstanceTransitionItemOutput> Items { get; set; } = [];
+}
+
+/// <summary>
 /// Output for instance data
 /// </summary>
 public sealed class GetInstanceDataOutput

--- a/src/BBT.Workflow.Domain/Instances/IInstanceTransitionRepository.cs
+++ b/src/BBT.Workflow.Domain/Instances/IInstanceTransitionRepository.cs
@@ -5,6 +5,14 @@ namespace BBT.Workflow.Instances;
 public interface IInstanceTransitionRepository : IRepository<InstanceTransition, Guid>
 {
     /// <summary>
+    /// Gets all transition records for the given instance, ordered by start time.
+    /// </summary>
+    /// <param name="instanceId">The instance identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of instance transitions.</returns>
+    Task<List<InstanceTransition>> GetListByInstanceIdAsync(Guid instanceId, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Updates a transition to mark it as completed.
     /// </summary>
     /// <param name="transition">The transition to update.</param>

--- a/src/BBT.Workflow.Domain/QueryExtensions/FilterOperatorParser.cs
+++ b/src/BBT.Workflow.Domain/QueryExtensions/FilterOperatorParser.cs
@@ -8,7 +8,7 @@ namespace BBT.Workflow.Definitions;
 public static class FilterOperatorParser
 {
     private static readonly Regex OperatorRegex = new(
-        @"^([^=]+)=(eq|ne|gt|ge|lt|le|between|match|like|startswith|endswith|in|nin):(.+)$", 
+        @"^([^=]+)=(eq|ne|gt|ge|lt|le|between|match|like|startswith|endswith|in|nin|contains):(.+)$", 
         RegexOptions.Compiled | RegexOptions.IgnoreCase,
         TimeSpan.FromMilliseconds(100));
     

--- a/src/BBT.Workflow.Domain/QueryExtensions/GraphQL/FilterFormatDetector.cs
+++ b/src/BBT.Workflow.Domain/QueryExtensions/GraphQL/FilterFormatDetector.cs
@@ -13,7 +13,7 @@ public static class FilterFormatDetector
     /// Supports Instance column names (key, status, flow, createdAt, etc.)
     /// </summary>
     private static readonly Regex LegacyFilterPattern = new(
-        @"^(attributes=|key=|status=|flow=|currentstate=|state=|createdat=|modifiedat=|completedat=|istransient=)?[a-zA-Z0-9._]+=(?:eq|ne|gt|ge|lt|le|between|match|like|startswith|endswith|in|nin):.+$",
+        @"^(attributes=|key=|status=|flow=|currentstate=|state=|createdat=|modifiedat=|tags=|completedat=|istransient=)?[a-zA-Z0-9._]+=(?:eq|ne|gt|ge|lt|le|between|match|like|startswith|endswith|in|nin|contains):.+$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase,
         TimeSpan.FromMilliseconds(100));
 

--- a/src/BBT.Workflow.Domain/QueryExtensions/InstanceColumnConditionBuilder.cs
+++ b/src/BBT.Workflow.Domain/QueryExtensions/InstanceColumnConditionBuilder.cs
@@ -54,6 +54,7 @@ public static class InstanceColumnConditionBuilder
             "endswith" => BuildEndsWithCondition(properColumnName, value, ref parameterIndex),
             "in" => BuildInCondition(properColumnName, value, ref parameterIndex),
             "nin" => BuildNotInCondition(properColumnName, value, ref parameterIndex),
+            "contains" => BuildAnyCondition(properColumnName, value, ref parameterIndex),
             _ => throw new ArgumentException($"Unsupported operator: {operatorType}", nameof(operatorType))
         };
     }
@@ -251,6 +252,23 @@ public static class InstanceColumnConditionBuilder
         }
 
         var condition = $"s.\"{columnName}\" NOT IN ({string.Join(", ", paramPlaceholders)})";
+        return (condition, parameters);
+    }
+
+    /// <summary>
+    /// Build any condition with type inference
+    /// </summary>
+    private static (string, List<NpgsqlParameter>) BuildAnyCondition(
+        string columnName, string value, ref int parameterIndex)
+    {
+        var parameters = new List<NpgsqlParameter>();
+        var paramIndex = parameterIndex++;
+
+        var columnType = GetColumnType(columnName);
+        var parameter = CreateTypedParameter(value, columnType);
+        parameters.Add(parameter);
+
+        var condition = $"{{{paramIndex}}} = ANY(s.\"{columnName}\")";
         return (condition, parameters);
     }
 

--- a/src/BBT.Workflow.Domain/QueryExtensions/InstanceFieldDiscriminator.cs
+++ b/src/BBT.Workflow.Domain/QueryExtensions/InstanceFieldDiscriminator.cs
@@ -23,7 +23,8 @@ public static class InstanceFieldDiscriminator
         "CompletedAt",
         "IsTransient",
         "EffectiveStateType",
-        "EffectiveStateSubType"
+        "EffectiveStateSubType",
+        "Tags"
     };
 
     /// <summary>

--- a/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceTransitionRepository.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceTransitionRepository.cs
@@ -14,6 +14,15 @@ public class EfCoreInstanceTransitionRepository(
     : EfCoreRepository<WorkflowDbContext, InstanceTransition, Guid>(dbContext, serviceProvider),
         IInstanceTransitionRepository
 {
+    /// <inheritdoc />
+    public async Task<List<InstanceTransition>> GetListByInstanceIdAsync(Guid instanceId, CancellationToken cancellationToken = default)
+    {
+        return await (await GetQueryableAsync())
+            .Where(p => p.InstanceId == instanceId)
+            .OrderBy(p => p.StartedAt)
+            .ToListAsync(cancellationToken);
+    }
+
     /// <summary>
     /// Inserts a new instance transition and transfers to data sinks
     /// </summary>


### PR DESCRIPTION
Added endpoint to retrieve instance transition history.

## Summary by Sourcery

Add support for querying workflow instance transition execution history and extend instance filtering with a contains operator and tag column support.

New Features:
- Expose a new HTTP endpoint and application service method to retrieve ordered transition execution records for a workflow instance by key or ID, including HATEOAS metadata.
- Introduce DTOs and repository support for returning instance transition history items with timing and payload details.

Enhancements:
- Extend instance filtering to support a contains operator on array-backed columns such as tags, including parser, discriminator, and SQL condition builder updates.
- Document the new tags column and contains filter operator in the instance filtering feature documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Instance filtering now supports a "contains" operator for tags, enabling more precise filtering capabilities
  * New API endpoint available to retrieve and view instance transition records and execution history

* **Documentation**
  * Updated to document new filtering operators and query capabilities for tag-based instance filtering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->