### PR TITLE
Forward current user to remote/subflow; allow when no roles; filter transitions by role grants

### DIFF
--- a/BBT.Workflow.slnx
+++ b/BBT.Workflow.slnx
@@ -33,12 +33,4 @@
     <Project Path="workers/BBT.Workflow.Workers.Inbox/BBT.Workflow.Workers.Inbox.csproj" />
     <Project Path="workers/BBT.Workflow.Workers.Outbox/BBT.Workflow.Workers.Outbox.csproj" />
   </Folder>
-<!--  <Project Path="../aether/framework/src/BBT.Aether.Abstractions/BBT.Aether.Abstractions.csproj" />-->
-<!--  <Project Path="../aether/framework/src/BBT.Aether.Application/BBT.Aether.Application.csproj" />-->
-<!--  <Project Path="../aether/framework/src/BBT.Aether.Aspects/BBT.Aether.Aspects.csproj" />-->
-<!--  <Project Path="../aether/framework/src/BBT.Aether.AspNetCore/BBT.Aether.AspNetCore.csproj" />-->
-<!--  <Project Path="../aether/framework/src/BBT.Aether.Core/BBT.Aether.Core.csproj" />-->
-<!--  <Project Path="../aether/framework/src/BBT.Aether.Domain/BBT.Aether.Domain.csproj" />-->
-<!--  <Project Path="../aether/framework/src/BBT.Aether.Infrastructure/BBT.Aether.Infrastructure.csproj" />-->
-<!--  <Project Path="../aether/framework/src/BBT.Aether.TestBase/BBT.Aether.TestBase.csproj" />-->
 </Solution>

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs
@@ -3,6 +3,7 @@ using BBT.Aether.Application.Dtos;
 using BBT.Aether.AspNetCore.Controllers;
 using BBT.Aether.AspNetCore.Pagination;
 using BBT.Aether.Results;
+using BBT.Aether.Users;
 using BBT.Workflow.Authorization;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Domain.Shared;
@@ -28,6 +29,7 @@ public sealed class FunctionController(
     IFunctionAppService functionAppService,
     IAuthorizeAppService authorizeAppService,
     IInstanceQueryAppService queryAppService,
+    ICurrentUser currentUser,
     IPaginationLinkGenerator linkGenerator,
     IServiceScopeFactory serviceScopeFactory,
     IUrlTemplateBuilder urlTemplateBuilder) : AetherControllerBase
@@ -255,6 +257,8 @@ public sealed class FunctionController(
         Dictionary<string, string?> queryParams,
         CancellationToken cancellationToken)
     {
+        // State function uses role from ICurrentUser (claims bound by middleware), not query string.
+        var role = currentUser.Roles?.FirstOrDefault();
         var input = new GetInstanceStateInput
         {
             Domain = domain,
@@ -263,7 +267,8 @@ public sealed class FunctionController(
             Version = version,
             Extensions = extensions,
             Headers = headers,
-            QueryParams = queryParams
+            QueryParams = queryParams,
+            Role = role
         };
         return await queryAppService.GetInstanceStateAsync(input, cancellationToken);
     }

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/HostedServices/Discovery/DomainDiscoveryInitializationHostedService.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/HostedServices/Discovery/DomainDiscoveryInitializationHostedService.cs
@@ -22,7 +22,7 @@ public sealed class DomainDiscoveryInitializationHostedService(
             var discoveryResolver = scope.ServiceProvider.GetRequiredService<IDomainDiscoveryResolver>();
             
             // Step 1: Register this domain
-            // await registrationService.RegisterDomainAsync(stoppingToken);
+            await registrationService.RegisterDomainAsync(stoppingToken);
             
             // Step 2: Fetch and cache all domains
             await discoveryResolver.RefreshBulkCacheAsync(stoppingToken);

--- a/src/BBT.Workflow.Application/Authorization/AuthorizeAppService.cs
+++ b/src/BBT.Workflow.Application/Authorization/AuthorizeAppService.cs
@@ -1,6 +1,5 @@
 using BBT.Aether.Application.Services;
 using BBT.Aether.Results;
-using BBT.Aether.Users;
 using BBT.Workflow.Caching;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Gateway;
@@ -22,8 +21,7 @@ public sealed class AuthorizeAppService(
     IRuntimeInfoProvider runtimeInfoProvider,
     IComponentCacheStore componentCacheStore,
     IInstanceRepository instanceRepository,
-    IInstanceTransitionRepository instanceTransitionRepository,
-    ICurrentUser currentUser,
+    ITransitionAuthorizationManager transitionAuthorizationManager,
     IAuthorizeGateway authorizeGateway,
     ILogger<AuthorizeAppService> logger) : ApplicationService(serviceProvider), IAuthorizeAppService
 {
@@ -271,76 +269,25 @@ public sealed class AuthorizeAppService(
         if (checkQueryRoles)
             return await EvaluateQueryRolesAsync(workflow, role, instance, cancellationToken);
 
-        IReadOnlyCollection<RoleGrant>? roleGrants = null;
         if (!string.IsNullOrWhiteSpace(transitionKey))
         {
             var transition = workflow.FindTransitionInContext(transitionKey);
-            if (transition != null)
-                roleGrants = transition.Roles;
+            if (transition == null)
+                return false;
+            return await transitionAuthorizationManager.IsTransitionAllowedForRoleAsync(workflow, transition, instance, role, cancellationToken);
         }
-        else if (!string.IsNullOrWhiteSpace(functionKey))
+
+        if (!string.IsNullOrWhiteSpace(functionKey))
         {
             var fnResult = await componentCacheStore.GetFunctionAsync(domain, functionKey, workflowVersion, cancellationToken);
-            if (fnResult.IsSuccess)
-                roleGrants = fnResult.Value!.Roles;
+            if (!fnResult.IsSuccess)
+                return false;
+            if (fnResult.Value!.Roles.Count == 0)
+                return true; // No roles defined on function → allow
+            return await transitionAuthorizationManager.IsRoleAllowedForGrantsAsync(role, fnResult.Value!.Roles, instance, cancellationToken);
         }
-
-        if (roleGrants == null || roleGrants.Count == 0)
-            return false;
-
-        if (instance != null)
-            return await EvaluateRolesWithPredefinedAsync(role, roleGrants, instance, cancellationToken);
-
-        return EvaluateRoles(role, roleGrants);
-    }
-
-    /// <summary>
-    /// Evaluates role grants with resolution of predefined instance roles ($InstanceStarter, $PreviousUser).
-    /// For predefined roles, matching is against CurrentUser.ActorUserName (instance starter or previous transition creator).
-    /// DENY always wins; then any ALLOW match (including resolved predefined) yields true.
-    /// </summary>
-    private async Task<bool> EvaluateRolesWithPredefinedAsync(
-        string role,
-        IReadOnlyCollection<RoleGrant> roleGrants,
-        Instance instance,
-        CancellationToken cancellationToken)
-    {
-        var normalizedRole = role.Trim();
-        var currentActorUserName = currentUser.ActorUserName?.Trim();
-
-        string? previousUserCreatedBy = null;
-        if (roleGrants.Any(g => string.Equals(g.Role, PredefinedInstanceRoles.PreviousUser, StringComparison.Ordinal)))
-            previousUserCreatedBy = (await instanceTransitionRepository.GetLastCompletedManualTransitionAsync(instance.Id, cancellationToken))?.CreatedBy;
-
-        bool IsMatch(RoleGrant g)
-        {
-            var resolvedValue = ResolvePredefinedRole(g.Role, instance, previousUserCreatedBy);
-            if (resolvedValue != null)
-                return !string.IsNullOrEmpty(currentActorUserName) && string.Equals(currentActorUserName, resolvedValue, StringComparison.Ordinal);
-            return string.Equals(g.Role, normalizedRole, StringComparison.OrdinalIgnoreCase);
-        }
-
-        if (roleGrants.Any(g => g.IsDeny && IsMatch(g)))
-            return false;
-
-        if (roleGrants.Any(g => g.IsAllow && IsMatch(g)))
-            return true;
 
         return false;
-    }
-
-    /// <summary>
-    /// Resolves predefined role to the effective user identifier (CreatedBy) for comparison with CurrentUser.ActorUserName.
-    /// </summary>
-    private static string? ResolvePredefinedRole(string? grantRole, Instance instance, string? previousUserCreatedBy)
-    {
-        if (string.IsNullOrWhiteSpace(grantRole))
-            return null;
-        if (string.Equals(grantRole, PredefinedInstanceRoles.InstanceStarter, StringComparison.Ordinal))
-            return instance.CreatedBy;
-        if (string.Equals(grantRole, PredefinedInstanceRoles.PreviousUser, StringComparison.Ordinal))
-            return previousUserCreatedBy;
-        return null;
     }
 
     /// <summary>
@@ -361,28 +308,7 @@ public sealed class AuthorizeAppService(
         var state = workflow.FindState(currentStateKey);
         var queryRoles = state is { QueryRoles.Count: > 0 } ? state.QueryRoles : workflow.QueryRoles;
         if (queryRoles.Count == 0)
-            return false;
-        return await EvaluateRolesWithPredefinedAsync(role, queryRoles, instance, cancellationToken);
-    }
-
-    /// <summary>
-    /// Evaluates role against role grants. DENY always wins; else any ALLOW match → true; else false.
-    /// </summary>
-    private static bool EvaluateRoles(string role, IReadOnlyCollection<RoleGrant> roleGrants)
-    {
-        if (roleGrants.Count == 0)
-            return false;
-        var normalizedRole = role.Trim();
-        foreach (var g in roleGrants)
-        {
-            if (string.Equals(g.Role, normalizedRole, StringComparison.OrdinalIgnoreCase) && g.IsDeny)
-                return false;
-        }
-        foreach (var g in roleGrants)
-        {
-            if (string.Equals(g.Role, normalizedRole, StringComparison.OrdinalIgnoreCase) && g.IsAllow)
-                return true;
-        }
-        return false;
+            return true; // No query roles defined → allow
+        return await transitionAuthorizationManager.IsRoleAllowedForGrantsAsync(role, queryRoles, instance, cancellationToken);
     }
 }

--- a/src/BBT.Workflow.Application/Authorization/ITransitionAuthorizationManager.cs
+++ b/src/BBT.Workflow.Application/Authorization/ITransitionAuthorizationManager.cs
@@ -1,0 +1,60 @@
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Instances;
+using WorkflowDefinition = BBT.Workflow.Definitions.Workflow;
+
+namespace BBT.Workflow.Authorization;
+
+/// <summary>
+/// Encapsulates transition-level role grant evaluation (static roles + $InstanceStarter / $PreviousUser).
+/// Used by AuthorizeAppService for single-transition checks and by InstanceQueryAppService for filtering available transitions.
+/// </summary>
+public interface ITransitionAuthorizationManager
+{
+    /// <summary>
+    /// Evaluates whether the given role is allowed for the transition using transition.Roles.
+    /// When instance is present, predefined roles ($InstanceStarter, $PreviousUser) are resolved and matched against current user.
+    /// DENY always wins; if no DENY match, any ALLOW match yields true.
+    /// </summary>
+    /// <param name="workflow">The workflow definition (for context).</param>
+    /// <param name="transition">The transition whose Roles are evaluated.</param>
+    /// <param name="instance">Optional instance for resolving $InstanceStarter and $PreviousUser.</param>
+    /// <param name="role">The caller's role to check.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if the role is allowed for the transition; false otherwise.</returns>
+    Task<bool> IsTransitionAllowedForRoleAsync(
+        WorkflowDefinition workflow,
+        Transition transition,
+        Instance? instance,
+        string role,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Filters a list of transition keys to only those allowed for the given role.
+    /// Uses the same evaluation as <see cref="IsTransitionAllowedForRoleAsync"/> per transition.
+    /// </summary>
+    /// <param name="workflow">The workflow definition.</param>
+    /// <param name="currentState">Current state (used to resolve transition by key via workflow context).</param>
+    /// <param name="instance">Optional instance for predefined role resolution.</param>
+    /// <param name="transitionKeys">Candidate transition keys to filter.</param>
+    /// <param name="role">The caller's role.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of transition keys that are allowed for the role.</returns>
+    Task<IReadOnlyList<string>> FilterAuthorizedTransitionKeysAsync(
+        WorkflowDefinition workflow,
+        State currentState,
+        Instance? instance,
+        IReadOnlyList<string> transitionKeys,
+        string role,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Evaluates whether the given role is allowed for a set of role grants (e.g. function or state queryRoles).
+    /// When instance is present, predefined roles ($InstanceStarter, $PreviousUser) are resolved.
+    /// DENY always wins; if no DENY match, any ALLOW match yields true.
+    /// </summary>
+    Task<bool> IsRoleAllowedForGrantsAsync(
+        string role,
+        IReadOnlyCollection<RoleGrant> roleGrants,
+        Instance? instance,
+        CancellationToken cancellationToken = default);
+}

--- a/src/BBT.Workflow.Application/Authorization/TransitionAuthorizationManager.cs
+++ b/src/BBT.Workflow.Application/Authorization/TransitionAuthorizationManager.cs
@@ -1,0 +1,145 @@
+using BBT.Aether.Users;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Instances;
+using WorkflowDefinition = BBT.Workflow.Definitions.Workflow;
+
+namespace BBT.Workflow.Authorization;
+
+/// <summary>
+/// Evaluates transition-level role grants (static + $InstanceStarter / $PreviousUser).
+/// DENY always wins; if no DENY match, any ALLOW match yields allowed.
+/// </summary>
+public sealed class TransitionAuthorizationManager(
+    ICurrentUser currentUser,
+    IInstanceTransitionRepository instanceTransitionRepository) : ITransitionAuthorizationManager
+{
+    /// <inheritdoc />
+    public async Task<bool> IsTransitionAllowedForRoleAsync(
+        WorkflowDefinition workflow,
+        Transition transition,
+        Instance? instance,
+        string role,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(role))
+            return false;
+
+        var roleGrants = transition.Roles;
+        if (roleGrants.Count == 0)
+            return true; // No roles defined → allow
+
+        if (instance != null)
+            return await EvaluateRolesWithPredefinedAsync(role, roleGrants, instance, cancellationToken);
+
+        return EvaluateRoles(role, roleGrants);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<string>> FilterAuthorizedTransitionKeysAsync(
+        WorkflowDefinition workflow,
+        State currentState,
+        Instance? instance,
+        IReadOnlyList<string> transitionKeys,
+        string role,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(role) || transitionKeys.Count == 0)
+            return transitionKeys;
+
+        var result = new List<string>();
+        foreach (var key in transitionKeys)
+        {
+            var transition = workflow.FindTransitionInContext(key);
+            if (transition == null)
+                continue;
+            var allowed = await IsTransitionAllowedForRoleAsync(workflow, transition, instance, role, cancellationToken);
+            if (allowed)
+                result.Add(key);
+        }
+        return result;
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> IsRoleAllowedForGrantsAsync(
+        string role,
+        IReadOnlyCollection<RoleGrant> roleGrants,
+        Instance? instance,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(role))
+            return false;
+        if (roleGrants.Count == 0)
+            return true; // No roles defined → allow
+        if (instance != null)
+            return await EvaluateRolesWithPredefinedAsync(role, roleGrants, instance, cancellationToken);
+        return EvaluateRoles(role, roleGrants);
+    }
+
+    /// <summary>
+    /// Evaluates role grants with resolution of predefined instance roles ($InstanceStarter, $PreviousUser).
+    /// </summary>
+    private async Task<bool> EvaluateRolesWithPredefinedAsync(
+        string role,
+        IReadOnlyCollection<RoleGrant> roleGrants,
+        Instance instance,
+        CancellationToken cancellationToken)
+    {
+        var normalizedRole = role.Trim();
+        var currentActorUserName = currentUser.ActorUserName?.Trim();
+
+        string? previousUserCreatedBy = null;
+        if (roleGrants.Any(g => string.Equals(g.Role, PredefinedInstanceRoles.PreviousUser, StringComparison.Ordinal)))
+            previousUserCreatedBy = (await instanceTransitionRepository.GetLastCompletedManualTransitionAsync(instance.Id, cancellationToken))?.CreatedBy;
+
+        bool IsMatch(RoleGrant g)
+        {
+            var resolvedValue = ResolvePredefinedRole(g.Role, instance, previousUserCreatedBy);
+            if (resolvedValue != null)
+                return !string.IsNullOrEmpty(currentActorUserName) && string.Equals(currentActorUserName, resolvedValue, StringComparison.Ordinal);
+            return string.Equals(g.Role, normalizedRole, StringComparison.OrdinalIgnoreCase);
+        }
+
+        if (roleGrants.Any(g => g.IsDeny && IsMatch(g)))
+            return false;
+
+        if (roleGrants.Any(g => g.IsAllow && IsMatch(g)))
+            return true;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Resolves predefined role to the effective user identifier for comparison with CurrentUser.ActorUserName.
+    /// </summary>
+    private static string? ResolvePredefinedRole(string? grantRole, Instance instance, string? previousUserCreatedBy)
+    {
+        if (string.IsNullOrWhiteSpace(grantRole))
+            return null;
+        if (string.Equals(grantRole, PredefinedInstanceRoles.InstanceStarter, StringComparison.Ordinal))
+            return instance.CreatedBy;
+        if (string.Equals(grantRole, PredefinedInstanceRoles.PreviousUser, StringComparison.Ordinal))
+            return previousUserCreatedBy;
+        return null;
+    }
+
+    /// <summary>
+    /// Evaluates role against role grants (static only). DENY always wins; else any ALLOW match → true.
+    /// </summary>
+    private static bool EvaluateRoles(string role, IReadOnlyCollection<RoleGrant> roleGrants)
+    {
+        if (roleGrants.Count == 0)
+            return true; // No roles defined → allow
+        var normalizedRole = role.Trim();
+        foreach (var g in roleGrants)
+        {
+            if (string.Equals(g.Role, normalizedRole, StringComparison.OrdinalIgnoreCase) && g.IsDeny)
+                return false;
+        }
+        foreach (var g in roleGrants)
+        {
+            if (string.Equals(g.Role, normalizedRole, StringComparison.OrdinalIgnoreCase) && g.IsAllow)
+                return true;
+        }
+        return false;
+    }
+}

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/HandleSubFlowStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/HandleSubFlowStep.cs
@@ -58,7 +58,11 @@ public sealed class HandleSubFlowStep(
     /// </summary>
     private Error CreateConfigInvalidError(TransitionExecutionContext context)
     {
-        logger.SubFlowConfigInvalid(context.Target!.Key, context.InstanceId);
+        if (context.Target?.SubFlow == null)
+        {
+            logger.SubFlowConfigInvalid(context.Target!.Key, context.InstanceId);    
+        }
+        
         return WorkflowErrors.ConfigInvalid(context.InstanceId, context.Target.Key);
     }
 

--- a/src/BBT.Workflow.Application/Instances/DTOs/GetFunctionWithInstanceInput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/GetFunctionWithInstanceInput.cs
@@ -28,8 +28,14 @@ public sealed class GetFunctionWithInstanceInput : IHasDomain
     /// Extensions to be appended to the data href URL
     /// </summary>
     public string[]? Extensions { get; set; }
+
     public Dictionary<string, string?> Headers { get; set; }
+
     public Dictionary<string, string?> QueryParams { get; set; }
 
+    /// <summary>
+    /// Caller role for state function (e.g. to filter available transitions by transition role grants when calling SubFlow state).
+    /// </summary>
+    public string? Role { get; set; }
 }
 

--- a/src/BBT.Workflow.Application/Instances/DTOs/GetInstanceStateInput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/GetInstanceStateInput.cs
@@ -28,7 +28,14 @@ public sealed class GetInstanceStateInput : IHasDomain
     /// Extensions to be appended to the data href URL
     /// </summary>
     public string[]? Extensions { get; set; }
-    public Dictionary<string, string?> Headers { get; set; }
-     public Dictionary<string, string?> QueryParams { get; set; }
 
+    public Dictionary<string, string?> Headers { get; set; }
+
+    public Dictionary<string, string?> QueryParams { get; set; }
+
+    /// <summary>
+    /// Caller role for filtering available transitions by transition role grants.
+    /// When set, only transitions allowed for this role are returned; when null or empty, all available transitions are returned.
+    /// </summary>
+    public string? Role { get; set; }
 }

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -2,6 +2,7 @@ using BBT.Aether;
 using BBT.Aether.Application.Services;
 using BBT.Aether.Domain.Entities;
 using BBT.Aether.Results;
+using BBT.Workflow.Authorization;
 using BBT.Workflow.Caching;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Logging;
@@ -15,6 +16,7 @@ using BBT.Workflow.Shared;
 using System.Text.Json;
 using BBT.Workflow.Definitions.GraphQL;
 using BBT.Workflow.Tasks.Coordinator;
+
 namespace BBT.Workflow.Instances;
 
 public sealed class InstanceQueryAppService(
@@ -27,6 +29,7 @@ public sealed class InstanceQueryAppService(
     IInstanceQueryGateway instanceQueryGateway,
     ITaskConditionService taskConditionService,
     IUrlTemplateBuilder urlTemplateBuilder,
+    ITransitionAuthorizationManager transitionAuthorizationManager,
     ILogger<InstanceQueryAppService> logger)
     : ApplicationService(serviceProvider), IInstanceQueryAppService
 {
@@ -92,7 +95,8 @@ public sealed class InstanceQueryAppService(
                     {
                         parsedRequest = request;
                         // Apply sort from query param (overrides envelope orderBy when provided)
-                        if (!string.IsNullOrWhiteSpace(input.Sort) && GraphQLFilterParser.ParseOrderBy(input.Sort) is { } orderBy)
+                        if (!string.IsNullOrWhiteSpace(input.Sort) && GraphQLFilterParser.ParseOrderBy(input.Sort) is
+                                { } orderBy)
                         {
                             parsedRequest.OrderBy = orderBy;
                         }
@@ -171,13 +175,15 @@ public sealed class InstanceQueryAppService(
                         throw new UserFriendlyException(
                             instanceOutputResult.Error.Code,
                             instanceOutputResult.Error.Message,
-                            instanceOutputResult.Error.Detail).WithData("Target", instanceOutputResult.Error.Target ?? string.Empty);
+                            instanceOutputResult.Error.Detail).WithData("Target",
+                            instanceOutputResult.Error.Target ?? string.Empty);
                     }
 
                     list.Add(instanceOutputResult.Value!);
                 }
 
-                var resultPagedList = new HateoasPagedList<GetInstanceOutput>(list, pagedList.CurrentPage, pagedList.PageSize,
+                var resultPagedList = new HateoasPagedList<GetInstanceOutput>(list, pagedList.CurrentPage,
+                    pagedList.PageSize,
                     pagedList.HasNext);
 
                 return InstanceListWithGroupsResponse<GetInstanceOutput>.FromPagedList(resultPagedList, null);
@@ -263,13 +269,14 @@ public sealed class InstanceQueryAppService(
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>SubFlowStateInfo containing transitions, state, view extensions, and active correlations from SubFlow</returns>
     private async Task<SubFlowStateInfo> GetSubFlowTransitionsAsync(
-    InstanceCorrelationInfo activeSubFlowCorrelation,
-    Instance mainInstance,
-    BBT.Workflow.Definitions.Workflow currentWorkflow,
-    string[]? extensions,
-    Dictionary<string, string?> headers,
-    Dictionary<string, string?> queryParams,
-    CancellationToken cancellationToken = default)
+        InstanceCorrelationInfo activeSubFlowCorrelation,
+        Instance mainInstance,
+        BBT.Workflow.Definitions.Workflow currentWorkflow,
+        string[]? extensions,
+        Dictionary<string, string?> headers,
+        Dictionary<string, string?> queryParams,
+        string? role,
+        CancellationToken cancellationToken = default)
     {
         try
         {
@@ -279,7 +286,10 @@ public sealed class InstanceQueryAppService(
                 Workflow = activeSubFlowCorrelation.SubFlowName,
                 Version = activeSubFlowCorrelation.SubFlowVersion,
                 Instance = activeSubFlowCorrelation.SubFlowInstanceId.ToString(),
-                Extensions = extensions
+                Extensions = extensions,
+                Headers = headers,
+                QueryParams = queryParams,
+                Role = role
             };
 
             var subFlowResult = await instanceQueryGateway.GetFunctionWithStateAsync(
@@ -289,7 +299,7 @@ public sealed class InstanceQueryAppService(
             if (subFlowResult.IsSuccess && subFlowResult.Value != null)
             {
                 var subFlowValue = subFlowResult.Value;
-                
+
                 // Extract transition names from TransitionItem list
                 var transitionNames = subFlowValue.Transitions?
                     .Select(t => t.Name)
@@ -383,7 +393,7 @@ public sealed class InstanceQueryAppService(
         {
             Id = instance.Id,
             Flow = instance.Flow,
-            FlowVersion =flow?.Version ?? string.Empty,
+            FlowVersion = flow?.Version ?? string.Empty,
             Etag = instanceData?.ETag ?? string.Empty,
             Domain = domain,
             Key = instance.Key!,
@@ -463,7 +473,8 @@ public sealed class InstanceQueryAppService(
                             input.Extensions,
                             cancellationToken);
 
-                        result.Extensions = subFlowExtensionsResult.Value?.Extensions ?? new Dictionary<string, object>();
+                        result.Extensions = subFlowExtensionsResult.Value?.Extensions ??
+                                            new Dictionary<string, object>();
 
                         return ConditionalResult<GetInstanceDataOutput>.Success(result);
                     }
@@ -560,7 +571,7 @@ public sealed class InstanceQueryAppService(
     /// Builds the complete instance state output including transitions, correlations, and view information.
     /// When there's an active SubFlow, includes the SubFlow's view extensions in data href and merges active correlations.
     /// </summary>
-private async Task<Result<GetInstanceStateOutput>> BuildInstanceStateOutputAsync(
+    private async Task<Result<GetInstanceStateOutput>> BuildInstanceStateOutputAsync(
         Instance instance,
         Definitions.Workflow currentWorkflow,
         GetInstanceStateInput input,
@@ -576,91 +587,88 @@ private async Task<Result<GetInstanceStateOutput>> BuildInstanceStateOutputAsync
             .FirstOrDefault();
 
         var subFlowStateInfo = activeSubFlowCorrelation != null
-            ? await GetSubFlowTransitionsAsync(activeSubFlowCorrelation, instance, currentWorkflow, input.Extensions,input.Headers,input.QueryParams, cancellationToken)
+            ? await GetSubFlowTransitionsAsync(activeSubFlowCorrelation, instance, currentWorkflow, input.Extensions,
+                input.Headers, input.QueryParams, input.Role, cancellationToken)
             : GetMainFlowTransitions(instance, currentWorkflow, transitionInfo);
 
-        // Build transition items with href links
-        var transitionItems = subFlowStateInfo.AvailableTransitions.Select(transitionKey => new TransitionItem
-        {
-            Name = transitionKey,
-            Href = urlTemplateBuilder.BuildTransitionUrl(input.Domain, input.Workflow, instance.Id.ToString(), transitionKey),
-            Schema = new HrefBase { Href = urlTemplateBuilder.BuildSchemaUrl(input.Domain, input.Workflow, instance.Id.ToString(), transitionKey) }
-        }).ToList();
-
-        // Get current state using Railway pattern
-        return currentWorkflow.GetState(instance.CurrentState!)
+        var stateResult = currentWorkflow.GetState(instance.CurrentState!)
             .Ensure(
                 state => state != null,
-                Error.NotFound("notfound", $"State {instance.CurrentState} not found in workflow {input.Workflow}"))
-           .Map(currentStateValue =>
+                Error.NotFound("notfound", $"State {instance.CurrentState} not found in workflow {input.Workflow}"));
+        if (!stateResult.IsSuccess)
+            return Result<GetInstanceStateOutput>.Fail(stateResult.Error);
+
+        var currentStateValue = stateResult.Value!;
+        var keysForTransitions = subFlowStateInfo.AvailableTransitions;
+        if (!string.IsNullOrWhiteSpace(input.Role))
+            keysForTransitions = (await transitionAuthorizationManager.FilterAuthorizedTransitionKeysAsync(
+                    currentWorkflow, currentStateValue, instance, keysForTransitions, input.Role!, cancellationToken))
+                .ToList();
+
+        var transitionItems = keysForTransitions.Select(transitionKey => new TransitionItem
+        {
+            Name = transitionKey,
+            Href = urlTemplateBuilder.BuildTransitionUrl(input.Domain, input.Workflow, instance.Id.ToString(),
+                transitionKey),
+            Schema = new HrefBase
             {
-                // Get view definition from main flow
-                var viewDefinition = GetViewDefinition(instance, currentWorkflow, currentStateValue);
+                Href = urlTemplateBuilder.BuildSchemaUrl(input.Domain, input.Workflow, instance.Id.ToString(),
+                    transitionKey)
+            }
+        }).ToList();
 
-                // Get extensions and loadData from first view entry (if available)
-                // For state output, we use the first/default view entry's extensions
-                var firstViewEntry = viewDefinition?.Views.FirstOrDefault();
-                var viewExtensions = firstViewEntry?.Extensions ?? [];
-                var viewLoadData = firstViewEntry?.LoadData ?? false;
+        var viewDefinition = GetViewDefinition(instance, currentWorkflow, currentStateValue);
+        var firstViewEntry = viewDefinition?.Views.FirstOrDefault();
+        var viewExtensions = firstViewEntry?.Extensions ?? [];
+        var viewLoadData = firstViewEntry?.LoadData ?? false;
+        var allExtensions = subFlowStateInfo.SubFlowData != null
+            ? ExtractExtensionsFromDataHref(subFlowStateInfo.SubFlowData.Href)
+            : (input.Extensions ?? []).Concat(viewExtensions).ToArray();
+        var dataHref = new DataHref
+        {
+            Href = allExtensions.Length > 0
+                ? urlTemplateBuilder.BuildDataWithExtensionsUrl(input.Domain, input.Workflow, instance.Id.ToString(),
+                    allExtensions)
+                : urlTemplateBuilder.BuildDataUrl(input.Domain, input.Workflow, instance.Id.ToString())
+        };
+        var viewHref = new ViewHref
+        {
+            Href = urlTemplateBuilder.BuildViewUrl(input.Domain, input.Workflow, instance.Id.ToString()),
+            LoadData = subFlowStateInfo.SubFlowView?.LoadData ?? viewLoadData
+        };
+        var mainFlowCorrelationHrefs = transitionInfo.ActiveCorrelations.Select(correlation =>
+            new ActiveCorrelationHref
+            {
+                CorrelationId = correlation.CorrelationId,
+                ParentState = correlation.ParentState,
+                SubFlowInstanceId = correlation.SubFlowInstanceId,
+                SubFlowType = correlation.SubFlowType,
+                SubFlowDomain = correlation.SubFlowDomain,
+                SubFlowName = correlation.SubFlowName,
+                SubFlowVersion = correlation.SubFlowVersion,
+                IsCompleted = correlation.IsCompleted,
+                Href = allExtensions.Length > 0
+                    ? urlTemplateBuilder.BuildDataWithExtensionsUrl(correlation.SubFlowDomain, correlation.SubFlowName,
+                        correlation.SubFlowInstanceId.ToString(), allExtensions)
+                    : urlTemplateBuilder.BuildDataUrl(correlation.SubFlowDomain, correlation.SubFlowName,
+                        correlation.SubFlowInstanceId.ToString())
+            }).ToList();
+        var allActiveCorrelations = subFlowStateInfo.SubFlowActiveCorrelations != null
+            ? mainFlowCorrelationHrefs.Concat(subFlowStateInfo.SubFlowActiveCorrelations).ToList()
+            : mainFlowCorrelationHrefs;
 
-                // Build data href with extensions
-                // If SubFlow is active, use SubFlow's extensions; otherwise use main flow extensions
-                var allExtensions = subFlowStateInfo.SubFlowData != null
-                    ? ExtractExtensionsFromDataHref(subFlowStateInfo.SubFlowData.Href)
-                    : (input.Extensions ?? []).Concat(viewExtensions).ToArray();
-
-                var dataHref = new DataHref
-                {
-                    Href = allExtensions.Length > 0
-                        ? urlTemplateBuilder.BuildDataWithExtensionsUrl(input.Domain, input.Workflow, instance.Id.ToString(),
-                            allExtensions)
-                        : urlTemplateBuilder.BuildDataUrl(input.Domain, input.Workflow, instance.Id.ToString())
-                };
-
-                // Build view href - use SubFlow view's LoadData if available, otherwise use main flow
-                var viewHref = new ViewHref
-                {
-                    Href = urlTemplateBuilder.BuildViewUrl(input.Domain, input.Workflow, instance.Id.ToString()),
-                    LoadData = subFlowStateInfo.SubFlowView?.LoadData ?? viewLoadData
-                };
-
-                // Build active correlations with href links from main flow
-                var mainFlowCorrelationHrefs = transitionInfo.ActiveCorrelations.Select(correlation =>
-                    new ActiveCorrelationHref
-                    {
-                        CorrelationId = correlation.CorrelationId,
-                        ParentState = correlation.ParentState,
-                        SubFlowInstanceId = correlation.SubFlowInstanceId,
-                        SubFlowType = correlation.SubFlowType,
-                        SubFlowDomain = correlation.SubFlowDomain,
-                        SubFlowName = correlation.SubFlowName,
-                        SubFlowVersion = correlation.SubFlowVersion,
-                        IsCompleted = correlation.IsCompleted,
-                        Href = allExtensions.Length > 0
-                            ? urlTemplateBuilder.BuildDataWithExtensionsUrl(correlation.SubFlowDomain, correlation.SubFlowName,
-                                correlation.SubFlowInstanceId.ToString(),
-                                allExtensions)
-                            : urlTemplateBuilder.BuildDataUrl(correlation.SubFlowDomain, correlation.SubFlowName,
-                                correlation.SubFlowInstanceId.ToString())
-                    }).ToList();
-
-                // Merge SubFlow active correlations if available
-                var allActiveCorrelations = subFlowStateInfo.SubFlowActiveCorrelations != null
-                    ? mainFlowCorrelationHrefs.Concat(subFlowStateInfo.SubFlowActiveCorrelations).ToList()
-                    : mainFlowCorrelationHrefs;
-
-                return new GetInstanceStateOutput
-                {
-                    Data = dataHref,
-                    View = viewHref,
-                    State = subFlowStateInfo.CurrentState ?? string.Empty,
-                    Status = subFlowStateInfo.Status,
-                    ActiveCorrelations = allActiveCorrelations,
-                    Transitions = transitionItems,
-                    ETag = instance.LatestData?.ETag ?? string.Empty
-                };
-            });
+        return Result<GetInstanceStateOutput>.Ok(new GetInstanceStateOutput
+        {
+            Data = dataHref,
+            View = viewHref,
+            State = subFlowStateInfo.CurrentState ?? string.Empty,
+            Status = subFlowStateInfo.Status,
+            ActiveCorrelations = allActiveCorrelations,
+            Transitions = transitionItems,
+            ETag = instance.LatestData?.ETag ?? string.Empty
+        });
     }
+
     /// <summary>
     /// Extracts extension parameters from a data href URL.
     /// </summary>
@@ -684,7 +692,8 @@ private async Task<Result<GetInstanceStateOutput>> BuildInstanceStateOutputAsync
 
         if (queryParams.TryGetValue("extensions", out var extensionsValues))
         {
-            return extensionsValues.SelectMany(v => v?.Split(',', StringSplitOptions.RemoveEmptyEntries) ?? []).ToArray();
+            return extensionsValues.SelectMany(v => v?.Split(',', StringSplitOptions.RemoveEmptyEntries) ?? [])
+                .ToArray();
         }
 
         return [];
@@ -1038,8 +1047,8 @@ private async Task<Result<GetInstanceStateOutput>> BuildInstanceStateOutputAsync
         State currentState,
         string? platform,
         string? transitionKey = null,
-        Dictionary<string, string?>? headers=null,
-        Dictionary<string, string?>? queryParams=null, 
+        Dictionary<string, string?>? headers = null,
+        Dictionary<string, string?>? queryParams = null,
         CancellationToken cancellationToken = default)
     {
         var subFlowViewResult = await instanceQueryGateway.GetFunctionWithViewAsync(
@@ -1049,9 +1058,8 @@ private async Task<Result<GetInstanceStateOutput>> BuildInstanceStateOutputAsync
                 Domain = instance.Subflow!.SubFlowDomain,
                 Workflow = instance.Subflow!.SubFlowName,
                 Version = instance.Subflow!.SubFlowVersion,
-                Headers=headers,
-                QueryParams=queryParams
-
+                Headers = headers,
+                QueryParams = queryParams
             },
             platform?.ToLowerInvariant(),
             transitionKey,

--- a/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
@@ -54,6 +54,7 @@ public static class WorkflowApplicationModuleServiceCollectionExtensions
         services.AddScoped<IInstanceQueryAppService, InstanceQueryAppService>();
         services.AddScoped<IInstanceRetryAppService, InstanceRetryAppService>();
         services.AddScoped<IFunctionAppService, FunctionAppService>();
+        services.AddScoped<ITransitionAuthorizationManager, TransitionAuthorizationManager>();
         services.AddScoped<IAuthorizeAppService, AuthorizeAppService>();
         services.AddScoped<IInstanceExtensionService, InstanceExtensionService>();
         services.AddScoped<ISubflowCompletionService, SubflowCompletionService>();

--- a/src/BBT.Workflow.Application/SubFlow/Services/ChildSubflowCancellationService.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/ChildSubflowCancellationService.cs
@@ -1,8 +1,6 @@
-using BBT.Aether.Application.Services;
 using BBT.Aether.Results;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Gateway;
-using BBT.Workflow.Instances;
 using BBT.Workflow.Logging;
 using Microsoft.Extensions.Logging;
 
@@ -18,10 +16,9 @@ namespace BBT.Workflow.SubFlow;
 /// making it reusable across different consumers (handlers, hooks, controllers).
 /// </remarks>
 public sealed class ChildSubflowCancellationService(
-    IServiceProvider serviceProvider,
     IInstanceCommandGateway instanceCommandGateway,
     ILogger<ChildSubflowCancellationService> logger)
-    : ApplicationService(serviceProvider), IChildSubflowCancellationService
+    :  IChildSubflowCancellationService
 {
     /// <inheritdoc />
     public async Task<Result> CancelChildSubflowAsync(

--- a/src/BBT.Workflow.Application/SubFlow/Services/SubflowCompletionService.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubflowCompletionService.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using BBT.Aether.Application.Services;
 using BBT.Aether.Guids;
 using BBT.Workflow.Caching;
 using BBT.Workflow.Definitions;
@@ -18,7 +17,6 @@ namespace BBT.Workflow.SubFlow;
 
 /// <inheritdoc cref="ISubflowCompletionService" />
 public sealed class SubflowCompletionService(
-    IServiceProvider serviceProvider,
     IComponentCacheStore componentCacheStore,
     IInstanceRepository instanceRepository,
     IScriptEngine scriptEngine,
@@ -27,7 +25,7 @@ public sealed class SubflowCompletionService(
     IGuidGenerator guidGenerator,
     IWorkflowExecutionService workflowExecutionService,
     ILogger<SubflowCompletionService> logger)
-    : ApplicationService(serviceProvider), ISubflowCompletionService
+    : ISubflowCompletionService
 {
     /// <inheritdoc />
     public async Task CompletionAsync(

--- a/src/BBT.Workflow.Application/SubFlow/Services/SubflowStateService.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubflowStateService.cs
@@ -1,4 +1,3 @@
-using BBT.Aether.Application.Services;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Logging;
 using Microsoft.Extensions.Logging;
@@ -7,10 +6,9 @@ namespace BBT.Workflow.SubFlow;
 
 /// <inheritdoc cref="ISubflowStateService" />
 public sealed class SubflowStateService(
-    IServiceProvider serviceProvider,
     IInstanceRepository instanceRepository,
     ILogger<SubflowStateService> logger)
-    : ApplicationService(serviceProvider), ISubflowStateService
+    :  ISubflowStateService
 {
     /// <inheritdoc />
     public async Task UpdateParentStateAsync(

--- a/src/BBT.Workflow.Domain/CurrentUser/CurrentUserHeaderExtensions.cs
+++ b/src/BBT.Workflow.Domain/CurrentUser/CurrentUserHeaderExtensions.cs
@@ -5,8 +5,9 @@ namespace BBT.Workflow.CurrentUser;
 /// <summary>
 /// Header key constants aligned with Aether claim types used by HeaderCurrentUserResolver.
 /// Used when building ICurrentUser from a request headers dictionary (e.g. in background job execution scope).
+/// Also used when forwarding current user to remote or subflow requests.
 /// </summary>
-internal static class CurrentUserHeaderKeys
+public static class CurrentUserHeaderKeys
 {
     public const string UserId = "userId";
     public const string UserName = "sub";
@@ -16,6 +17,14 @@ internal static class CurrentUserHeaderKeys
     public const string ActorSub = "act_sub";
     public const string ActorUserId = "act_uid";
     public const string ConsentId = "consent_id";
+
+    /// <summary>
+    /// All header keys that should be forwarded to remote/subflow requests so the downstream can resolve ICurrentUser.
+    /// </summary>
+    public static readonly string[] ForwardKeys =
+    [
+        UserId, UserName, Name, SurName, Role, ActorSub, ActorUserId, ConsentId
+    ];
 }
 
 /// <summary>
@@ -59,6 +68,32 @@ public static class CurrentUserHeaderExtensions
             actorUserId,
             actorUserName,
             consentId);
+    }
+
+    /// <summary>
+    /// Builds the forward headers dictionary from the current user for remote/subflow requests.
+    /// Downstream can resolve ICurrentUser from these headers.
+    /// </summary>
+    public static Dictionary<string, string?> ToForwardHeaders(this ICurrentUser currentUser)
+    {
+        var headers = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        if (!string.IsNullOrEmpty(currentUser.Id))
+            headers[CurrentUserHeaderKeys.UserId] = currentUser.Id;
+        if (!string.IsNullOrEmpty(currentUser.UserName))
+            headers[CurrentUserHeaderKeys.UserName] = currentUser.UserName;
+        if (!string.IsNullOrEmpty(currentUser.Name))
+            headers[CurrentUserHeaderKeys.Name] = currentUser.Name;
+        if (!string.IsNullOrEmpty(currentUser.Surname))
+            headers[CurrentUserHeaderKeys.SurName] = currentUser.Surname;
+        if (currentUser.Roles is { Length: > 0 })
+            headers[CurrentUserHeaderKeys.Role] = string.Join(",", currentUser.Roles);
+        if (!string.IsNullOrEmpty(currentUser.ActorUserId))
+            headers[CurrentUserHeaderKeys.ActorUserId] = currentUser.ActorUserId;
+        if (!string.IsNullOrEmpty(currentUser.ActorUserName))
+            headers[CurrentUserHeaderKeys.ActorSub] = currentUser.ActorUserName;
+        if (!string.IsNullOrEmpty(currentUser.ConsentId))
+            headers[CurrentUserHeaderKeys.ConsentId] = currentUser.ConsentId;
+        return headers;
     }
 
     private static string? GetHeader(IReadOnlyDictionary<string, string?> headers, string key)

--- a/src/BBT.Workflow.Infrastructure/Authorization/Remote/RemoteAuthorizeAppService.cs
+++ b/src/BBT.Workflow.Infrastructure/Authorization/Remote/RemoteAuthorizeAppService.cs
@@ -86,7 +86,7 @@ public sealed class RemoteAuthorizeAppService(
                 return Result<AuthorizeOutput>.Ok(output ?? new AuthorizeOutput { Allowed = false });
             }
 
-            var error = await MapStatusCodeToErrorCore(response, cancellationToken);
+            var error = await RemoteHttpResponseHelper.MapToErrorAsync(response, cancellationToken, JsonOptions);
             return Result<AuthorizeOutput>.Fail(error);
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or OperationCanceledException)
@@ -128,7 +128,7 @@ public sealed class RemoteAuthorizeAppService(
                 return Result<AuthorizationMatrixOutput>.Ok(output!);
             }
 
-            var error = await MapStatusCodeToErrorCore(response, cancellationToken);
+            var error = await RemoteHttpResponseHelper.MapToErrorAsync(response, cancellationToken, JsonOptions);
             return Result<AuthorizationMatrixOutput>.Fail(error);
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or OperationCanceledException)
@@ -137,106 +137,4 @@ public sealed class RemoteAuthorizeAppService(
         }
     }
 
-    /// <summary>
-    /// Maps HTTP status codes to appropriate Error types following Railway Pattern guidelines.
-    /// - 400 Bad Request → Validation Error
-    /// - 404 Not Found → NotFound Error
-    /// - 409 Conflict → Conflict Error
-    /// - 401 Unauthorized → Unauthorized Error
-    /// - 403 Forbidden → Forbidden Error
-    /// - 5xx Server Error → Dependency Error (external service failed)
-    /// - Other → Dependency Error
-    /// </summary>
-    private static async Task<Error> MapStatusCodeToErrorCore(HttpResponseMessage response,
-        CancellationToken cancellationToken)
-    {
-        var errorContent = await response.ReadDecompressedContentAsync(cancellationToken);
-        var statusCode = response.StatusCode;
-
-        // Check if response has Aether error format header
-        if (response.Headers.TryGetValues("_aether_error_format", out var values) &&
-            values.Any(v => v.Equals("true", StringComparison.OrdinalIgnoreCase)))
-        {
-            try
-            {
-                var errorResponse = JsonSerializer.Deserialize<ServiceErrorResponse>(errorContent, JsonOptions);
-                if (errorResponse?.Error != null)
-                {
-                    var prefix = errorResponse.Error.Prefix ?? InferPrefixFromStatusCode(statusCode);
-                    var code = errorResponse.Error.Code ?? "remote_error";
-
-                    return prefix switch
-                    {
-                        ErrorCodes.Prefixes.Validation => Error.Validation(code, errorResponse.Error.Message,
-                            errorResponse.Error.Target),
-                        ErrorCodes.Prefixes.NotFound => Error.NotFound(code, errorResponse.Error.Message,
-                            errorResponse.Error.Target),
-                        ErrorCodes.Prefixes.Conflict => Error.Conflict(code, errorResponse.Error.Message,
-                            errorResponse.Error.Target),
-                        ErrorCodes.Prefixes.Unauthorized => Error.Unauthorized(code, errorResponse.Error.Message),
-                        ErrorCodes.Prefixes.Forbidden => Error.Forbidden(code, errorResponse.Error.Message),
-                        ErrorCodes.Prefixes.Dependency => Error.Dependency(code, errorResponse.Error.Message,
-                            errorResponse.Error.Target),
-                        ErrorCodes.Prefixes.Transient => Error.Transient(code, errorResponse.Error.Message,
-                            errorResponse.Error.Target),
-                        _ => Error.Failure(code, errorResponse.Error.Message, errorResponse.Error.Details)
-                    };
-                }
-            }
-            catch (JsonException)
-            {
-                // If JSON deserialization fails, fall back to status code mapping
-            }
-        }
-
-        return statusCode switch
-        {
-            HttpStatusCode.BadRequest => Error.Validation(
-                "remote_bad_request",
-                $"Remote API validation error: {errorContent}"),
-
-            HttpStatusCode.NotFound => Error.NotFound(
-                "remote_not_found",
-                "Requested resource not found on remote API",
-                errorContent),
-
-            HttpStatusCode.Conflict => Error.Conflict(
-                "remote_conflict",
-                $"Remote API conflict: {errorContent}"),
-
-            HttpStatusCode.Unauthorized => Error.Unauthorized(
-                "remote_unauthorized",
-                "Unauthorized access to remote API"),
-
-            HttpStatusCode.Forbidden => Error.Forbidden(
-                "remote_forbidden",
-                "Forbidden access to remote API"),
-
-            HttpStatusCode.InternalServerError or
-                HttpStatusCode.BadGateway or
-                HttpStatusCode.ServiceUnavailable or
-                HttpStatusCode.GatewayTimeout => Error.Dependency(
-                "remote_service_error",
-                $"Remote API service error: {response.ReasonPhrase}",
-                ((int)statusCode).ToString()),
-
-            _ => Error.Dependency(
-                "remote_http_error",
-                $"Remote API returned HTTP {(int)statusCode}: {response.ReasonPhrase}",
-                ((int)statusCode).ToString())
-        };
-    }
-
-    private static string InferPrefixFromStatusCode(HttpStatusCode statusCode)
-    {
-        return statusCode switch
-        {
-            HttpStatusCode.BadRequest => ErrorCodes.Prefixes.Validation,
-            HttpStatusCode.NotFound => ErrorCodes.Prefixes.NotFound,
-            HttpStatusCode.Conflict => ErrorCodes.Prefixes.Conflict,
-            HttpStatusCode.Unauthorized => ErrorCodes.Prefixes.Unauthorized,
-            HttpStatusCode.Forbidden => ErrorCodes.Prefixes.Forbidden,
-            _ => ErrorCodes.Prefixes.Dependency
-        };
-    }
 }

--- a/src/BBT.Workflow.Infrastructure/Authorization/Remote/RemoteAuthorizeAppService.cs
+++ b/src/BBT.Workflow.Infrastructure/Authorization/Remote/RemoteAuthorizeAppService.cs
@@ -5,6 +5,9 @@ using BBT.Workflow.Definitions;
 using BBT.Workflow.Discovery;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Instances.Remote;
+using BBT.Aether.Users;
+using BBT.Workflow.CurrentUser;
+using BBT.Workflow.Remote;
 using BBT.Workflow.Remote.Configuration;
 using Microsoft.Extensions.Options;
 
@@ -18,7 +21,8 @@ namespace BBT.Workflow.Authorization.Remote;
 public sealed class RemoteAuthorizeAppService(
     HttpClient httpClient,
     IOptions<RemoteOptions> options,
-    IDomainDiscoveryResolver endpointResolver)
+    IDomainDiscoveryResolver endpointResolver,
+    ICurrentUser currentUser)
     : IRemoteAuthorizeAppService
 {
     private readonly RemoteOptions _options = options.Value;
@@ -69,7 +73,10 @@ public sealed class RemoteAuthorizeAppService(
                 relativePath += "?" + string.Join("&", queryParams);
 
             var requestUri = new Uri(endpoint.BaseUrl, relativePath.TrimStart('/'));
-            var response = await httpClient.GetAsync(requestUri, cancellationToken);
+            using var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            var forwardHeaders = currentUser.ToForwardHeaders();
+            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, null);
+            var response = await httpClient.SendAsync(requestMessage, cancellationToken);
 
             // 200 and 403 both return AuthorizeOutput body (allowed true/false)
             if (response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.Forbidden)
@@ -109,7 +116,10 @@ public sealed class RemoteAuthorizeAppService(
                 relativePath += "?version=" + Uri.EscapeDataString(version);
 
             var requestUri = new Uri(endpoint.BaseUrl, relativePath.TrimStart('/'));
-            var response = await httpClient.GetAsync(requestUri, cancellationToken);
+            using var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            var forwardHeaders = currentUser.ToForwardHeaders();
+            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, null);
+            var response = await httpClient.SendAsync(requestMessage, cancellationToken);
 
             if (response.StatusCode == HttpStatusCode.OK)
             {

--- a/src/BBT.Workflow.Infrastructure/BBT.Workflow.Infrastructure.csproj
+++ b/src/BBT.Workflow.Infrastructure/BBT.Workflow.Infrastructure.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BBT.Aether.Infrastructure" Version="$(AetherPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.9" />
     <PackageReference Include="Dapr.Client" Version="$(DaprPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="$(MicrosoftPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="$(MicrosoftPackageVersion)" />
@@ -20,6 +21,7 @@
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
     <PackageReference Include="prometheus-net" Version="$(PrometheusVersion)" />
     <ProjectReference Include="..\BBT.Workflow.Application\BBT.Workflow.Application.csproj" />
+    <ProjectReference Include="..\BBT.Workflow.Domain\BBT.Workflow.Domain.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Remote\" />

--- a/src/BBT.Workflow.Infrastructure/Gateway/LocalInstanceQueryGateway.cs
+++ b/src/BBT.Workflow.Infrastructure/Gateway/LocalInstanceQueryGateway.cs
@@ -101,7 +101,10 @@ public sealed class LocalInstanceQueryGateway : IInstanceQueryGateway
                 Workflow = input.Workflow,
                 Version = input.Version,
                 Instance = input.Instance,
-                Extensions = input.Extensions
+                Extensions = input.Extensions,
+                Headers = input.Headers,
+                QueryParams = input.QueryParams,
+                Role = input.Role
             };
             return await queryService.GetInstanceStateAsync(stateInput, cancellationToken);
         }

--- a/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceCommandAppService.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceCommandAppService.cs
@@ -82,7 +82,7 @@ public sealed class RemoteInstanceCommandAppService(
             };
 
             var forwardHeaders = currentUser.ToForwardHeaders();
-            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, input.Headers, IsRestrictedHeader);
+            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, input.Headers, RemoteHttpResponseHelper.IsRestrictedHeader);
 
             var response = await httpClient.SendAsync(requestMessage, cancellationToken);
 
@@ -150,7 +150,7 @@ public sealed class RemoteInstanceCommandAppService(
             };
 
             var forwardHeaders = currentUser.ToForwardHeaders();
-            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, input.Headers, IsRestrictedHeader);
+            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, input.Headers, RemoteHttpResponseHelper.IsRestrictedHeader);
 
             var response = await httpClient.SendAsync(requestMessage, cancellationToken);
 
@@ -211,7 +211,7 @@ public sealed class RemoteInstanceCommandAppService(
             };
 
             var forwardHeaders = currentUser.ToForwardHeaders();
-            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, input.Headers, IsRestrictedHeader);
+            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, input.Headers, RemoteHttpResponseHelper.IsRestrictedHeader);
 
             var response = await httpClient.SendAsync(requestMessage, cancellationToken);
 
@@ -259,7 +259,7 @@ public sealed class RemoteInstanceCommandAppService(
             };
 
             var forwardHeaders = currentUser.ToForwardHeaders();
-            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, null, IsRestrictedHeader);
+            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, null, RemoteHttpResponseHelper.IsRestrictedHeader);
 
             var response = await httpClient.SendAsync(requestMessage, cancellationToken);
 
@@ -310,7 +310,7 @@ public sealed class RemoteInstanceCommandAppService(
             };
 
             var forwardHeaders = currentUser.ToForwardHeaders();
-            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, null, IsRestrictedHeader);
+            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, null, RemoteHttpResponseHelper.IsRestrictedHeader);
 
             var response = await httpClient.SendAsync(requestMessage, cancellationToken);
 
@@ -340,7 +340,8 @@ public sealed class RemoteInstanceCommandAppService(
         }
 
         // Map status codes to appropriate Error types (per Railway Pattern)
-        return await MapStatusCodeToError<T>(response, cancellationToken);
+        var error = await RemoteHttpResponseHelper.MapToErrorAsync(response, cancellationToken, JsonOptions);
+        return Result<T>.Fail(error);
     }
 
     /// <summary>
@@ -349,141 +350,10 @@ public sealed class RemoteInstanceCommandAppService(
     private static async Task<Result> HandleResponseAsync(HttpResponseMessage response,
         CancellationToken cancellationToken)
     {
-        // Success case
         if (response.IsSuccessStatusCode)
-        {
             return Result.Ok();
-        }
 
-        // Map status codes to appropriate Error types
-        var error = await MapStatusCodeToErrorCore(response, cancellationToken);
+        var error = await RemoteHttpResponseHelper.MapToErrorAsync(response, cancellationToken, JsonOptions);
         return Result.Fail(error);
-    }
-
-    /// <summary>
-    /// Maps HTTP status codes to appropriate Error types following Railway Pattern guidelines.
-    /// - 400 Bad Request → Validation Error
-    /// - 404 Not Found → NotFound Error
-    /// - 409 Conflict → Conflict Error
-    /// - 401 Unauthorized → Unauthorized Error
-    /// - 403 Forbidden → Forbidden Error
-    /// - 5xx Server Error → Dependency Error (external service failed)
-    /// - Other → Dependency Error
-    /// </summary>
-    private static async Task<Result<T>> MapStatusCodeToError<T>(HttpResponseMessage response,
-        CancellationToken cancellationToken)
-    {
-        var error = await MapStatusCodeToErrorCore(response, cancellationToken);
-        return Result<T>.Fail(error);
-    }
-
-    private static async Task<Error> MapStatusCodeToErrorCore(HttpResponseMessage response,
-        CancellationToken cancellationToken)
-    {
-        var errorContent = await response.ReadDecompressedContentAsync(cancellationToken);
-        var statusCode = response.StatusCode;
-
-        // Check if response has Aether error format header
-        if (response.Headers.TryGetValues("_aether_error_format", out var values) &&
-            values.Any(v => v.Equals("true", StringComparison.OrdinalIgnoreCase)))
-        {
-            try
-            {
-                var errorResponse = JsonSerializer.Deserialize<ServiceErrorResponse>(errorContent, JsonOptions);
-                if (errorResponse?.Error != null)
-                {
-                    // Use the prefix from remote service if available, otherwise infer from status code
-                    var prefix = errorResponse.Error.Prefix ?? InferPrefixFromStatusCode(statusCode);
-                    var code = errorResponse.Error.Code ?? "remote_error";
-
-                    // Map to appropriate Error type based on prefix
-                    return prefix switch
-                    {
-                        ErrorCodes.Prefixes.Validation => Error.Validation(code, errorResponse.Error.Message,
-                            errorResponse.Error.Target),
-                        ErrorCodes.Prefixes.NotFound => Error.NotFound(code, errorResponse.Error.Message,
-                            errorResponse.Error.Target),
-                        ErrorCodes.Prefixes.Conflict => Error.Conflict(code, errorResponse.Error.Message,
-                            errorResponse.Error.Target),
-                        ErrorCodes.Prefixes.Unauthorized => Error.Unauthorized(code, errorResponse.Error.Message),
-                        ErrorCodes.Prefixes.Forbidden => Error.Forbidden(code, errorResponse.Error.Message),
-                        ErrorCodes.Prefixes.Dependency => Error.Dependency(code, errorResponse.Error.Message,
-                            errorResponse.Error.Target),
-                        ErrorCodes.Prefixes.Transient => Error.Transient(code, errorResponse.Error.Message,
-                            errorResponse.Error.Target),
-                        _ => Error.Failure(code, errorResponse.Error.Message, errorResponse.Error.Details)
-                    };
-                }
-            }
-            catch (JsonException)
-            {
-                // If JSON deserialization fails, fall back to status code mapping
-            }
-        }
-
-        // Map status code to appropriate Error type (Railway Pattern best practice)
-        return statusCode switch
-        {
-            System.Net.HttpStatusCode.BadRequest => Error.Validation(
-                "remote_bad_request",
-                $"Remote API validation error: {errorContent}"),
-
-            System.Net.HttpStatusCode.NotFound => Error.NotFound(
-                "remote_not_found",
-                "Requested resource not found on remote API",
-                errorContent),
-
-            System.Net.HttpStatusCode.Conflict => Error.Conflict(
-                "remote_conflict",
-                $"Remote API conflict: {errorContent}"),
-
-            System.Net.HttpStatusCode.Unauthorized => Error.Unauthorized(
-                "remote_unauthorized",
-                "Unauthorized access to remote API"),
-
-            System.Net.HttpStatusCode.Forbidden => Error.Forbidden(
-                "remote_forbidden",
-                "Forbidden access to remote API"),
-
-            System.Net.HttpStatusCode.InternalServerError or
-                System.Net.HttpStatusCode.BadGateway or
-                System.Net.HttpStatusCode.ServiceUnavailable or
-                System.Net.HttpStatusCode.GatewayTimeout => Error.Dependency(
-                    "remote_service_error",
-                    $"Remote API service error: {response.ReasonPhrase}",
-                    ((int)statusCode).ToString()),
-
-            _ => Error.Dependency(
-                "remote_http_error",
-                $"Remote API returned HTTP {(int)statusCode}: {response.ReasonPhrase}",
-                ((int)statusCode).ToString())
-        };
-    }
-
-    /// <summary>
-    /// Infers error prefix from HTTP status code for Aether error format
-    /// </summary>
-    private static string InferPrefixFromStatusCode(System.Net.HttpStatusCode statusCode)
-    {
-        return statusCode switch
-        {
-            System.Net.HttpStatusCode.BadRequest => ErrorCodes.Prefixes.Validation,
-            System.Net.HttpStatusCode.NotFound => ErrorCodes.Prefixes.NotFound,
-            System.Net.HttpStatusCode.Conflict => ErrorCodes.Prefixes.Conflict,
-            System.Net.HttpStatusCode.Unauthorized => ErrorCodes.Prefixes.Unauthorized,
-            System.Net.HttpStatusCode.Forbidden => ErrorCodes.Prefixes.Forbidden,
-            _ => ErrorCodes.Prefixes.Dependency
-        };
-    }
-
-    /// <summary>
-    /// Checks if a header is restricted and cannot be set manually
-    /// </summary>
-    private static bool IsRestrictedHeader(string headerName)
-    {
-        return headerName.Equals("Content-Type", StringComparison.OrdinalIgnoreCase) ||
-               headerName.Equals("Content-Length", StringComparison.OrdinalIgnoreCase) ||
-               headerName.Equals("Host", StringComparison.OrdinalIgnoreCase) ||
-               headerName.Equals("Connection", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceCommandAppService.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceCommandAppService.cs
@@ -3,6 +3,9 @@ using System.Text.Json;
 using BBT.Aether.Results;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Discovery;
+using BBT.Aether.Users;
+using BBT.Workflow.CurrentUser;
+using BBT.Workflow.Remote;
 using BBT.Workflow.Remote.Configuration;
 using BBT.Workflow.SubFlow;
 using Microsoft.Extensions.Options;
@@ -16,7 +19,8 @@ namespace BBT.Workflow.Instances.Remote;
 public sealed class RemoteInstanceCommandAppService(
     HttpClient httpClient,
     IOptions<RemoteOptions> options,
-    IDomainDiscoveryResolver endpointResolver)
+    IDomainDiscoveryResolver endpointResolver,
+    ICurrentUser currentUser)
     : IRemoteInstanceCommandAppService
 {
     private readonly RemoteOptions _options = options.Value;
@@ -77,14 +81,8 @@ public sealed class RemoteInstanceCommandAppService(
                 Content = content
             };
 
-            if (input.Headers != null)
-                foreach (var header in input.Headers)
-                {
-                    if (!IsRestrictedHeader(header.Key))
-                    {
-                        requestMessage.Headers.TryAddWithoutValidation(header.Key, header.Value);
-                    }
-                }
+            var forwardHeaders = currentUser.ToForwardHeaders();
+            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, input.Headers, IsRestrictedHeader);
 
             var response = await httpClient.SendAsync(requestMessage, cancellationToken);
 
@@ -151,14 +149,8 @@ public sealed class RemoteInstanceCommandAppService(
                 Content = content
             };
 
-            if (input.Headers != null)
-                foreach (var header in input.Headers)
-                {
-                    if (!IsRestrictedHeader(header.Key))
-                    {
-                        requestMessage.Headers.TryAddWithoutValidation(header.Key, header.Value);
-                    }
-                }
+            var forwardHeaders = currentUser.ToForwardHeaders();
+            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, input.Headers, IsRestrictedHeader);
 
             var response = await httpClient.SendAsync(requestMessage, cancellationToken);
 
@@ -218,13 +210,8 @@ public sealed class RemoteInstanceCommandAppService(
                 Content = content
             };
 
-            foreach (var header in input.Headers)
-            {
-                if (!IsRestrictedHeader(header.Key))
-                {
-                    requestMessage.Headers.TryAddWithoutValidation(header.Key, header.Value);
-                }
-            }
+            var forwardHeaders = currentUser.ToForwardHeaders();
+            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, input.Headers, IsRestrictedHeader);
 
             var response = await httpClient.SendAsync(requestMessage, cancellationToken);
 
@@ -270,6 +257,9 @@ public sealed class RemoteInstanceCommandAppService(
             {
                 Content = content
             };
+
+            var forwardHeaders = currentUser.ToForwardHeaders();
+            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, null, IsRestrictedHeader);
 
             var response = await httpClient.SendAsync(requestMessage, cancellationToken);
 
@@ -318,6 +308,9 @@ public sealed class RemoteInstanceCommandAppService(
             {
                 Content = content
             };
+
+            var forwardHeaders = currentUser.ToForwardHeaders();
+            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, null, IsRestrictedHeader);
 
             var response = await httpClient.SendAsync(requestMessage, cancellationToken);
 

--- a/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceQueryAppService.cs
@@ -11,26 +11,6 @@ using Microsoft.Extensions.Options;
 namespace BBT.Workflow.Instances.Remote;
 
 /// <summary>
-/// DTO for Aether error format from remote API responses
-/// </summary>
-internal sealed record ServiceErrorResponse
-{
-    public ServiceErrorInfo? Error { get; init; }
-}
-
-/// <summary>
-/// Error information from Aether format
-/// </summary>
-internal sealed record ServiceErrorInfo
-{
-    public string? Prefix { get; init; }
-    public string? Code { get; init; }
-    public string? Message { get; init; }
-    public string? Details { get; init; }
-    public string? Target { get; init; }
-}
-
-/// <summary>
 /// Remote implementation of instance query operations using HTTP client calls to InstanceController.
 /// Uses IDomainDiscoveryResolver to dynamically resolve endpoint URLs based on target domain.
 /// </summary>
@@ -545,8 +525,8 @@ public sealed class RemoteInstanceQueryAppService(
             return Result<T>.Ok(result!);
         }
 
-        // Map status codes to appropriate Error types (per Railway Pattern)
-        return await MapStatusCodeToError<T>(response, cancellationToken);
+        var error = await RemoteHttpResponseHelper.MapToErrorAsync(response, cancellationToken, JsonOptions);
+        return Result<T>.Fail(error);
     }
 
     /// <summary>
@@ -554,7 +534,6 @@ public sealed class RemoteInstanceQueryAppService(
     /// </summary>
     private static async Task<ConditionalResult<T>> HandleConditionalResponseAsync<T>(HttpResponseMessage response, CancellationToken cancellationToken)
     {
-        // Success case
         if (response.IsSuccessStatusCode)
         {
             var responseContent = await response.ReadDecompressedContentAsync(cancellationToken);
@@ -562,117 +541,7 @@ public sealed class RemoteInstanceQueryAppService(
             return ConditionalResult<T>.Success(result!);
         }
 
-        // Map status codes to appropriate Error types
-        var error = await MapStatusCodeToErrorCore(response, cancellationToken);
+        var error = await RemoteHttpResponseHelper.MapToErrorAsync(response, cancellationToken, JsonOptions);
         return ConditionalResult<T>.Fail(error);
-    }
-
-    /// <summary>
-    /// Maps HTTP status codes to appropriate Error types following Railway Pattern guidelines.
-    /// - 400 Bad Request → Validation Error
-    /// - 404 Not Found → NotFound Error
-    /// - 409 Conflict → Conflict Error
-    /// - 401 Unauthorized → Unauthorized Error
-    /// - 403 Forbidden → Forbidden Error
-    /// - 5xx Server Error → Dependency Error (external service failed)
-    /// - Other → Dependency Error
-    /// </summary>
-    private static async Task<Result<T>> MapStatusCodeToError<T>(HttpResponseMessage response, CancellationToken cancellationToken)
-    {
-        var error = await MapStatusCodeToErrorCore(response, cancellationToken);
-        return Result<T>.Fail(error);
-    }
-
-    private static async Task<Error> MapStatusCodeToErrorCore(HttpResponseMessage response, CancellationToken cancellationToken)
-    {
-        var errorContent = await response.ReadDecompressedContentAsync(cancellationToken);
-        var statusCode = response.StatusCode;
-
-        // Check if response has Aether error format header
-        if (response.Headers.TryGetValues("_aether_error_format", out var values) &&
-            values.Any(v => v.Equals("true", StringComparison.OrdinalIgnoreCase)))
-        {
-            try
-            {
-                var errorResponse = JsonSerializer.Deserialize<ServiceErrorResponse>(errorContent, JsonOptions);
-                if (errorResponse?.Error != null)
-                {
-                    // Use the prefix from remote service if available, otherwise infer from status code
-                    var prefix = errorResponse.Error.Prefix ?? InferPrefixFromStatusCode(statusCode);
-                    var code = errorResponse.Error.Code ?? "remote_error";
-                    
-                    // Map to appropriate Error type based on prefix
-                    return prefix switch
-                    {
-                        ErrorCodes.Prefixes.Validation => Error.Validation(code, errorResponse.Error.Message, errorResponse.Error.Target),
-                        ErrorCodes.Prefixes.NotFound => Error.NotFound(code, errorResponse.Error.Message, errorResponse.Error.Target),
-                        ErrorCodes.Prefixes.Conflict => Error.Conflict(code, errorResponse.Error.Message, errorResponse.Error.Target),
-                        ErrorCodes.Prefixes.Unauthorized => Error.Unauthorized(code, errorResponse.Error.Message),
-                        ErrorCodes.Prefixes.Forbidden => Error.Forbidden(code, errorResponse.Error.Message),
-                        ErrorCodes.Prefixes.Dependency => Error.Dependency(code, errorResponse.Error.Message, errorResponse.Error.Target),
-                        ErrorCodes.Prefixes.Transient => Error.Transient(code, errorResponse.Error.Message, errorResponse.Error.Target),
-                        _ => Error.Failure(code, errorResponse.Error.Message, errorResponse.Error.Details)
-                    };
-                }
-            }
-            catch (JsonException)
-            {
-                // If JSON deserialization fails, fall back to status code mapping
-            }
-        }
-
-        // Map status code to appropriate Error type (Railway Pattern best practice)
-        return statusCode switch
-        {
-            System.Net.HttpStatusCode.BadRequest => Error.Validation(
-                "remote_bad_request",
-                $"Remote API validation error: {errorContent}"),
-
-            System.Net.HttpStatusCode.NotFound => Error.NotFound(
-                "remote_not_found",
-                "Requested resource not found on remote API",
-                errorContent),
-
-            System.Net.HttpStatusCode.Conflict => Error.Conflict(
-                "remote_conflict",
-                $"Remote API conflict: {errorContent}"),
-
-            System.Net.HttpStatusCode.Unauthorized => Error.Unauthorized(
-                "remote_unauthorized",
-                "Unauthorized access to remote API"),
-
-            System.Net.HttpStatusCode.Forbidden => Error.Forbidden(
-                "remote_forbidden",
-                "Forbidden access to remote API"),
-
-            System.Net.HttpStatusCode.InternalServerError or
-            System.Net.HttpStatusCode.BadGateway or
-            System.Net.HttpStatusCode.ServiceUnavailable or
-            System.Net.HttpStatusCode.GatewayTimeout => Error.Dependency(
-                "remote_service_error",
-                $"Remote API service error: {response.ReasonPhrase}",
-                ((int)statusCode).ToString()),
-
-            _ => Error.Dependency(
-                "remote_http_error",
-                $"Remote API returned HTTP {(int)statusCode}: {response.ReasonPhrase}",
-                ((int)statusCode).ToString())
-        };
-    }
-
-    /// <summary>
-    /// Infers error prefix from HTTP status code for Aether error format
-    /// </summary>
-    private static string InferPrefixFromStatusCode(System.Net.HttpStatusCode statusCode)
-    {
-        return statusCode switch
-        {
-            System.Net.HttpStatusCode.BadRequest => ErrorCodes.Prefixes.Validation,
-            System.Net.HttpStatusCode.NotFound => ErrorCodes.Prefixes.NotFound,
-            System.Net.HttpStatusCode.Conflict => ErrorCodes.Prefixes.Conflict,
-            System.Net.HttpStatusCode.Unauthorized => ErrorCodes.Prefixes.Unauthorized,
-            System.Net.HttpStatusCode.Forbidden => ErrorCodes.Prefixes.Forbidden,
-            _ => ErrorCodes.Prefixes.Dependency
-        };
     }
 }

--- a/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceQueryAppService.cs
@@ -2,6 +2,9 @@ using System.Text.Json;
 using BBT.Aether.Results;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Discovery;
+using BBT.Aether.Users;
+using BBT.Workflow.CurrentUser;
+using BBT.Workflow.Remote;
 using BBT.Workflow.Remote.Configuration;
 using Microsoft.Extensions.Options;
 
@@ -34,7 +37,8 @@ internal sealed record ServiceErrorInfo
 public sealed class RemoteInstanceQueryAppService(
     HttpClient httpClient,
     IOptions<RemoteOptions> options,
-    IDomainDiscoveryResolver endpointResolver)
+    IDomainDiscoveryResolver endpointResolver,
+    ICurrentUser currentUser)
     : IRemoteInstanceQueryAppService
 {
     private readonly RemoteOptions _options = options.Value;
@@ -82,13 +86,16 @@ public sealed class RemoteInstanceQueryAppService(
                 relativePath += "?" + string.Join("&", queryParams);
 
             var requestUri = new Uri(endpoint.BaseUrl, relativePath.TrimStart('/'));
-            var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            using var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
             // Add If-None-Match header for ETag support
             if (!string.IsNullOrEmpty(input.IfNoneMatch))
             {
                 requestMessage.Headers.TryAddWithoutValidation("If-None-Match", input.IfNoneMatch);
             }
+
+            var forwardHeaders = currentUser.ToForwardHeaders();
+            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, input.Headers);
 
             var response = await httpClient.SendAsync(requestMessage, cancellationToken);
 
@@ -143,13 +150,16 @@ public sealed class RemoteInstanceQueryAppService(
                 relativePath += "?" + string.Join("&", queryParams);
 
             var requestUri = new Uri(endpoint.BaseUrl, relativePath.TrimStart('/'));
-            var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            using var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
             // Add If-None-Match header for ETag support
             if (!string.IsNullOrEmpty(input.IfNoneMatch))
             {
                 requestMessage.Headers.TryAddWithoutValidation("If-None-Match", input.IfNoneMatch);
             }
+
+            var forwardHeaders = currentUser.ToForwardHeaders();
+            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, input.Headers);
 
             var response = await httpClient.SendAsync(requestMessage, cancellationToken);
 
@@ -227,7 +237,10 @@ public sealed class RemoteInstanceQueryAppService(
                 relativePath += "?" + string.Join("&", queryParams);
 
             var requestUri = new Uri(endpoint.BaseUrl, relativePath.TrimStart('/'));
-            var response = await httpClient.GetAsync(requestUri, cancellationToken);
+            using var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            var forwardHeaders = currentUser.ToForwardHeaders();
+            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, input.Headers);
+            var response = await httpClient.SendAsync(requestMessage, cancellationToken);
 
             return await HandleResponseAsync<InstanceListWithGroupsResponse<GetInstanceOutput>>(response, cancellationToken);
         }
@@ -273,7 +286,10 @@ public sealed class RemoteInstanceQueryAppService(
                 relativePath += "?" + string.Join("&", queryParams);
 
             var requestUri = new Uri(endpoint.BaseUrl, relativePath.TrimStart('/'));
-            var response = await httpClient.GetAsync(requestUri, cancellationToken);
+            using var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            var forwardHeaders = currentUser.ToForwardHeaders();
+            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, input.Headers);
+            var response = await httpClient.SendAsync(requestMessage, cancellationToken);
 
             // Status code → Result.Fail (per Railway Pattern)
             return await HandleResponseAsync<GetInstanceHistoryOutput>(response, cancellationToken);
@@ -321,11 +337,19 @@ public sealed class RemoteInstanceQueryAppService(
                 }
             }
 
+            if (!string.IsNullOrEmpty(input.Role))
+            {
+                queryParams.Add($"role={Uri.EscapeDataString(input.Role)}");
+            }
+
             if (queryParams.Count > 0)
                 relativePath += "?" + string.Join("&", queryParams);
 
             var requestUri = new Uri(endpoint.BaseUrl, relativePath.TrimStart('/'));
-            var response = await httpClient.GetAsync(requestUri, cancellationToken);
+            using var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            var forwardHeaders = currentUser.ToForwardHeaders();
+            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, input.Headers);
+            var response = await httpClient.SendAsync(requestMessage, cancellationToken);
 
             // Status code → Result.Fail (per Railway Pattern)
             return await HandleResponseAsync<GetInstanceStateOutput>(response, cancellationToken);
@@ -389,7 +413,10 @@ public sealed class RemoteInstanceQueryAppService(
                 relativePath += "?" + string.Join("&", queryParams);
 
             var requestUri = new Uri(endpoint.BaseUrl, relativePath.TrimStart('/'));
-            var response = await httpClient.GetAsync(requestUri, cancellationToken);
+            using var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            var forwardHeaders = currentUser.ToForwardHeaders();
+            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, input.Headers);
+            var response = await httpClient.SendAsync(requestMessage, cancellationToken);
 
             // Status code → Result.Fail (per Railway Pattern)
             return await HandleResponseAsync<GetViewOutput>(response, cancellationToken);
@@ -434,7 +461,10 @@ public sealed class RemoteInstanceQueryAppService(
                 relativePath += "&" + string.Join("&", queryParams);
 
             var requestUri = new Uri(endpoint.BaseUrl, relativePath.TrimStart('/'));
-            var response = await httpClient.GetAsync(requestUri, cancellationToken);
+            using var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            var forwardHeaders = currentUser.ToForwardHeaders();
+            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, input.Headers);
+            var response = await httpClient.SendAsync(requestMessage, cancellationToken);
 
             // Status code → Result.Fail (per Railway Pattern)
             return await HandleResponseAsync<DTOs.GetSchemaOutput>(response, cancellationToken);
@@ -486,7 +516,10 @@ public sealed class RemoteInstanceQueryAppService(
                 relativePath += "?" + string.Join("&", queryParams);
 
             var requestUri = new Uri(endpoint.BaseUrl, relativePath.TrimStart('/'));
-            var response = await httpClient.GetAsync(requestUri, cancellationToken);
+            using var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            var forwardHeaders = currentUser.ToForwardHeaders();
+            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, input.Headers);
+            var response = await httpClient.SendAsync(requestMessage, cancellationToken);
 
             // Status code → Result.Fail (per Railway Pattern)
             return await HandleResponseAsync<DTOs.GetExtensionsOutput>(response, cancellationToken);

--- a/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceRetryAppService.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceRetryAppService.cs
@@ -6,6 +6,9 @@ using BBT.Workflow.Definitions;
 using BBT.Workflow.Discovery;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Instances.Remote;
+using BBT.Aether.Users;
+using BBT.Workflow.CurrentUser;
+using BBT.Workflow.Remote;
 using BBT.Workflow.Remote.Configuration;
 using Microsoft.Extensions.Options;
 
@@ -18,7 +21,8 @@ namespace BBT.Workflow.Infrastructure.Instances.Remote;
 public sealed class RemoteInstanceRetryAppService(
     HttpClient httpClient,
     IOptions<RemoteOptions> options,
-    IDomainDiscoveryResolver endpointResolver)
+    IDomainDiscoveryResolver endpointResolver,
+    ICurrentUser currentUser)
     : IRemoteInstanceRetryAppService
 {
     private readonly RemoteOptions _options = options.Value;
@@ -74,14 +78,8 @@ public sealed class RemoteInstanceRetryAppService(
                 Content = content
             };
 
-            // Forward headers
-            foreach (var header in input.Headers)
-            {
-                if (!IsRestrictedHeader(header.Key))
-                {
-                    requestMessage.Headers.TryAddWithoutValidation(header.Key, header.Value);
-                }
-            }
+            var forwardHeaders = currentUser.ToForwardHeaders();
+            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, input.Headers, IsRestrictedHeader);
 
             var response = await httpClient.SendAsync(requestMessage, cancellationToken);
 

--- a/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceRetryAppService.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceRetryAppService.cs
@@ -79,7 +79,7 @@ public sealed class RemoteInstanceRetryAppService(
             };
 
             var forwardHeaders = currentUser.ToForwardHeaders();
-            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, input.Headers, IsRestrictedHeader);
+            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, input.Headers, RemoteHttpResponseHelper.IsRestrictedHeader);
 
             var response = await httpClient.SendAsync(requestMessage, cancellationToken);
 
@@ -100,7 +100,6 @@ public sealed class RemoteInstanceRetryAppService(
     private static async Task<Result<T>> HandleResponseAsync<T>(HttpResponseMessage response,
         CancellationToken cancellationToken)
     {
-        // Success case
         if (response.IsSuccessStatusCode)
         {
             var responseContent = await response.ReadDecompressedContentAsync(cancellationToken);
@@ -108,143 +107,7 @@ public sealed class RemoteInstanceRetryAppService(
             return Result<T>.Ok(result!);
         }
 
-        // Map status codes to appropriate Error types (per Railway Pattern)
-        return await MapStatusCodeToError<T>(response, cancellationToken);
+        var error = await RemoteHttpResponseHelper.MapToErrorAsync(response, cancellationToken, JsonOptions);
+        return Result<T>.Fail(error);
     }
-
-    /// <summary>
-    /// Maps HTTP status codes to appropriate Error types following Railway Pattern guidelines.
-    /// </summary>
-    private static async Task<Result<T>> MapStatusCodeToError<T>(HttpResponseMessage response,
-        CancellationToken cancellationToken)
-    {
-        var errorContent = await response.ReadDecompressedContentAsync(cancellationToken);
-        var statusCode = response.StatusCode;
-
-        // Check if response has Aether error format header
-        if (response.Headers.TryGetValues("_aether_error_format", out var values) &&
-            values.Any(v => v.Equals("true", StringComparison.OrdinalIgnoreCase)))
-        {
-            try
-            {
-                var errorResponse = JsonSerializer.Deserialize<ServiceErrorResponse>(errorContent, JsonOptions);
-                if (errorResponse?.Error != null)
-                {
-                    // Use the prefix from remote service if available, otherwise infer from status code
-                    var prefix = errorResponse.Error.Prefix ?? InferPrefixFromStatusCode(statusCode);
-                    var code = errorResponse.Error.Code ?? "remote_error";
-
-                    // Map to appropriate Error type based on prefix
-                    var error = prefix switch
-                    {
-                        ErrorCodes.Prefixes.Validation => Error.Validation(code, errorResponse.Error.Message,
-                            errorResponse.Error.Target),
-                        ErrorCodes.Prefixes.NotFound => Error.NotFound(code, errorResponse.Error.Message,
-                            errorResponse.Error.Target),
-                        ErrorCodes.Prefixes.Conflict => Error.Conflict(code, errorResponse.Error.Message,
-                            errorResponse.Error.Target),
-                        ErrorCodes.Prefixes.Unauthorized => Error.Unauthorized(code, errorResponse.Error.Message),
-                        ErrorCodes.Prefixes.Forbidden => Error.Forbidden(code, errorResponse.Error.Message),
-                        ErrorCodes.Prefixes.Dependency => Error.Dependency(code, errorResponse.Error.Message,
-                            errorResponse.Error.Target),
-                        ErrorCodes.Prefixes.Transient => Error.Transient(code, errorResponse.Error.Message,
-                            errorResponse.Error.Target),
-                        _ => Error.Failure(code, errorResponse.Error.Message, errorResponse.Error.Details)
-                    };
-                    return Result<T>.Fail(error);
-                }
-            }
-            catch (JsonException)
-            {
-                // If JSON deserialization fails, fall back to status code mapping
-            }
-        }
-
-        // Map status code to appropriate Error type (Railway Pattern best practice)
-        var mappedError = statusCode switch
-        {
-            System.Net.HttpStatusCode.BadRequest => Error.Validation(
-                "remote_bad_request",
-                $"Remote API validation error: {errorContent}"),
-
-            System.Net.HttpStatusCode.NotFound => Error.NotFound(
-                "remote_not_found",
-                "Requested resource not found on remote API",
-                errorContent),
-
-            System.Net.HttpStatusCode.Conflict => Error.Conflict(
-                "remote_conflict",
-                $"Remote API conflict: {errorContent}"),
-
-            System.Net.HttpStatusCode.Unauthorized => Error.Unauthorized(
-                "remote_unauthorized",
-                "Unauthorized access to remote API"),
-
-            System.Net.HttpStatusCode.Forbidden => Error.Forbidden(
-                "remote_forbidden",
-                "Forbidden access to remote API"),
-
-            System.Net.HttpStatusCode.InternalServerError or
-                System.Net.HttpStatusCode.BadGateway or
-                System.Net.HttpStatusCode.ServiceUnavailable or
-                System.Net.HttpStatusCode.GatewayTimeout => Error.Dependency(
-                    "remote_service_error",
-                    $"Remote API service error: {response.ReasonPhrase}",
-                    ((int)statusCode).ToString()),
-
-            _ => Error.Dependency(
-                "remote_http_error",
-                $"Remote API returned HTTP {(int)statusCode}: {response.ReasonPhrase}",
-                ((int)statusCode).ToString())
-        };
-
-        return Result<T>.Fail(mappedError);
-    }
-
-    /// <summary>
-    /// Infers error prefix from HTTP status code for Aether error format
-    /// </summary>
-    private static string InferPrefixFromStatusCode(System.Net.HttpStatusCode statusCode)
-    {
-        return statusCode switch
-        {
-            System.Net.HttpStatusCode.BadRequest => ErrorCodes.Prefixes.Validation,
-            System.Net.HttpStatusCode.NotFound => ErrorCodes.Prefixes.NotFound,
-            System.Net.HttpStatusCode.Conflict => ErrorCodes.Prefixes.Conflict,
-            System.Net.HttpStatusCode.Unauthorized => ErrorCodes.Prefixes.Unauthorized,
-            System.Net.HttpStatusCode.Forbidden => ErrorCodes.Prefixes.Forbidden,
-            _ => ErrorCodes.Prefixes.Dependency
-        };
-    }
-
-    /// <summary>
-    /// Checks if a header is restricted and cannot be set manually
-    /// </summary>
-    private static bool IsRestrictedHeader(string headerName)
-    {
-        return headerName.Equals("Content-Type", StringComparison.OrdinalIgnoreCase) ||
-               headerName.Equals("Content-Length", StringComparison.OrdinalIgnoreCase) ||
-               headerName.Equals("Host", StringComparison.OrdinalIgnoreCase) ||
-               headerName.Equals("Connection", StringComparison.OrdinalIgnoreCase);
-    }
-}
-
-/// <summary>
-/// DTO for deserializing error responses from remote services
-/// </summary>
-internal sealed class ServiceErrorResponse
-{
-    public ServiceError? Error { get; set; }
-}
-
-/// <summary>
-/// DTO for service error details
-/// </summary>
-internal sealed class ServiceError
-{
-    public string? Code { get; set; }
-    public string? Message { get; set; }
-    public string? Prefix { get; set; }
-    public string? Target { get; set; }
-    public string? Details { get; set; }
 }

--- a/src/BBT.Workflow.Infrastructure/Remote/CurrentUserForwardHeadersHelper.cs
+++ b/src/BBT.Workflow.Infrastructure/Remote/CurrentUserForwardHeadersHelper.cs
@@ -1,0 +1,35 @@
+using BBT.Workflow.CurrentUser;
+
+namespace BBT.Workflow.Remote;
+
+/// <summary>
+/// Merges current user forward headers and optional input headers into outbound HTTP requests for remote/subflow calls.
+/// Callers obtain forward headers via ICurrentUser.ToForwardHeaders() and pass them here with optional input.Headers.
+/// </summary>
+public static class CurrentUserForwardHeadersHelper
+{
+    /// <summary>
+    /// Merges forward headers with input headers. Input headers take precedence (override) for the same key.
+    /// </summary>
+    public static void MergeIntoRequest(HttpRequestMessage request, Dictionary<string, string?> forwardHeaders, IReadOnlyDictionary<string, string?>? inputHeaders, Func<string, bool>? isRestrictedHeader = null)
+    {
+        isRestrictedHeader ??= _ => false;
+        foreach (var kv in forwardHeaders)
+        {
+            if (string.IsNullOrEmpty(kv.Value) || isRestrictedHeader(kv.Key))
+                continue;
+            request.Headers.TryAddWithoutValidation(kv.Key, kv.Value);
+        }
+        if (inputHeaders != null)
+        {
+            foreach (var kv in inputHeaders)
+            {
+                if (isRestrictedHeader(kv.Key))
+                    continue;
+                request.Headers.Remove(kv.Key);
+                if (!string.IsNullOrEmpty(kv.Value))
+                    request.Headers.TryAddWithoutValidation(kv.Key, kv.Value);
+            }
+        }
+    }
+}

--- a/src/BBT.Workflow.Infrastructure/Remote/RemoteHttpResponseHelper.cs
+++ b/src/BBT.Workflow.Infrastructure/Remote/RemoteHttpResponseHelper.cs
@@ -1,0 +1,170 @@
+using System.Net;
+using System.Text.Json;
+using BBT.Aether.Results;
+using BBT.Workflow.Domain;
+
+namespace BBT.Workflow.Remote;
+
+/// <summary>
+/// Shared helper for remote HTTP client responses: maps status codes to Aether Errors (Railway Pattern)
+/// and provides common utilities (e.g. restricted headers). Used by RemoteInstanceCommandAppService,
+/// RemoteInstanceQueryAppService, RemoteInstanceRetryAppService, and RemoteAuthorizeAppService.
+/// Each service keeps its own success handling (e.g. Authorize 200/403 as success, Query 304 NotModified).
+/// </summary>
+public static class RemoteHttpResponseHelper
+{
+    private static readonly JsonSerializerOptions DefaultErrorJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = false
+    };
+
+    /// <summary>
+    /// Maps HTTP response to an Aether Error when the response is not successful.
+    /// - Respects _aether_error_format header and deserializes remote error body when present.
+    /// - Otherwise maps status code: 400→Validation, 404→NotFound, 409→Conflict, 401→Unauthorized,
+    ///   403→Forbidden, 5xx→Dependency, other→Dependency.
+    /// </summary>
+    /// <param name="response">The non-success HTTP response.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="jsonOptions">Optional JSON options for deserializing Aether error body; uses default if null.</param>
+    /// <returns>The mapped <see cref="Error"/>.</returns>
+    public static async Task<Error> MapToErrorAsync(
+        HttpResponseMessage response,
+        CancellationToken cancellationToken,
+        JsonSerializerOptions? jsonOptions = null)
+    {
+        var errorContent = await response.ReadDecompressedContentAsync(cancellationToken);
+        var statusCode = response.StatusCode;
+        var options = jsonOptions ?? DefaultErrorJsonOptions;
+
+        var aetherError = TryParseAetherError(response, errorContent, statusCode, options);
+        if (aetherError is { } e)
+            return e;
+
+        return MapStatusCodeToError(statusCode, response.ReasonPhrase, errorContent);
+    }
+
+    /// <summary>
+    /// Returns true if the header name is restricted and must not be set manually on outbound requests
+    /// (e.g. Content-Type, Content-Length, Host, Connection). Use with CurrentUserForwardHeadersHelper.
+    /// </summary>
+    public static bool IsRestrictedHeader(string headerName)
+    {
+        return headerName.Equals("Content-Type", StringComparison.OrdinalIgnoreCase) ||
+               headerName.Equals("Content-Length", StringComparison.OrdinalIgnoreCase) ||
+               headerName.Equals("Host", StringComparison.OrdinalIgnoreCase) ||
+               headerName.Equals("Connection", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static Error? TryParseAetherError(
+        HttpResponseMessage response,
+        string errorContent,
+        HttpStatusCode statusCode,
+        JsonSerializerOptions options)
+    {
+        if (!response.Headers.TryGetValues("_aether_error_format", out var values) ||
+            !values.Any(v => v.Equals("true", StringComparison.OrdinalIgnoreCase)))
+            return null;
+
+        try
+        {
+            var errorResponse = JsonSerializer.Deserialize<ServiceErrorResponse>(errorContent, options);
+            if (errorResponse?.Error == null)
+                return null;
+
+            var prefix = errorResponse.Error.Prefix ?? InferPrefixFromStatusCode(statusCode);
+            var code = errorResponse.Error.Code ?? "remote_error";
+
+            return prefix switch
+            {
+                ErrorCodes.Prefixes.Validation => Error.Validation(code, errorResponse.Error.Message!, errorResponse.Error.Target),
+                ErrorCodes.Prefixes.NotFound => Error.NotFound(code, errorResponse.Error.Message!, errorResponse.Error.Target),
+                ErrorCodes.Prefixes.Conflict => Error.Conflict(code, errorResponse.Error.Message!, errorResponse.Error.Target),
+                ErrorCodes.Prefixes.Unauthorized => Error.Unauthorized(code, errorResponse.Error.Message!),
+                ErrorCodes.Prefixes.Forbidden => Error.Forbidden(code, errorResponse.Error.Message!),
+                ErrorCodes.Prefixes.Dependency => Error.Dependency(code, errorResponse.Error.Message!, errorResponse.Error.Target),
+                ErrorCodes.Prefixes.Transient => Error.Transient(code, errorResponse.Error.Message!, errorResponse.Error.Target),
+                _ => Error.Failure(code, errorResponse.Error.Message!, errorResponse.Error.Details)
+            };
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static Error MapStatusCodeToError(HttpStatusCode statusCode, string? reasonPhrase, string errorContent)
+    {
+        return statusCode switch
+        {
+            HttpStatusCode.BadRequest => Error.Validation(
+                "remote_bad_request",
+                $"Remote API validation error: {errorContent}"),
+
+            HttpStatusCode.NotFound => Error.NotFound(
+                "remote_not_found",
+                "Requested resource not found on remote API",
+                errorContent),
+
+            HttpStatusCode.Conflict => Error.Conflict(
+                "remote_conflict",
+                $"Remote API conflict: {errorContent}"),
+
+            HttpStatusCode.Unauthorized => Error.Unauthorized(
+                "remote_unauthorized",
+                "Unauthorized access to remote API"),
+
+            HttpStatusCode.Forbidden => Error.Forbidden(
+                "remote_forbidden",
+                "Forbidden access to remote API"),
+
+            HttpStatusCode.InternalServerError or
+                HttpStatusCode.BadGateway or
+                HttpStatusCode.ServiceUnavailable or
+                HttpStatusCode.GatewayTimeout => Error.Dependency(
+                "remote_service_error",
+                $"Remote API service error: {reasonPhrase}",
+                ((int)statusCode).ToString()),
+
+            _ => Error.Dependency(
+                "remote_http_error",
+                $"Remote API returned HTTP {(int)statusCode}: {reasonPhrase}",
+                ((int)statusCode).ToString())
+        };
+    }
+
+    private static string InferPrefixFromStatusCode(HttpStatusCode statusCode)
+    {
+        return statusCode switch
+        {
+            HttpStatusCode.BadRequest => ErrorCodes.Prefixes.Validation,
+            HttpStatusCode.NotFound => ErrorCodes.Prefixes.NotFound,
+            HttpStatusCode.Conflict => ErrorCodes.Prefixes.Conflict,
+            HttpStatusCode.Unauthorized => ErrorCodes.Prefixes.Unauthorized,
+            HttpStatusCode.Forbidden => ErrorCodes.Prefixes.Forbidden,
+            _ => ErrorCodes.Prefixes.Dependency
+        };
+    }
+}
+
+/// <summary>
+/// DTO for Aether error format from remote API responses. Used by <see cref="RemoteHttpResponseHelper"/>.
+/// </summary>
+internal sealed record ServiceErrorResponse
+{
+    public ServiceErrorInfo? Error { get; init; }
+}
+
+/// <summary>
+/// Error details from Aether error format.
+/// </summary>
+internal sealed record ServiceErrorInfo
+{
+    public string? Prefix { get; init; }
+    public string? Code { get; init; }
+    public string? Message { get; init; }
+    public string? Details { get; init; }
+    public string? Target { get; init; }
+}


### PR DESCRIPTION
## Summary
- **Current user forwarding:** Use `ICurrentUser.ToForwardHeaders()` instead of `IHttpContextAccessor`. Added Domain `ToForwardHeaders` extension and `CurrentUserForwardHeadersHelper.MergeIntoRequest`; applied in all remote services (Query, Command, Retry, Authorize) so downstream can resolve the current user from headers.
- **Authorization:** When a component has no roles defined (transition, function, or query roles), treat as **allow**. When roles exist, evaluate DENY/ALLOW match and predefined roles ($InstanceStarter, $PreviousUser).
- **Transition authorization:** Introduced `TransitionAuthorizationManager` and filter state/function transitions by transition role grants; added role/headers to instance and function inputs where needed.

## Related
Branch: `397-filter-state-function-transitions-by-transition-role-grants-static-roles-instancestarterprevioususer`

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Forward current user context to remote and subflow HTTP calls and centralize role-based transition authorization, including support for predefined instance roles and transition filtering.

New Features:
- Forward current user identity and role information as headers on all remote instance, authorization, command, and retry HTTP calls so downstream services can reconstruct the caller context.
- Introduce a transition authorization manager service used to evaluate and filter workflow transitions and functions based on role grants, including predefined roles like instance starter and previous user.
- Allow querying instance state with an optional caller role to return only transitions authorized for that role, including for SubFlow state functions.

Enhancements:
- Treat components with no role grants (functions, transitions, and query roles) as allowed by default instead of denied.
- Refactor authorization logic to reuse shared transition authorization checks in both authorization and instance query flows.
- Expand current-user header key utilities into a public API and add helpers to build and merge forward headers into outbound HTTP requests.
- Enable domain registration in the orchestration host discovery initialization by activating the registration call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transitions are now filtered by caller role; only permitted actions are shown.
  * Added centralized role-based authorization for transitions, including dynamic instance roles.
  * Forwarding of user headers for remote workflow calls; improved remote error mapping.

* **Bug Fixes**
  * Domain discovery now registers domains during startup as intended.

* **Refactor**
  * Simplified authorization and remote-request flows for consistency and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->