### PR TITLE
Add hasView/hasSchema to state function response to avoid unnecessary view/schema requests

### DIFF
--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -661,31 +661,28 @@ public sealed class InstanceQueryAppService(
             var subFlowItemsByName =
                 subFlowStateInfo.SubFlowTransitionItems.ToDictionary(t => t.Name, StringComparer.Ordinal);
             transitionItems = keysForTransitions
-                .Where(key => subFlowItemsByName.TryGetValue(key, out _))
-                .Select(transitionKey =>
+                .Select(key => (Key: key, SubFlowItem: subFlowItemsByName.GetValueOrDefault(key)))
+                .Where(t => t.SubFlowItem is not null)
+                .Select(t => new TransitionItem
                 {
-                    var subFlowItem = subFlowItemsByName[transitionKey];
-                    return new TransitionItem
+                    Name = t.Key,
+                    Href = urlTemplateBuilder.BuildTransitionUrl(input.Domain, input.Workflow,
+                        instance.Id.ToString(),
+                        t.Key),
+                    View = new ViewHref
                     {
-                        Name = transitionKey,
-                        Href = urlTemplateBuilder.BuildTransitionUrl(input.Domain, input.Workflow,
+                        Href = urlTemplateBuilder.BuildViewUrl(input.Domain, input.Workflow, instance.Id.ToString(),
+                            t.Key),
+                        HasView = t.SubFlowItem!.View?.HasView ?? false,
+                        LoadData = t.SubFlowItem.View?.LoadData ?? false,
+                    },
+                    Schema = new SchemaHref
+                    {
+                        Href = urlTemplateBuilder.BuildSchemaUrl(input.Domain, input.Workflow,
                             instance.Id.ToString(),
-                            transitionKey),
-                        View = new ViewHref
-                        {
-                            Href = urlTemplateBuilder.BuildViewUrl(input.Domain, input.Workflow, instance.Id.ToString(),
-                                transitionKey),
-                            HasView = subFlowItem.View?.HasView ?? false,
-                            LoadData = subFlowItem.View?.LoadData ?? false,
-                        },
-                        Schema = new SchemaHref
-                        {
-                            Href = urlTemplateBuilder.BuildSchemaUrl(input.Domain, input.Workflow,
-                                instance.Id.ToString(),
-                                transitionKey),
-                            HasSchema = subFlowItem.Schema?.HasSchema ?? false
-                        }
-                    };
+                            t.Key),
+                        HasSchema = t.SubFlowItem.Schema?.HasSchema ?? false
+                    }
                 })
                 .ToList();
         }

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -311,14 +311,15 @@ public sealed class InstanceQueryAppService(
                     .Select(t => t.Name)
                     .ToList() ?? new List<string>();
 
-                // Return complete SubFlow state including view extensions and active correlations
+                // Return complete SubFlow state including view extensions, active correlations, and transition items (with HasView)
                 return new SubFlowStateInfo(
                     AvailableTransitions: transitionNames,
                     CurrentState: subFlowValue.State,
                     Status: subFlowValue.Status,
                     SubFlowData: subFlowValue.Data,
                     SubFlowView: subFlowValue.View,
-                    SubFlowActiveCorrelations: subFlowValue.ActiveCorrelations);
+                    SubFlowActiveCorrelations: subFlowValue.ActiveCorrelations,
+                    SubFlowTransitionItems: subFlowValue.Transitions);
             }
         }
         catch (Exception ex)
@@ -391,7 +392,8 @@ public sealed class InstanceQueryAppService(
         Dictionary<string, string?>? queryParameters,
         CancellationToken cancellationToken)
     {
-        var flowResult = await componentCacheStore.GetFlowAsync(domain, workflow, instance.FlowVersion ?? null, cancellationToken);
+        var flowResult =
+            await componentCacheStore.GetFlowAsync(domain, workflow, instance.FlowVersion ?? null, cancellationToken);
 
         var flow = flowResult.IsSuccess ? flowResult.Value! : null;
 
@@ -438,7 +440,9 @@ public sealed class InstanceQueryAppService(
 
         response.Extensions = extensionsResult.Value!;
 
-        response.Attributes = await ApplySchemaFieldFilterAsync(flow, response.Attributes, instance, cancellationToken) ?? response.Attributes;
+        response.Attributes =
+            await ApplySchemaFieldFilterAsync(flow, response.Attributes, instance, cancellationToken) ??
+            response.Attributes;
 
         return Result<GetInstanceOutput>.Ok(response);
     }
@@ -469,7 +473,8 @@ public sealed class InstanceQueryAppService(
             return data;
 
         var callerRoles = instance != null
-            ? await transitionAuthorizationManager.GetEffectiveCallerRolesForFieldVisibilityAsync(instance, cancellationToken)
+            ? await transitionAuthorizationManager.GetEffectiveCallerRolesForFieldVisibilityAsync(instance,
+                cancellationToken)
             : currentUser.Roles;
         var visiblePaths = SchemaFieldVisibilityService.GetVisiblePaths(pathRoleGrants, callerRoles);
         var pathsWithRoles = new HashSet<string>(pathRoleGrants.Keys, StringComparer.Ordinal);
@@ -507,7 +512,8 @@ public sealed class InstanceQueryAppService(
                         Etag = instance.LatestData?.ETag ?? string.Empty
                     };
 
-                    result.Data = await ApplySchemaFieldFilterAsync(flow, result.Data, instance, cancellationToken) ?? result.Data;
+                    result.Data = await ApplySchemaFieldFilterAsync(flow, result.Data, instance, cancellationToken) ??
+                                  result.Data;
 
                     // If there's an active SubFlow and extensions are requested, fetch from SubFlow
                     if (instance.Subflow != null)
@@ -649,22 +655,73 @@ public sealed class InstanceQueryAppService(
                     currentWorkflow, currentStateValue, instance, keysForTransitions, input.Role!, cancellationToken))
                 .ToList();
 
-        var transitionItems = keysForTransitions.Select(transitionKey => new TransitionItem
+        List<TransitionItem> transitionItems;
+        if (subFlowStateInfo.SubFlowTransitionItems != null)
         {
-            Name = transitionKey,
-            Href = urlTemplateBuilder.BuildTransitionUrl(input.Domain, input.Workflow, instance.Id.ToString(),
-                transitionKey),
-            Schema = new HrefBase
+            var subFlowItemsByName =
+                subFlowStateInfo.SubFlowTransitionItems.ToDictionary(t => t.Name, StringComparer.Ordinal);
+            transitionItems = keysForTransitions
+                .Where(key => subFlowItemsByName.TryGetValue(key, out _))
+                .Select(transitionKey =>
+                {
+                    var subFlowItem = subFlowItemsByName[transitionKey];
+                    return new TransitionItem
+                    {
+                        Name = transitionKey,
+                        Href = urlTemplateBuilder.BuildTransitionUrl(input.Domain, input.Workflow,
+                            instance.Id.ToString(),
+                            transitionKey),
+                        View = new ViewHref
+                        {
+                            Href = urlTemplateBuilder.BuildViewUrl(input.Domain, input.Workflow, instance.Id.ToString(),
+                                transitionKey),
+                            HasView = subFlowItem.View?.HasView ?? false,
+                            LoadData = subFlowItem.View?.LoadData ?? false,
+                        },
+                        Schema = new SchemaHref
+                        {
+                            Href = urlTemplateBuilder.BuildSchemaUrl(input.Domain, input.Workflow,
+                                instance.Id.ToString(),
+                                transitionKey),
+                            HasSchema = subFlowItem.Schema?.HasSchema ?? false
+                        }
+                    };
+                })
+                .ToList();
+        }
+        else
+        {
+            transitionItems = keysForTransitions.Select(transitionKey =>
             {
-                Href = urlTemplateBuilder.BuildSchemaUrl(input.Domain, input.Workflow, instance.Id.ToString(),
-                    transitionKey)
-            }
-        }).ToList();
+                var transition = currentWorkflow.ResolveTransition(transitionKey, currentStateValue);
+                var hasView = transition?.View is { Views.Count: > 0 };
+                var hasSchema = transition?.Schema != null;
+                return new TransitionItem
+                {
+                    Name = transitionKey,
+                    Href = urlTemplateBuilder.BuildTransitionUrl(input.Domain, input.Workflow, instance.Id.ToString(),
+                        transitionKey),
+                    View = new ViewHref
+                    {
+                        Href = urlTemplateBuilder.BuildViewUrl(input.Domain, input.Workflow, instance.Id.ToString(),
+                            transitionKey),
+                        HasView = hasView
+                    },
+                    Schema = new SchemaHref
+                    {
+                        Href = urlTemplateBuilder.BuildSchemaUrl(input.Domain, input.Workflow, instance.Id.ToString(),
+                            transitionKey),
+                        HasSchema = hasSchema
+                    }
+                };
+            }).ToList();
+        }
 
         var viewDefinition = GetViewDefinition(instance, currentWorkflow, currentStateValue);
         var firstViewEntry = viewDefinition?.Views.FirstOrDefault();
         var viewExtensions = firstViewEntry?.Extensions ?? [];
         var viewLoadData = firstViewEntry?.LoadData ?? false;
+        var stateHasView = viewDefinition is { Views.Count: > 0 };
         var allExtensions = subFlowStateInfo.SubFlowData != null
             ? ExtractExtensionsFromDataHref(subFlowStateInfo.SubFlowData.Href)
             : (input.Extensions ?? []).Concat(viewExtensions).ToArray();
@@ -678,6 +735,7 @@ public sealed class InstanceQueryAppService(
         var viewHref = new ViewHref
         {
             Href = urlTemplateBuilder.BuildViewUrl(input.Domain, input.Workflow, instance.Id.ToString()),
+            HasView = subFlowStateInfo.SubFlowView?.HasView ?? stateHasView,
             LoadData = subFlowStateInfo.SubFlowView?.LoadData ?? viewLoadData
         };
         var mainFlowCorrelationHrefs = transitionInfo.ActiveCorrelations.Select(correlation =>
@@ -1140,23 +1198,24 @@ public sealed class InstanceQueryAppService(
         // Return subflow view directly (remote call already handled view selection)
         return subFlowViewResult.Value!;
     }
-        /// <inheritdoc />
+
+    /// <inheritdoc />
     public async Task<Result<GetInstanceHierarchyOutput>> GetInstanceHierarchyAsync(
         GetInstanceHierarchyInput input,
         CancellationToken cancellationToken = default)
     {
         runtimeInfoProvider.Check(input.Domain);
- 
+
         var instanceResult = await GetInstanceByIdOrKeyAsync(input.Instance, cancellationToken);
         if (!instanceResult.IsSuccess)
         {
             return Result<GetInstanceHierarchyOutput>.Fail(instanceResult.Error);
         }
- 
+
         var instance = instanceResult.Value!;
         var flowResult = await componentCacheStore.GetFlowAsync(input.Domain, input.Workflow, null, cancellationToken);
         var flowVersion = flowResult.IsSuccess ? flowResult.Value?.Version : null;
- 
+
         var rootNode = new InstanceHierarchyNode
         {
             Id = instance.Id,
@@ -1171,16 +1230,16 @@ public sealed class InstanceQueryAppService(
             CompletedAt = instance.CompletedAt,
             ParentState = null
         };
- 
+
         rootNode.Children = await BuildHierarchyTreeAsync(
             instance.Id,
             input.Workflow,
             input.Domain,
             cancellationToken);
- 
+
         return Result<GetInstanceHierarchyOutput>.Ok(new GetInstanceHierarchyOutput { Root = rootNode });
     }
- 
+
     private async Task<List<InstanceHierarchyNode>> BuildHierarchyTreeAsync(
         Guid parentInstanceId,
         string parentFlow,
@@ -1192,26 +1251,26 @@ public sealed class InstanceQueryAppService(
         {
             correlations = await instanceCorrelationRepository.GetByParentAsync(parentInstanceId, cancellationToken);
         }
- 
+
         if (correlations.Count == 0)
         {
             return [];
         }
- 
+
         var children = new List<InstanceHierarchyNode>();
         foreach (var correlation in correlations)
         {
             var childFlow = correlation.SubFlowName;
             var childDomain = correlation.SubFlowDomain;
             Instance? childInstance = null;
- 
+
             using (currentSchema.Use(childFlow))
             {
                 childInstance = await instanceRepository.FindByIdentifierAsReadOnlyAsync(
                     correlation.SubFlowInstanceId.ToString(),
                     cancellationToken);
             }
- 
+
             var node = new InstanceHierarchyNode
             {
                 Id = correlation.SubFlowInstanceId,
@@ -1220,24 +1279,26 @@ public sealed class InstanceQueryAppService(
                 Domain = childDomain,
                 FlowVersion = correlation.SubFlowVersion,
                 CurrentState = correlation.SubFlowCurrentState ?? childInstance?.CurrentState,
-                Status = childInstance?.Status ?? (correlation.IsCompleted ? InstanceStatus.Completed : InstanceStatus.Active),
+                Status = childInstance?.Status ??
+                         (correlation.IsCompleted ? InstanceStatus.Completed : InstanceStatus.Active),
                 SubFlowType = correlation.SubFlowType,
                 IsCompleted = correlation.IsCompleted,
                 CompletedAt = correlation.CompletedAt,
                 ParentState = correlation.ParentState
             };
- 
+
             node.Children = await BuildHierarchyTreeAsync(
                 correlation.SubFlowInstanceId,
                 childFlow,
                 childDomain,
                 cancellationToken);
- 
+
             children.Add(node);
         }
- 
+
         return children;
     }
+
     /// <summary>
     /// Builds a GetViewOutput from a View and ViewEntry.
     /// </summary>
@@ -1266,11 +1327,13 @@ public sealed class InstanceQueryAppService(
     /// <param name="SubFlowData">Data href from SubFlow (contains extensions info) - null for main flow</param>
     /// <param name="SubFlowView">View href from SubFlow - null for main flow</param>
     /// <param name="SubFlowActiveCorrelations">Active correlations from SubFlow - empty for main flow</param>
+    /// <param name="SubFlowTransitionItems">Transition items from SubFlow (includes HasView) - null for main flow</param>
     private sealed record SubFlowStateInfo(
         List<string> AvailableTransitions,
         string? CurrentState,
         InstanceStatus? Status,
         DataHref? SubFlowData = null,
         ViewHref? SubFlowView = null,
-        List<ActiveCorrelationHref>? SubFlowActiveCorrelations = null);
+        List<ActiveCorrelationHref>? SubFlowActiveCorrelations = null,
+        List<TransitionItem>? SubFlowTransitionItems = null);
 }

--- a/src/BBT.Workflow.Domain/Definitions/IUrlTemplateBuilder.cs
+++ b/src/BBT.Workflow.Domain/Definitions/IUrlTemplateBuilder.cs
@@ -88,14 +88,15 @@ public interface IUrlTemplateBuilder
     string BuildDataWithExtensionsUrl(string domain, string workflow, string instance, IEnumerable<string> extensions, string? apiVersionPrefix = null);
     
     /// <summary>
-    /// Builds URL for instance view endpoint.
+    /// Builds URL for instance view endpoint. When transitionKey is provided, appends ?transitionKey= to support transition-specific view requests.
     /// </summary>
     /// <param name="domain">The domain name</param>
     /// <param name="workflow">The workflow name</param>
     /// <param name="instance">The instance key or ID</param>
+    /// <param name="transitionKey">Optional transition key for transition-specific view URL</param>
     /// <param name="apiVersionPrefix">Optional API version prefix (e.g., "api/v1")</param>
     /// <returns>Generated client-facing URL</returns>
-    string BuildViewUrl(string domain, string workflow, string instance, string? apiVersionPrefix = null);
+    string BuildViewUrl(string domain, string workflow, string instance, string? transitionKey = null, string? apiVersionPrefix = null);
     
     /// <summary>
     /// Builds URL for instance schema endpoint.

--- a/src/BBT.Workflow.Domain/Shared/HrefBase.cs
+++ b/src/BBT.Workflow.Domain/Shared/HrefBase.cs
@@ -23,11 +23,16 @@ public sealed class TransitionItem : HrefBase
     /// Transition name
     /// </summary>
     public string Name { get; set; } = string.Empty;
-    
+
     /// <summary>
-    /// Schema href link
+    /// View href for this transition. When HasView is true, the view endpoint returns meaningful content when called with this transition key.
     /// </summary>
-    public HrefBase? Schema {get; set; }
+    public ViewHref? View { get; set; }
+
+    /// <summary>
+    /// Schema href for this transition. When HasSchema is true, the schema endpoint returns meaningful content for this transition key.
+    /// </summary>
+    public SchemaHref? Schema { get; set; }
 }
 
 /// <summary>
@@ -38,10 +43,26 @@ public sealed class DataHref : HrefBase
 }
 
 /// <summary>
+/// Schema href link with has-schema flag. When true, the schema endpoint returns meaningful content for the transition.
+/// </summary>
+public sealed class SchemaHref : HrefBase
+{
+    /// <summary>
+    /// Whether this transition has a schema reference. When true, the schema endpoint returns meaningful content.
+    /// </summary>
+    public bool HasSchema { get; set; }
+}
+
+/// <summary>
 /// View href link with load data flag
 /// </summary>
 public sealed class ViewHref : HrefBase
 {
+    /// <summary>
+    /// Whether the current state has a view definition (state view or wizard single-transition view). When true, the view endpoint returns meaningful content.
+    /// </summary>
+    public bool HasView { get; set; }
+
     /// <summary>
     /// Whether to load data
     /// </summary>

--- a/src/BBT.Workflow.Infrastructure/Definitions/UrlTemplateBuilder.cs
+++ b/src/BBT.Workflow.Infrastructure/Definitions/UrlTemplateBuilder.cs
@@ -79,9 +79,11 @@ public sealed class UrlTemplateBuilder : IUrlTemplateBuilder
     }
     
     /// <inheritdoc />
-    public string BuildViewUrl(string domain, string workflow, string instance, string? apiVersionPrefix = null)
+    public string BuildViewUrl(string domain, string workflow, string instance, string? transitionKey = null, string? apiVersionPrefix = null)
     {
         var path = string.Format(_options.View, domain, workflow, instance);
+        if (!string.IsNullOrEmpty(transitionKey))
+            path += "?transitionKey=" + Uri.EscapeDataString(transitionKey);
         return BuildUrl(path, apiVersionPrefix);
     }
     


### PR DESCRIPTION
## Summary
Implements [Issue #430](https://github.com/burgan-tech/vnext/issues/430) and extends the scope with transition-level view/schema hints so clients can avoid unnecessary view and schema requests (and 404s).

## Changes

### State-level view
- **ViewHref**: Added `HasView` — indicates whether the current state has a view definition. Clients can skip calling the view endpoint when `false`.
- State view is exposed as `output.View.HasView` (no root-level `HasView` on `GetInstanceStateOutput`).

### Transition-level view and schema
- **TransitionItem.View**: New `ViewHref?` with `Href` (transition-specific view URL with `?transitionKey=`) and `HasView` (whether this transition has a view definition).
- **TransitionItem.Schema**: Type changed from `HrefBase?` to `SchemaHref?`; new **SchemaHref** type with `Href` and `HasSchema` (whether this transition has a schema reference).
- Removed root-level `HasView` from `TransitionItem`; view hint is now under `TransitionItem.View.HasView`.

### URL building
- **BuildViewUrl**: Added optional `transitionKey` parameter; when set, appends `?transitionKey={key}` to the view URL for transition-specific view requests.

### SubFlow
- **SubFlowStateInfo**: Added `SubFlowTransitionItems` so transition list (including View/Schema and HasView/HasSchema) from the SubFlow state response is preserved when merging; Hrefs are rebuilt for the main instance context.

## Acceptance criteria (from issue and plan)
- `output.View.HasView` is `true` when the current state has a resolvable view, `false` otherwise.
- Each `TransitionItem.View` has `Href` and `HasView`; each `TransitionItem.Schema` has `Href` and `HasSchema`.
- Existing clients that ignore the new properties remain compatible.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Add view and schema presence hints to instance state responses and support transition-specific view URLs to reduce unnecessary client requests.

New Features:
- Expose HasView flag on state-level view hrefs so clients can detect when a state has a resolvable view.
- Expose per-transition View and Schema href objects, including HasView and HasSchema flags, on transition items.

Enhancements:
- Preserve and remap SubFlow transition items (including view/schema hints) when building main instance state responses.
- Extend view URL generation to support an optional transitionKey query parameter for transition-specific views.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved workflow transitions with richer metadata and explicit view/schema indicators.
  * Added support for transition-specific view URLs via an optional transition key.
  * Expanded subflow state info to include per-transition items with enhanced metadata.

* **Bug Fixes**
  * Added fallback and logging when subflow transition queries fail, ensuring main-flow transitions are used as needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->