### PR TITLE
feat(workflow): trigger parent shared transitions when instance is in active subflow

### DIFF
--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ForwardToActiveSubflowStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ForwardToActiveSubflowStep.cs
@@ -31,6 +31,12 @@ public class ForwardToActiveSubflowStep : ITransitionStep
             return Task.FromResult(Result<StepOutcome>.Ok(StepOutcome.Continue()));
         }
 
+        // Parent shared transition available in current state: execute on parent, do not forward
+        if (IsParentSharedTransition(context))
+        {
+            return Task.FromResult(Result<StepOutcome>.Ok(StepOutcome.Continue()));
+        }
+
         // Enqueue post-commit job - actual forward happens after lock release
         context.Directives.EnqueuePostCommit(new ForwardToSubflowJob(
             context.Instance.Subflow!.SubFlowInstanceId,
@@ -72,4 +78,12 @@ public class ForwardToActiveSubflowStep : ITransitionStep
     /// </summary>
     private static bool HasActiveSubflow(TransitionExecutionContext context)
         => context.Instance.HasActiveSubFlow || context.Instance.Subflow != null;
+
+    /// <summary>
+    /// Returns true if the requested transition is a parent shared transition (and was validated, so available in current state).
+    /// When true, the transition runs on the parent; we do not forward to the active subflow.
+    /// </summary>
+    private static bool IsParentSharedTransition(TransitionExecutionContext context)
+        => context.Transition != null &&
+           context.Workflow.FindSharedTransition(context.TransitionKey) != null;
 }

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/HandleSubFlowStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/HandleSubFlowStep.cs
@@ -36,6 +36,12 @@ public sealed class HandleSubFlowStep(
             return Result<StepOutcome>.Ok(StepOutcome.Continue());
         }
 
+        // Idempotent re-entry: already in this SubFlow state with active correlation - do not start subflow again
+        if (HasActiveCorrelationForSameState(context))
+        {
+            return Result<StepOutcome>.Ok(CreateStepOutcome(context));
+        }
+
         // Railway chain: Validate config -> Execute operations -> Create outcome
         return await Result.Ok(context)
             .Ensure(
@@ -52,6 +58,15 @@ public sealed class HandleSubFlowStep(
     {
         return context is { Target.StateType: StateType.SubFlow, Transition: not null };
     }
+
+    /// <summary>
+    /// Returns true when there is already an active subflow correlation for the same target state.
+    /// Used to avoid starting the subflow again on idempotent re-entry (e.g. shared transition with target $self).
+    /// </summary>
+    private static bool HasActiveCorrelationForSameState(TransitionExecutionContext context)
+        => context.Instance.Subflow != null &&
+           context.Target != null &&
+           context.Instance.Subflow.ParentState == context.Target.Key;
 
     /// <summary>
     /// Creates configuration invalid error.

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -311,9 +311,15 @@ public sealed class InstanceQueryAppService(
                     .Select(t => t.Name)
                     .ToList() ?? new List<string>();
 
+                // Include parent's shared transitions (for current state) so clients can discover and call them while in subflow
+                var availableTransitions = MergeWithParentAvailableTransitions(
+                    transitionNames,
+                    mainInstance,
+                    currentWorkflow);
+
                 // Return complete SubFlow state including view extensions and active correlations
                 return new SubFlowStateInfo(
-                    AvailableTransitions: transitionNames,
+                    AvailableTransitions: availableTransitions,
                     CurrentState: subFlowValue.State,
                     Status: subFlowValue.Status,
                     SubFlowData: subFlowValue.Data,
@@ -333,6 +339,23 @@ public sealed class InstanceQueryAppService(
 
         // Fallback to main flow transitions
         return GetMainFlowTransitions(mainInstance, currentWorkflow);
+    }
+
+    /// <summary>
+    /// Merges subflow transition names with the parent workflow's shared transitions only (manual/event, available in current state).
+    /// When in active subflow, clients see subflow transitions plus parent's shared transitions; state-level parent transitions are not included.
+    /// </summary>
+    private static List<string> MergeWithParentAvailableTransitions(
+        List<string> subflowTransitionNames,
+        Instance mainInstance,
+        BBT.Workflow.Definitions.Workflow currentWorkflow)
+    {
+        var stateResult = currentWorkflow.GetState(mainInstance.GetCurrentState);
+        if (!stateResult.IsSuccess)
+            return subflowTransitionNames;
+
+        var parentSharedOnly = currentWorkflow.GetAvailableSharedTransitionKeysOnly(stateResult.Value!);
+        return subflowTransitionNames.Union(parentSharedOnly).ToList();
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/PipelineServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/PipelineServiceCollectionExtensions.cs
@@ -49,6 +49,7 @@ public static class PipelineServiceCollectionExtensions
         // State Machine Validation - Specification Pattern
         services.AddScoped<ITransitionSpecification, ResumeModeSpecification>();
         services.AddScoped<ITransitionSpecification, SubFlowBypassSpecification>();
+        services.AddScoped<ITransitionSpecification, SharedTransitionTargetSelfWhenInSubFlowSpecification>();
         services.AddScoped<ITransitionSpecification, WellKnownTransitionSpecification>();
         services.AddScoped<ITransitionSpecification, ActorAuthorizationSpecification>();
         services.AddScoped<ITransitionSpecification, StateTransitionListSpecification>();

--- a/src/BBT.Workflow.Domain/Definitions/Specifications/SharedTransitionTargetSelfWhenInSubFlowSpecification.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Specifications/SharedTransitionTargetSelfWhenInSubFlowSpecification.cs
@@ -1,0 +1,50 @@
+using BBT.Aether.Results;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Execution;
+using BBT.Workflow.Logging;
+
+namespace BBT.Workflow.Definitions.Specifications;
+
+/// <summary>
+/// When the instance has an active SubFlow and the requested transition is a parent shared transition,
+/// the transition's target must be $self so the parent state does not change (subflow has not finished).
+/// Any other target results in validation failure.
+/// </summary>
+public sealed class SharedTransitionTargetSelfWhenInSubFlowSpecification : ITransitionSpecification
+{
+    /// <inheritdoc />
+    /// <summary>
+    /// Runs after SubFlowBypassSpecification (20) but before SharedTransitionAvailabilitySpecification (60).
+    /// Only applies when we are executing a parent shared transition while in active SubFlow.
+    /// </summary>
+    public int Priority => 25;
+
+    /// <inheritdoc />
+    /// <summary>
+    /// Applicable when the instance has an active SubFlow and the requested transition is a parent shared transition.
+    /// </summary>
+    public bool IsApplicable(TransitionExecutionContext context)
+        => context.Instance.HasActiveSubFlow &&
+           context.Workflow.FindSharedTransition(context.TransitionKey) != null;
+
+    /// <inheritdoc />
+    /// <summary>
+    /// Validates that the shared transition's target is $self. Otherwise returns failure.
+    /// </summary>
+    public Result IsSatisfiedBy(TransitionExecutionContext context)
+    {
+        if (context.Transition == null)
+        {
+            return Result.Fail(Error.NotFound(
+                "TransitionNotFound",
+                $"Transition '{context.TransitionKey}' not found"));
+        }
+
+        if (context.Transition.Target == WellKnownStateKeys.Self)
+            return Result.Ok();
+
+        return Result.Fail(WorkflowErrors.SharedTransitionTargetMustBeSelfWhenInSubFlow(
+            context.TransitionKey,
+            context.Transition.Target));
+    }
+}

--- a/src/BBT.Workflow.Domain/Definitions/Specifications/SubFlowBypassSpecification.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Specifications/SubFlowBypassSpecification.cs
@@ -5,9 +5,9 @@ namespace BBT.Workflow.Definitions.Specifications;
 
 /// <summary>
 /// Specification for active SubFlow bypass scenario.
-/// When a parent instance has an active SubFlow, all transition requests are forwarded
-/// to the child SubFlow instead of being executed on the parent.
-/// This specification bypasses all validations in that case.
+/// When a parent instance has an active SubFlow, transition requests are forwarded
+/// to the child SubFlow unless the transition is a parent shared transition available in the current state.
+/// When applicable, this specification bypasses all validations (request will be forwarded to child).
 /// </summary>
 public sealed class SubFlowBypassSpecification : ITransitionSpecification
 {
@@ -16,14 +16,16 @@ public sealed class SubFlowBypassSpecification : ITransitionSpecification
     /// Second highest priority - executes after Resume but before other validations.
     /// </summary>
     public int Priority => 20;
-    
+
     /// <inheritdoc />
     /// <summary>
-    /// Applicable when the parent instance has an active SubFlow.
+    /// Applicable when the parent has an active SubFlow and the requested transition is NOT
+    /// a parent shared transition available in the current state. When it is a parent shared
+    /// transition (and available), we do not bypass so it executes on the parent.
     /// </summary>
     public bool IsApplicable(TransitionExecutionContext context)
-        => context.Instance.HasActiveSubFlow;
-    
+        => context.Instance.HasActiveSubFlow && !IsParentSharedTransitionAndAvailable(context);
+
     /// <inheritdoc />
     /// <summary>
     /// Always returns Ok to bypass all validations.
@@ -31,8 +33,25 @@ public sealed class SubFlowBypassSpecification : ITransitionSpecification
     /// </summary>
     public Result IsSatisfiedBy(TransitionExecutionContext context)
     {
-        // Active SubFlow exists - bypass all validations (request will be forwarded to child)
+        // Active SubFlow exists and not a parent shared transition - bypass all validations (request will be forwarded to child)
         // Parent instance acts as a proxy while SubFlow is active
         return Result.Ok();
+    }
+
+    /// <summary>
+    /// Returns true if the requested transition is a parent shared transition and is available in the current state.
+    /// Aligned with SharedTransitionAvailabilitySpecification logic.
+    /// </summary>
+    private static bool IsParentSharedTransitionAndAvailable(TransitionExecutionContext context)
+    {
+        var sharedTransition = context.Workflow.FindSharedTransition(context.TransitionKey);
+        if (sharedTransition == null)
+            return false;
+
+        // If AvailableIn is empty or null, transition is available in all states
+        if (sharedTransition.AvailableIn == null || !sharedTransition.AvailableIn.Any())
+            return true;
+
+        return sharedTransition.AvailableIn.Contains(context.Current.Key);
     }
 }

--- a/src/BBT.Workflow.Domain/Definitions/Workflow.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Workflow.cs
@@ -425,15 +425,23 @@ public sealed class Workflow : IDomainEntity, IReference, IReferenceSetter, IHas
             .Select(t => t.Key)
             .ToList();
 
-        // Get manual shared transitions
-        var manualSharedTransitions = SharedTransitions
-            .Where(t => t.AvailableIn.Contains(currentState.Key) &&
+        // Get manual shared transitions (AvailableIn empty/null = available in all states, aligned with SharedTransitionAvailabilitySpecification)
+        var manualSharedTransitions = GetAvailableSharedTransitionKeysOnly(currentState);
+        manualTransitions.AddRange(manualSharedTransitions);
+        return manualTransitions;
+    }
+
+    /// <summary>
+    /// Gets only the manual/event shared transition keys available in the given state.
+    /// Does not include state-level transitions. Used when instance is in subflow to expose parent shared transitions only.
+    /// </summary>
+    public List<string> GetAvailableSharedTransitionKeysOnly(State currentState)
+    {
+        return SharedTransitions
+            .Where(t => (t.AvailableIn == null || !t.AvailableIn.Any() || t.AvailableIn.Contains(currentState.Key)) &&
                         (t.TriggerType == TriggerType.Manual || t.TriggerType == TriggerType.Event))
             .Select(t => t.Key)
             .ToList();
-
-        manualTransitions.AddRange(manualSharedTransitions);
-        return manualTransitions;
     }
 
     public static Workflow Create()

--- a/src/BBT.Workflow.Domain/Logging/WorkflowErrors.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowErrors.cs
@@ -189,6 +189,17 @@ public static class WorkflowErrors
             target: transitionKey);
 
     /// <summary>
+    /// When the instance has an active SubFlow, a shared transition's target must be $self so the state does not change.
+    /// </summary>
+    /// <param name="transitionKey">The shared transition key.</param>
+    /// <param name="currentTarget">The transition's target value (must be $self).</param>
+    public static Error SharedTransitionTargetMustBeSelfWhenInSubFlow(string transitionKey, string currentTarget)
+        => Error.Validation(
+            WorkflowErrorCodes.SharedTransitionTargetMustBeSelfWhenInSubFlow,
+            $"Shared transition '{transitionKey}' cannot be executed while in active SubFlow with target '{currentTarget}'. Target must be '$self'.",
+            target: transitionKey);
+
+    /// <summary>
     /// StartTransition can only be executed from Initial state.
     /// </summary>
     /// <param name="instanceId">The instance ID.</param>

--- a/src/BBT.Workflow.Domain/WorkflowErrorCodes.cs
+++ b/src/BBT.Workflow.Domain/WorkflowErrorCodes.cs
@@ -60,7 +60,8 @@ public static class WorkflowErrorCodes
     public const string TransitionNotAvailableInCurrentState = "Transition:100020";
     public const string SharedTransitionNotAvailableInState = "Transition:100021";
     public const string StartTransitionNotFromInitialState = "Transition:100022";
-    
+    public const string SharedTransitionTargetMustBeSelfWhenInSubFlow = "Transition:100023";
+
     #endregion
     
     #region Execution Errors (200xxx)


### PR DESCRIPTION
## Summary
Implements [Issue #425](https://github.com/burgan-tech/vnext/issues/425): when the main flow is in an active subflow and a transition is requested, the parent's shared transitions (if available in the current state) are executed on the parent instead of being forwarded to the subflow.

## Changes

### Validation / policy
- **SubFlowBypassSpecification**: Bypass only when the transition is *not* a parent shared transition available in the current state. When it is, validation runs and the transition executes on the parent.
- **SharedTransitionTargetSelfWhenInSubFlowSpecification** (new): When in active subflow and the transition is a parent shared transition, the target must be `$self`; otherwise validation fails with `SharedTransitionTargetMustBeSelfWhenInSubFlow`.

### Pipeline
- **ForwardToActiveSubflowStep**: If the transition is a parent shared transition, do not forward to the subflow; continue the pipeline on the parent.
- **HandleSubFlowStep**: If the target is the same SubFlow state and there is already an active correlation, do not start the subflow again (idempotent re-entry).

### API
- **InstanceQueryAppService**: When in active subflow, available transitions = subflow transitions ∪ parent **shared** transitions only (manual/event). Parent state-level transitions are not included.
- **Workflow**: Added `GetAvailableSharedTransitionKeysOnly`; `GetAvailableUserTransitionKeys` treats empty `AvailableIn` as available in all states.

## Testing
- Build: `dotnet build vnext.sln` succeeds.
- Recommended: unit tests for SubFlowBypassSpecification, SharedTransitionTargetSelfWhenInSubFlowSpecification, ForwardToActiveSubflowStep, HandleSubFlowStep; integration test for shared transition (target $self) while in subflow.

Closes #425

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Handle shared parent transitions correctly when a workflow instance is in an active subflow and prevent unnecessary subflow re-starts.

New Features:
- Allow executing parent shared transitions directly on the parent workflow while a subflow is active when those transitions are available in the current state.
- Expose parent shared transition keys alongside subflow transitions in instance queries when an active subflow exists.

Bug Fixes:
- Avoid restarting an already active subflow when re-entering the same subflow state, ensuring idempotent behavior for self-targeted transitions.

Enhancements:
- Tighten subflow bypass logic so that validations are skipped only for non-shared transitions while a subflow is active.
- Enforce that shared transitions executed during an active subflow must target the current state ($self), with a dedicated validation specification and error code.
- Add workflow utilities for retrieving only shared transition keys available in a given state and treat empty AvailableIn as global availability.
- Ensure the forward-to-subflow pipeline step does not forward parent shared transitions down to the active subflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Parent shared transitions can now be executed within active subflows when targeting themselves.
  * Available transitions in subflows now include applicable parent transitions.

* **Bug Fixes**
  * Fixed duplicate subflow initiation when re-entering the same state.
  * Corrected bypass logic to allow parent shared transitions in subflow contexts.

* **Chores**
  * Added validation specification and error handling for subflow transition constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->