### PR TITLE
feat(etag): Redesign ETag strategy for authorization-aware responses

### DIFF
--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs
@@ -175,8 +175,21 @@ public sealed class FunctionController(
 
         if (functionType == Definitions.Functions.FunctionTypeConst.Longpooling)
         {
-            return FromResult(await ProcessLongpoolingFunctionAsync(domain, workflow, instance, parameters.Version,
-                parameters.Extensions, requestContext.Headers, requestContext.QueryParameters, cancellationToken));
+            var stateResult = await ProcessLongpoolingFunctionAsync(domain, workflow, instance, ifNoneMatch,
+                parameters.Version, parameters.Extensions, requestContext.Headers, requestContext.QueryParameters, cancellationToken);
+
+            if (stateResult.IsNotModified)
+                return StatusCode(304);
+
+            if (stateResult.Result.IsSuccess && stateResult.Result.Value is { } stateValue)
+            {
+                if (!string.IsNullOrEmpty(stateValue.Etag))
+                    HttpContext.Response.Headers[HeadersConstants.ETag] = stateValue.Etag;
+                if (!string.IsNullOrEmpty(stateValue.EntityEtag))
+                    HttpContext.Response.Headers[HeadersConstants.XEntityETag] = stateValue.EntityEtag;
+            }
+
+            return FromResult(stateResult.Result);
         }
 
         if (functionType == Definitions.Functions.FunctionTypeConst.View)
@@ -260,23 +273,24 @@ public sealed class FunctionController(
         return StatusCode(403, result.Value);
     }
 
-    private async Task<Result<GetInstanceStateOutput>> ProcessLongpoolingFunctionAsync(
+    private async Task<ConditionalResult<GetInstanceStateOutput>> ProcessLongpoolingFunctionAsync(
         string domain,
         string workflow,
         string instance,
+        string? ifNoneMatch,
         string? version,
         string[]? extensions,
         Dictionary<string, string?> headers,
         Dictionary<string, string?> queryParams,
         CancellationToken cancellationToken)
     {
-        // State function uses role from ICurrentUser (claims bound by middleware), not query string.
         var role = currentUser.Roles?.FirstOrDefault();
         var input = new GetInstanceStateInput
         {
             Domain = domain,
             Workflow = workflow,
             Instance = instance,
+            IfNoneMatch = ifNoneMatch,
             Version = version,
             Extensions = extensions,
             Headers = headers,
@@ -308,7 +322,7 @@ public sealed class FunctionController(
         });
 
         var results = await Task.WhenAll(tasks);
-        var list = results.Where(r => r.IsSuccess).Select(r => r.Value!).ToList();
+        var list = results.Where(r => r.Result.IsSuccess).Select(r => r.Result.Value!).ToList();
 
         var route = urlTemplateBuilder.BuildFunctionListUrl(domain, workflow,
             Definitions.Functions.FunctionTypeConst.Longpooling, InstanceUrlTemplates.GetApiVersionPrefix("1"));
@@ -532,9 +546,12 @@ public sealed class FunctionController(
 
         var response = await queryAppService.GetInstanceDataAsync(input, cancellationToken);
 
-        if (response.Result.IsSuccess && !string.IsNullOrEmpty(response.Result.Value?.Etag))
+        if (response.Result.IsSuccess && response.Result.Value is { } dataValue)
         {
-            HttpContext.Response.Headers[HeadersConstants.ETag] = response.Result.Value.Etag;
+            if (!string.IsNullOrEmpty(dataValue.Etag))
+                HttpContext.Response.Headers[HeadersConstants.ETag] = dataValue.Etag;
+            if (!string.IsNullOrEmpty(dataValue.EntityEtag))
+                HttpContext.Response.Headers[HeadersConstants.XEntityETag] = dataValue.EntityEtag;
         }
 
         return response;

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
@@ -259,12 +259,18 @@ public sealed class InstanceController(
         };
 
         var result = await queryAppService.GetInstanceAsync(input, cancellationToken);
-        
-        if (result.Result.IsSuccess && !string.IsNullOrEmpty(result.Result.Value?.Etag))
+
+        if (result.IsNotModified)
+            return StatusCode(304);
+
+        if (result.Result.IsSuccess && result.Result.Value is { } value)
         {
-            HttpContext.Response.Headers[HeadersConstants.ETag] = result.Result.Value.Etag;
+            if (!string.IsNullOrEmpty(value.Etag))
+                HttpContext.Response.Headers[HeadersConstants.ETag] = value.Etag;
+            if (!string.IsNullOrEmpty(value.EntityEtag))
+                HttpContext.Response.Headers[HeadersConstants.XEntityETag] = value.EntityEtag;
         }
-        
+
         return FromResult(result.Result);
     }
 
@@ -338,8 +344,6 @@ public sealed class InstanceController(
                 var hateoasResult = linkGenerator.CreateHateoasResult(tempPagedList, instanceOutputs, route);
                 response.Value!.Links = hateoasResult.Links;
             }
-
-            return Result.Ok(response.Value).ToAcceptedResult(HttpContext);
         }
 
         return response.ToActionResult(HttpContext);
@@ -395,12 +399,18 @@ public sealed class InstanceController(
         };
 
         var result = await queryAppService.GetInstanceDataAsync(input, cancellationToken);
-        
-        if (result.Result.IsSuccess && !string.IsNullOrEmpty(result.Result.Value?.Etag))
+
+        if (result.IsNotModified)
+            return StatusCode(304);
+
+        if (result.Result.IsSuccess && result.Result.Value is { } value)
         {
-            HttpContext.Response.Headers[HeadersConstants.ETag] = result.Result.Value.Etag;
+            if (!string.IsNullOrEmpty(value.Etag))
+                HttpContext.Response.Headers[HeadersConstants.ETag] = value.Etag;
+            if (!string.IsNullOrEmpty(value.EntityEtag))
+                HttpContext.Response.Headers[HeadersConstants.XEntityETag] = value.EntityEtag;
         }
-        
+
         return FromResult(result.Result);
     }
 } 

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Utilities/UtilityController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Utilities/UtilityController.cs
@@ -95,29 +95,38 @@ public sealed class UtilityController(
         [FromBody] DefinitionCacheInvalidationEvent eventData,
         CancellationToken cancellationToken = default)
     {
-        var podInstance = Environment.GetEnvironmentVariable("HOSTNAME") 
-            ?? Environment.GetEnvironmentVariable("POD_NAME") 
+        var podInstance = Environment.GetEnvironmentVariable("HOSTNAME")
+            ?? Environment.GetEnvironmentVariable("POD_NAME")
             ?? Environment.MachineName;
         var hostEnvironment = configuration["ASPNETCORE_ENVIRONMENT"];
-        // Environment match validation
-        if (!string.Equals(eventData.Environment, hostEnvironment, StringComparison.OrdinalIgnoreCase))
+
+        try
         {
-            logger.LogDebug(
-                "Definition cache invalidation ignored - environment mismatch. PodInstance: {PodInstance}, EventEnvironment: {EventEnvironment}, CurrentEnvironment: {CurrentEnvironment}",
-                podInstance, eventData.Environment, hostEnvironment);
+            // Environment match validation
+            if (!string.Equals(eventData.Environment, hostEnvironment, StringComparison.OrdinalIgnoreCase))
+            {
+                logger.LogDebug(
+                    "Definition cache invalidation ignored - environment mismatch. PodInstance: {PodInstance}, EventEnvironment: {EventEnvironment}, CurrentEnvironment: {CurrentEnvironment}",
+                    podInstance, eventData.Environment, hostEnvironment);
+                return Ok();
+            }
+
+            logger.DefinitionCacheInvalidationReceived(
+                podInstance,
+                eventData.Domain,
+                eventData.RequestedBy);
+
+            // Update only in-memory cache (distributed cache already updated by initiating pod)
+            await runtimeCacheInitializer.InitializeAsync(cancellationToken);
+
+            logger.DefinitionCacheInvalidationSucceeded(podInstance);
+
             return Ok();
         }
-        
-        logger.DefinitionCacheInvalidationReceived(
-            podInstance,
-            eventData.Domain, 
-            eventData.RequestedBy);
-        
-        // Update only in-memory cache (distributed cache already updated by initiating pod)
-        await runtimeCacheInitializer.InitializeAsync(cancellationToken);
-        
-        logger.DefinitionCacheInvalidationSucceeded(podInstance);
-            
-        return Ok();
+        catch (Exception ex)
+        {
+            logger.DefinitionCacheInvalidationFailed(podInstance, ex.ToString());
+            return Ok();
+        }
     }
 } 

--- a/src/BBT.Workflow.Application/Gateway/IInstanceQueryGateway.cs
+++ b/src/BBT.Workflow.Application/Gateway/IInstanceQueryGateway.cs
@@ -62,8 +62,8 @@ public interface IInstanceQueryGateway
     /// </summary>
     /// <param name="input">The get function with instance input containing domain, workflow, and instance.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>Result containing the instance state output.</returns>
-    Task<Result<GetInstanceStateOutput>> GetFunctionWithStateAsync(
+    /// <returns>ConditionalResult for instance state (supports 304 when If-None-Match matches).</returns>
+    Task<ConditionalResult<GetInstanceStateOutput>> GetFunctionWithStateAsync(
         GetFunctionWithInstanceInput input,
         CancellationToken cancellationToken = default);
 

--- a/src/BBT.Workflow.Application/Instances/DTOs/GetFunctionWithInstanceInput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/GetFunctionWithInstanceInput.cs
@@ -20,6 +20,11 @@ public sealed class GetFunctionWithInstanceInput : IHasDomain
     public string Instance { get; set; } = string.Empty;
     
     /// <summary>
+    /// ETag for conditional requests (If-None-Match). When set, state endpoint may return 304.
+    /// </summary>
+    public string? IfNoneMatch { get; set; }
+
+    /// <summary>
     /// Version of the workflow
     /// </summary>
     public string? Version { get; set; }

--- a/src/BBT.Workflow.Application/Instances/DTOs/GetInstanceStateInput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/GetInstanceStateInput.cs
@@ -20,6 +20,11 @@ public sealed class GetInstanceStateInput : IHasDomain
     public string Instance { get; set; } = string.Empty;
 
     /// <summary>
+    /// ETag value for conditional requests (If-None-Match header).
+    /// </summary>
+    public string? IfNoneMatch { get; set; }
+
+    /// <summary>
     /// Version of the workflow
     /// </summary>
     public string? Version { get; set; }

--- a/src/BBT.Workflow.Application/Instances/DTOs/GetInstanceStateOutput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/GetInstanceStateOutput.cs
@@ -38,7 +38,34 @@ public sealed class GetInstanceStateOutput
     public List<TransitionItem> Transitions { get; set; } = [];
 
     /// <summary>
-    /// ETag from the latest instance data
+    /// Representation ETag (RFC 7232 quoted) for cache validation.
     /// </summary>
-    public string ETag { get; set; } = string.Empty;
+    public string? Etag
+    {
+        get
+        {
+            if (string.IsNullOrEmpty(_etag))
+                return null;
+            var unquoted = _etag.Replace("\"", "");
+            return $"\"{unquoted}\"";
+        }
+        set => _etag = value;
+    }
+    private string? _etag = string.Empty;
+
+    /// <summary>
+    /// Entity (DB row) version for concurrency, RFC 7232 quoted. Exposed as X-Entity-ETag response header.
+    /// </summary>
+    public string? EntityEtag
+    {
+        get
+        {
+            if (string.IsNullOrEmpty(_entityEtag))
+                return null;
+            var unquoted = _entityEtag.Replace("\"", "");
+            return $"\"{unquoted}\"";
+        }
+        set => _entityEtag = value;
+    }
+    private string? _entityEtag = string.Empty;
 }

--- a/src/BBT.Workflow.Application/Instances/IInstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/IInstanceQueryAppService.cs
@@ -38,9 +38,10 @@ public interface IInstanceQueryAppService : IApplicationService
         CancellationToken cancellationToken = default);
     
     /// <summary>
-    /// Retrieves the complete state information for an instance including data href, view, state, status, correlations, transitions and ETag
+    /// Retrieves the complete state information for an instance including data href, view, state, status, correlations, transitions and ETag.
+    /// Returns ConditionalResult for If-None-Match support (304 when representation unchanged).
     /// </summary>
-    Task<Result<GetInstanceStateOutput>> GetInstanceStateAsync(
+    Task<ConditionalResult<GetInstanceStateOutput>> GetInstanceStateAsync(
         GetInstanceStateInput input,
         CancellationToken cancellationToken = default);
     

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -17,6 +17,7 @@ using Microsoft.Extensions.Logging;
 using BBT.Workflow.Shared;
 using System.Text.Json;
 using BBT.Workflow.Definitions.GraphQL;
+using BBT.Workflow.RepresentationEtag;
 using BBT.Workflow.Tasks.Coordinator;
 using BBT.Aether.MultiSchema;
 
@@ -37,6 +38,7 @@ public sealed class InstanceQueryAppService(
     ICurrentSchema currentSchema,
     ITransitionAuthorizationManager transitionAuthorizationManager,
     ICurrentUser currentUser,
+    IRepresentationEtagService representationEtagService,
     ILogger<InstanceQueryAppService> logger)
     : ApplicationService(serviceProvider), IInstanceQueryAppService
 {
@@ -50,14 +52,6 @@ public sealed class InstanceQueryAppService(
             .MatchAsync(
                 onSuccess: async instance =>
                 {
-                    // Check ETag for conditional requests
-                    if (!string.IsNullOrEmpty(input.IfNoneMatch) &&
-                        instance.LatestData != null &&
-                        instance.LatestData.ETag.MatchesIfNoneMatch(input.IfNoneMatch))
-                    {
-                        return ConditionalResult<GetInstanceOutput>.NotModified();
-                    }
-
                     var result = await BuildInstanceOutputAsync(
                         input.Domain,
                         input.Extensions,
@@ -75,7 +69,18 @@ public sealed class InstanceQueryAppService(
                         return ConditionalResult<GetInstanceOutput>.Fail(result.Error);
                     }
 
-                    return ConditionalResult<GetInstanceOutput>.Success(result.Value!);
+                    var response = result.Value!;
+                    var entityEtag = instance.LatestData?.ETag ?? string.Empty;
+                    response.EntityEtag = entityEtag;
+                    var representationEtag = representationEtagService.Generate(response);
+
+                    if (!string.IsNullOrEmpty(input.IfNoneMatch) && representationEtag.MatchesIfNoneMatch(input.IfNoneMatch))
+                    {
+                        return ConditionalResult<GetInstanceOutput>.NotModified();
+                    }
+
+                    response.Etag = representationEtag;
+                    return ConditionalResult<GetInstanceOutput>.Success(response);
                 },
                 onFailure: error => ConditionalResult<GetInstanceOutput>.Fail(error));
     }
@@ -303,9 +308,9 @@ public sealed class InstanceQueryAppService(
                 subFlowInput,
                 cancellationToken);
 
-            if (subFlowResult.IsSuccess && subFlowResult.Value != null)
+            if (subFlowResult.Result.IsSuccess && subFlowResult.Result.Value != null)
             {
-                var subFlowValue = subFlowResult.Value;
+                var subFlowValue = subFlowResult.Result.Value;
 
                 // Extract transition names from TransitionItem list
                 var transitionNames = subFlowValue.Transitions?
@@ -426,7 +431,7 @@ public sealed class InstanceQueryAppService(
             Id = instance.Id,
             Flow = instance.Flow,
             FlowVersion = instance.FlowVersion,
-            Etag = instanceData?.ETag ?? string.Empty,
+            EntityEtag = instanceData?.ETag ?? string.Empty,
             Domain = domain,
             Key = instance.Key!,
             Tags = instance.Tags,
@@ -522,19 +527,11 @@ public sealed class InstanceQueryAppService(
                 onSuccess: async data =>
                 {
                     var (flow, instance) = data;
-
-                    // Check ETag for conditional requests
-                    if (!string.IsNullOrEmpty(input.IfNoneMatch) &&
-                        instance.LatestData != null &&
-                        instance.LatestData.ETag.MatchesIfNoneMatch(input.IfNoneMatch))
-                    {
-                        return ConditionalResult<GetInstanceDataOutput>.NotModified();
-                    }
+                    var entityEtag = instance.LatestData?.ETag ?? string.Empty;
 
                     var result = new GetInstanceDataOutput
                     {
-                        Data = instance.LatestData?.Data.JsonElement,
-                        Etag = instance.LatestData?.ETag ?? string.Empty
+                        Data = instance.LatestData?.Data.JsonElement
                     };
 
                     result.Data = await ApplySchemaFieldFilterAsync(flow, result.Data, instance, cancellationToken) ??
@@ -550,37 +547,44 @@ public sealed class InstanceQueryAppService(
 
                         result.Extensions = subFlowExtensionsResult.Value?.Extensions ??
                                             new Dictionary<string, object>();
-
-                        return ConditionalResult<GetInstanceDataOutput>.Success(result);
                     }
-
-                    // No active SubFlow - process extensions locally
-                    var scriptContext = await scriptContextFactory.NewBuilder(instanceRepository)
-                        .WithWorkflow(flow)
-                        .WithInstance(instance)
-                        .WithRuntime(runtimeInfoProvider)
-                        .WithTransition(string.Empty)
-                        .WithBody(instance.LatestData?.Data ?? new JsonData("{}"))
-                        .WithHeaders(input.Headers)
-                        .WithQueryParameters(input.QueryParameters)
-                        .BuildAsync(cancellationToken);
-
-                    // Execute extensions with fail-fast behavior
-                    var extensionsResult = await instanceExtensionService.ProcessExtensionsAsync(
-                        input.Extensions,
-                        scriptContext,
-                        flow,
-                        ExtensionScope.GetInstance,
-                        cancellationToken);
-
-                    // Propagate extension errors - fail-fast behavior
-                    if (!extensionsResult.IsSuccess)
+                    else
                     {
-                        return ConditionalResult<GetInstanceDataOutput>.Fail(extensionsResult.Error);
+                        // No active SubFlow - process extensions locally
+                        var scriptContext = await scriptContextFactory.NewBuilder(instanceRepository)
+                            .WithWorkflow(flow)
+                            .WithInstance(instance)
+                            .WithRuntime(runtimeInfoProvider)
+                            .WithTransition(string.Empty)
+                            .WithBody(instance.LatestData?.Data ?? new JsonData("{}"))
+                            .WithHeaders(input.Headers)
+                            .WithQueryParameters(input.QueryParameters)
+                            .BuildAsync(cancellationToken);
+
+                        var extensionsResult = await instanceExtensionService.ProcessExtensionsAsync(
+                            input.Extensions,
+                            scriptContext,
+                            flow,
+                            ExtensionScope.GetInstance,
+                            cancellationToken);
+
+                        if (!extensionsResult.IsSuccess)
+                        {
+                            return ConditionalResult<GetInstanceDataOutput>.Fail(extensionsResult.Error);
+                        }
+
+                        result.Extensions = extensionsResult.Value!;
                     }
 
-                    result.Extensions = extensionsResult.Value!;
+                    result.EntityEtag = entityEtag;
+                    var representationEtag = representationEtagService.Generate(result);
 
+                    if (!string.IsNullOrEmpty(input.IfNoneMatch) && representationEtag.MatchesIfNoneMatch(input.IfNoneMatch))
+                    {
+                        return ConditionalResult<GetInstanceDataOutput>.NotModified();
+                    }
+
+                    result.Etag = representationEtag;
                     return ConditionalResult<GetInstanceDataOutput>.Success(result);
                 },
                 onFailure: ConditionalResult<GetInstanceDataOutput>.Fail);
@@ -628,18 +632,35 @@ public sealed class InstanceQueryAppService(
         return viewDefinition;
     }
 
-    public async Task<Result<GetInstanceStateOutput>> GetInstanceStateAsync(
+    public async Task<ConditionalResult<GetInstanceStateOutput>> GetInstanceStateAsync(
         GetInstanceStateInput input,
         CancellationToken cancellationToken = default)
     {
         runtimeInfoProvider.Check(input.Domain);
 
-        // Railway chain: Get Instance → Get Workflow → Build State Output
         return await GetInstanceByIdOrKeyAsync(input.Instance, cancellationToken)
             .BindAsync(instance =>
                 componentCacheStore.GetFlowAsync(input.Domain, input.Workflow, input.Version, cancellationToken)
                     .MapAsync(workflow => (instance, workflow)))
-            .ThenAsync(data => BuildInstanceStateOutputAsync(data.instance, data.workflow, input, cancellationToken));
+            .MatchAsync(
+                onSuccess: async data =>
+                {
+                    var buildResult = await BuildInstanceStateOutputAsync(data.instance, data.workflow, input, cancellationToken);
+                    if (!buildResult.IsSuccess)
+                        return ConditionalResult<GetInstanceStateOutput>.Fail(buildResult.Error);
+
+                    var output = buildResult.Value!;
+                    var entityEtag = data.instance.LatestData?.ETag ?? string.Empty;
+                    output.EntityEtag = entityEtag;
+                    var representationEtag = representationEtagService.Generate(output);
+
+                    if (!string.IsNullOrEmpty(input.IfNoneMatch) && representationEtag.MatchesIfNoneMatch(input.IfNoneMatch))
+                        return ConditionalResult<GetInstanceStateOutput>.NotModified();
+
+                    output.Etag = representationEtag;
+                    return ConditionalResult<GetInstanceStateOutput>.Success(output);
+                },
+                onFailure: error => ConditionalResult<GetInstanceStateOutput>.Fail(error));
     }
 
     /// <summary>
@@ -788,8 +809,7 @@ public sealed class InstanceQueryAppService(
             State = subFlowStateInfo.CurrentState ?? string.Empty,
             Status = subFlowStateInfo.Status,
             ActiveCorrelations = allActiveCorrelations,
-            Transitions = transitionItems,
-            ETag = instance.LatestData?.ETag ?? string.Empty
+            Transitions = transitionItems
         });
     }
 

--- a/src/BBT.Workflow.Application/Instances/InstanceRetryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceRetryAppService.cs
@@ -94,12 +94,12 @@ public sealed class InstanceRetryAppService(
             subflowStateInput,
             cancellationToken);
 
-        if (!subflowStateResult.IsSuccess)
+        if (!subflowStateResult.Result.IsSuccess)
         {
-            return Result<RetryInstanceOutput>.Fail(subflowStateResult.Error);
+            return Result<RetryInstanceOutput>.Fail(subflowStateResult.Result.Error);
         }
 
-        var subflowState = subflowStateResult.Value!;
+        var subflowState = subflowStateResult.Result.Value!;
 
         // SubFlow not Faulted → Error (both instance and subflow are not faulted)
         if (subflowState.Status == null || !subflowState.Status.Equals(InstanceStatus.Faulted))

--- a/src/BBT.Workflow.Application/Instances/Remote/IRemoteInstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/Remote/IRemoteInstanceQueryAppService.cs
@@ -41,7 +41,7 @@ public interface IRemoteInstanceQueryAppService
     /// Retrieves function result for an instance (e.g., "state" function returns GetInstanceStateOutput)
     /// GET {baseUrl}/api/v{version}/{domain}/workflows/{workflow}/instances/{instance}/functions/{function}
     /// </summary>
-    Task<Result<GetInstanceStateOutput>> GetFunctionWithStateAsync(
+    Task<ConditionalResult<GetInstanceStateOutput>> GetFunctionWithStateAsync(
         GetFunctionWithInstanceInput input,
         CancellationToken cancellationToken = default);
     

--- a/src/BBT.Workflow.Application/Instances/ViewContentResolutionService.cs
+++ b/src/BBT.Workflow.Application/Instances/ViewContentResolutionService.cs
@@ -120,7 +120,7 @@ public sealed class ViewContentResolutionService(
         var attrs = DeserializeAttributes(instanceOutput.Attributes);
         var contentRaw = attrs?.Content ?? string.Empty;
         var type = attrs?.Type ?? string.Empty;
-        var contentTyped = View.GetContentAsTypedFromString(contentRaw, type);
+        var contentTyped = View.GetContentAsTypedFromObject(contentRaw, type);
         return new GetViewOutput
         {
             Key = instanceOutput.Key ?? viewKey,

--- a/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using BBT.Workflow.Definitions.CastHandlers;
 using BBT.Workflow.Definitions.Validators;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Monitoring;
+using BBT.Workflow.RepresentationEtag;
 using BBT.Workflow.Resilience;
 using BBT.Workflow.Runtime;
 using BBT.Workflow.Extentions;
@@ -57,6 +58,7 @@ public static class WorkflowApplicationModuleServiceCollectionExtensions
         services.AddScoped<IFunctionAppService, FunctionAppService>();
         services.AddScoped<ITransitionAuthorizationManager, TransitionAuthorizationManager>();
         services.AddScoped<IAuthorizeAppService, AuthorizeAppService>();
+        services.AddScoped<IRepresentationEtagService, RepresentationEtagService>();
         services.AddScoped<IInstanceExtensionService, InstanceExtensionService>();
         services.AddScoped<ISubflowCompletionService, SubflowCompletionService>();
         services.AddScoped<ISubflowStateService, SubflowStateService>();

--- a/src/BBT.Workflow.Application/RepresentationEtag/IRepresentationEtagService.cs
+++ b/src/BBT.Workflow.Application/RepresentationEtag/IRepresentationEtagService.cs
@@ -1,0 +1,16 @@
+namespace BBT.Workflow.RepresentationEtag;
+
+/// <summary>
+/// Generates representation ETags for HTTP cache validation from the response body only.
+/// Representation ETag = base64url(SHA256(canonical JSON of the response DTO)).
+/// </summary>
+public interface IRepresentationEtagService
+{
+    /// <summary>
+    /// Generates a representation ETag by serializing the response DTO to canonical JSON and hashing it.
+    /// The DTO's Etag property must be unset (null/empty) when passed so the hash is deterministic.
+    /// </summary>
+    /// <param name="responseDto">The response DTO that will be returned (EntityEtag may be set; Etag must not be set yet).</param>
+    /// <returns>Unquoted representation ETag string (base64url SHA256 of canonical JSON).</returns>
+    string Generate(object responseDto);
+}

--- a/src/BBT.Workflow.Application/RepresentationEtag/RepresentationEtagService.cs
+++ b/src/BBT.Workflow.Application/RepresentationEtag/RepresentationEtagService.cs
@@ -1,0 +1,28 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using BBT.Workflow.Canonicalization;
+
+namespace BBT.Workflow.RepresentationEtag;
+
+/// <summary>
+/// Generates representation ETags from the response body only: canonical JSON of the DTO then SHA256 + base64url.
+/// Uses <see cref="JsonSerializerConstants.JsonOptions"/> and <see cref="IJsonCanonicalizer"/> from DI for consistency.
+/// </summary>
+public sealed class RepresentationEtagService(IJsonCanonicalizer canonicalizer) : IRepresentationEtagService
+{
+    /// <inheritdoc />
+    public string Generate(object responseDto)
+    {
+        var json = JsonSerializer.Serialize(responseDto, JsonSerializerConstants.JsonOptions);
+        var canonicalJson = canonicalizer.Canonicalize(json);
+        var hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(canonicalJson));
+        return ToBase64Url(hashBytes);
+    }
+
+    private static string ToBase64Url(byte[] bytes)
+    {
+        var base64 = Convert.ToBase64String(bytes);
+        return base64.Replace('+', '-').Replace('/', '_').TrimEnd('=');
+    }
+}

--- a/src/BBT.Workflow.Application/Tasks/Executors/Notification/NotificationTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Notification/NotificationTaskExecutor.cs
@@ -215,15 +215,15 @@ public sealed class NotificationTaskExecutor : TaskExecutorBase<NotificationTask
         };
 
         var stateResult = await _instanceQueryGateway.GetFunctionWithStateAsync(input, cancellationToken);
-        if (!stateResult.IsSuccess)
+        if (!stateResult.Result.IsSuccess)
         {
             return Result.Fail(Error.Failure(
                 WorkflowErrorCodes.TaskExecution,
-                $"Notification task state fetch failed: {stateResult.Error.Message}",
-                detail: stateResult.Error.Detail));
+                $"Notification task state fetch failed: {stateResult.Result.Error.Message}",
+                detail: stateResult.Result.Error.Detail));
         }
 
-        context.ScriptContext.SetBody(new { state = stateResult.Value });
+        context.ScriptContext.SetBody(new { state = stateResult.Result.Value });
         return Result.Ok();
     }
 }

--- a/src/BBT.Workflow.Domain/Canonicalization/IJsonCanonicalizer.cs
+++ b/src/BBT.Workflow.Domain/Canonicalization/IJsonCanonicalizer.cs
@@ -1,0 +1,15 @@
+namespace BBT.Workflow.Canonicalization;
+
+/// <summary>
+/// Canonicalizes JSON for deterministic hashing (e.g. representation ETag).
+/// Registered as scoped; one instance per request, buffer reused within the scope.
+/// </summary>
+public interface IJsonCanonicalizer
+{
+    /// <summary>
+    /// Produces a canonical JSON string from the given JSON (sorted keys, consistent number/string formatting).
+    /// </summary>
+    /// <param name="json">Raw JSON string.</param>
+    /// <returns>Canonical JSON string.</returns>
+    string Canonicalize(string json);
+}

--- a/src/BBT.Workflow.Domain/Canonicalization/JsonCanonicalizer.cs
+++ b/src/BBT.Workflow.Domain/Canonicalization/JsonCanonicalizer.cs
@@ -1,0 +1,327 @@
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace BBT.Workflow.Canonicalization;
+
+public sealed class JsonCanonicalizer : IJsonCanonicalizer
+{
+    private readonly StringBuilder _buffer = new();
+
+    /// <summary>
+    /// Parameterless constructor for DI. Use <see cref="Canonicalize"/> to canonicalize JSON.
+    /// </summary>
+    public JsonCanonicalizer()
+    {
+    }
+
+    /// <summary>
+    /// Produces a canonical JSON string from the given JSON. One instance per scope (e.g. per request).
+    /// </summary>
+    public string Canonicalize(string jsonData)
+    {
+        _buffer.Clear();
+        Serialize(new JsonDecoder(jsonData).Root);
+        return _buffer.ToString();
+    }
+
+    /// <summary>
+    /// Legacy entry point for one-shot canonicalization; prefer injecting <see cref="IJsonCanonicalizer"/> and calling <see cref="Canonicalize"/>.
+    /// </summary>
+    public JsonCanonicalizer(string jsonData)
+    {
+        Serialize(new JsonDecoder(jsonData).Root);
+    }
+
+    /// <summary>
+    /// Legacy entry point for one-shot canonicalization from UTF-8 bytes.
+    /// </summary>
+    public JsonCanonicalizer(byte[] jsonData)
+        : this(new UTF8Encoding(false, true).GetString(jsonData))
+    {
+    }
+
+    public string GetEncodedString() => _buffer.ToString();
+
+    public byte[] GetEncodedUTF8() => new UTF8Encoding(false, true).GetBytes(GetEncodedString());
+
+    private void Escape(char c) => _buffer.Append('\\').Append(c);
+
+    private void SerializeString(string value)
+    {
+        _buffer.Append('"');
+        foreach (var c in value)
+        {
+            switch (c)
+            {
+                case '\n': Escape('n'); break;
+                case '\b': Escape('b'); break;
+                case '\f': Escape('f'); break;
+                case '\r': Escape('r'); break;
+                case '\t': Escape('t'); break;
+                case '"':
+                case '\\': Escape(c); break;
+                default:
+                    if (c < ' ')
+                        _buffer.Append("\\u").Append(((int)c).ToString("x4"));
+                    else
+                        _buffer.Append(c);
+                    break;
+            }
+        }
+        _buffer.Append('"');
+    }
+
+    private void Serialize(object? o)
+    {
+        if (o is SortedDictionary<string, object> dict)
+        {
+            _buffer.Append('{');
+            var next = false;
+            foreach (var kv in dict)
+            {
+                if (next) _buffer.Append(',');
+                next = true;
+                SerializeString(kv.Key);
+                _buffer.Append(':');
+                Serialize(kv.Value);
+            }
+            _buffer.Append('}');
+        }
+        else if (o is List<object> list)
+        {
+            _buffer.Append('[');
+            var next = false;
+            foreach (var value in list)
+            {
+                if (next) _buffer.Append(',');
+                next = true;
+                Serialize(value);
+            }
+            _buffer.Append(']');
+        }
+        else if (o == null)
+        {
+            _buffer.Append("null");
+        }
+        else if (o is string s)
+        {
+            SerializeString(s);
+        }
+        else if (o is bool b)
+        {
+            _buffer.Append(b ? "true" : "false");
+        }
+        else if (o is double d)
+        {
+            _buffer.Append(Es6NumberSerialization.SerializeNumber(d));
+        }
+        else
+        {
+            throw new InvalidOperationException("Unknown object type: " + o.GetType().FullName);
+        }
+    }
+
+    /// <summary>
+    /// ES6-style number serialization for canonical JSON (deterministic, no unnecessary decimals).
+    /// </summary>
+    private static class Es6NumberSerialization
+    {
+        public static string SerializeNumber(double value)
+        {
+            if (double.IsNaN(value)) return "null";
+            if (double.IsPositiveInfinity(value)) return "1e+400";
+            if (double.IsNegativeInfinity(value)) return "-1e+400";
+            var s = value.ToString("G17", CultureInfo.InvariantCulture);
+            if (double.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out var roundTrip) &&
+                Math.Abs(roundTrip - value) < double.Epsilon &&
+                Math.Truncate(value) == value && value >= long.MinValue && value <= long.MaxValue)
+            {
+                var l = (long)value;
+                if (l.ToString(CultureInfo.InvariantCulture) == s.TrimEnd('0').TrimEnd('.'))
+                    return l.ToString(CultureInfo.InvariantCulture);
+            }
+            return s;
+        }
+    }
+
+    private class JsonDecoder
+    {
+        private const char LeftCurly = '{';
+        private const char RightCurly = '}';
+        private const char Quote = '"';
+        private const char Colon = ':';
+        private const char LeftBracket = '[';
+        private const char RightBracket = ']';
+        private const char Comma = ',';
+        private const char Backslash = '\\';
+
+        private static readonly Regex NumberPattern = new(@"^-?[0-9]+(\.[0-9]+)?([eE][-+]?[0-9]+)?$", RegexOptions.Compiled);
+        private static readonly Regex BooleanPattern = new(@"^true|false$", RegexOptions.Compiled);
+
+        private int _index;
+        private readonly string _jsonData;
+
+        internal object? Root { get; }
+
+        internal JsonDecoder(string jsonData)
+        {
+            _jsonData = jsonData;
+            if (TestNextNonWhiteSpaceChar() == LeftBracket)
+                Root = ParseArray();
+            else
+            {
+                ScanFor(LeftCurly);
+                Root = ParseObject();
+            }
+            while (_index < _jsonData.Length)
+            {
+                if (!IsWhiteSpace(_jsonData[_index++]))
+                    throw new InvalidOperationException("Improperly terminated JSON object");
+            }
+        }
+
+        private object? ParseElement()
+        {
+            return Scan() switch
+            {
+                LeftCurly => ParseObject(),
+                Quote => ParseQuotedString(),
+                LeftBracket => ParseArray(),
+                _ => ParseSimpleType()
+            };
+        }
+
+        private SortedDictionary<string, object> ParseObject()
+        {
+            var dict = new SortedDictionary<string, object>(StringComparer.Ordinal);
+            var next = false;
+            while (TestNextNonWhiteSpaceChar() != RightCurly)
+            {
+                if (next) ScanFor(Comma);
+                next = true;
+                ScanFor(Quote);
+                var name = ParseQuotedString();
+                ScanFor(Colon);
+                dict.Add(name, ParseElement()!);
+            }
+            Scan();
+            return dict;
+        }
+
+        private List<object> ParseArray()
+        {
+            var list = new List<object>();
+            var next = false;
+            while (TestNextNonWhiteSpaceChar() != RightBracket)
+            {
+                if (next) ScanFor(Comma);
+                else next = true;
+                list.Add(ParseElement()!);
+            }
+            Scan();
+            return list;
+        }
+
+        private object? ParseSimpleType()
+        {
+            _index--;
+            var temp = new StringBuilder();
+            char c;
+            while ((c = TestNextNonWhiteSpaceChar()) != Comma && c != RightBracket && c != RightCurly)
+            {
+                if (IsWhiteSpace(NextChar())) break;
+                temp.Append(_jsonData[_index - 1]);
+            }
+            var token = temp.ToString();
+            if (token.Length == 0) throw new InvalidOperationException("Missing argument");
+            if (NumberPattern.IsMatch(token))
+                return double.Parse(token, NumberStyles.Float, CultureInfo.InvariantCulture);
+            if (BooleanPattern.IsMatch(token))
+                return bool.Parse(token);
+            if (token == "null") return null;
+            throw new InvalidOperationException("Unrecognized or malformed JSON token: " + token);
+        }
+
+        private string ParseQuotedString()
+        {
+            var result = new StringBuilder();
+            while (true)
+            {
+                var c = NextChar();
+                if (c < ' ')
+                    throw new InvalidOperationException(c == '\n' ? "Unterminated string literal" : "Unescaped control character");
+                if (c == Quote) break;
+                if (c == Backslash)
+                {
+                    c = NextChar() switch
+                    {
+                        '"' or '\\' or '/' => NextChar(),
+                        'b' => '\b',
+                        'f' => '\f',
+                        'n' => '\n',
+                        'r' => '\r',
+                        't' => '\t',
+                        'u' => ParseUnicodeEscape(),
+                        _ => throw new InvalidOperationException("Unsupported escape")
+                    };
+                }
+                result.Append(c);
+            }
+            return result.ToString();
+        }
+
+        private char ParseUnicodeEscape()
+        {
+            var c = (char)0;
+            for (var i = 0; i < 4; i++)
+                c = (char)((c << 4) + GetHexChar());
+            return c;
+        }
+
+        private char GetHexChar()
+        {
+            var c = NextChar();
+            return c switch
+            {
+                >= '0' and <= '9' => (char)(c - '0'),
+                >= 'a' and <= 'f' => (char)(c - 'a' + 10),
+                >= 'A' and <= 'F' => (char)(c - 'A' + 10),
+                _ => throw new InvalidOperationException("Bad hex in \\u escape: " + c)
+            };
+        }
+
+        private char TestNextNonWhiteSpaceChar()
+        {
+            var save = _index;
+            var c = Scan();
+            _index = save;
+            return c;
+        }
+
+        private void ScanFor(char expected)
+        {
+            var c = Scan();
+            if (c != expected)
+                throw new InvalidOperationException($"Expected '{expected}' but got '{c}'");
+        }
+
+        private char NextChar()
+        {
+            if (_index < _jsonData.Length)
+                return _jsonData[_index++];
+            throw new InvalidOperationException("Unexpected EOF reached");
+        }
+
+        private static bool IsWhiteSpace(char c) => c is ' ' or '\n' or '\r' or '\t';
+
+        private char Scan()
+        {
+            while (true)
+            {
+                var c = NextChar();
+                if (!IsWhiteSpace(c)) return c;
+            }
+        }
+    }
+}

--- a/src/BBT.Workflow.Domain/Definitions/Views/View.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Views/View.cs
@@ -93,7 +93,7 @@ public sealed class View : IDomainEntity, IViewReference, IReferenceSetter
     /// <returns>Parsed JSON as <see cref="JsonElement"/> for JSON-structured types when parseable; otherwise the original content string.</returns>
     public object GetContentAsTyped()
     {
-        return GetContentAsTypedFromString(Content, Type.ToString());
+        return GetContentAsTypedFromObject(Content, Type.ToString());
     }
 
     /// <summary>
@@ -103,7 +103,7 @@ public sealed class View : IDomainEntity, IViewReference, IReferenceSetter
     /// <param name="content">Raw view content (e.g. JSON string or markup).</param>
     /// <param name="type">View type name (e.g. Json, Html, Markdown).</param>
     /// <returns>Parsed JSON as <see cref="JsonElement"/> for JSON-structured types when parseable; otherwise the original content string.</returns>
-    public static object GetContentAsTypedFromString(object? content, string? type)
+    public static object GetContentAsTypedFromObject(object? content, string? type)
     {
         if (content == null)
             return string.Empty;

--- a/src/BBT.Workflow.Domain/Instances/DTOs/GetInstanceOutput.cs
+++ b/src/BBT.Workflow.Domain/Instances/DTOs/GetInstanceOutput.cs
@@ -29,6 +29,23 @@ public sealed class GetInstanceOutput
         set => _etag = value;
     }
     private string? _etag = string.Empty;
+
+    /// <summary>
+    /// Entity (DB row) version for concurrency and write operations, returned with quotes per RFC 7232. Exposed as X-Entity-ETag response header.
+    /// </summary>
+    public string? EntityEtag
+    {
+        get
+        {
+            if (string.IsNullOrEmpty(_entityEtag))
+                return null;
+            var unquoted = _entityEtag.Replace("\"", "");
+            return $"\"{unquoted}\"";
+        }
+        set => _entityEtag = value;
+    }
+    private string? _entityEtag = string.Empty;
+
     public List<string>? Tags { get; set; } = [];
     /// <summary>
     /// Instance metadata (state, audit, duration). Excludes fields already at root (id, key, flow, domain, flowVersion, eTag, tags).
@@ -142,6 +159,22 @@ public sealed class GetInstanceDataOutput
         set => _etag = value;
     }
     private string? _etag = string.Empty;
+
+    /// <summary>
+    /// Entity (DB row) version for concurrency and write operations, returned with quotes per RFC 7232. Exposed as X-Entity-ETag response header.
+    /// </summary>
+    public string? EntityEtag
+    {
+        get
+        {
+            if (string.IsNullOrEmpty(_entityEtag))
+                return null;
+            var unquoted = _entityEtag.Replace("\"", "");
+            return $"\"{unquoted}\"";
+        }
+        set => _entityEtag = value;
+    }
+    private string? _entityEtag = string.Empty;
 
     public Dictionary<string, object>? Extensions { get; set; }
 }

--- a/src/BBT.Workflow.Domain/Microsoft/Extensions/DependencyInjection/WorkflowDomainModuleServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Domain/Microsoft/Extensions/DependencyInjection/WorkflowDomainModuleServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using BBT.Workflow.Canonicalization;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Definitions.Validators;
 using BBT.Workflow.Rules;
@@ -37,6 +38,7 @@ public static class WorkflowDomainModuleServiceCollectionExtensions
         services.AddSingleton<IResultRuleEngine<State>, ResultRuleEngine<State>>();
         services.AddSingleton<IScriptContextFactory, ScriptContextFactory>();
         services.AddSingleton<IJsonSchemaValidator, CachedJsonSchemaValidator>();
+        services.AddScoped<IJsonCanonicalizer, JsonCanonicalizer>();
         return services;
     }
 }

--- a/src/BBT.Workflow.Domain/Shared/HeadersConstants.cs
+++ b/src/BBT.Workflow.Domain/Shared/HeadersConstants.cs
@@ -1,5 +1,13 @@
 namespace BBT.Workflow.Domain.Shared;
+
+/// <summary>
+/// HTTP header name constants for workflow API.
+/// </summary>
 public static class HeadersConstants
 {
+    /// <summary>Response header for representation ETag (cache validation).</summary>
     public const string ETag = "ETag";
+
+    /// <summary>Response header for entity/row version (concurrency and write operations).</summary>
+    public const string XEntityETag = "X-Entity-ETag";
 }

--- a/src/BBT.Workflow.Domain/Shared/JsonSerializerConstants.cs
+++ b/src/BBT.Workflow.Domain/Shared/JsonSerializerConstants.cs
@@ -25,7 +25,9 @@ public static class JsonSerializerConstants
             DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
             PropertyNameCaseInsensitive = true,
             IncludeFields = true,
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            ReferenceHandler = ReferenceHandler.IgnoreCycles,
+            MaxDepth = 256
         };
 
         // Add converters for proper serialization of enums and dynamic objects

--- a/src/BBT.Workflow.Execution/Invokers/GetInstanceDataRemoteInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/GetInstanceDataRemoteInvoker.cs
@@ -185,7 +185,7 @@ public sealed class GetInstanceDataRemoteInvoker : ITaskInvoker<GetInstanceDataB
         CancellationToken cancellationToken)
     {
         var responseHeaders = InvokerHelpers.MergeHeaders(response.Headers, response.Content.Headers);
-        var content = await response.Content.ReadAsStringAsync(cancellationToken);
+        var content = await response.ReadDecompressedContentAsync(cancellationToken);
         var responseData = InvokerHelpers.TryParseJson(content);
         var metadata = CreateMetadata(binding, reasonPhrase: response.ReasonPhrase);
 

--- a/src/BBT.Workflow.Execution/Invokers/GetInstancesRemoteInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/GetInstancesRemoteInvoker.cs
@@ -185,7 +185,7 @@ public sealed class GetInstancesRemoteInvoker : ITaskInvoker<GetInstancesBinding
         CancellationToken cancellationToken)
     {
         var responseHeaders = InvokerHelpers.MergeHeaders(response.Headers, response.Content.Headers);
-        var content = await response.Content.ReadAsStringAsync(cancellationToken);
+        var content = await response.ReadDecompressedContentAsync(cancellationToken);
         var responseData = InvokerHelpers.TryParseJson(content);
         var metadata = CreateMetadata(binding, reasonPhrase: response.ReasonPhrase);
 

--- a/src/BBT.Workflow.Execution/Invokers/InvokerHelpers.cs
+++ b/src/BBT.Workflow.Execution/Invokers/InvokerHelpers.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Headers;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace BBT.Workflow.Execution.Invokers;
 
@@ -9,7 +10,17 @@ namespace BBT.Workflow.Execution.Invokers;
 internal static class InvokerHelpers
 {
     /// <summary>
+    /// JSON options for TriggerTask response parsing: MaxDepth 256 and IgnoreCycles to handle large/deep payloads safely.
+    /// </summary>
+    private static readonly JsonSerializerOptions TriggerTaskJsonOptions = new()
+    {
+        MaxDepth = 256,
+        ReferenceHandler = ReferenceHandler.IgnoreCycles
+    };
+
+    /// <summary>
     /// Attempts to parse JSON content. Returns the original content if parsing fails.
+    /// Used for TriggerTask (e.g. GetInstances / GetInstanceData) response body parsing.
     /// </summary>
     /// <param name="content">The content to parse.</param>
     /// <returns>Parsed JSON object or the original content if parsing fails.</returns>
@@ -20,7 +31,7 @@ internal static class InvokerHelpers
 
         try
         {
-            return JsonSerializer.Deserialize<object>(content);
+            return JsonSerializer.Deserialize<object>(content, TriggerTaskJsonOptions);
         }
         catch (JsonException)
         {

--- a/src/BBT.Workflow.Execution/System/Net/Http/HttpResponseMessageExtensions.cs
+++ b/src/BBT.Workflow.Execution/System/Net/Http/HttpResponseMessageExtensions.cs
@@ -1,0 +1,50 @@
+using System.IO.Compression;
+
+namespace System.Net.Http;
+
+/// <summary>
+/// Extension methods for reading HTTP response content with support for compressed encodings.
+/// Used by Execution invokers when the platform returns gzip, deflate, or br encoded responses.
+/// </summary>
+public static class HttpResponseMessageExtensions
+{
+    /// <summary>
+    /// Reads the response content as a string, decompressing when Content-Encoding is gzip, deflate, or br.
+    /// Use this when the client does not use AutomaticDecompression or when a proxy strips encoding headers.
+    /// </summary>
+    /// <param name="response">The HTTP response message.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The decompressed or raw response body as string.</returns>
+    public static async Task<string> ReadDecompressedContentAsync(this HttpResponseMessage response,
+        CancellationToken cancellationToken)
+    {
+        var encodings = response.Content.Headers.ContentEncoding;
+        if (encodings.Count == 0)
+            return await response.Content.ReadAsStringAsync(cancellationToken);
+
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+
+        if (encodings.Contains("gzip"))
+        {
+            await using var gzip = new GZipStream(stream, CompressionMode.Decompress);
+            using var reader = new StreamReader(gzip);
+            return await reader.ReadToEndAsync(cancellationToken);
+        }
+
+        if (encodings.Contains("deflate"))
+        {
+            await using var deflate = new ZLibStream(stream, CompressionMode.Decompress);
+            using var reader = new StreamReader(deflate);
+            return await reader.ReadToEndAsync(cancellationToken);
+        }
+
+        if (encodings.Contains("br"))
+        {
+            await using var brotli = new BrotliStream(stream, CompressionMode.Decompress);
+            using var reader = new StreamReader(brotli);
+            return await reader.ReadToEndAsync(cancellationToken);
+        }
+
+        return await response.Content.ReadAsStringAsync(cancellationToken);
+    }
+}

--- a/src/BBT.Workflow.HttpApi.Shared/Microsoft/Extensions/DependencyInjection/WorkflowApiBaseServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.HttpApi.Shared/Microsoft/Extensions/DependencyInjection/WorkflowApiBaseServiceCollectionExtensions.cs
@@ -77,7 +77,8 @@ public static class WorkflowApiBaseServiceCollectionExtensions
                 options.JsonSerializerOptions.DictionaryKeyPolicy = centralOptions.DictionaryKeyPolicy;
                 options.JsonSerializerOptions.PropertyNameCaseInsensitive = centralOptions.PropertyNameCaseInsensitive;
                 options.JsonSerializerOptions.DefaultIgnoreCondition = centralOptions.DefaultIgnoreCondition;
-                options.JsonSerializerOptions.ReferenceHandler = ReferenceHandler.IgnoreCycles;
+                options.JsonSerializerOptions.ReferenceHandler = centralOptions.ReferenceHandler;
+                options.JsonSerializerOptions.MaxDepth = centralOptions.MaxDepth;
                 
                 // Add converters from centralized configuration
                 foreach (var converter in centralOptions.Converters)

--- a/src/BBT.Workflow.Infrastructure/Authorization/Remote/RemoteAuthorizeAppService.cs
+++ b/src/BBT.Workflow.Infrastructure/Authorization/Remote/RemoteAuthorizeAppService.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Text.Json;
 using BBT.Aether.Results;
+using BBT.Workflow;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Discovery;
 using BBT.Workflow.Instances;
@@ -28,13 +29,6 @@ public sealed class RemoteAuthorizeAppService(
     private readonly RemoteOptions _options = options.Value;
 
     private string ApiVersionPrefix => InstanceUrlTemplates.GetApiVersionPrefix(_options.ApiVersion);
-
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        PropertyNameCaseInsensitive = true,
-        WriteIndented = false
-    };
 
     /// <inheritdoc />
     public async Task<Result<AuthorizeOutput>> GetAuthorizeResultForInstanceAsync(
@@ -82,11 +76,11 @@ public sealed class RemoteAuthorizeAppService(
             if (response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.Forbidden)
             {
                 var responseContent = await response.ReadDecompressedContentAsync(cancellationToken);
-                var output = JsonSerializer.Deserialize<AuthorizeOutput>(responseContent, JsonOptions);
+                var output = JsonSerializer.Deserialize<AuthorizeOutput>(responseContent, JsonSerializerConstants.JsonOptions);
                 return Result<AuthorizeOutput>.Ok(output ?? new AuthorizeOutput { Allowed = false });
             }
 
-            var error = await RemoteHttpResponseHelper.MapToErrorAsync(response, cancellationToken, JsonOptions);
+            var error = await RemoteHttpResponseHelper.MapToErrorAsync(response, cancellationToken, JsonSerializerConstants.JsonOptions);
             return Result<AuthorizeOutput>.Fail(error);
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or OperationCanceledException)
@@ -124,11 +118,11 @@ public sealed class RemoteAuthorizeAppService(
             if (response.StatusCode == HttpStatusCode.OK)
             {
                 var responseContent = await response.ReadDecompressedContentAsync(cancellationToken);
-                var output = JsonSerializer.Deserialize<AuthorizationMatrixOutput>(responseContent, JsonOptions);
+                var output = JsonSerializer.Deserialize<AuthorizationMatrixOutput>(responseContent, JsonSerializerConstants.JsonOptions);
                 return Result<AuthorizationMatrixOutput>.Ok(output!);
             }
 
-            var error = await RemoteHttpResponseHelper.MapToErrorAsync(response, cancellationToken, JsonOptions);
+            var error = await RemoteHttpResponseHelper.MapToErrorAsync(response, cancellationToken, JsonSerializerConstants.JsonOptions);
             return Result<AuthorizationMatrixOutput>.Fail(error);
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or OperationCanceledException)

--- a/src/BBT.Workflow.Infrastructure/Discovery/DomainDiscoveryResolver.cs
+++ b/src/BBT.Workflow.Infrastructure/Discovery/DomainDiscoveryResolver.cs
@@ -1,9 +1,9 @@
 using System.Net;
 using System.Net.Http.Json;
-using System.Text.Json;
 using System.Web;
 using BBT.Aether.DistributedCache;
 using BBT.Aether.DistributedLock;
+using BBT.Workflow;
 using BBT.Aether.Results;
 using BBT.Workflow.Logging;
 using Microsoft.Extensions.Logging;
@@ -27,12 +27,6 @@ public sealed class DomainDiscoveryResolver(
     private const string BulkCacheLockKey = "discovery:bulk-lock";
     private const int LockExpiryInSeconds = 30;
     private const string IfNoneMatchHeader = "If-None-Match";
-
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        PropertyNameCaseInsensitive = true
-    };
 
     /// <inheritdoc />
     public async Task<Result<DiscoveryEndpoint>> GetEndpointAsync(
@@ -137,7 +131,7 @@ public sealed class DomainDiscoveryResolver(
                     WorkflowErrors.DomainDiscoveryFailed(domain, $"HTTP {response.StatusCode}"));
             }
 
-            var dto = await response.Content.ReadFromJsonAsync<SingleDomainResponse>(JsonOptions, cancellationToken);
+            var dto = await response.Content.ReadFromJsonAsync<SingleDomainResponse>(JsonSerializerConstants.JsonOptions, cancellationToken);
 
             if (dto?.Data is null || string.IsNullOrWhiteSpace(dto.Data.BaseUrl))
             {
@@ -318,7 +312,7 @@ public sealed class DomainDiscoveryResolver(
             try
             {
                 var httpClient = httpClientFactory.CreateClient(DomainRegistrationService.HttpClientName);
-                var response = await httpClient.GetFromJsonAsync<FunctionDataListResponse>(nextUrl, JsonOptions, cancellationToken);
+                var response = await httpClient.GetFromJsonAsync<FunctionDataListResponse>(nextUrl, JsonSerializerConstants.JsonOptions, cancellationToken);
 
                 if (response?.Items is { Count: > 0 })
                 {
@@ -394,7 +388,7 @@ public sealed class DomainDiscoveryResolver(
                 return ETagCheckResult.Failed();
             }
 
-            var dto = await response.Content.ReadFromJsonAsync<SingleDomainResponse>(JsonOptions, cancellationToken);
+            var dto = await response.Content.ReadFromJsonAsync<SingleDomainResponse>(JsonSerializerConstants.JsonOptions, cancellationToken);
 
             if (dto?.Data is null || string.IsNullOrWhiteSpace(dto.Data.BaseUrl))
             {

--- a/src/BBT.Workflow.Infrastructure/Discovery/DomainRegistrationService.cs
+++ b/src/BBT.Workflow.Infrastructure/Discovery/DomainRegistrationService.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Net.Http.Json;
-using System.Text.Json;
+using BBT.Workflow;
 using BBT.Workflow.ExceptionHandling;
 using BBT.Workflow.Runtime;
 using Microsoft.Extensions.Configuration;
@@ -28,12 +28,6 @@ public sealed class DomainRegistrationService(
     /// </summary>
     public const string HttpClientName = "ServiceDiscovery";
     private const string VNextApiBaseUrlKey = "vNextApi:BaseUrl";
-
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        WriteIndented = false
-    };
 
     /// <inheritdoc />
     public async Task RegisterDomainAsync(CancellationToken cancellationToken = default)
@@ -97,7 +91,7 @@ public sealed class DomainRegistrationService(
         {
             var httpClient = httpClientFactory.CreateClient(HttpClientName);
             
-            var response = await httpClient.PostAsJsonAsync(requestUrl, requestBody, JsonOptions, cancellationToken);
+            var response = await httpClient.PostAsJsonAsync(requestUrl, requestBody, JsonSerializerConstants.JsonOptions, cancellationToken);
 
             if (response.IsSuccessStatusCode)
             {

--- a/src/BBT.Workflow.Infrastructure/Gateway/LocalInstanceQueryGateway.cs
+++ b/src/BBT.Workflow.Infrastructure/Gateway/LocalInstanceQueryGateway.cs
@@ -85,7 +85,7 @@ public sealed class LocalInstanceQueryGateway : IInstanceQueryGateway
     }
 
     /// <inheritdoc />
-    public async Task<Result<GetInstanceStateOutput>> GetFunctionWithStateAsync(
+    public async Task<ConditionalResult<GetInstanceStateOutput>> GetFunctionWithStateAsync(
         GetFunctionWithInstanceInput input,
         CancellationToken cancellationToken = default)
     {
@@ -104,7 +104,8 @@ public sealed class LocalInstanceQueryGateway : IInstanceQueryGateway
                 Extensions = input.Extensions,
                 Headers = input.Headers,
                 QueryParams = input.QueryParams,
-                Role = input.Role
+                Role = input.Role,
+                IfNoneMatch = input.IfNoneMatch
             };
             return await queryService.GetInstanceStateAsync(stateInput, cancellationToken);
         }

--- a/src/BBT.Workflow.Infrastructure/Gateway/RemoteInstanceQueryGateway.cs
+++ b/src/BBT.Workflow.Infrastructure/Gateway/RemoteInstanceQueryGateway.cs
@@ -56,7 +56,7 @@ public sealed class RemoteInstanceQueryGateway : IInstanceQueryGateway
     }
 
     /// <inheritdoc />
-    public Task<Result<GetInstanceStateOutput>> GetFunctionWithStateAsync(
+    public Task<ConditionalResult<GetInstanceStateOutput>> GetFunctionWithStateAsync(
         GetFunctionWithInstanceInput input,
         CancellationToken cancellationToken = default)
     {

--- a/src/BBT.Workflow.Infrastructure/Gateway/RoutedInstanceQueryGateway.cs
+++ b/src/BBT.Workflow.Infrastructure/Gateway/RoutedInstanceQueryGateway.cs
@@ -73,7 +73,7 @@ public sealed class RoutedInstanceQueryGateway : IInstanceQueryGateway
     }
 
     /// <inheritdoc />
-    public Task<Result<GetInstanceStateOutput>> GetFunctionWithStateAsync(
+    public Task<ConditionalResult<GetInstanceStateOutput>> GetFunctionWithStateAsync(
         GetFunctionWithInstanceInput input,
         CancellationToken cancellationToken = default)
     {

--- a/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceCommandAppService.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceCommandAppService.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.Json;
 using BBT.Aether.Results;
+using BBT.Workflow;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Discovery;
 using BBT.Aether.Users;
@@ -26,12 +27,6 @@ public sealed class RemoteInstanceCommandAppService(
     private readonly RemoteOptions _options = options.Value;
 
     private string ApiVersionPrefix => InstanceUrlTemplates.GetApiVersionPrefix(_options.ApiVersion);
-
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        WriteIndented = false
-    };
 
     /// <summary>
     /// Starts a new workflow instance by calling the remote API
@@ -73,7 +68,7 @@ public sealed class RemoteInstanceCommandAppService(
                 Attributes = input.Instance.Attributes
             };
 
-            var jsonContent = JsonSerializer.Serialize(requestBody, JsonOptions);
+            var jsonContent = JsonSerializer.Serialize(requestBody, JsonSerializerConstants.JsonOptions);
             var content = new StringContent(jsonContent, Encoding.UTF8, "application/json");
 
             var requestMessage = new HttpRequestMessage(HttpMethod.Post, requestUri)
@@ -141,7 +136,7 @@ public sealed class RemoteInstanceCommandAppService(
                 ExtraProperties = input.Instance.ExtraProperties
             };
 
-            var jsonContent = JsonSerializer.Serialize(requestBody, JsonOptions);
+            var jsonContent = JsonSerializer.Serialize(requestBody, JsonSerializerConstants.JsonOptions);
             var content = new StringContent(jsonContent, Encoding.UTF8, "application/json");
 
             var requestMessage = new HttpRequestMessage(HttpMethod.Post, requestUri)
@@ -199,7 +194,7 @@ public sealed class RemoteInstanceCommandAppService(
             var requestUri = new Uri(endpoint.BaseUrl, relativePath.TrimStart('/'));
 
             var content = input.Data != null
-                ? new StringContent(JsonSerializer.Serialize(input.Data, JsonOptions), Encoding.UTF8,
+                ? new StringContent(JsonSerializer.Serialize(input.Data, JsonSerializerConstants.JsonOptions), Encoding.UTF8,
                     "application/json")
                 : new StringContent("{}", Encoding.UTF8, "application/json");
 
@@ -248,7 +243,7 @@ public sealed class RemoteInstanceCommandAppService(
 
             var requestUri = new Uri(endpoint.BaseUrl, relativePath.TrimStart('/'));
 
-            var jsonContent = JsonSerializer.Serialize(input, JsonOptions);
+            var jsonContent = JsonSerializer.Serialize(input, JsonSerializerConstants.JsonOptions);
             var content = new StringContent(jsonContent, Encoding.UTF8, "application/json");
 
             var requestMessage = new HttpRequestMessage(HttpMethod.Post, requestUri)
@@ -299,7 +294,7 @@ public sealed class RemoteInstanceCommandAppService(
 
             var requestUri = new Uri(endpoint.BaseUrl, relativePath.TrimStart('/'));
 
-            var jsonContent = JsonSerializer.Serialize(input, JsonOptions);
+            var jsonContent = JsonSerializer.Serialize(input, JsonSerializerConstants.JsonOptions);
             var content = new StringContent(jsonContent, Encoding.UTF8, "application/json");
 
             var requestMessage = new HttpRequestMessage(HttpMethod.Post, requestUri)
@@ -333,12 +328,12 @@ public sealed class RemoteInstanceCommandAppService(
         if (response.IsSuccessStatusCode)
         {
             var responseContent = await response.ReadDecompressedContentAsync(cancellationToken);
-            var result = JsonSerializer.Deserialize<T>(responseContent, JsonOptions);
+            var result = JsonSerializer.Deserialize<T>(responseContent, JsonSerializerConstants.JsonOptions);
             return Result<T>.Ok(result!);
         }
 
         // Map status codes to appropriate Error types (per Railway Pattern)
-        var error = await RemoteHttpResponseHelper.MapToErrorAsync(response, cancellationToken, JsonOptions);
+        var error = await RemoteHttpResponseHelper.MapToErrorAsync(response, cancellationToken, JsonSerializerConstants.JsonOptions);
         return Result<T>.Fail(error);
     }
 
@@ -351,7 +346,7 @@ public sealed class RemoteInstanceCommandAppService(
         if (response.IsSuccessStatusCode)
             return Result.Ok();
 
-        var error = await RemoteHttpResponseHelper.MapToErrorAsync(response, cancellationToken, JsonOptions);
+        var error = await RemoteHttpResponseHelper.MapToErrorAsync(response, cancellationToken, JsonSerializerConstants.JsonOptions);
         return Result.Fail(error);
     }
 }

--- a/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceQueryAppService.cs
@@ -25,12 +25,6 @@ public sealed class RemoteInstanceQueryAppService(
 
     private string ApiVersionPrefix => InstanceUrlTemplates.GetApiVersionPrefix(_options.ApiVersion);
 
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        WriteIndented = false
-    };
-
     /// <summary>
     /// Retrieves a single instance with optional extensions
     /// GET {baseUrl}/api/v{version}/{domain}/workflows/{workflow}/instances/{instance}
@@ -305,7 +299,7 @@ public sealed class RemoteInstanceQueryAppService(
     /// Retrieves function result for an instance (e.g., "state" function returns GetInstanceStateOutput)
     /// GET {baseUrl}/api/v{version}/{domain}/workflows/{workflow}/instances/{instance}/functions/{function}
     /// </summary>
-    public async Task<Result<GetInstanceStateOutput>> GetFunctionWithStateAsync(
+    public async Task<ConditionalResult<GetInstanceStateOutput>> GetFunctionWithStateAsync(
         GetFunctionWithInstanceInput input,
         CancellationToken cancellationToken = default)
     {
@@ -349,15 +343,21 @@ public sealed class RemoteInstanceQueryAppService(
             using var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
             var forwardHeaders = currentUser.ToForwardHeaders();
             CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, input.Headers);
+            if (!string.IsNullOrEmpty(input.IfNoneMatch))
+                requestMessage.Headers.TryAddWithoutValidation("If-None-Match", input.IfNoneMatch);
             var response = await httpClient.SendAsync(requestMessage, cancellationToken);
 
-            // Status code → Result.Fail (per Railway Pattern)
-            return await HandleResponseAsync<GetInstanceStateOutput>(response, cancellationToken);
+            if (response.StatusCode == System.Net.HttpStatusCode.NotModified)
+                return ConditionalResult<GetInstanceStateOutput>.NotModified();
+
+            var result = await HandleResponseAsync<GetInstanceStateOutput>(response, cancellationToken);
+            return result.IsSuccess
+                ? ConditionalResult<GetInstanceStateOutput>.Success(result.Value!)
+                : ConditionalResult<GetInstanceStateOutput>.Fail(result.Error);
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or OperationCanceledException)
         {
-            // Network errors → Transient error (per Railway Pattern)
-            return Result<GetInstanceStateOutput>.Fail(Error.Transient("remote_network_error", ex.Message));
+            return ConditionalResult<GetInstanceStateOutput>.Fail(Error.Transient("remote_network_error", ex.Message));
         }
     }
 
@@ -535,11 +535,11 @@ public sealed class RemoteInstanceQueryAppService(
         if (response.IsSuccessStatusCode)
         {
             var responseContent = await response.ReadDecompressedContentAsync(cancellationToken);
-            var result = JsonSerializer.Deserialize<T>(responseContent, JsonOptions);
+            var result = JsonSerializer.Deserialize<T>(responseContent, JsonSerializerConstants.JsonOptions);
             return Result<T>.Ok(result!);
         }
 
-        var error = await RemoteHttpResponseHelper.MapToErrorAsync(response, cancellationToken, JsonOptions);
+        var error = await RemoteHttpResponseHelper.MapToErrorAsync(response, cancellationToken, JsonSerializerConstants.JsonOptions);
         return Result<T>.Fail(error);
     }
 
@@ -551,11 +551,11 @@ public sealed class RemoteInstanceQueryAppService(
         if (response.IsSuccessStatusCode)
         {
             var responseContent = await response.ReadDecompressedContentAsync(cancellationToken);
-            var result = JsonSerializer.Deserialize<T>(responseContent, JsonOptions);
+            var result = JsonSerializer.Deserialize<T>(responseContent, JsonSerializerConstants.JsonOptions);
             return ConditionalResult<T>.Success(result!);
         }
 
-        var error = await RemoteHttpResponseHelper.MapToErrorAsync(response, cancellationToken, JsonOptions);
+        var error = await RemoteHttpResponseHelper.MapToErrorAsync(response, cancellationToken, JsonSerializerConstants.JsonOptions);
         return ConditionalResult<T>.Fail(error);
     }
 }

--- a/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceRetryAppService.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceRetryAppService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Text;
 using System.Text.Json;
 using BBT.Aether.Results;
+using BBT.Workflow;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Discovery;
 using BBT.Workflow.Instances;
@@ -28,12 +29,6 @@ public sealed class RemoteInstanceRetryAppService(
     private readonly RemoteOptions _options = options.Value;
 
     private string ApiVersionPrefix => InstanceUrlTemplates.GetApiVersionPrefix(_options.ApiVersion);
-
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        WriteIndented = false
-    };
 
     /// <summary>
     /// Retries a faulted workflow instance by calling the remote API
@@ -68,7 +63,7 @@ public sealed class RemoteInstanceRetryAppService(
 
             // Build request body from data if provided
             var content = input.Data != null
-                ? new StringContent(JsonSerializer.Serialize(input.Data, JsonOptions), Encoding.UTF8, "application/json")
+                ? new StringContent(JsonSerializer.Serialize(input.Data, JsonSerializerConstants.JsonOptions), Encoding.UTF8, "application/json")
                 : new StringContent("{}", Encoding.UTF8, "application/json");
 
             var requestMessage = new HttpRequestMessage(HttpMethod.Post, requestUri)
@@ -101,11 +96,11 @@ public sealed class RemoteInstanceRetryAppService(
         if (response.IsSuccessStatusCode)
         {
             var responseContent = await response.ReadDecompressedContentAsync(cancellationToken);
-            var result = JsonSerializer.Deserialize<T>(responseContent, JsonOptions);
+            var result = JsonSerializer.Deserialize<T>(responseContent, JsonSerializerConstants.JsonOptions);
             return Result<T>.Ok(result!);
         }
 
-        var error = await RemoteHttpResponseHelper.MapToErrorAsync(response, cancellationToken, JsonOptions);
+        var error = await RemoteHttpResponseHelper.MapToErrorAsync(response, cancellationToken, JsonSerializerConstants.JsonOptions);
         return Result<T>.Fail(error);
     }
 }

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceRetryAppServiceTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceRetryAppServiceTests.cs
@@ -162,14 +162,14 @@ public class InstanceRetryGatewayTests
         };
 
         _queryGateway.GetFunctionWithStateAsync(input, Arg.Any<CancellationToken>())
-            .Returns(Result<GetInstanceStateOutput>.Ok(expectedOutput));
+            .Returns(ConditionalResult<GetInstanceStateOutput>.Success(expectedOutput));
 
         // Act
         var result = await _queryGateway.GetFunctionWithStateAsync(input);
 
         // Assert
-        result.IsSuccess.ShouldBeTrue();
-        result.Value!.Status.ShouldBe(InstanceStatus.Faulted);
+        result.Result.IsSuccess.ShouldBeTrue();
+        result.Result.Value!.Status.ShouldBe(InstanceStatus.Faulted);
     }
 
     [Fact]


### PR DESCRIPTION
# Redesign ETag strategy for authorization-aware responses

## Summary

This PR redesigns the ETag strategy so that cache validation and concurrency control use the right signals: **representation ETag** for what the client sees (authorization-aware) and **entity ETag** for the persisted row version (concurrency and writes).

## Motivation

- **Representation ETag** (`ETag` header): Must reflect the actual response body the client receives. When responses are filtered by authorization (e.g. view/state), the ETag should be computed from the canonical form of that representation so conditional GET (`If-None-Match`) is correct per user/role.
- **Entity ETag** (`X-Entity-ETag` header): Represents the database row version for optimistic concurrency and write operations (e.g. retry, commands). This is independent of how the representation is rendered.

## Changes

### Domain & application

- **Headers**: `HeadersConstants.ETag` and `HeadersConstants.XEntityETag` for the two headers.
- **GetInstanceOutput**: Added `Etag` (representation) and `EntityEtag` (entity), both formatted per RFC 7232 (quoted).
- **Representation ETag**: New `IRepresentationEtagService` / `RepresentationEtagService` to compute ETags from the canonicalized response body.
- **Canonicalization**: New `IJsonCanonicalizer` / `JsonCanonicalizer` in Domain for stable JSON hashing of view/state payloads.

### API & infrastructure

- **Controllers**: Instance, function, and utility controllers set both `ETag` and `X-Entity-ETag` where applicable.
- **Gateways & remote**: Instance query gateway and remote app services (query, command, retry) propagate both ETags; remote invokers and `HttpResponseMessageExtensions` read ETag from remote responses.
- **View/state**: `GetInstanceStateOutput`, `GetFunctionWithInstanceInput`, and view resolution use the new representation/entity ETag flow.

### Other

- **Authorization, discovery, registration**: Use the new header constants.
- **Tests**: `InstanceRetryAppServiceTests` updated for the new ETag/entity ETag usage.

## Testing

- Existing instance/function/utility and remote tests updated; ensure conditional GET and write flows (e.g. retry) use the correct headers in integration/API tests.

## Checklist

- [x] Representation ETag derived from canonical response body (authorization-aware).
- [x] Entity ETag exposed for concurrency/writes via `X-Entity-ETag`.
- [x] Controllers and gateways set both headers and propagate through remote calls.
- [x] No breaking change to public API shape; new headers are additive.

## Summary by Sourcery

Introduce a representation ETag pipeline based on canonicalized JSON for authorization-aware responses while separating it from the entity ETag used for concurrency, and propagate both through instance, data, and state APIs including local and remote gateways.

New Features:
- Add representation ETag generation service that hashes canonicalized response DTO JSON for cache validation.
- Expose distinct EntityEtag fields and X-Entity-ETag headers for instance, data, and state responses to support optimistic concurrency.
- Support conditional GET semantics (If-None-Match/304) for instance state and function-based state endpoints using representation ETags.
- Add HTTP response decompression helper for execution invokers to transparently handle gzip/deflate/brotli content.

Enhancements:
- Refine instance query, controller, and gateway flows to compute and return both representation and entity ETags without changing existing payload structures.
- Unify JSON serializer configuration via shared JsonSerializerConstants, including max depth and cycle handling, and reuse it across remote services and discovery/registration.
- Improve view content handling and state notification execution to work with the new conditional result patterns.
- Make definition cache invalidation more robust with structured logging and exception handling.

Tests:
- Update instance retry application tests to work with ConditionalResult-based state queries and validate faulted subflow handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for HTTP conditional requests (If-None-Match) to enable 304 Not Modified responses for improved caching and reduced bandwidth usage.

* **Bug Fixes**
  * Improved response handling with proper decompression support for gzip, deflate, and Brotli-encoded content.

* **Refactor**
  * Centralized JSON serialization configuration for consistency across the application and added safeguards for handling deep or circular object structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->