### PR TITLE
feat(instances): enrich Start/Transition response with full instance data when sync=true

### DIFF
--- a/src/BBT.Workflow.Application/Authorization/ISchemaFieldFilterService.cs
+++ b/src/BBT.Workflow.Application/Authorization/ISchemaFieldFilterService.cs
@@ -1,0 +1,22 @@
+using System.Text.Json;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Instances;
+
+namespace BBT.Workflow.Authorization;
+
+/// <summary>
+/// Applies master schema field-level visibility filtering to instance data based on effective caller roles.
+/// </summary>
+public interface ISchemaFieldFilterService
+{
+    /// <summary>
+    /// Filters the given JSON data by the caller's visible fields according to the workflow's master schema role grants.
+    /// Returns filtered <see cref="JsonElement"/> or the original data if no schema or no role grants are defined.
+    /// When <paramref name="instance"/> is provided, also evaluates $InstanceStarter and $PreviousUser predefined roles.
+    /// </summary>
+    Task<JsonElement?> ApplyAsync(
+        Definitions.Workflow? workflow,
+        JsonElement? data,
+        Instance? instance = null,
+        CancellationToken cancellationToken = default);
+}

--- a/src/BBT.Workflow.Application/Authorization/SchemaFieldFilterService.cs
+++ b/src/BBT.Workflow.Application/Authorization/SchemaFieldFilterService.cs
@@ -1,0 +1,48 @@
+using System.Text.Json;
+using BBT.Aether.Users;
+using BBT.Workflow.Caching;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Definitions.Schemas;
+using BBT.Workflow.Instances;
+
+namespace BBT.Workflow.Authorization;
+
+/// <summary>
+/// Applies master schema field-level visibility filtering to instance data based on effective caller roles.
+/// Extracted from InstanceQueryAppService to allow reuse in command and query paths.
+/// </summary>
+public sealed class SchemaFieldFilterService(
+    IComponentCacheStore componentCacheStore,
+    ITransitionAuthorizationManager transitionAuthorizationManager,
+    ICurrentUser currentUser) : ISchemaFieldFilterService
+{
+    /// <inheritdoc />
+    public async Task<JsonElement?> ApplyAsync(
+        Definitions.Workflow? workflow,
+        JsonElement? data,
+        Instance? instance = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (workflow?.Schema is null || !data.HasValue)
+            return data;
+        var element = data.GetValueOrDefault();
+        if (element.ValueKind != JsonValueKind.Object)
+            return data;
+
+        var schemaResult = await componentCacheStore.GetSchemaAsync(workflow.Schema, cancellationToken);
+        if (!schemaResult.IsSuccess)
+            return data;
+
+        var pathRoleGrants = SchemaRolesParser.ParsePropertyRoles(schemaResult.Value!.Schema);
+        if (pathRoleGrants.Count == 0)
+            return data;
+
+        var callerRoles = instance != null
+            ? await transitionAuthorizationManager.GetEffectiveCallerRolesForFieldVisibilityAsync(instance,
+                cancellationToken)
+            : currentUser.Roles;
+        var visiblePaths = SchemaFieldVisibilityService.GetVisiblePaths(pathRoleGrants, callerRoles);
+        var pathsWithRoles = new HashSet<string>(pathRoleGrants.Keys, StringComparer.Ordinal);
+        return InstanceDataRoleFilter.FilterByVisiblePaths(element, pathsWithRoles, visiblePaths);
+    }
+}

--- a/src/BBT.Workflow.Application/Instances/DTOs/StartInstanceInput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/StartInstanceInput.cs
@@ -73,11 +73,42 @@ public sealed class CreateInstanceInput: IHasExtraProperties
 public sealed class StartInstanceOutput
 {
     public Guid Id { get; set; }
+    public string? Key { get; set; }
 
     /// <summary>
     /// Instance status (Active, Busy, Completed, etc.)
     /// </summary>
     public InstanceStatus? Status { get; set; }
+
+    /// <summary>
+    /// Instance attributes filtered by master-schema role grants. Populated only when sync=true.
+    /// </summary>
+    public JsonElement? Attributes { get; set; }
+
+    /// <summary>
+    /// Representation ETag (SHA256 of canonical response JSON), returned with quotes per RFC 7232. Populated only when sync=true.
+    /// </summary>
+    public string? ETag
+    {
+        get => _etag is null ? null : $"\"{_etag.Replace("\"", "")}\"";
+        set => _etag = value;
+    }
+    private string? _etag;
+
+    /// <summary>
+    /// Entity (DB row) version for concurrency, returned with quotes per RFC 7232. Populated only when sync=true.
+    /// </summary>
+    public string? EntityEtag
+    {
+        get => _entityEtag is null ? null : $"\"{_entityEtag.Replace("\"", "")}\"";
+        set => _entityEtag = value;
+    }
+    private string? _entityEtag;
+
+    /// <summary>
+    /// Computed extension fields. Populated only when sync=true.
+    /// </summary>
+    public Dictionary<string, object>? Extensions { get; set; }
 }
 
 /// <summary>

--- a/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
@@ -1,5 +1,8 @@
 using System.Diagnostics;
+using System.Text.Json;
 using BBT.Aether;
+using BBT.Workflow.Authorization;
+using BBT.Workflow.RepresentationEtag;
 using BBT.Aether.Application.Services;
 using BBT.Aether.BackgroundJob;
 using BBT.Aether.Guids;
@@ -40,6 +43,8 @@ public sealed class InstanceCommandAppService(
     ITransitionDataMapper transitionDataMapper,
     ITransitionValidationService transitionValidationService,
     IWorkflowContext workflowContext,
+    IRepresentationEtagService representationEtagService,
+    ISchemaFieldFilterService schemaFieldFilterService,
     ILogger<InstanceCommandAppService> logger)
     : ApplicationService(serviceProvider), IInstanceCommandAppService
 {
@@ -59,7 +64,11 @@ public sealed class InstanceCommandAppService(
         // Step 2: Check existing instance
         var existingInstanceResult = await CheckExistingInstanceAsync(input, cancellationToken);
         if (existingInstanceResult.HasValue)
+        {
+            if (input.Sync && existingInstanceResult.Value.IsSuccess)
+                return await EnrichSyncOutputAsync(existingInstanceResult.Value.Value!, existingInstanceResult.Value.Value!.Id, workflow, cancellationToken);
             return existingInstanceResult.Value;
+        }
 
         // Step 3-6: Continue with normal railway flow for NEW instances
         return await PrepareInstanceAsync(workflow, input, cancellationToken)
@@ -117,6 +126,7 @@ public sealed class InstanceCommandAppService(
         return Result<StartInstanceOutput>.Ok(new StartInstanceOutput
         {
             Id = existingInstance.Id,
+            Key = existingInstance.Key,
             Status = existingInstance.Status
         });
     }
@@ -269,8 +279,12 @@ public sealed class InstanceCommandAppService(
             .MapAsync(transitionOutput => new StartInstanceOutput
             {
                 Id = data.Instance.Id,
+                Key = data.Instance.Key,
                 Status = transitionOutput.Status
-            });
+            })
+            .ThenAsync(output => input.Sync
+                ? EnrichSyncOutputAsync(output, output.Id, data.Workflow, cancellationToken)
+                : Task.FromResult(Result<StartInstanceOutput>.Ok(output)));
     }
 
     /// <summary>
@@ -385,9 +399,18 @@ public sealed class InstanceCommandAppService(
 
         var context = BuildTransitionContext(resolvedInstance, transitionKey, input);
 
+        var workflowDefinition = workflowResult.Value;
+
         return await workflowExecutionService
             .ExecuteTransitionAsync(context, cancellationToken)
-            .OnSuccess(output => AddTransitionHeader(output, resolvedInstance.Flow, resolvedInstance.FlowVersion));
+            .OnSuccess(output => AddTransitionHeader(output, resolvedInstance.Flow, resolvedInstance.FlowVersion))
+            .ThenAsync(output =>
+            {
+                if (input.Sync)
+                    return EnrichSyncOutputAsync(output, output.Id, workflowDefinition, cancellationToken);
+                output.Key = resolvedInstance.Key;
+                return Task.FromResult(Result<TransitionOutput>.Ok(output));
+            });
     }
 
     /// <summary>
@@ -428,6 +451,69 @@ public sealed class InstanceCommandAppService(
             WorkflowInfo.Name,
             WorkflowInfo.Generate(runtimeInfoProvider.Domain, flow, version, output.Id)
         );
+    }
+
+    /// <summary>
+    /// Enriches a sync=true StartInstanceOutput with attributes (schema-filtered), etag, entityEtag, key and extensions.
+    /// The instance is reloaded from the repository to ensure post-execution state is reflected.
+    /// </summary>
+    private Task<Result<StartInstanceOutput>> EnrichSyncOutputAsync(
+        StartInstanceOutput output,
+        Guid instanceId,
+        Definitions.Workflow? workflow,
+        CancellationToken cancellationToken)
+        => EnrichOutputCoreAsync(output, instanceId, workflow, cancellationToken);
+
+    /// <summary>
+    /// Enriches a sync=true TransitionOutput with attributes (schema-filtered), etag, entityEtag, key and extensions.
+    /// The instance is reloaded from the repository to ensure post-execution state is reflected.
+    /// </summary>
+    private Task<Result<TransitionOutput>> EnrichSyncOutputAsync(
+        TransitionOutput output,
+        Guid instanceId,
+        Definitions.Workflow? workflow,
+        CancellationToken cancellationToken)
+        => EnrichOutputCoreAsync(output, instanceId, workflow, cancellationToken);
+
+    private async Task<Result<TOutput>> EnrichOutputCoreAsync<TOutput>(
+        TOutput output,
+        Guid instanceId,
+        Definitions.Workflow? workflow,
+        CancellationToken cancellationToken)
+        where TOutput : class
+    {
+        var freshInstance = await instanceRepository.FindByIdentifierAsync(instanceId.ToString(), cancellationToken);
+        if (freshInstance is null)
+            return Result<TOutput>.Ok(output);
+
+        var latestData = freshInstance.LatestData;
+        var rawAttributes = latestData?.Data.JsonElement;
+        var filteredAttributes = await schemaFieldFilterService.ApplyAsync(workflow, rawAttributes, freshInstance, cancellationToken);
+
+        var key = freshInstance.Key;
+        var entityEtag = latestData?.ETag;
+        var attributes = filteredAttributes ?? rawAttributes;
+
+        if (output is StartInstanceOutput start)
+        {
+            start.Key = key;
+            start.Attributes = attributes;
+            start.EntityEtag = entityEtag;
+            start.Extensions = new Dictionary<string, object>();
+            // ETag must be generated after all other fields are set (ETag itself is null at generation time)
+            start.ETag = representationEtagService.Generate(start);
+        }
+        else if (output is TransitionOutput transition)
+        {
+            transition.Key = key;
+            transition.Attributes = attributes;
+            transition.EntityEtag = entityEtag;
+            transition.Extensions = new Dictionary<string, object>();
+            // ETag must be generated after all other fields are set (ETag itself is null at generation time)
+            transition.ETag = representationEtagService.Generate(transition);
+        }
+
+        return Result<TOutput>.Ok(output);
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -2,11 +2,9 @@ using BBT.Aether;
 using BBT.Aether.Application.Services;
 using BBT.Aether.Domain.Entities;
 using BBT.Aether.Results;
-using BBT.Aether.Users;
 using BBT.Workflow.Authorization;
 using BBT.Workflow.Caching;
 using BBT.Workflow.Definitions;
-using BBT.Workflow.Definitions.Schemas;
 using BBT.Workflow.Logging;
 using BBT.Workflow.Extentions;
 using BBT.Workflow.Gateway;
@@ -37,8 +35,8 @@ public sealed class InstanceQueryAppService(
     IUrlTemplateBuilder urlTemplateBuilder,
     ICurrentSchema currentSchema,
     ITransitionAuthorizationManager transitionAuthorizationManager,
-    ICurrentUser currentUser,
     IRepresentationEtagService representationEtagService,
+    ISchemaFieldFilterService schemaFieldFilterService,
     ILogger<InstanceQueryAppService> logger)
     : ApplicationService(serviceProvider), IInstanceQueryAppService
 {
@@ -471,45 +469,10 @@ public sealed class InstanceQueryAppService(
         response.Extensions = extensionsResult.Value!;
 
         response.Attributes =
-            await ApplySchemaFieldFilterAsync(flow, response.Attributes, instance, cancellationToken) ??
+            await schemaFieldFilterService.ApplyAsync(flow, response.Attributes, instance, cancellationToken) ??
             response.Attributes;
 
         return Result<GetInstanceOutput>.Ok(response);
-    }
-
-    /// <summary>
-    /// Applies master schema field-level visibility: filters instance data by effective caller roles
-    /// (static roles from header; when instance is present, also $InstanceStarter and $PreviousUser when matched).
-    /// Returns filtered JsonElement or original if workflow has no schema or schema has no roles.
-    /// </summary>
-    private async Task<JsonElement?> ApplySchemaFieldFilterAsync(
-        Definitions.Workflow? workflow,
-        JsonElement? data,
-        Instance? instance = null,
-        CancellationToken cancellationToken = default)
-    {
-        if (workflow?.Schema is null || !data.HasValue)
-            return data;
-        var element = data.GetValueOrDefault();
-        if (element.ValueKind != JsonValueKind.Object)
-            return data;
-
-        var schemaResult = await componentCacheStore.GetSchemaAsync(workflow.Schema, cancellationToken);
-        if (!schemaResult.IsSuccess)
-            return data;
-
-        var pathRoleGrants = SchemaRolesParser.ParsePropertyRoles(schemaResult.Value!.Schema);
-        if (pathRoleGrants.Count == 0)
-            return data;
-
-        var callerRoles = instance != null
-            ? await transitionAuthorizationManager.GetEffectiveCallerRolesForFieldVisibilityAsync(instance,
-                cancellationToken)
-            : currentUser.Roles;
-        var visiblePaths = SchemaFieldVisibilityService.GetVisiblePaths(pathRoleGrants, callerRoles);
-        var pathsWithRoles = new HashSet<string>(pathRoleGrants.Keys, StringComparer.Ordinal);
-        var filtered = InstanceDataRoleFilter.FilterByVisiblePaths(element, pathsWithRoles, visiblePaths);
-        return filtered;
     }
 
     public async Task<ConditionalResult<GetInstanceDataOutput>> GetInstanceDataAsync(
@@ -534,7 +497,7 @@ public sealed class InstanceQueryAppService(
                         Data = instance.LatestData?.Data.JsonElement
                     };
 
-                    result.Data = await ApplySchemaFieldFilterAsync(flow, result.Data, instance, cancellationToken) ??
+                    result.Data = await schemaFieldFilterService.ApplyAsync(flow, result.Data, instance, cancellationToken) ??
                                   result.Data;
 
                     // If there's an active SubFlow and extensions are requested, fetch from SubFlow

--- a/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
@@ -59,6 +59,7 @@ public static class WorkflowApplicationModuleServiceCollectionExtensions
         services.AddScoped<ITransitionAuthorizationManager, TransitionAuthorizationManager>();
         services.AddScoped<IAuthorizeAppService, AuthorizeAppService>();
         services.AddScoped<IRepresentationEtagService, RepresentationEtagService>();
+        services.AddScoped<ISchemaFieldFilterService, SchemaFieldFilterService>();
         services.AddScoped<IInstanceExtensionService, InstanceExtensionService>();
         services.AddScoped<ISubflowCompletionService, SubflowCompletionService>();
         services.AddScoped<ISubflowStateService, SubflowStateService>();

--- a/src/BBT.Workflow.Domain/Instances/DTOs/TransitionOutput.cs
+++ b/src/BBT.Workflow.Domain/Instances/DTOs/TransitionOutput.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 namespace BBT.Workflow.Instances;
 
 /// <summary>
@@ -9,10 +11,42 @@ public sealed class TransitionOutput
     /// The workflow instance identifier.
     /// </summary>
     public Guid Id { get; set; }
-    
+
+    public string? Key { get; set; }
+
     /// <summary>
     /// Instance status (Active, Busy, Completed, etc.)
     /// </summary>
     public InstanceStatus? Status { get; set; }
+
+    /// <summary>
+    /// Instance attributes filtered by master-schema role grants. Populated only when sync=true.
+    /// </summary>
+    public JsonElement? Attributes { get; set; }
+
+    /// <summary>
+    /// Representation ETag (SHA256 of canonical response JSON), returned with quotes per RFC 7232. Populated only when sync=true.
+    /// </summary>
+    public string? ETag
+    {
+        get => _etag is null ? null : $"\"{_etag.Replace("\"", "")}\"";
+        set => _etag = value;
+    }
+    private string? _etag;
+
+    /// <summary>
+    /// Entity (DB row) version for concurrency, returned with quotes per RFC 7232. Populated only when sync=true.
+    /// </summary>
+    public string? EntityEtag
+    {
+        get => _entityEtag is null ? null : $"\"{_entityEtag.Replace("\"", "")}\"";
+        set => _entityEtag = value;
+    }
+    private string? _entityEtag;
+
+    /// <summary>
+    /// Computed extension fields. Populated only when sync=true.
+    /// </summary>
+    public Dictionary<string, object>? Extensions { get; set; }
 }
 


### PR DESCRIPTION
## Summary

Closes #393.

- **sync=false**: `id`, `key`, `status` döner (minimal response)
- **sync=true**: `id`, `key`, `status`, `attributes`, `etag`, `entityEtag`, `extensions` döner (REST API GET davranışı)

### Temel Değişiklikler

- **`ISchemaFieldFilterService` / `SchemaFieldFilterService`** (yeni): `InstanceQueryAppService`'deki private `ApplySchemaFieldFilterAsync` mantığı kod tekrarını önlemek için shared service olarak çıkarıldı. Command ve Query path'lerinde ortak kullanılır.
- **`StartInstanceOutput` & `TransitionOutput`** DTOs genişletildi: `Key`, `Attributes`, `ETag` (RFC 7232), `EntityEtag` (RFC 7232), `Extensions` eklendi.
- **`InstanceCommandAppService`**: sync=true durumunda execution sonrası instance DB'den reload edilir, attributes master-schema field filter'dan geçirilir, ETag diğer tüm alanlar set edildikten sonra üretilir (circular-free RFC 7232 uyumlu).
- **`InstanceQueryAppService`**: Yeni `ISchemaFieldFilterService` kullanımına geçildi, artık kullanılmayan `ICurrentUser` ve related usings temizlendi.

## Test plan

- [ ] `sync=false` ile instance başlatma → response `{ id, key, status }` — diğer alanlar absent
- [ ] `sync=true` ile instance başlatma → response `{ id, key, status, attributes, etag, entityEtag, extensions: {} }`
- [ ] `sync=true` + master-schema role grant → `attributes`'ta sadece yetkili field'lar görünür
- [ ] `sync=true` ile transition → aynı zengin response
- [ ] Idempotent case (active instance): sync=true → zengin response
- [ ] `GET /instances/{id}` sorguları etkilenmedi (InstanceQueryAppService davranışı korundu)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enrich synchronous instance start and transition responses with full, schema-filtered instance data and ETag metadata while introducing a reusable schema field filtering service.

New Features:
- Return key, schema-filtered attributes, representation ETag, entityEtag and extensions in StartInstanceOutput and TransitionOutput when sync=true, including idempotent and transition scenarios.

Enhancements:
- Reload instances after execution for sync=true commands to base enriched responses on the latest persisted state and generate RFC 7232–compliant representation ETags.
- Extract master-schema field-level visibility logic into a shared ISchemaFieldFilterService and apply it consistently across command and query paths, simplifying InstanceQueryAppService and removing direct ICurrentUser usage.

Chores:
- Register the new SchemaFieldFilterService in the application DI module.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Instance start and transition operations now return enriched metadata when using sync mode, including instance key, filtered attributes, ETags for synchronization, and extensions
  * Instance attributes are automatically filtered based on field-level visibility grants determined by workflow roles

<!-- end of auto-generated comment: release notes by coderabbit.ai -->