### PR TITLE
feat(view): return content typed by ViewType for view function (#429)

### DIFF
--- a/src/BBT.Workflow.Application/Instances/DTOs/GetViewOutput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/GetViewOutput.cs
@@ -11,9 +11,9 @@ public sealed class GetViewOutput
     public string Key { get; set; }
     
     /// <summary>
-    /// The view content as JSON
+    /// The view content. When <see cref="Type"/> is Json, DeepLink, Http, or URN, this is a JSON object or array; when Html or Markdown, this is a string.
     /// </summary>
-    public string? Content { get; set; }
+    public object? Content { get; set; }
 
     /// <summary>
     /// The view type

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -1240,16 +1240,18 @@ public sealed class InstanceQueryAppService(
     }
     /// <summary>
     /// Builds a GetViewOutput from a View and ViewEntry.
+    /// Content is returned as JSON object/array for Json, DeepLink, Http, URN when parseable; otherwise as string (including Html, Markdown and parse failures).
     /// </summary>
     /// <param name="view">The view to build output from</param>
     /// <param name="viewEntry">The view entry containing extensions and loadData information</param>
-    /// <returns>GetViewOutput with view content</returns>
+    /// <returns>GetViewOutput with view content typed by view type</returns>
     private GetViewOutput BuildViewOutput(View view, ViewEntry viewEntry)
     {
+        var content = view.GetContentAsTyped();
         return new GetViewOutput
         {
             Key = view.Key,
-            Content = view.Content,
+            Content = content,
             Type = view.Type.ToString(),
             Display = view.Display,
             Label = ""

--- a/src/BBT.Workflow.Domain/Definitions/Views/View.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Views/View.cs
@@ -102,9 +102,6 @@ public sealed class View : IDomainEntity, IViewReference, IReferenceSetter
     /// <returns>Parsed JSON as <see cref="JsonElement"/> for JSON-structured types when parseable; otherwise the original content string.</returns>
     public object GetContentAsTyped()
     {
-        if (Type is ViewType.Html or ViewType.Markdown)
-            return Content;
-
         if (Type is ViewType.Json or ViewType.DeepLink or ViewType.Http or ViewType.URN)
         {
             try

--- a/src/BBT.Workflow.Domain/Definitions/Views/View.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Views/View.cs
@@ -95,6 +95,31 @@ public sealed class View : IDomainEntity, IViewReference, IReferenceSetter
         return $"{nameof(View)}:{domain}:{flow}:{key}:{version}";
     }
 
+    /// <summary>
+    /// Returns content typed by <see cref="Type"/>: for Json, DeepLink, Http, URN attempts JSON parse (on failure returns original string);
+    /// for Html, Markdown returns the content string. Used when exposing view content (e.g. view function response).
+    /// </summary>
+    /// <returns>Parsed JSON as <see cref="JsonElement"/> for JSON-structured types when parseable; otherwise the original content string.</returns>
+    public object GetContentAsTyped()
+    {
+        if (Type is ViewType.Html or ViewType.Markdown)
+            return Content;
+
+        if (Type is ViewType.Json or ViewType.DeepLink or ViewType.Http or ViewType.URN)
+        {
+            try
+            {
+                return JsonSerializer.Deserialize<JsonElement>(Content);
+            }
+            catch (JsonException)
+            {
+                return Content;
+            }
+        }
+
+        return Content;
+    }
+
     private void SetKey(string key)
     {
         Key = Check.NotNullOrWhiteSpace(key, nameof(Key), ViewConstants.MaxKeyLength);

--- a/test/BBT.Workflow.Application.Tests/Instances/ViewGetContentAsTypedTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/ViewGetContentAsTypedTests.cs
@@ -1,0 +1,111 @@
+using System.Text.Json;
+using BBT.Workflow.Definitions;
+using BBT.Workflow;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Instances;
+
+/// <summary>
+/// Unit tests for View.GetContentAsTyped() (Issue #429 – view content typed by ViewType).
+/// </summary>
+public class ViewGetContentAsTypedTests
+{
+    private static View CreateView(ViewType type, string content)
+    {
+        var json = $$"""
+            {"type": {{(int)type}}, "content": "{{content.Replace("\"", "\\\"")}}", "display": "test"}
+            """;
+        var view = JsonSerializer.Deserialize<View>(json, JsonSerializerConstants.JsonOptions);
+        view.ShouldNotBeNull();
+        return view;
+    }
+
+    [Fact]
+    public void GetContentAsTyped_Html_ReturnsContentAsString()
+    {
+        var view = CreateView(ViewType.Html, "<p>hello</p>");
+        var result = view.GetContentAsTyped();
+        result.ShouldBeOfType<string>();
+        result.ShouldBe("<p>hello</p>");
+    }
+
+    [Fact]
+    public void GetContentAsTyped_Markdown_ReturnsContentAsString()
+    {
+        var view = CreateView(ViewType.Markdown, "# Title");
+        var result = view.GetContentAsTyped();
+        result.ShouldBeOfType<string>();
+        result.ShouldBe("# Title");
+    }
+
+    [Fact]
+    public void GetContentAsTyped_Json_WithValidJson_ReturnsJsonElement()
+    {
+        var view = CreateView(ViewType.Json, """{"a":1,"b":"x"}""");
+        var result = view.GetContentAsTyped();
+        result.ShouldBeOfType<JsonElement>();
+        var el = (JsonElement)result;
+        el.GetProperty("a").GetInt32().ShouldBe(1);
+        el.GetProperty("b").GetString().ShouldBe("x");
+    }
+
+    [Fact]
+    public void GetContentAsTyped_Json_WithInvalidJson_ReturnsOriginalString_NoException()
+    {
+        var view = CreateView(ViewType.Json, "not valid json");
+        var result = view.GetContentAsTyped();
+        result.ShouldBeOfType<string>();
+        result.ShouldBe("not valid json");
+    }
+
+    [Fact]
+    public void GetContentAsTyped_DeepLink_WithValidJson_ReturnsJsonElement()
+    {
+        var view = CreateView(ViewType.DeepLink, """{"url":"myapp://path","scheme":"myapp"}""");
+        var result = view.GetContentAsTyped();
+        result.ShouldBeOfType<JsonElement>();
+        var el = (JsonElement)result;
+        el.GetProperty("url").GetString().ShouldBe("myapp://path");
+    }
+
+    [Fact]
+    public void GetContentAsTyped_DeepLink_WithInvalidJson_ReturnsOriginalString_NoException()
+    {
+        var view = CreateView(ViewType.DeepLink, "not json");
+        var result = view.GetContentAsTyped();
+        result.ShouldBeOfType<string>();
+        result.ShouldBe("not json");
+    }
+
+    [Fact]
+    public void GetContentAsTyped_Http_WithValidJson_ReturnsJsonElement()
+    {
+        var view = CreateView(ViewType.Http, """{"method":"GET","url":"https://example.com"}""");
+        var result = view.GetContentAsTyped();
+        result.ShouldBeOfType<JsonElement>();
+        var el = (JsonElement)result;
+        el.GetProperty("method").GetString().ShouldBe("GET");
+    }
+
+    [Fact]
+    public void GetContentAsTyped_URN_WithValidJson_ReturnsJsonElement()
+    {
+        var view = CreateView(ViewType.URN, """{"urn":"urn:example:1"}""");
+        var result = view.GetContentAsTyped();
+        result.ShouldBeOfType<JsonElement>();
+        var el = (JsonElement)result;
+        el.GetProperty("urn").GetString().ShouldBe("urn:example:1");
+    }
+
+    [Fact]
+    public void GetContentAsTyped_Json_WithValidJsonArray_ReturnsJsonElement()
+    {
+        var view = CreateView(ViewType.Json, "[1,2,3]");
+        var result = view.GetContentAsTyped();
+        result.ShouldBeOfType<JsonElement>();
+        var el = (JsonElement)result;
+        el.GetArrayLength().ShouldBe(3);
+        el[0].GetInt32().ShouldBe(1);
+    }
+}


### PR DESCRIPTION
## Summary
Implements [Issue #429](https://github.com/burgan-tech/vnext/issues/429): view function returns `content` typed by `viewType` instead of always as string.

## Changes
- **GetViewOutput.Content**: `string?` → `object?`. API response now returns:
  - **Json, DeepLink, Http, URN**: parsed JSON object/array when content is valid JSON; otherwise original string (no error).
  - **Html, Markdown**: string (unchanged).
- **View.GetContentAsTyped()**: New domain method on `View` that resolves content by `ViewType` (DDD: behavior stays in the entity). Uses `JsonSerializer.Deserialize<JsonElement>` for JSON-structured types; on `JsonException` returns original string.
- **InstanceQueryAppService.BuildViewOutput**: Uses `view.GetContentAsTyped()` for the `Content` property.
- **ViewGetContentAsTypedTests**: Unit tests for all `ViewType` values and invalid-JSON fallback (9 tests).

## Breaking change
Clients of the view function will receive `content` as either a string or a JSON object/array depending on `type`. They should branch on `type` or treat `content` as `object`.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Type view function responses according to the view type instead of always returning content as a string.

New Features:
- Expose view content as either a string or parsed JSON (object/array) in GetViewOutput based on the view type.

Enhancements:
- Add View.GetContentAsTyped() domain method to centralize typing and JSON parsing of view content for Json, DeepLink, Http, and URN view types.

Tests:
- Add unit test coverage for View.GetContentAsTyped() across all view types, including valid and invalid JSON scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Content field in API responses now returns properly typed data based on view type. JSON-compatible views return parsed objects; text-based and unparseable content returns strings, improving type safety and reducing serialization errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->