### PR TITLE
feat(domain): Add AddHeader and RemoveHeader to tasks with Headers support

### DIFF
--- a/src/BBT.Workflow.Domain/Definitions/Tasks/DaprServiceTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/DaprServiceTask.cs
@@ -67,6 +67,31 @@ public sealed class DaprServiceTask : WorkflowTask
     {
         Headers = JsonSerializer.SerializeToElement(headers);
     }
+
+    /// <summary>
+    /// Adds or updates a single header by key. If the key already exists, its value is overwritten.
+    /// </summary>
+    /// <param name="key">The header key. Must not be null or whitespace.</param>
+    /// <param name="value">The header value; can be null.</param>
+    public void AddHeader(string key, string? value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        var d = TaskHeadersHelper.ToMutableDictionary(Headers);
+        d[key] = value;
+        Headers = TaskHeadersHelper.FromDictionary(d);
+    }
+
+    /// <summary>
+    /// Removes a header by key. Does nothing if the key does not exist.
+    /// </summary>
+    /// <param name="key">The header key to remove. Must not be null or whitespace.</param>
+    public void RemoveHeader(string key)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        var d = TaskHeadersHelper.ToMutableDictionary(Headers);
+        d.Remove(key);
+        Headers = TaskHeadersHelper.FromDictionary(d);
+    }
     
     /// <summary>
     /// Internal property setters for object pooling

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/DirectTriggerTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/DirectTriggerTask.cs
@@ -156,6 +156,31 @@ public sealed class DirectTriggerTask : WorkflowTask
     }
 
     /// <summary>
+    /// Adds or updates a single header by key. If the key already exists, its value is overwritten.
+    /// </summary>
+    /// <param name="key">The header key. Must not be null or whitespace.</param>
+    /// <param name="value">The header value; can be null.</param>
+    public void AddHeader(string key, string? value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        var d = TaskHeadersHelper.ToMutableDictionary(Headers);
+        d[key] = value;
+        Headers = TaskHeadersHelper.FromDictionary(d);
+    }
+
+    /// <summary>
+    /// Removes a header by key. Does nothing if the key does not exist.
+    /// </summary>
+    /// <param name="key">The header key to remove. Must not be null or whitespace.</param>
+    public void RemoveHeader(string key)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        var d = TaskHeadersHelper.ToMutableDictionary(Headers);
+        d.Remove(key);
+        Headers = TaskHeadersHelper.FromDictionary(d);
+    }
+
+    /// <summary>
     /// Internal property setters for object pooling
     /// </summary>
     internal void SetTransitionNameInternal(string transitionName) => TransitionName = transitionName;

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/GetInstanceDataTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/GetInstanceDataTask.cs
@@ -115,6 +115,31 @@ public sealed class GetInstanceDataTask : WorkflowTask
     }
 
     /// <summary>
+    /// Adds or updates a single header by key. If the key already exists, its value is overwritten.
+    /// </summary>
+    /// <param name="key">The header key. Must not be null or whitespace.</param>
+    /// <param name="value">The header value; can be null.</param>
+    public void AddHeader(string key, string? value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        var d = TaskHeadersHelper.ToMutableDictionary(Headers);
+        d[key] = value;
+        Headers = TaskHeadersHelper.FromDictionary(d);
+    }
+
+    /// <summary>
+    /// Removes a header by key. Does nothing if the key does not exist.
+    /// </summary>
+    /// <param name="key">The header key to remove. Must not be null or whitespace.</param>
+    public void RemoveHeader(string key)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        var d = TaskHeadersHelper.ToMutableDictionary(Headers);
+        d.Remove(key);
+        Headers = TaskHeadersHelper.FromDictionary(d);
+    }
+
+    /// <summary>
     /// Internal property setters for object pooling
     /// </summary>
     internal void SetTriggerDomainInternal(string triggerDomain) => TriggerDomain = triggerDomain;

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/GetInstancesTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/GetInstancesTask.cs
@@ -117,6 +117,31 @@ public sealed class GetInstancesTask : WorkflowTask
     }
 
     /// <summary>
+    /// Adds or updates a single header by key. If the key already exists, its value is overwritten.
+    /// </summary>
+    /// <param name="key">The header key. Must not be null or whitespace.</param>
+    /// <param name="value">The header value; can be null.</param>
+    public void AddHeader(string key, string? value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        var d = TaskHeadersHelper.ToMutableDictionary(Headers);
+        d[key] = value;
+        Headers = TaskHeadersHelper.FromDictionary(d);
+    }
+
+    /// <summary>
+    /// Removes a header by key. Does nothing if the key does not exist.
+    /// </summary>
+    /// <param name="key">The header key to remove. Must not be null or whitespace.</param>
+    public void RemoveHeader(string key)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        var d = TaskHeadersHelper.ToMutableDictionary(Headers);
+        d.Remove(key);
+        Headers = TaskHeadersHelper.FromDictionary(d);
+    }
+
+    /// <summary>
     /// Internal property setters for object pooling
     /// </summary>
     internal void SetTriggerDomainInternal(string triggerDomain) => TriggerDomain = triggerDomain;

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/HttpTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/HttpTask.cs
@@ -68,6 +68,31 @@ public sealed class HttpTask : WorkflowTask
     }
 
     /// <summary>
+    /// Adds or updates a single header by key. If the key already exists, its value is overwritten.
+    /// </summary>
+    /// <param name="key">The header key. Must not be null or whitespace.</param>
+    /// <param name="value">The header value; can be null.</param>
+    public void AddHeader(string key, string? value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        var d = TaskHeadersHelper.ToMutableDictionary(Headers);
+        d[key] = value;
+        Headers = TaskHeadersHelper.FromDictionary(d);
+    }
+
+    /// <summary>
+    /// Removes a header by key. Does nothing if the key does not exist.
+    /// </summary>
+    /// <param name="key">The header key to remove. Must not be null or whitespace.</param>
+    public void RemoveHeader(string key)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        var d = TaskHeadersHelper.ToMutableDictionary(Headers);
+        d.Remove(key);
+        Headers = TaskHeadersHelper.FromDictionary(d);
+    }
+
+    /// <summary>
     /// Internal property setters for object pooling
     /// </summary>
     internal void SetHeadersInternal(JsonElement? headers) => Headers = headers;

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/StartTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/StartTask.cs
@@ -127,6 +127,31 @@ public sealed class StartTask : WorkflowTask
     }
 
     /// <summary>
+    /// Adds or updates a single header by key. If the key already exists, its value is overwritten.
+    /// </summary>
+    /// <param name="key">The header key. Must not be null or whitespace.</param>
+    /// <param name="value">The header value; can be null.</param>
+    public void AddHeader(string key, string? value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        var d = TaskHeadersHelper.ToMutableDictionary(Headers);
+        d[key] = value;
+        Headers = TaskHeadersHelper.FromDictionary(d);
+    }
+
+    /// <summary>
+    /// Removes a header by key. Does nothing if the key does not exist.
+    /// </summary>
+    /// <param name="key">The header key to remove. Must not be null or whitespace.</param>
+    public void RemoveHeader(string key)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        var d = TaskHeadersHelper.ToMutableDictionary(Headers);
+        d.Remove(key);
+        Headers = TaskHeadersHelper.FromDictionary(d);
+    }
+
+    /// <summary>
     /// Internal property setters for object pooling
     /// </summary>
     internal void SetTriggerDomainInternal(string triggerDomain) => TriggerDomain = triggerDomain;

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/SubProcessTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/SubProcessTask.cs
@@ -126,6 +126,31 @@ public sealed class SubProcessTask : WorkflowTask
     }
 
     /// <summary>
+    /// Adds or updates a single header by key. If the key already exists, its value is overwritten.
+    /// </summary>
+    /// <param name="key">The header key. Must not be null or whitespace.</param>
+    /// <param name="value">The header value; can be null.</param>
+    public void AddHeader(string key, string? value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        var d = TaskHeadersHelper.ToMutableDictionary(Headers);
+        d[key] = value;
+        Headers = TaskHeadersHelper.FromDictionary(d);
+    }
+
+    /// <summary>
+    /// Removes a header by key. Does nothing if the key does not exist.
+    /// </summary>
+    /// <param name="key">The header key to remove. Must not be null or whitespace.</param>
+    public void RemoveHeader(string key)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        var d = TaskHeadersHelper.ToMutableDictionary(Headers);
+        d.Remove(key);
+        Headers = TaskHeadersHelper.FromDictionary(d);
+    }
+
+    /// <summary>
     /// Internal property setters for object pooling
     /// </summary>
     internal void SetTriggerDomainInternal(string triggerDomain) => TriggerDomain = triggerDomain;

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/TaskHeadersHelper.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/TaskHeadersHelper.cs
@@ -1,0 +1,65 @@
+using System.Text.Json;
+
+namespace BBT.Workflow.Definitions;
+
+/// <summary>
+/// Helper for converting task headers between <see cref="JsonElement"/> and <see cref="Dictionary{TKey,TValue}"/>.
+/// Used by tasks that support Headers to implement AddHeader and RemoveHeader.
+/// </summary>
+internal static class TaskHeadersHelper
+{
+    /// <summary>
+    /// Converts task headers from <see cref="JsonElement"/> to a mutable dictionary.
+    /// Returns an empty dictionary when headers is null, not a JSON object, or when parsing fails.
+    /// </summary>
+    /// <param name="headers">The headers as JsonElement, or null.</param>
+    /// <returns>A mutable dictionary; empty if headers is null or invalid.</returns>
+    public static Dictionary<string, string?> ToMutableDictionary(JsonElement? headers)
+    {
+        if (!headers.HasValue)
+            return new Dictionary<string, string?>();
+
+        var element = headers.Value;
+        try
+        {
+            if (element.ValueKind != JsonValueKind.Object)
+                return new Dictionary<string, string?>();
+
+            var dictionary = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+            foreach (var property in element.EnumerateObject())
+            {
+                dictionary[property.Name] = GetStringValue(property.Value);
+            }
+
+            return dictionary;
+        }
+        catch (JsonException)
+        {
+            return new Dictionary<string, string?>();
+        }
+    }
+
+    /// <summary>
+    /// Converts a dictionary of headers to <see cref="JsonElement"/> for storage on the task.
+    /// Returns null when the dictionary is null or empty.
+    /// </summary>
+    /// <param name="dict">The headers dictionary.</param>
+    /// <returns>JsonElement for the headers, or null if dict is null or empty.</returns>
+    public static JsonElement? FromDictionary(Dictionary<string, string?>? dict)
+    {
+        if (dict == null || dict.Count == 0)
+            return null;
+
+        return JsonSerializer.SerializeToElement(dict);
+    }
+
+    private static string? GetStringValue(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.Null => null,
+            JsonValueKind.String => element.GetString(),
+            _ => element.GetRawText()
+        };
+    }
+}

--- a/test/BBT.Workflow.Domain.Tests/Definitions/Tasks/TaskHeadersTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Definitions/Tasks/TaskHeadersTests.cs
@@ -1,0 +1,175 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using BBT.Workflow.Definitions;
+using Xunit;
+
+namespace BBT.Workflow.Definitions.Tasks;
+
+/// <summary>
+/// Unit tests for AddHeader and RemoveHeader on tasks that support Headers.
+/// </summary>
+public class TaskHeadersTests
+{
+    private static Dictionary<string, string?> GetHeadersDictionary(HttpTask task)
+    {
+        if (!task.Headers.HasValue)
+            return new Dictionary<string, string?>();
+        var json = task.Headers.Value.GetRawText();
+        return JsonSerializer.Deserialize<Dictionary<string, string?>>(json)
+               ?? new Dictionary<string, string?>();
+    }
+
+    [Fact]
+    public void AddHeader_WhenHeadersIsNull_ShouldAddNewHeader()
+    {
+        var task = HttpTask.CreateEmpty();
+
+        task.AddHeader("X-Custom", "value");
+
+        var headers = GetHeadersDictionary(task);
+        Assert.Single(headers);
+        Assert.Equal("value", headers["X-Custom"]);
+    }
+
+    [Fact]
+    public void AddHeader_WhenKeyExists_ShouldOverrideValue()
+    {
+        var task = HttpTask.CreateEmpty();
+        task.SetHeaders(new Dictionary<string, string?> { ["X-Foo"] = "original" });
+
+        task.AddHeader("X-Foo", "overridden");
+
+        var headers = GetHeadersDictionary(task);
+        Assert.Single(headers);
+        Assert.Equal("overridden", headers["X-Foo"]);
+    }
+
+    [Fact]
+    public void AddHeader_WhenHeadersAlreadyHasEntries_ShouldAddNewKey()
+    {
+        var task = HttpTask.CreateEmpty();
+        task.SetHeaders(new Dictionary<string, string?> { ["A"] = "a" });
+
+        task.AddHeader("B", "b");
+
+        var headers = GetHeadersDictionary(task);
+        Assert.Equal(2, headers.Count);
+        Assert.Equal("a", headers["A"]);
+        Assert.Equal("b", headers["B"]);
+    }
+
+    [Fact]
+    public void AddHeader_ShouldThrowWhenKeyIsNull()
+    {
+        var task = HttpTask.CreateEmpty();
+        Assert.ThrowsAny<ArgumentException>(() => task.AddHeader(null!, "value"));
+    }
+
+    [Fact]
+    public void AddHeader_ShouldThrowWhenKeyIsWhitespace()
+    {
+        var task = HttpTask.CreateEmpty();
+        Assert.ThrowsAny<ArgumentException>(() => task.AddHeader("", "value"));
+        Assert.ThrowsAny<ArgumentException>(() => task.AddHeader("   ", "value"));
+    }
+
+    [Fact]
+    public void AddHeader_ShouldAcceptNullValue()
+    {
+        var task = HttpTask.CreateEmpty();
+        task.AddHeader("X-Nullable", null);
+        var headers = GetHeadersDictionary(task);
+        Assert.Single(headers);
+        Assert.Null(headers["X-Nullable"]);
+    }
+
+    [Fact]
+    public void RemoveHeader_WhenKeyExists_ShouldRemoveIt()
+    {
+        var task = HttpTask.CreateEmpty();
+        task.SetHeaders(new Dictionary<string, string?>
+        {
+            ["X-Remove"] = "v1",
+            ["X-Keep"] = "v2"
+        });
+
+        task.RemoveHeader("X-Remove");
+
+        var headers = GetHeadersDictionary(task);
+        Assert.Single(headers);
+        Assert.True(headers.ContainsKey("X-Keep"));
+        Assert.Equal("v2", headers["X-Keep"]);
+    }
+
+    [Fact]
+    public void RemoveHeader_WhenKeyDoesNotExist_ShouldDoNothing()
+    {
+        var task = HttpTask.CreateEmpty();
+        task.SetHeaders(new Dictionary<string, string?> { ["X-Only"] = "v" });
+
+        task.RemoveHeader("X-Missing");
+
+        var headers = GetHeadersDictionary(task);
+        Assert.Single(headers);
+        Assert.Equal("v", headers["X-Only"]);
+    }
+
+    [Fact]
+    public void RemoveHeader_WhenHeadersIsNull_ShouldDoNothing()
+    {
+        var task = HttpTask.CreateEmpty();
+        task.RemoveHeader("X-Any");
+        Assert.False(task.Headers.HasValue);
+    }
+
+    [Fact]
+    public void RemoveHeader_ShouldThrowWhenKeyIsNull()
+    {
+        var task = HttpTask.CreateEmpty();
+        Assert.ThrowsAny<ArgumentException>(() => task.RemoveHeader(null!));
+    }
+
+    [Fact]
+    public void RemoveHeader_ShouldThrowWhenKeyIsWhitespace()
+    {
+        var task = HttpTask.CreateEmpty();
+        Assert.ThrowsAny<ArgumentException>(() => task.RemoveHeader(""));
+        Assert.ThrowsAny<ArgumentException>(() => task.RemoveHeader("   "));
+    }
+
+    [Fact]
+    public void RemoveHeader_WhenLastHeaderRemoved_ShouldSetHeadersToNull()
+    {
+        var task = HttpTask.CreateEmpty();
+        task.SetHeaders(new Dictionary<string, string?> { ["Only"] = "v" });
+
+        task.RemoveHeader("Only");
+
+        Assert.False(task.Headers.HasValue);
+    }
+
+    [Fact]
+    public void AddHeader_AndRemoveHeader_RoundTrip_ShouldBeConsistent()
+    {
+        var task = HttpTask.CreateEmpty();
+        task.AddHeader("A", "1");
+        task.AddHeader("B", "2");
+        task.RemoveHeader("A");
+        var headers = GetHeadersDictionary(task);
+        Assert.Single(headers);
+        Assert.Equal("2", headers["B"]);
+    }
+
+    [Fact]
+    public void GetInstancesTask_AddHeader_RemoveHeader_ShouldBehaveSameAsHttpTask()
+    {
+        var task = GetInstancesTask.CreateEmpty();
+        task.AddHeader("X-Test", "value");
+        var json = task.Headers!.Value.GetRawText();
+        var dict = JsonSerializer.Deserialize<Dictionary<string, string?>>(json);
+        Assert.NotNull(dict);
+        Assert.Equal("value", dict["X-Test"]);
+        task.RemoveHeader("X-Test");
+        Assert.False(task.Headers.HasValue);
+    }
+}

--- a/test/BBT.Workflow.Domain.Tests/Definitions/Tasks/TaskHeadersTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Definitions/Tasks/TaskHeadersTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using BBT.Workflow.Definitions;


### PR DESCRIPTION
## Summary
Adds `AddHeader(string key, string? value)` and `RemoveHeader(string key)` to all task definitions that support Headers, so developers can add or remove headers at runtime in CSX mappings without replacing the entire headers dictionary.

Closes #417

## Changes
- **TaskHeadersHelper** (internal): `ToMutableDictionary(JsonElement?)` and `FromDictionary(Dictionary<string, string?>?)` for consistent header serialization across tasks.
- **AddHeader(key, value)**: Adds or overrides a single header; `ArgumentException` for null/whitespace key.
- **RemoveHeader(key)**: Removes a header by key; no-op if key does not exist; same key validation.
- Applied to: HttpTask, StartTask, SubProcessTask, GetInstancesTask, GetInstanceDataTask, DirectTriggerTask, DaprServiceTask.
- **TaskHeadersTests**: Unit tests for add/override, remove, null key handling, and round-trip behavior.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Add runtime header mutation support to header-capable workflow tasks and centralize header JSON conversion.

New Features:
- Expose AddHeader and RemoveHeader APIs on workflow tasks that support headers to add, update, or remove individual headers at runtime.

Enhancements:
- Introduce an internal TaskHeadersHelper utility to consistently convert between JsonElement-based task headers and mutable dictionaries across tasks.

Tests:
- Add TaskHeadersTests to verify AddHeader and RemoveHeader behavior, including key validation, null/empty handling, and round-trip consistency across tasks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tasks gained public AddHeader and RemoveHeader methods to manage individual headers at runtime across multiple task types.

* **Tests**
  * Added comprehensive unit tests covering header add/remove behavior, validation for null/whitespace keys, null values, overriding keys, and removing the last header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->