### PR TITLE
feat(instances): return mapped instance data in start/transition sync response (#393)

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,13 @@
+# vNext - Claude Ignore Rules
+
+# Git files
+.git/
+
+# Binary and log files
+*.log
+*.tmp
+*.cache
+
+# Temporary files
+*.bak
+*.orig

--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,13 @@
+# vNext - Cursor Ignore Rules
+
+# Git files
+.git/
+
+# Binary and log files
+*.log
+*.tmp
+*.cache
+
+# Temporary files
+*.bak
+*.orig

--- a/.gitignore
+++ b/.gitignore
@@ -273,6 +273,13 @@ switcher.json
 # AI
 ai-docs/
 
+# Claude
+.claude/worktrees/*
+
+#Cursor
+.cursor/plans/*
+.cursor/*.log
+
 appsettings.secrets.json
 deploy/nuget-api-key.txt
 deploy/npm-auth-token.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,110 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## First-Time Setup
+
+On macOS/Linux, run the setup script before building (required for PostSharp compatibility with .NET 10):
+
+```bash
+./scripts/setup-netstandard-ref.sh
+```
+
+## Build & Run
+
+```bash
+# Restore and build entire solution
+dotnet restore
+dotnet build
+
+# Run with full infrastructure (recommended for development)
+cd etc/docker && ./run-docker.sh          # Infrastructure only (default)
+cd etc/docker && ./run-docker.sh dev      # Dev mode with debugger
+cd etc/docker && ./run-docker.sh stage    # Staging mode
+
+# Run API hosts locally (requires infrastructure running)
+dotnet run --project orchestration/BBT.Workflow.Orchestration.HttpApi.Host
+dotnet run --project execution/BBT.Workflow.Execution.HttpApi.Host
+```
+
+**Ports**: Orchestration → 4201, Execution → 4202
+
+## Testing
+
+```bash
+dotnet test                               # Run all tests
+dotnet test test/BBT.Workflow.Application.Tests   # Single project
+dotnet test --filter "FullyQualifiedName~MyTest"  # Single test
+```
+
+Test projects: `Domain.Tests`, `Application.Tests`, `Infrastructure.Tests`, `TestBase` (shared utilities).
+
+## Architecture Overview
+
+This is a **distributed workflow orchestration engine** built on .NET 10, Clean Architecture, DDD, and the Aether SDK.
+
+### Two API Hosts (microservices boundary)
+
+| Host | Project | Purpose |
+|------|---------|---------|
+| Orchestration | `orchestration/BBT.Workflow.Orchestration.HttpApi.Host` | Public-facing: manages workflow definitions, instances, transitions |
+| Execution | `execution/BBT.Workflow.Execution.HttpApi.Host` | Internal: executes task invokers for a specific transition |
+
+The two services communicate via **Dapr service invocation**. Orchestration calls Execution for task processing; Execution calls back to Orchestration to report outcomes.
+
+### Layer Responsibilities (`src/`)
+
+| Project | Role |
+|---------|------|
+| `BBT.Workflow.Domain` | Aggregates, entities, domain events, value objects, business rules. No infrastructure dependencies. |
+| `BBT.Workflow.Application` | Application services, DTOs, pipeline logic, use cases. Depends on Domain only. |
+| `BBT.Workflow.Infrastructure` | EF Core repositories, external integrations, event hooks. Implements Domain and Application interfaces. |
+| `BBT.Workflow.Events.Contracts` | Shared distributed event definitions (CloudEvents). |
+| `BBT.Workflow.Execution` / `Execution.Abstractions` | Task invoker bindings and contracts for the Execution service. |
+| `BBT.Workflow.Tasks.Abstractions` | Task interface contracts used by both Orchestration and Execution. |
+| `BBT.Workflow.HttpApi.Shared` | Shared middleware, telemetry enrichment, utilities for both API hosts. |
+
+### Workers (`workers/`)
+
+| Worker | Purpose |
+|--------|---------|
+| `BBT.Workflow.Workers.Inbox` | Consumes domain events from the distributed event bus (async handlers). |
+| `BBT.Workflow.Workers.Outbox` | Publishes outbox events to the event bus (transactional outbox pattern). |
+| `BBT.Workflow.DbMigrator` | Runs EF Core schema migrations at deploy time. |
+
+### Transition Pipeline
+
+Workflow execution flows through a deterministic **transition pipeline**. When a transition is triggered:
+1. Orchestration validates and persists state
+2. Orchestration invokes Execution via Dapr
+3. Execution runs task invokers (C# scripts, HTTP calls, etc.)
+4. Execution reports back; Orchestration applies the result and may auto-trigger the next transition
+
+Synchronous mode (`sync=true`) waits for the entire pipeline to complete and returns instance data in the response.
+
+### Key Infrastructure
+
+- **Database**: PostgreSQL with multi-schema support (one schema per tenant/flow)
+- **Cache**: Redis via `IDistributedCache`
+- **Messaging**: Dapr pub/sub + transactional Inbox/Outbox workers
+- **Scripting**: `modules/BBT.Workflow.Modules.Scripting` — Roslyn-based C# script engine
+- **Observability**: OpenTelemetry (Jaeger in Docker), structured logging via `WorkflowLogs.cs`
+
+### Multi-Schema Tenancy
+
+Each workflow "flow" has its own PostgreSQL schema. Schema resolution uses `ICurrentSchema` populated from HTTP headers, routes, or query string. Always wrap infrastructure operations with `currentSchema.Use(flow)`.
+
+### Domain Events (dual-processing pattern)
+
+Every domain event requires **two** handlers (see `.claude/CLAUDE.md` for the full checklist):
+- **Event Hook** (`IEventPublishHook<T>` in `*.Infrastructure/*/Events/`) — synchronous, local, within the same UoW
+- **Event Handler** (`IEventHandler<T>` in `workers/BBT.Workflow.Workers.Inbox/Handlers/`) — asynchronous, distributed, fault-tolerant
+
+### Context7 MCP Sources
+
+For domain/platform knowledge beyond what's in code:
+- vNext domain: `burgan-tech/vnext-runtime` (tag `vnext-runtime`)
+- Aether SDK: `burgan-tech/aether` (tag `aether`)
+- Examples: tag `vnext-example`
+
+Detailed docs live in `/docs` (implementation) and `/ai-docs` (AI-generated).

--- a/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Functions/ScriptBase.cs
+++ b/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Functions/ScriptBase.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
@@ -254,6 +256,299 @@ public abstract class ScriptBase
         {
             return defaultValue;
         }
+    }
+
+    #endregion
+
+    #region Dynamic Collection Functions
+
+    /// <summary>
+    /// Safely casts a dynamic value to <see cref="List{T}"/> of <see cref="object"/>.
+    /// Arrays in <c>Instance.Data</c> are represented as <c>List&lt;object?&gt;</c> at runtime.
+    /// Returns an empty list if the value is null or not a list.
+    /// </summary>
+    /// <param name="list">The dynamic value to cast</param>
+    /// <returns>A <see cref="List{T}"/> of nullable objects, or an empty list</returns>
+    protected static List<object?> AsList(object? list)
+    {
+        return list as List<object?> ?? [];
+    }
+
+    /// <summary>
+    /// Gets a list property from a dynamic object by property name.
+    /// Equivalent to <c>GetPropertyValue</c> followed by <c>AsList</c>.
+    /// </summary>
+    /// <param name="obj">The dynamic object containing the list property</param>
+    /// <param name="propertyName">The property name of the list</param>
+    /// <returns>The list, or an empty list if the property does not exist or is not a list</returns>
+    /// <example>
+    /// <code>
+    /// var items = GetList(context.Instance.Data, "items");
+    /// </code>
+    /// </example>
+    protected static List<object?> GetList(object? obj, string propertyName)
+    {
+        return AsList(GetPropertyValue(obj!, propertyName));
+    }
+
+    /// <summary>
+    /// Filters a dynamic list using a predicate. Equivalent to LINQ <c>.Where()</c>.
+    /// </summary>
+    /// <param name="list">The dynamic list to filter</param>
+    /// <param name="predicate">The condition each element must satisfy</param>
+    /// <returns>A new list containing only matching elements</returns>
+    /// <example>
+    /// <code>
+    /// var active = ListFilter(context.Instance.Data.items, x => x.status == "active");
+    /// </code>
+    /// </example>
+    protected static List<object?> ListFilter(object? list, Func<dynamic, bool> predicate)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        return AsList(list).Where(item => predicate(item!)).ToList();
+    }
+
+    /// <summary>
+    /// Returns the first element in a dynamic list that satisfies the predicate, or null if none found.
+    /// Equivalent to LINQ <c>.FirstOrDefault()</c>.
+    /// </summary>
+    /// <param name="list">The dynamic list to search</param>
+    /// <param name="predicate">Optional filter condition; if null, returns the first element</param>
+    /// <returns>The first matching element, or null</returns>
+    /// <example>
+    /// <code>
+    /// var item = ListFirst(context.Instance.Data.items, x => x.id == targetId);
+    /// </code>
+    /// </example>
+    protected static dynamic? ListFirst(object? list, Func<dynamic, bool>? predicate = null)
+    {
+        var items = AsList(list);
+        return predicate == null
+            ? items.FirstOrDefault()
+            : items.FirstOrDefault(item => predicate(item!));
+    }
+
+    /// <summary>
+    /// Returns the last element in a dynamic list that satisfies the predicate, or null if none found.
+    /// Equivalent to LINQ <c>.LastOrDefault()</c>.
+    /// </summary>
+    /// <param name="list">The dynamic list to search</param>
+    /// <param name="predicate">Optional filter condition; if null, returns the last element</param>
+    /// <returns>The last matching element, or null</returns>
+    protected static dynamic? ListLast(object? list, Func<dynamic, bool>? predicate = null)
+    {
+        var items = AsList(list);
+        return predicate == null
+            ? items.LastOrDefault()
+            : items.LastOrDefault(item => predicate(item!));
+    }
+
+    /// <summary>
+    /// Determines whether any element in a dynamic list satisfies the predicate.
+    /// Equivalent to LINQ <c>.Any()</c>.
+    /// </summary>
+    /// <param name="list">The dynamic list to check</param>
+    /// <param name="predicate">Optional filter condition; if null, checks whether the list has any element</param>
+    /// <returns><c>true</c> if a matching element exists; otherwise <c>false</c></returns>
+    /// <example>
+    /// <code>
+    /// var hasErrors = ListAny(context.Instance.Data.errors);
+    /// var hasPending = ListAny(context.Instance.Data.items, x => x.status == "pending");
+    /// </code>
+    /// </example>
+    protected static bool ListAny(object? list, Func<dynamic, bool>? predicate = null)
+    {
+        var items = AsList(list);
+        return predicate == null
+            ? items.Count > 0
+            : items.Any(item => predicate(item!));
+    }
+
+    /// <summary>
+    /// Returns the number of elements in a dynamic list, optionally filtered by a predicate.
+    /// Equivalent to LINQ <c>.Count()</c>.
+    /// </summary>
+    /// <param name="list">The dynamic list to count</param>
+    /// <param name="predicate">Optional filter condition</param>
+    /// <returns>The count of matching elements</returns>
+    /// <example>
+    /// <code>
+    /// var total = ListCount(context.Instance.Data.items);
+    /// var activeCount = ListCount(context.Instance.Data.items, x => x.active == true);
+    /// </code>
+    /// </example>
+    protected static int ListCount(object? list, Func<dynamic, bool>? predicate = null)
+    {
+        var items = AsList(list);
+        return predicate == null
+            ? items.Count
+            : items.Count(item => predicate(item!));
+    }
+
+    /// <summary>
+    /// Projects each element of a dynamic list into a new form.
+    /// Equivalent to LINQ <c>.Select()</c>.
+    /// </summary>
+    /// <typeparam name="TResult">The type of projected elements</typeparam>
+    /// <param name="list">The dynamic list to project</param>
+    /// <param name="selector">A transform function applied to each element</param>
+    /// <returns>A list of projected values</returns>
+    /// <example>
+    /// <code>
+    /// var ids = ListSelect&lt;string&gt;(context.Instance.Data.items, x => (string)x.id);
+    /// </code>
+    /// </example>
+    protected static List<TResult> ListSelect<TResult>(object? list, Func<dynamic, TResult> selector)
+    {
+        ArgumentNullException.ThrowIfNull(selector);
+        return AsList(list).Select(item => selector(item!)).ToList();
+    }
+
+    /// <summary>
+    /// Adds an item to a dynamic list. The list must be backed by a <c>List&lt;object?&gt;</c>.
+    /// </summary>
+    /// <param name="list">The dynamic list to modify</param>
+    /// <param name="item">The item to add</param>
+    /// <example>
+    /// <code>
+    /// var items = GetList(context.Instance.Data, "items");
+    /// ListAdd(items, newItem);
+    /// </code>
+    /// </example>
+    protected static void ListAdd(object? list, object? item)
+    {
+        AsList(list).Add(item);
+    }
+
+    /// <summary>
+    /// Removes all elements from a dynamic list that satisfy the predicate.
+    /// Equivalent to <c>List&lt;T&gt;.RemoveAll()</c>.
+    /// </summary>
+    /// <param name="list">The dynamic list to modify</param>
+    /// <param name="predicate">The condition to match elements for removal</param>
+    /// <returns>The number of elements removed</returns>
+    /// <example>
+    /// <code>
+    /// var removed = ListRemove(context.Instance.Data.items, x => x.status == "deleted");
+    /// </code>
+    /// </example>
+    protected static int ListRemove(object? list, Func<dynamic, bool> predicate)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        return AsList(list).RemoveAll(item => predicate(item!));
+    }
+
+    #endregion
+
+    #region Dynamic Object Functions
+
+    /// <summary>
+    /// Creates a new empty dynamic object (<see cref="ExpandoObject"/>).
+    /// Use <see cref="SetProperty"/> to assign properties to it.
+    /// </summary>
+    /// <returns>A new <c>dynamic</c> ExpandoObject instance</returns>
+    /// <example>
+    /// <code>
+    /// dynamic item = CreateObject();
+    /// SetProperty(item, "id", Guid.NewGuid().ToString());
+    /// SetProperty(item, "status", "pending");
+    /// </code>
+    /// </example>
+    protected static dynamic CreateObject()
+    {
+        return new ExpandoObject();
+    }
+
+    /// <summary>
+    /// Creates a new empty dynamic list compatible with <c>Instance.Data</c> array fields.
+    /// </summary>
+    /// <returns>A new empty <c>List&lt;object?&gt;</c></returns>
+    /// <example>
+    /// <code>
+    /// var newList = CreateList();
+    /// ListAdd(newList, CreateObject());
+    /// SetProperty(context.Instance.Data, "items", newList);
+    /// </code>
+    /// </example>
+    protected static List<object?> CreateList()
+    {
+        return [];
+    }
+
+    /// <summary>
+    /// Sets a property value on a dynamic object. Supports <see cref="ExpandoObject"/> and
+    /// regular CLR objects. If the object is an <c>ExpandoObject</c>, the property is created
+    /// if it does not already exist.
+    /// </summary>
+    /// <param name="obj">The dynamic object to modify</param>
+    /// <param name="propertyName">The property name to set</param>
+    /// <param name="value">The value to assign</param>
+    /// <example>
+    /// <code>
+    /// SetProperty(context.Instance.Data, "processedAt", DateTime.UtcNow);
+    /// </code>
+    /// </example>
+    protected static void SetProperty(object obj, string propertyName, object? value)
+    {
+        ArgumentNullException.ThrowIfNull(obj);
+        if (string.IsNullOrWhiteSpace(propertyName)) return;
+
+        if (obj is IDictionary<string, object?> dict)
+        {
+            dict[propertyName] = value;
+            return;
+        }
+
+        obj.GetType()
+           .GetProperty(propertyName,
+               System.Reflection.BindingFlags.Public |
+               System.Reflection.BindingFlags.Instance |
+               System.Reflection.BindingFlags.IgnoreCase)
+           ?.SetValue(obj, value);
+    }
+
+    /// <summary>
+    /// Removes a property from a dynamic object. Only works with <see cref="ExpandoObject"/>;
+    /// returns <c>false</c> for other types.
+    /// </summary>
+    /// <param name="obj">The dynamic object to modify</param>
+    /// <param name="propertyName">The property name to remove</param>
+    /// <returns><c>true</c> if the property was found and removed; otherwise <c>false</c></returns>
+    /// <example>
+    /// <code>
+    /// RemoveProperty(context.Instance.Data, "tempField");
+    /// </code>
+    /// </example>
+    protected static bool RemoveProperty(object obj, string propertyName)
+    {
+        if (obj is IDictionary<string, object?> dict)
+            return dict.Remove(propertyName);
+
+        return false;
+    }
+
+    /// <summary>
+    /// Converts a dynamic object to a <c>Dictionary&lt;string, object?&gt;</c>.
+    /// Useful when you need to enumerate properties or pass dynamic data to typed APIs.
+    /// Returns an empty dictionary for null input.
+    /// </summary>
+    /// <param name="obj">The dynamic object to convert</param>
+    /// <returns>A dictionary of property names and values</returns>
+    /// <example>
+    /// <code>
+    /// var dict = ToDictionary(context.Instance.Data);
+    /// foreach (var kv in dict) { ... }
+    /// </code>
+    /// </example>
+    protected static Dictionary<string, object?> ToDictionary(object? obj)
+    {
+        if (obj is IDictionary<string, object?> dict)
+            return new Dictionary<string, object?>(dict);
+
+        if (obj is IDictionary<string, object> dict2)
+            return dict2.ToDictionary(kv => kv.Key, kv => (object?)kv.Value);
+
+        return [];
     }
 
     #endregion

--- a/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Functions/ScriptBase.cs
+++ b/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Functions/ScriptBase.cs
@@ -288,6 +288,7 @@ public abstract class ScriptBase
     /// </example>
     protected static List<object?> GetList(object? obj, string propertyName)
     {
+        if (obj is null) return [];
         return AsList(GetPropertyValue(obj!, propertyName));
     }
 

--- a/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Functions/ScriptBase.cs
+++ b/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Functions/ScriptBase.cs
@@ -297,11 +297,13 @@ public abstract class ScriptBase
     /// <param name="list">The dynamic list to filter</param>
     /// <param name="predicate">The condition each element must satisfy</param>
     /// <returns>A new list containing only matching elements</returns>
-    /// <example>
+    /// <remarks>
+    /// When the list comes from a <c>dynamic</c> source, convert it first to avoid CS1977:
     /// <code>
-    /// var active = ListFilter(context.Instance.Data.items, x => x.status == "active");
+    /// var items = AsList(context.Instance.Data.items);
+    /// var active = ListFilter(items, x => x.status == "active");
     /// </code>
-    /// </example>
+    /// </remarks>
     protected static List<object?> ListFilter(object? list, Func<dynamic, bool> predicate)
     {
         ArgumentNullException.ThrowIfNull(predicate);
@@ -315,11 +317,13 @@ public abstract class ScriptBase
     /// <param name="list">The dynamic list to search</param>
     /// <param name="predicate">Optional filter condition; if null, returns the first element</param>
     /// <returns>The first matching element, or null</returns>
-    /// <example>
+    /// <remarks>
+    /// When the list comes from a <c>dynamic</c> source, convert it first to avoid CS1977:
     /// <code>
-    /// var item = ListFirst(context.Instance.Data.items, x => x.id == targetId);
+    /// var items = AsList(context.Instance.Data.items);
+    /// var item = ListFirst(items, x => x.id == targetId);
     /// </code>
-    /// </example>
+    /// </remarks>
     protected static dynamic? ListFirst(object? list, Func<dynamic, bool>? predicate = null)
     {
         var items = AsList(list);
@@ -350,12 +354,25 @@ public abstract class ScriptBase
     /// <param name="list">The dynamic list to check</param>
     /// <param name="predicate">Optional filter condition; if null, checks whether the list has any element</param>
     /// <returns><c>true</c> if a matching element exists; otherwise <c>false</c></returns>
-    /// <example>
+    /// <remarks>
+    /// <b>Important:</b> When the list comes from a dynamic source (e.g. <c>context.Instance.Data.items</c>),
+    /// C# cannot combine a <c>dynamic</c> argument with a lambda in the same call (CS1977).
+    /// Always convert to a typed list first using <see cref="AsList"/> or <see cref="GetList"/>:
     /// <code>
+    /// // ✗ Fails with CS1977 — dynamic argument + lambda in same call
+    /// // ListAny(context.Instance.Data.items, x => x.status == "pending");
+    ///
+    /// // ✓ Correct — convert to List&lt;object?&gt; first
+    /// var items = AsList(context.Instance.Data.items);
+    /// var hasPending = ListAny(items, x => x.status == "pending");
+    ///
+    /// // ✓ Also correct — using GetList when accessing by property name
+    /// var hasPending = ListAny(GetList(context.Instance.Data, "items"), x => x.status == "pending");
+    ///
+    /// // ✓ No-predicate form works directly (no lambda → no CS1977)
     /// var hasErrors = ListAny(context.Instance.Data.errors);
-    /// var hasPending = ListAny(context.Instance.Data.items, x => x.status == "pending");
     /// </code>
-    /// </example>
+    /// </remarks>
     protected static bool ListAny(object? list, Func<dynamic, bool>? predicate = null)
     {
         var items = AsList(list);

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
@@ -45,6 +45,7 @@ public sealed class InstanceController(
         [FromBody] CreateInstanceDto request,
         [FromQuery] string? version = null,
         [FromQuery] bool sync = false,
+        [FromQuery] string[]? extensions = null,
         CancellationToken cancellationToken = default
     )
     {
@@ -55,7 +56,8 @@ public sealed class InstanceController(
                 Key = request?.Key,
                 Tags = request?.Tags,
                 Attributes = request?.Attributes
-            }
+            },
+            Extensions = extensions
         };
         var httpContext = httpContextAccessor.HttpContext;
         if (httpContext is not null)
@@ -76,6 +78,7 @@ public sealed class InstanceController(
         [FromBody] CreateSubInstanceDto request,
         [FromQuery] string? version = null,
         [FromQuery] bool sync = false,
+        [FromQuery] string[]? extensions = null,
         CancellationToken cancellationToken = default
     )
     {
@@ -90,7 +93,8 @@ public sealed class InstanceController(
                 Callback = request.Callback,
                 ExtraProperties = new ExtraPropertyDictionary(request.ExtraProperties)
             },
-            StrictIdempotency = true
+            StrictIdempotency = true,
+            Extensions = extensions
         };
         var httpContext = httpContextAccessor.HttpContext;
         if (httpContext is not null)
@@ -158,10 +162,14 @@ public sealed class InstanceController(
         [FromRoute] string transitionKey,
         [FromBody] TransitionDataInput? data = null,
         [FromQuery] bool sync = false,
+        [FromQuery] string[]? extensions = null,
         CancellationToken cancellationToken = default
     )
     {
-        var input = new TransitionInput(domain, workflow, data, sync);
+        var input = new TransitionInput(domain, workflow, data, sync)
+        {
+            Extensions = extensions
+        };
         var httpContext = httpContextAccessor.HttpContext;
         if (httpContext is not null)
         {
@@ -284,7 +292,7 @@ public sealed class InstanceController(
         [FromRoute] string domain,
         [FromRoute] string workflow,
         [FromQuery] string? filter = null,
-        [FromQuery] string[]? extension = null,
+        [FromQuery] string[]? extensions = null,
         [FromQuery][Range(1, 1000)] int page = 1,
         [FromQuery][Range(1, 100)] int pageSize = 10,
         [FromQuery] string? sort = null,
@@ -298,7 +306,7 @@ public sealed class InstanceController(
         {
             Domain = domain,
             Workflow = workflow,
-            Extension = extension,
+            Extensions = extensions,
             Page = page,
             PageSize = pageSize,
             PageUrl = urlTemplateBuilder.BuildInstanceListUrl(domain, workflow),
@@ -354,7 +362,7 @@ public sealed class InstanceController(
         [FromRoute] string domain,
         [FromRoute] string workflow,
         [FromRoute] string instance,
-        [FromQuery] string[]? extension = null,
+        [FromQuery] string[]? extensions = null,
         [FromQuery] string? version = null,
         CancellationToken cancellationToken = default)
     {
@@ -365,7 +373,7 @@ public sealed class InstanceController(
             Domain = domain,
             Workflow = workflow,
             Instance = instance,
-            Extensions = extension,
+            Extensions = extensions,
             Version = version,
             Headers = requestContext.Headers,
             QueryParameters = requestContext.QueryParameters

--- a/src/BBT.Workflow.Application/Authorization/ISchemaFieldFilterService.cs
+++ b/src/BBT.Workflow.Application/Authorization/ISchemaFieldFilterService.cs
@@ -1,0 +1,22 @@
+using System.Text.Json;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Instances;
+
+namespace BBT.Workflow.Authorization;
+
+/// <summary>
+/// Applies master schema field-level visibility filtering to instance data based on effective caller roles.
+/// </summary>
+public interface ISchemaFieldFilterService
+{
+    /// <summary>
+    /// Filters the given JSON data by the caller's visible fields according to the workflow's master schema role grants.
+    /// Returns filtered <see cref="JsonElement"/> or the original data if no schema or no role grants are defined.
+    /// When <paramref name="instance"/> is provided, also evaluates $InstanceStarter and $PreviousUser predefined roles.
+    /// </summary>
+    Task<JsonElement?> ApplyAsync(
+        Definitions.Workflow? workflow,
+        JsonElement? data,
+        Instance? instance = null,
+        CancellationToken cancellationToken = default);
+}

--- a/src/BBT.Workflow.Application/Authorization/SchemaFieldFilterService.cs
+++ b/src/BBT.Workflow.Application/Authorization/SchemaFieldFilterService.cs
@@ -1,0 +1,48 @@
+using System.Text.Json;
+using BBT.Aether.Users;
+using BBT.Workflow.Caching;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Definitions.Schemas;
+using BBT.Workflow.Instances;
+
+namespace BBT.Workflow.Authorization;
+
+/// <summary>
+/// Applies master schema field-level visibility filtering to instance data based on effective caller roles.
+/// Extracted from InstanceQueryAppService to allow reuse in command and query paths.
+/// </summary>
+public sealed class SchemaFieldFilterService(
+    IComponentCacheStore componentCacheStore,
+    ITransitionAuthorizationManager transitionAuthorizationManager,
+    ICurrentUser currentUser) : ISchemaFieldFilterService
+{
+    /// <inheritdoc />
+    public async Task<JsonElement?> ApplyAsync(
+        Definitions.Workflow? workflow,
+        JsonElement? data,
+        Instance? instance = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (workflow?.Schema is null || !data.HasValue)
+            return data;
+        var element = data.GetValueOrDefault();
+        if (element.ValueKind != JsonValueKind.Object)
+            return data;
+
+        var schemaResult = await componentCacheStore.GetSchemaAsync(workflow.Schema, cancellationToken);
+        if (!schemaResult.IsSuccess)
+            return data;
+
+        var pathRoleGrants = SchemaRolesParser.ParsePropertyRoles(schemaResult.Value!.Schema);
+        if (pathRoleGrants.Count == 0)
+            return data;
+
+        var callerRoles = instance != null
+            ? await transitionAuthorizationManager.GetEffectiveCallerRolesForFieldVisibilityAsync(instance,
+                cancellationToken)
+            : currentUser.Roles;
+        var visiblePaths = SchemaFieldVisibilityService.GetVisiblePaths(pathRoleGrants, callerRoles);
+        var pathsWithRoles = new HashSet<string>(pathRoleGrants.Keys, StringComparer.Ordinal);
+        return InstanceDataRoleFilter.FilterByVisiblePaths(element, pathsWithRoles, visiblePaths);
+    }
+}

--- a/src/BBT.Workflow.Application/Instances/DTOs/GetInstanceInput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/GetInstanceInput.cs
@@ -63,7 +63,7 @@ public sealed class GetInstanceListInput : IHasDomain
     /// <summary>
     /// Extensions requested for data enrichment
     /// </summary>
-    public string[]? Extension { get; set; }
+    public string[]? Extensions { get; set; }
 
     /// <summary>
     /// Filter to apply to the query (JSON format, e.g. GraphQL-style or legacy)

--- a/src/BBT.Workflow.Application/Instances/DTOs/StartInstanceInput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/StartInstanceInput.cs
@@ -73,11 +73,42 @@ public sealed class CreateInstanceInput: IHasExtraProperties
 public sealed class StartInstanceOutput
 {
     public Guid Id { get; set; }
+    public string? Key { get; set; }
 
     /// <summary>
     /// Instance status (Active, Busy, Completed, etc.)
     /// </summary>
     public InstanceStatus? Status { get; set; }
+
+    /// <summary>
+    /// Instance attributes filtered by master-schema role grants. Populated only when sync=true.
+    /// </summary>
+    public JsonElement? Attributes { get; set; }
+
+    /// <summary>
+    /// Representation ETag (SHA256 of canonical response JSON), returned with quotes per RFC 7232. Populated only when sync=true.
+    /// </summary>
+    public string? ETag
+    {
+        get => _etag is null ? null : $"\"{_etag.Replace("\"", "")}\"";
+        set => _etag = value;
+    }
+    private string? _etag;
+
+    /// <summary>
+    /// Entity (DB row) version for concurrency, returned with quotes per RFC 7232. Populated only when sync=true.
+    /// </summary>
+    public string? EntityEtag
+    {
+        get => _entityEtag is null ? null : $"\"{_entityEtag.Replace("\"", "")}\"";
+        set => _entityEtag = value;
+    }
+    private string? _entityEtag;
+
+    /// <summary>
+    /// Computed extension fields. Populated only when sync=true.
+    /// </summary>
+    public Dictionary<string, object>? Extensions { get; set; }
 }
 
 /// <summary>

--- a/src/BBT.Workflow.Application/Instances/DTOs/StartInstanceInput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/StartInstanceInput.cs
@@ -28,6 +28,12 @@ public sealed class StartInstanceInput(
     public bool StrictIdempotency { get; set; } = false;
 
     /// <summary>
+    /// Extension data to evaluate and include in the sync response. Keys are extension identifiers.
+    /// Evaluated only when <see cref="Sync"/> is true.
+    /// </summary>
+    public string[]? Extensions { get; set; }
+
+    /// <summary>
     /// Creates a WorkflowExecutionContext from this StartInstanceInput for starting a new workflow instance.
     /// </summary>
     /// <param name="instanceId">The workflow instance identifier</param>
@@ -70,45 +76,8 @@ public sealed class CreateInstanceInput: IHasExtraProperties
     public ExtraPropertyDictionary ExtraProperties { get; set; } = new();
 }
 
-public sealed class StartInstanceOutput
+public sealed class StartInstanceOutput : InstanceOutputBase
 {
-    public Guid Id { get; set; }
-    public string? Key { get; set; }
-
-    /// <summary>
-    /// Instance status (Active, Busy, Completed, etc.)
-    /// </summary>
-    public InstanceStatus? Status { get; set; }
-
-    /// <summary>
-    /// Instance attributes filtered by master-schema role grants. Populated only when sync=true.
-    /// </summary>
-    public JsonElement? Attributes { get; set; }
-
-    /// <summary>
-    /// Representation ETag (SHA256 of canonical response JSON), returned with quotes per RFC 7232. Populated only when sync=true.
-    /// </summary>
-    public string? ETag
-    {
-        get => _etag is null ? null : $"\"{_etag.Replace("\"", "")}\"";
-        set => _etag = value;
-    }
-    private string? _etag;
-
-    /// <summary>
-    /// Entity (DB row) version for concurrency, returned with quotes per RFC 7232. Populated only when sync=true.
-    /// </summary>
-    public string? EntityEtag
-    {
-        get => _entityEtag is null ? null : $"\"{_entityEtag.Replace("\"", "")}\"";
-        set => _entityEtag = value;
-    }
-    private string? _entityEtag;
-
-    /// <summary>
-    /// Computed extension fields. Populated only when sync=true.
-    /// </summary>
-    public Dictionary<string, object>? Extensions { get; set; }
 }
 
 /// <summary>

--- a/src/BBT.Workflow.Application/Instances/DTOs/TransitionInput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/TransitionInput.cs
@@ -23,6 +23,12 @@ public sealed class TransitionInput(
     public bool Sync { get; set; } = sync;
 
     /// <summary>
+    /// Extension data to evaluate and include in the sync response. Keys are extension identifiers.
+    /// Evaluated only when <see cref="Sync"/> is true.
+    /// </summary>
+    public string[]? Extensions { get; set; }
+
+    /// <summary>
     /// Creates a WorkflowExecutionContext from this TransitionInput for manual transition execution.
     /// </summary>
     /// <param name="instanceId">The workflow instance identifier</param>

--- a/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
@@ -1,5 +1,8 @@
 using System.Diagnostics;
+using System.Text.Json;
 using BBT.Aether;
+using BBT.Workflow.Authorization;
+using BBT.Workflow.RepresentationEtag;
 using BBT.Aether.Application.Services;
 using BBT.Aether.BackgroundJob;
 using BBT.Aether.Guids;
@@ -40,6 +43,8 @@ public sealed class InstanceCommandAppService(
     ITransitionDataMapper transitionDataMapper,
     ITransitionValidationService transitionValidationService,
     IWorkflowContext workflowContext,
+    IRepresentationEtagService representationEtagService,
+    ISchemaFieldFilterService schemaFieldFilterService,
     ILogger<InstanceCommandAppService> logger)
     : ApplicationService(serviceProvider), IInstanceCommandAppService
 {
@@ -59,7 +64,11 @@ public sealed class InstanceCommandAppService(
         // Step 2: Check existing instance
         var existingInstanceResult = await CheckExistingInstanceAsync(input, cancellationToken);
         if (existingInstanceResult.HasValue)
+        {
+            if (input.Sync && existingInstanceResult.Value.IsSuccess)
+                return await EnrichSyncOutputAsync(existingInstanceResult.Value.Value!, existingInstanceResult.Value.Value!.Id, workflow, cancellationToken);
             return existingInstanceResult.Value;
+        }
 
         // Step 3-6: Continue with normal railway flow for NEW instances
         return await PrepareInstanceAsync(workflow, input, cancellationToken)
@@ -117,6 +126,7 @@ public sealed class InstanceCommandAppService(
         return Result<StartInstanceOutput>.Ok(new StartInstanceOutput
         {
             Id = existingInstance.Id,
+            Key = existingInstance.Key,
             Status = existingInstance.Status
         });
     }
@@ -269,8 +279,12 @@ public sealed class InstanceCommandAppService(
             .MapAsync(transitionOutput => new StartInstanceOutput
             {
                 Id = data.Instance.Id,
+                Key = data.Instance.Key,
                 Status = transitionOutput.Status
-            });
+            })
+            .ThenAsync(output => input.Sync
+                ? EnrichSyncOutputAsync(output, output.Id, data.Workflow, cancellationToken)
+                : Task.FromResult(Result<StartInstanceOutput>.Ok(output)));
     }
 
     /// <summary>
@@ -385,9 +399,18 @@ public sealed class InstanceCommandAppService(
 
         var context = BuildTransitionContext(resolvedInstance, transitionKey, input);
 
+        var workflowDefinition = workflowResult.Value;
+
         return await workflowExecutionService
             .ExecuteTransitionAsync(context, cancellationToken)
-            .OnSuccess(output => AddTransitionHeader(output, resolvedInstance.Flow, resolvedInstance.FlowVersion));
+            .OnSuccess(output => AddTransitionHeader(output, resolvedInstance.Flow, resolvedInstance.FlowVersion))
+            .ThenAsync(output =>
+            {
+                if (input.Sync)
+                    return EnrichSyncOutputAsync(output, output.Id, workflowDefinition, cancellationToken);
+                output.Key = resolvedInstance.Key;
+                return Task.FromResult(Result<TransitionOutput>.Ok(output));
+            });
     }
 
     /// <summary>
@@ -428,6 +451,69 @@ public sealed class InstanceCommandAppService(
             WorkflowInfo.Name,
             WorkflowInfo.Generate(runtimeInfoProvider.Domain, flow, version, output.Id)
         );
+    }
+
+    /// <summary>
+    /// Enriches a sync=true StartInstanceOutput with attributes (schema-filtered), etag, entityEtag, key and extensions.
+    /// The instance is reloaded from the repository to ensure post-execution state is reflected.
+    /// </summary>
+    private Task<Result<StartInstanceOutput>> EnrichSyncOutputAsync(
+        StartInstanceOutput output,
+        Guid instanceId,
+        Definitions.Workflow? workflow,
+        CancellationToken cancellationToken)
+        => EnrichOutputCoreAsync(output, instanceId, workflow, cancellationToken);
+
+    /// <summary>
+    /// Enriches a sync=true TransitionOutput with attributes (schema-filtered), etag, entityEtag, key and extensions.
+    /// The instance is reloaded from the repository to ensure post-execution state is reflected.
+    /// </summary>
+    private Task<Result<TransitionOutput>> EnrichSyncOutputAsync(
+        TransitionOutput output,
+        Guid instanceId,
+        Definitions.Workflow? workflow,
+        CancellationToken cancellationToken)
+        => EnrichOutputCoreAsync(output, instanceId, workflow, cancellationToken);
+
+    private async Task<Result<TOutput>> EnrichOutputCoreAsync<TOutput>(
+        TOutput output,
+        Guid instanceId,
+        Definitions.Workflow? workflow,
+        CancellationToken cancellationToken)
+        where TOutput : class
+    {
+        var freshInstance = await instanceRepository.FindByIdentifierAsync(instanceId.ToString(), cancellationToken);
+        if (freshInstance is null)
+            return Result<TOutput>.Ok(output);
+
+        var latestData = freshInstance.LatestData;
+        var rawAttributes = latestData?.Data.JsonElement;
+        var filteredAttributes = await schemaFieldFilterService.ApplyAsync(workflow, rawAttributes, freshInstance, cancellationToken);
+
+        var key = freshInstance.Key;
+        var entityEtag = latestData?.ETag;
+        var attributes = filteredAttributes ?? rawAttributes;
+
+        if (output is StartInstanceOutput start)
+        {
+            start.Key = key;
+            start.Attributes = attributes;
+            start.EntityEtag = entityEtag;
+            start.Extensions = new Dictionary<string, object>();
+            // ETag must be generated after all other fields are set (ETag itself is null at generation time)
+            start.ETag = representationEtagService.Generate(start);
+        }
+        else if (output is TransitionOutput transition)
+        {
+            transition.Key = key;
+            transition.Attributes = attributes;
+            transition.EntityEtag = entityEtag;
+            transition.Extensions = new Dictionary<string, object>();
+            // ETag must be generated after all other fields are set (ETag itself is null at generation time)
+            transition.ETag = representationEtagService.Generate(transition);
+        }
+
+        return Result<TOutput>.Ok(output);
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
@@ -18,8 +18,10 @@ using BBT.Workflow.Execution.Services;
 using BBT.Workflow.Logging;
 using BBT.Workflow.Execution.Transitions.Services;
 using BBT.Workflow.Execution.Validation;
+using BBT.Workflow.Extentions;
 using BBT.Workflow.Headers;
 using BBT.Workflow.Runtime;
+using BBT.Workflow.Scripting;
 using Dapr.Jobs.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
@@ -45,6 +47,8 @@ public sealed class InstanceCommandAppService(
     IWorkflowContext workflowContext,
     IRepresentationEtagService representationEtagService,
     ISchemaFieldFilterService schemaFieldFilterService,
+    IInstanceExtensionService instanceExtensionService,
+    IScriptContextFactory scriptContextFactory,
     ILogger<InstanceCommandAppService> logger)
     : ApplicationService(serviceProvider), IInstanceCommandAppService
 {
@@ -66,7 +70,7 @@ public sealed class InstanceCommandAppService(
         if (existingInstanceResult.HasValue)
         {
             if (input.Sync && existingInstanceResult.Value.IsSuccess)
-                return await EnrichSyncOutputAsync(existingInstanceResult.Value.Value!, existingInstanceResult.Value.Value!.Id, workflow, cancellationToken);
+                return await EnrichSyncOutputAsync(existingInstanceResult.Value.Value!, existingInstanceResult.Value.Value!.Id, workflow, input.Extensions, cancellationToken);
             return existingInstanceResult.Value;
         }
 
@@ -283,7 +287,7 @@ public sealed class InstanceCommandAppService(
                 Status = transitionOutput.Status
             })
             .ThenAsync(output => input.Sync
-                ? EnrichSyncOutputAsync(output, output.Id, data.Workflow, cancellationToken)
+                ? EnrichSyncOutputAsync(output, output.Id, data.Workflow, input.Extensions, cancellationToken)
                 : Task.FromResult(Result<StartInstanceOutput>.Ok(output)));
     }
 
@@ -407,7 +411,7 @@ public sealed class InstanceCommandAppService(
             .ThenAsync(output =>
             {
                 if (input.Sync)
-                    return EnrichSyncOutputAsync(output, output.Id, workflowDefinition, cancellationToken);
+                    return EnrichSyncOutputAsync(output, output.Id, workflowDefinition, input.Extensions, cancellationToken);
                 output.Key = resolvedInstance.Key;
                 return Task.FromResult(Result<TransitionOutput>.Ok(output));
             });
@@ -461,8 +465,9 @@ public sealed class InstanceCommandAppService(
         StartInstanceOutput output,
         Guid instanceId,
         Definitions.Workflow? workflow,
+        string[]? extensionRequested,
         CancellationToken cancellationToken)
-        => EnrichOutputCoreAsync(output, instanceId, workflow, cancellationToken);
+        => EnrichOutputCoreAsync(output, instanceId, workflow, extensionRequested, cancellationToken);
 
     /// <summary>
     /// Enriches a sync=true TransitionOutput with attributes (schema-filtered), etag, entityEtag, key and extensions.
@@ -472,13 +477,15 @@ public sealed class InstanceCommandAppService(
         TransitionOutput output,
         Guid instanceId,
         Definitions.Workflow? workflow,
+        string[]? extensionRequested,
         CancellationToken cancellationToken)
-        => EnrichOutputCoreAsync(output, instanceId, workflow, cancellationToken);
+        => EnrichOutputCoreAsync(output, instanceId, workflow, extensionRequested, cancellationToken);
 
     private async Task<Result<TOutput>> EnrichOutputCoreAsync<TOutput>(
         TOutput output,
         Guid instanceId,
         Definitions.Workflow? workflow,
+        string[]? extensionRequested,
         CancellationToken cancellationToken)
         where TOutput : class
     {
@@ -494,12 +501,36 @@ public sealed class InstanceCommandAppService(
         var entityEtag = latestData?.ETag;
         var attributes = filteredAttributes ?? rawAttributes;
 
+        Dictionary<string, object> extensions = new();
+        if (workflow is not null)
+        {
+            var scriptContext = await scriptContextFactory.NewBuilder(instanceRepository)
+                .WithWorkflow(workflow)
+                .WithInstance(freshInstance)
+                .WithRuntime(runtimeInfoProvider)
+                .WithTransition(string.Empty)
+                .WithBody(latestData?.Data ?? new JsonData("{}"))
+                .BuildAsync(cancellationToken);
+
+            var extensionsResult = await instanceExtensionService.ProcessExtensionsAsync(
+                extensionRequested,
+                scriptContext,
+                workflow,
+                ExtensionScope.GetInstance,
+                cancellationToken);
+
+            if (!extensionsResult.IsSuccess)
+                return Result<TOutput>.Fail(extensionsResult.Error);
+
+            extensions = extensionsResult.Value!;
+        }
+
         if (output is StartInstanceOutput start)
         {
             start.Key = key;
             start.Attributes = attributes;
             start.EntityEtag = entityEtag;
-            start.Extensions = new Dictionary<string, object>();
+            start.Extensions = extensions;
             // ETag must be generated after all other fields are set (ETag itself is null at generation time)
             start.ETag = representationEtagService.Generate(start);
         }
@@ -508,7 +539,7 @@ public sealed class InstanceCommandAppService(
             transition.Key = key;
             transition.Attributes = attributes;
             transition.EntityEtag = entityEtag;
-            transition.Extensions = new Dictionary<string, object>();
+            transition.Extensions = extensions;
             // ETag must be generated after all other fields are set (ETag itself is null at generation time)
             transition.ETag = representationEtagService.Generate(transition);
         }

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -2,11 +2,9 @@ using BBT.Aether;
 using BBT.Aether.Application.Services;
 using BBT.Aether.Domain.Entities;
 using BBT.Aether.Results;
-using BBT.Aether.Users;
 using BBT.Workflow.Authorization;
 using BBT.Workflow.Caching;
 using BBT.Workflow.Definitions;
-using BBT.Workflow.Definitions.Schemas;
 using BBT.Workflow.Logging;
 using BBT.Workflow.Extentions;
 using BBT.Workflow.Gateway;
@@ -37,8 +35,8 @@ public sealed class InstanceQueryAppService(
     IUrlTemplateBuilder urlTemplateBuilder,
     ICurrentSchema currentSchema,
     ITransitionAuthorizationManager transitionAuthorizationManager,
-    ICurrentUser currentUser,
     IRepresentationEtagService representationEtagService,
+    ISchemaFieldFilterService schemaFieldFilterService,
     ILogger<InstanceQueryAppService> logger)
     : ApplicationService(serviceProvider), IInstanceQueryAppService
 {
@@ -471,45 +469,10 @@ public sealed class InstanceQueryAppService(
         response.Extensions = extensionsResult.Value!;
 
         response.Attributes =
-            await ApplySchemaFieldFilterAsync(flow, response.Attributes, instance, cancellationToken) ??
+            await schemaFieldFilterService.ApplyAsync(flow, response.Attributes, instance, cancellationToken) ??
             response.Attributes;
 
         return Result<GetInstanceOutput>.Ok(response);
-    }
-
-    /// <summary>
-    /// Applies master schema field-level visibility: filters instance data by effective caller roles
-    /// (static roles from header; when instance is present, also $InstanceStarter and $PreviousUser when matched).
-    /// Returns filtered JsonElement or original if workflow has no schema or schema has no roles.
-    /// </summary>
-    private async Task<JsonElement?> ApplySchemaFieldFilterAsync(
-        Definitions.Workflow? workflow,
-        JsonElement? data,
-        Instance? instance = null,
-        CancellationToken cancellationToken = default)
-    {
-        if (workflow?.Schema is null || !data.HasValue)
-            return data;
-        var element = data.GetValueOrDefault();
-        if (element.ValueKind != JsonValueKind.Object)
-            return data;
-
-        var schemaResult = await componentCacheStore.GetSchemaAsync(workflow.Schema, cancellationToken);
-        if (!schemaResult.IsSuccess)
-            return data;
-
-        var pathRoleGrants = SchemaRolesParser.ParsePropertyRoles(schemaResult.Value!.Schema);
-        if (pathRoleGrants.Count == 0)
-            return data;
-
-        var callerRoles = instance != null
-            ? await transitionAuthorizationManager.GetEffectiveCallerRolesForFieldVisibilityAsync(instance,
-                cancellationToken)
-            : currentUser.Roles;
-        var visiblePaths = SchemaFieldVisibilityService.GetVisiblePaths(pathRoleGrants, callerRoles);
-        var pathsWithRoles = new HashSet<string>(pathRoleGrants.Keys, StringComparer.Ordinal);
-        var filtered = InstanceDataRoleFilter.FilterByVisiblePaths(element, pathsWithRoles, visiblePaths);
-        return filtered;
     }
 
     public async Task<ConditionalResult<GetInstanceDataOutput>> GetInstanceDataAsync(
@@ -534,7 +497,7 @@ public sealed class InstanceQueryAppService(
                         Data = instance.LatestData?.Data.JsonElement
                     };
 
-                    result.Data = await ApplySchemaFieldFilterAsync(flow, result.Data, instance, cancellationToken) ??
+                    result.Data = await schemaFieldFilterService.ApplyAsync(flow, result.Data, instance, cancellationToken) ??
                                   result.Data;
 
                     // If there's an active SubFlow and extensions are requested, fetch from SubFlow

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -170,7 +170,7 @@ public sealed class InstanceQueryAppService(
                 {
                     var instanceOutputResult = await BuildInstanceOutputAsync(
                         input.Domain,
-                        input.Extension,
+                        input.Extensions,
                         input.Workflow,
                         instance,
                         instance.LatestData,

--- a/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
@@ -59,6 +59,7 @@ public static class WorkflowApplicationModuleServiceCollectionExtensions
         services.AddScoped<ITransitionAuthorizationManager, TransitionAuthorizationManager>();
         services.AddScoped<IAuthorizeAppService, AuthorizeAppService>();
         services.AddScoped<IRepresentationEtagService, RepresentationEtagService>();
+        services.AddScoped<ISchemaFieldFilterService, SchemaFieldFilterService>();
         services.AddScoped<IInstanceExtensionService, InstanceExtensionService>();
         services.AddScoped<ISubflowCompletionService, SubflowCompletionService>();
         services.AddScoped<ISubflowStateService, SubflowStateService>();

--- a/src/BBT.Workflow.Application/Tasks/Coordinator/TaskExecutionEngine.cs
+++ b/src/BBT.Workflow.Application/Tasks/Coordinator/TaskExecutionEngine.cs
@@ -533,6 +533,11 @@ public sealed class TaskExecutionEngine : ITaskExecutionEngine
             JsonSerializerConstants.JsonOptions));
         instanceTask.SetRequest(requestJson);
 
+        if (executorContext.RawInvocationResultJson != null)
+        {
+            instanceTask.SetInvocationResult(new JsonData(executorContext.RawInvocationResultJson));
+        }
+
         stopwatch.Stop();
 
         // 9. Handle infrastructure error - return without boundary resolution (not retriable)

--- a/src/BBT.Workflow.Application/Tasks/Executors/Core/TaskExecutorBase.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Core/TaskExecutorBase.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text;
+using System.Text.Json;
 using BBT.Aether.Results;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Scripting;
@@ -90,6 +91,8 @@ public abstract class TaskExecutorBase<TTask>(ILogger logger) : ITaskExecutor
                 taskKey, invokeResult.Error.Message);
             return CreateErrorResponse(invokeResult.Error, stopwatch.ElapsedMilliseconds);
         }
+
+        context.RawInvocationResultJson = JsonSerializer.Serialize(invokeResult.Value!, JsonSerializerConstants.JsonOptions);
 
         // Note: Business errors (HTTP 4xx/5xx) are NOT intercepted here.
         // The invocation result (including IsSuccess=false, StatusCode, Metadata/ExceptionType)

--- a/src/BBT.Workflow.Domain/Instances/DTOs/InstanceOutputBase.cs
+++ b/src/BBT.Workflow.Domain/Instances/DTOs/InstanceOutputBase.cs
@@ -1,0 +1,51 @@
+using System.Text.Json;
+
+namespace BBT.Workflow.Instances;
+
+/// <summary>
+/// Base output shared by instance operation responses (Start, Transition, etc.).
+/// </summary>
+public abstract class InstanceOutputBase
+{
+    /// <summary>
+    /// The workflow instance identifier.
+    /// </summary>
+    public Guid Id { get; set; }
+
+    public string? Key { get; set; }
+
+    /// <summary>
+    /// Instance status (Active, Busy, Completed, etc.)
+    /// </summary>
+    public InstanceStatus? Status { get; set; }
+
+    /// <summary>
+    /// Instance attributes filtered by master-schema role grants. Populated only when sync=true.
+    /// </summary>
+    public JsonElement? Attributes { get; set; }
+
+    /// <summary>
+    /// Representation ETag (SHA256 of canonical response JSON), returned with quotes per RFC 7232. Populated only when sync=true.
+    /// </summary>
+    public string? ETag
+    {
+        get => _etag is null ? null : $"\"{_etag.Replace("\"", "")}\"";
+        set => _etag = value;
+    }
+    private string? _etag;
+
+    /// <summary>
+    /// Entity (DB row) version for concurrency, returned with quotes per RFC 7232. Populated only when sync=true.
+    /// </summary>
+    public string? EntityEtag
+    {
+        get => _entityEtag is null ? null : $"\"{_entityEtag.Replace("\"", "")}\"";
+        set => _entityEtag = value;
+    }
+    private string? _entityEtag;
+
+    /// <summary>
+    /// Computed extension fields. Populated only when sync=true.
+    /// </summary>
+    public Dictionary<string, object>? Extensions { get; set; }
+}

--- a/src/BBT.Workflow.Domain/Instances/DTOs/TransitionOutput.cs
+++ b/src/BBT.Workflow.Domain/Instances/DTOs/TransitionOutput.cs
@@ -1,52 +1,9 @@
-using System.Text.Json;
-
 namespace BBT.Workflow.Instances;
 
 /// <summary>
 /// Output from a transition execution containing the instance ID and current status.
 /// </summary>
-public sealed class TransitionOutput
+public sealed class TransitionOutput : InstanceOutputBase
 {
-    /// <summary>
-    /// The workflow instance identifier.
-    /// </summary>
-    public Guid Id { get; set; }
-
-    public string? Key { get; set; }
-
-    /// <summary>
-    /// Instance status (Active, Busy, Completed, etc.)
-    /// </summary>
-    public InstanceStatus? Status { get; set; }
-
-    /// <summary>
-    /// Instance attributes filtered by master-schema role grants. Populated only when sync=true.
-    /// </summary>
-    public JsonElement? Attributes { get; set; }
-
-    /// <summary>
-    /// Representation ETag (SHA256 of canonical response JSON), returned with quotes per RFC 7232. Populated only when sync=true.
-    /// </summary>
-    public string? ETag
-    {
-        get => _etag is null ? null : $"\"{_etag.Replace("\"", "")}\"";
-        set => _etag = value;
-    }
-    private string? _etag;
-
-    /// <summary>
-    /// Entity (DB row) version for concurrency, returned with quotes per RFC 7232. Populated only when sync=true.
-    /// </summary>
-    public string? EntityEtag
-    {
-        get => _entityEtag is null ? null : $"\"{_entityEtag.Replace("\"", "")}\"";
-        set => _entityEtag = value;
-    }
-    private string? _entityEtag;
-
-    /// <summary>
-    /// Computed extension fields. Populated only when sync=true.
-    /// </summary>
-    public Dictionary<string, object>? Extensions { get; set; }
 }
 

--- a/src/BBT.Workflow.Domain/Instances/DTOs/TransitionOutput.cs
+++ b/src/BBT.Workflow.Domain/Instances/DTOs/TransitionOutput.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 namespace BBT.Workflow.Instances;
 
 /// <summary>
@@ -9,10 +11,42 @@ public sealed class TransitionOutput
     /// The workflow instance identifier.
     /// </summary>
     public Guid Id { get; set; }
-    
+
+    public string? Key { get; set; }
+
     /// <summary>
     /// Instance status (Active, Busy, Completed, etc.)
     /// </summary>
     public InstanceStatus? Status { get; set; }
+
+    /// <summary>
+    /// Instance attributes filtered by master-schema role grants. Populated only when sync=true.
+    /// </summary>
+    public JsonElement? Attributes { get; set; }
+
+    /// <summary>
+    /// Representation ETag (SHA256 of canonical response JSON), returned with quotes per RFC 7232. Populated only when sync=true.
+    /// </summary>
+    public string? ETag
+    {
+        get => _etag is null ? null : $"\"{_etag.Replace("\"", "")}\"";
+        set => _etag = value;
+    }
+    private string? _etag;
+
+    /// <summary>
+    /// Entity (DB row) version for concurrency, returned with quotes per RFC 7232. Populated only when sync=true.
+    /// </summary>
+    public string? EntityEtag
+    {
+        get => _entityEtag is null ? null : $"\"{_entityEtag.Replace("\"", "")}\"";
+        set => _entityEtag = value;
+    }
+    private string? _entityEtag;
+
+    /// <summary>
+    /// Computed extension fields. Populated only when sync=true.
+    /// </summary>
+    public Dictionary<string, object>? Extensions { get; set; }
 }
 

--- a/src/BBT.Workflow.Domain/Instances/InstanceTask.cs
+++ b/src/BBT.Workflow.Domain/Instances/InstanceTask.cs
@@ -27,6 +27,7 @@ public sealed class InstanceTask : Entity<Guid>
         BusinessStatus = BusinessStatus.Unknown;
         Request = new JsonData("");
         Response = new JsonData("");
+        InvocationResult = new JsonData("");
     }
 
     /// <summary>
@@ -75,12 +76,29 @@ public sealed class InstanceTask : Entity<Guid>
     public JsonData Response { get; private set; }
 
     /// <summary>
+    /// Raw invocation result captured after InvokeAsync, before output mapping (ProcessOutput).
+    /// Stores TaskInvocationResult as-is: Body, Data, StatusCode, Headers, Metadata, ErrorMessage.
+    /// Remains empty if the task never reached the invocation step (e.g., infra error before invoke).
+    /// </summary>
+    public JsonData InvocationResult { get; private set; }
+
+    /// <summary>
     /// Sets the request payload that was sent to the task.
     /// </summary>
     /// <param name="request">The request data from InputHandler.</param>
     public void SetRequest(JsonData request)
     {
         Request = request;
+    }
+
+    /// <summary>
+    /// Sets the raw invocation result before output mapping.
+    /// Called after InvokeAsync succeeds, before ProcessOutputAsync transforms the data.
+    /// </summary>
+    /// <param name="invocationResult">The serialized TaskInvocationResult.</param>
+    public void SetInvocationResult(JsonData invocationResult)
+    {
+        InvocationResult = invocationResult;
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Domain/Tasks/Executors/Core/TaskExecutorContext.cs
+++ b/src/BBT.Workflow.Domain/Tasks/Executors/Core/TaskExecutorContext.cs
@@ -28,5 +28,11 @@ public sealed record TaskExecutorContext(
     /// Holds the input handler response for auditing purposes.
     /// </summary>
     public ScriptResponse? InputResponse { get; set; }
+
+    /// <summary>
+    /// Holds the raw invocation result as serialized JSON, captured after InvokeAsync
+    /// and before output mapping (ProcessOutputAsync). Null if invocation never ran.
+    /// </summary>
+    public string? RawInvocationResultJson { get; set; }
 }
 

--- a/src/BBT.Workflow.Infrastructure/Data/InstancesModelCreatingExtensions.cs
+++ b/src/BBT.Workflow.Infrastructure/Data/InstancesModelCreatingExtensions.cs
@@ -222,6 +222,14 @@ public static class InstancesModelCreatingExtensions
                     .HasColumnName(nameof(InstanceTask.Response));
             });
 
+            b.OwnsOne(p => p.InvocationResult, d =>
+            {
+                d.Ignore(g => g.JsonElement);
+                d.Property(g => g.Json)
+                    .HasColumnType("jsonb")
+                    .HasColumnName(nameof(InstanceTask.InvocationResult));
+            });
+
             b.HasOne<InstanceTransition>()
                 .WithMany()
                 .HasForeignKey(p => p.TransitionId)

--- a/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceCommandAppService.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceCommandAppService.cs
@@ -55,6 +55,14 @@ public sealed class RemoteInstanceCommandAppService(
                 queryParams.Add($"version={Uri.EscapeDataString(input.Version)}");
             if (input.Sync)
                 queryParams.Add($"sync={input.Sync}");
+            
+            if (input.Extensions?.Length > 0)
+            {
+                foreach (var ext in input.Extensions)
+                {
+                    queryParams.Add($"extensions={Uri.EscapeDataString(ext)}");
+                }
+            }
 
             if (queryParams.Count > 0)
                 relativePath += "?" + string.Join("&", queryParams);
@@ -120,6 +128,14 @@ public sealed class RemoteInstanceCommandAppService(
                 queryParams.Add($"sync={input.Sync}");
 
             queryParams.Add("strictIdempotency=true");
+            
+            if (input.Extensions?.Length > 0)
+            {
+                foreach (var ext in input.Extensions)
+                {
+                    queryParams.Add($"extensions={Uri.EscapeDataString(ext)}");
+                }
+            }
 
             if (queryParams.Count > 0)
                 relativePath += "?" + string.Join("&", queryParams);
@@ -187,6 +203,14 @@ public sealed class RemoteInstanceCommandAppService(
             var queryParams = new List<string>();
             if (input.Sync)
                 queryParams.Add("sync=true");
+            
+            if (input.Extensions?.Length > 0)
+            {
+                foreach (var ext in input.Extensions)
+                {
+                    queryParams.Add($"extensions={Uri.EscapeDataString(ext)}");
+                }
+            }
 
             if (queryParams.Count > 0)
                 relativePath += "?" + string.Join("&", queryParams);

--- a/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceQueryAppService.cs
@@ -214,9 +214,9 @@ public sealed class RemoteInstanceQueryAppService(
                 queryParams.Add($"version={Uri.EscapeDataString(input.Version)}");
             }
 
-            if (input.Extension?.Length > 0)
+            if (input.Extensions?.Length > 0)
             {
-                foreach (var ext in input.Extension)
+                foreach (var ext in input.Extensions)
                 {
                     queryParams.Add($"extensions={Uri.EscapeDataString(ext)}");
                 }

--- a/src/BBT.Workflow.Infrastructure/Migrations/20260315214122_AddInstanceTask_InvocationResult.Designer.cs
+++ b/src/BBT.Workflow.Infrastructure/Migrations/20260315214122_AddInstanceTask_InvocationResult.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using BBT.Workflow.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BBT.Workflow.Migrations
 {
     [DbContext(typeof(WorkflowDbContext))]
-    partial class WorkflowDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260315214122_AddInstanceTask_InvocationResult")]
+    partial class AddInstanceTask_InvocationResult
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/BBT.Workflow.Infrastructure/Migrations/20260315214122_AddInstanceTask_InvocationResult.cs
+++ b/src/BBT.Workflow.Infrastructure/Migrations/20260315214122_AddInstanceTask_InvocationResult.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BBT.Workflow.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInstanceTask_InvocationResult : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "InvocationResult",
+                table: "InstanceTasks",
+                type: "jsonb",
+                nullable: false,
+                defaultValue: "{}");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "InvocationResult",
+                table: "InstanceTasks");
+        }
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/Scripting/DynamicHelperFunctionsTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Scripting/DynamicHelperFunctionsTests.cs
@@ -1,0 +1,505 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Workflow.Monitoring;
+using BBT.Workflow.Runtime;
+using BBT.Workflow.Scripting.Functions;
+using Dapr.Client;
+using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace BBT.Workflow.Scripting;
+
+/// <summary>
+/// Tests for dynamic data helper functions available via <see cref="ScriptBase"/>.
+/// Verifies collection helpers (ListFilter, ListFirst, ListLast, ListAny, ListCount,
+/// ListSelect, ListAdd, ListRemove) and object helpers (CreateObject, CreateList,
+/// SetProperty, RemoveProperty, ToDictionary, AsList, GetList) used inside scripts
+/// to work with Instance.Data dynamic values.
+/// </summary>
+[Collection("ScriptingTests")]
+public class DynamicHelperFunctionsTests : ApplicationTestBase<ApplicationEntryPoint>
+{
+    private readonly IScriptEngine _scriptEngine;
+
+    public DynamicHelperFunctionsTests()
+    {
+        _scriptEngine = GetRequiredService<IScriptEngine>();
+    }
+
+    protected override void AddApplication(IServiceCollection services)
+    {
+        var mockDaprClient = new Mock<DaprClient>();
+        mockDaprClient
+            .Setup(x => x.GetSecretAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyDictionary<string, string>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, string>());
+
+        services.AddSingleton(mockDaprClient.Object);
+
+        var mockLogger = new Mock<ILogger<ScriptServices>>();
+        services.AddSingleton(mockLogger.Object);
+
+        var mockConfiguration = new Mock<Microsoft.Extensions.Configuration.IConfiguration>();
+        services.AddSingleton(mockConfiguration.Object);
+
+        var mockMetrics = new Mock<IWorkflowMetrics>();
+        services.AddSingleton(mockMetrics.Object);
+
+        base.AddApplication(services);
+    }
+
+    /// <summary>
+    /// Compiles a script body and returns its mapping instance along with a minimal context.
+    /// Test data is created inside the script body using CreateList/CreateObject/SetProperty helpers.
+    /// </summary>
+    private async Task<(IMapping mapping, ScriptContext context)> BuildScriptAsync(string scriptBody)
+    {
+        var code = $$"""
+                     using System;
+                     using System.Collections.Generic;
+                     using System.Threading.Tasks;
+                     using BBT.Workflow.Scripting;
+                     using BBT.Workflow.Definitions;
+                     using BBT.Workflow.Scripting.Functions;
+
+                     public class TestMapping : ScriptBase, IMapping
+                     {
+                         public Task<ScriptResponse> InputHandler(WorkflowTask task, ScriptContext context)
+                         {
+                             {{scriptBody}}
+                         }
+
+                         public Task<ScriptResponse> OutputHandler(ScriptContext context)
+                             => Task.FromResult(new ScriptResponse { Data = null });
+                     }
+                     """;
+
+        var references = new List<MetadataReference>
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(IMapping).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(ScriptBase).Assembly.Location)
+        };
+
+        var usings = new[]
+        {
+            "System",
+            "System.Collections.Generic",
+            "System.Threading.Tasks",
+            "BBT.Workflow.Scripting",
+            "BBT.Workflow.Definitions",
+            "BBT.Workflow.Scripting.Functions"
+        };
+
+        var mapping = await _scriptEngine.CompileToInstanceAsync<IMapping>(code, references, usings);
+
+        var context = new ScriptContext.Builder(Mock.Of<ILogger<ScriptContext>>())
+            .SetWorkflow(WorkflowFactory.CreateDefault())
+            .SetInstance(InstanceFactory.CreateDefault())
+            .SetTransition(TransitionFactory.CreateDefault())
+            .SetRuntime(Mock.Of<IRuntimeInfoProvider>())
+            .SetDefinitions(new Dictionary<string, object>())
+            .Build();
+
+        return (mapping, context);
+    }
+
+    // ── Helper: builds a List<object?> with 3 items (id: 1/2/3, status: active/inactive/active)
+    // Used inline inside script bodies via CreateList/CreateObject/SetProperty/ListAdd helpers.
+    private const string ThreeItemListScript = """
+        var items = CreateList();
+        dynamic i1 = CreateObject(); SetProperty(i1, "id", "1"); SetProperty(i1, "status", "active");   ListAdd(items, i1);
+        dynamic i2 = CreateObject(); SetProperty(i2, "id", "2"); SetProperty(i2, "status", "inactive"); ListAdd(items, i2);
+        dynamic i3 = CreateObject(); SetProperty(i3, "id", "3"); SetProperty(i3, "status", "active");   ListAdd(items, i3);
+        """;
+
+    #region AsList / GetList
+
+    [Fact]
+    public async Task AsList_Should_Return_Empty_List_For_Null()
+    {
+        var (mapping, context) = await BuildScriptAsync(
+            """
+            var list = AsList(null);
+            return Task.FromResult(new ScriptResponse { Data = list.Count });
+            """);
+
+        var response = await mapping.InputHandler(WorkflowTaskFactory.CreateHttpTask(), context);
+
+        Assert.Equal(0, (int)response.Data);
+    }
+
+    [Fact]
+    public async Task AsList_Should_Return_Same_List_When_Already_List()
+    {
+        var (mapping, context) = await BuildScriptAsync(
+            $$"""
+            var original = CreateList();
+            ListAdd(original, "x");
+            var casted = AsList(original);
+            return Task.FromResult(new ScriptResponse { Data = casted.Count });
+            """);
+
+        var response = await mapping.InputHandler(WorkflowTaskFactory.CreateHttpTask(), context);
+
+        Assert.Equal(1, (int)response.Data);
+    }
+
+    [Fact]
+    public async Task GetList_Should_Return_Named_List_Property()
+    {
+        var (mapping, context) = await BuildScriptAsync(
+            $$"""
+            {{ThreeItemListScript}}
+            dynamic data = CreateObject();
+            SetProperty(data, "items", items);
+            var result = GetList(data, "items");
+            return Task.FromResult(new ScriptResponse { Data = result.Count });
+            """);
+
+        var response = await mapping.InputHandler(WorkflowTaskFactory.CreateHttpTask(), context);
+
+        Assert.Equal(3, (int)response.Data);
+    }
+
+    [Fact]
+    public async Task GetList_Should_Return_Empty_List_For_Missing_Property()
+    {
+        var (mapping, context) = await BuildScriptAsync(
+            """
+            dynamic data = CreateObject();
+            var result = GetList(data, "nonExistent");
+            return Task.FromResult(new ScriptResponse { Data = result.Count });
+            """);
+
+        var response = await mapping.InputHandler(WorkflowTaskFactory.CreateHttpTask(), context);
+
+        Assert.Equal(0, (int)response.Data);
+    }
+
+    #endregion
+
+    #region ListFilter
+
+    [Fact]
+    public async Task ListFilter_Should_Return_Only_Matching_Items()
+    {
+        var (mapping, context) = await BuildScriptAsync(
+            $$"""
+            {{ThreeItemListScript}}
+            var active = ListFilter(items, x => (string)x.status == "active");
+            return Task.FromResult(new ScriptResponse { Data = active.Count });
+            """);
+
+        var response = await mapping.InputHandler(WorkflowTaskFactory.CreateHttpTask(), context);
+
+        Assert.Equal(2, (int)response.Data);
+    }
+
+    [Fact]
+    public async Task ListFilter_Should_Return_Empty_List_When_No_Match()
+    {
+        var (mapping, context) = await BuildScriptAsync(
+            $$"""
+            {{ThreeItemListScript}}
+            var deleted = ListFilter(items, x => (string)x.status == "deleted");
+            return Task.FromResult(new ScriptResponse { Data = deleted.Count });
+            """);
+
+        var response = await mapping.InputHandler(WorkflowTaskFactory.CreateHttpTask(), context);
+
+        Assert.Equal(0, (int)response.Data);
+    }
+
+    #endregion
+
+    #region ListFirst / ListLast
+
+    [Fact]
+    public async Task ListFirst_Without_Predicate_Should_Return_First_Item()
+    {
+        var (mapping, context) = await BuildScriptAsync(
+            $$"""
+            {{ThreeItemListScript}}
+            var first = ListFirst(items);
+            return Task.FromResult(new ScriptResponse { Data = (string)first.id });
+            """);
+
+        var response = await mapping.InputHandler(WorkflowTaskFactory.CreateHttpTask(), context);
+
+        Assert.Equal("1", (string)response.Data);
+    }
+
+    [Fact]
+    public async Task ListFirst_With_Predicate_Should_Return_First_Matching_Item()
+    {
+        var (mapping, context) = await BuildScriptAsync(
+            $$"""
+            {{ThreeItemListScript}}
+            var first = ListFirst(items, x => (string)x.status == "inactive");
+            return Task.FromResult(new ScriptResponse { Data = (string)first.id });
+            """);
+
+        var response = await mapping.InputHandler(WorkflowTaskFactory.CreateHttpTask(), context);
+
+        Assert.Equal("2", (string)response.Data);
+    }
+
+    [Fact]
+    public async Task ListFirst_Should_Return_Null_When_No_Match()
+    {
+        var (mapping, context) = await BuildScriptAsync(
+            $$"""
+            {{ThreeItemListScript}}
+            var item = ListFirst(items, x => (string)x.status == "deleted");
+            return Task.FromResult(new ScriptResponse { Data = item == null });
+            """);
+
+        var response = await mapping.InputHandler(WorkflowTaskFactory.CreateHttpTask(), context);
+
+        Assert.True((bool)response.Data);
+    }
+
+    [Fact]
+    public async Task ListLast_With_Predicate_Should_Return_Last_Matching_Item()
+    {
+        var (mapping, context) = await BuildScriptAsync(
+            $$"""
+            {{ThreeItemListScript}}
+            var last = ListLast(items, x => (string)x.status == "active");
+            return Task.FromResult(new ScriptResponse { Data = (string)last.id });
+            """);
+
+        var response = await mapping.InputHandler(WorkflowTaskFactory.CreateHttpTask(), context);
+
+        Assert.Equal("3", (string)response.Data);
+    }
+
+    #endregion
+
+    #region ListAny / ListCount
+
+    [Fact]
+    public async Task ListAny_Without_Predicate_Should_Return_True_When_List_Has_Items()
+    {
+        var (mapping, context) = await BuildScriptAsync(
+            $$"""
+            {{ThreeItemListScript}}
+            var hasItems = ListAny(items);
+            return Task.FromResult(new ScriptResponse { Data = hasItems });
+            """);
+
+        var response = await mapping.InputHandler(WorkflowTaskFactory.CreateHttpTask(), context);
+
+        Assert.True((bool)response.Data);
+    }
+
+    [Fact]
+    public async Task ListAny_With_Predicate_Should_Return_False_When_No_Match()
+    {
+        var (mapping, context) = await BuildScriptAsync(
+            $$"""
+            {{ThreeItemListScript}}
+            var hasDeleted = ListAny(items, x => (string)x.status == "deleted");
+            return Task.FromResult(new ScriptResponse { Data = hasDeleted });
+            """);
+
+        var response = await mapping.InputHandler(WorkflowTaskFactory.CreateHttpTask(), context);
+
+        Assert.False((bool)response.Data);
+    }
+
+    [Fact]
+    public async Task ListCount_Without_Predicate_Should_Return_Total_Count()
+    {
+        var (mapping, context) = await BuildScriptAsync(
+            $$"""
+            {{ThreeItemListScript}}
+            var count = ListCount(items);
+            return Task.FromResult(new ScriptResponse { Data = count });
+            """);
+
+        var response = await mapping.InputHandler(WorkflowTaskFactory.CreateHttpTask(), context);
+
+        Assert.Equal(3, (int)response.Data);
+    }
+
+    [Fact]
+    public async Task ListCount_With_Predicate_Should_Return_Filtered_Count()
+    {
+        var (mapping, context) = await BuildScriptAsync(
+            $$"""
+            {{ThreeItemListScript}}
+            var count = ListCount(items, x => (string)x.status == "active");
+            return Task.FromResult(new ScriptResponse { Data = count });
+            """);
+
+        var response = await mapping.InputHandler(WorkflowTaskFactory.CreateHttpTask(), context);
+
+        Assert.Equal(2, (int)response.Data);
+    }
+
+    #endregion
+
+    #region ListSelect
+
+    [Fact]
+    public async Task ListSelect_Should_Project_Property_From_Each_Item()
+    {
+        var (mapping, context) = await BuildScriptAsync(
+            $$"""
+            {{ThreeItemListScript}}
+            var ids = ListSelect<string>(items, x => (string)x.id);
+            return Task.FromResult(new ScriptResponse { Data = string.Join(",", ids) });
+            """);
+
+        var response = await mapping.InputHandler(WorkflowTaskFactory.CreateHttpTask(), context);
+
+        Assert.Equal("1,2,3", (string)response.Data);
+    }
+
+    #endregion
+
+    #region ListAdd / ListRemove
+
+    [Fact]
+    public async Task ListAdd_Should_Increase_List_Count()
+    {
+        var (mapping, context) = await BuildScriptAsync(
+            $$"""
+            {{ThreeItemListScript}}
+            dynamic newItem = CreateObject();
+            SetProperty(newItem, "id", "4");
+            SetProperty(newItem, "status", "active");
+            ListAdd(items, newItem);
+            return Task.FromResult(new ScriptResponse { Data = items.Count });
+            """);
+
+        var response = await mapping.InputHandler(WorkflowTaskFactory.CreateHttpTask(), context);
+
+        Assert.Equal(4, (int)response.Data);
+    }
+
+    [Fact]
+    public async Task ListRemove_Should_Remove_Matching_Items_And_Return_Removed_Count()
+    {
+        var (mapping, context) = await BuildScriptAsync(
+            $$"""
+            {{ThreeItemListScript}}
+            var removed = ListRemove(items, x => (string)x.status == "inactive");
+            return Task.FromResult(new ScriptResponse { Data = removed });
+            """);
+
+        var response = await mapping.InputHandler(WorkflowTaskFactory.CreateHttpTask(), context);
+
+        Assert.Equal(1, (int)response.Data);
+    }
+
+    [Fact]
+    public async Task ListRemove_Should_Leave_Non_Matching_Items_In_List()
+    {
+        var (mapping, context) = await BuildScriptAsync(
+            $$"""
+            {{ThreeItemListScript}}
+            ListRemove(items, x => (string)x.status == "inactive");
+            return Task.FromResult(new ScriptResponse { Data = items.Count });
+            """);
+
+        var response = await mapping.InputHandler(WorkflowTaskFactory.CreateHttpTask(), context);
+
+        Assert.Equal(2, (int)response.Data);
+    }
+
+    #endregion
+
+    #region CreateObject / CreateList / SetProperty / RemoveProperty / ToDictionary
+
+    [Fact]
+    public async Task CreateObject_And_SetProperty_Should_Allow_Reading_Back_Value()
+    {
+        var (mapping, context) = await BuildScriptAsync(
+            """
+            dynamic obj = CreateObject();
+            SetProperty(obj, "name", "test-value");
+            return Task.FromResult(new ScriptResponse { Data = (string)obj.name });
+            """);
+
+        var response = await mapping.InputHandler(WorkflowTaskFactory.CreateHttpTask(), context);
+
+        Assert.Equal("test-value", (string)response.Data);
+    }
+
+    [Fact]
+    public async Task CreateList_Should_Return_New_Empty_List()
+    {
+        var (mapping, context) = await BuildScriptAsync(
+            """
+            var list = CreateList();
+            return Task.FromResult(new ScriptResponse { Data = list.Count });
+            """);
+
+        var response = await mapping.InputHandler(WorkflowTaskFactory.CreateHttpTask(), context);
+
+        Assert.Equal(0, (int)response.Data);
+    }
+
+    [Fact]
+    public async Task RemoveProperty_Should_Remove_Existing_Property_And_Return_True()
+    {
+        var (mapping, context) = await BuildScriptAsync(
+            """
+            dynamic obj = CreateObject();
+            SetProperty(obj, "tempField", "temporary");
+            SetProperty(obj, "name", "keep");
+            var removed = RemoveProperty(obj, "tempField");
+            return Task.FromResult(new ScriptResponse { Data = removed });
+            """);
+
+        var response = await mapping.InputHandler(WorkflowTaskFactory.CreateHttpTask(), context);
+
+        Assert.True((bool)response.Data);
+    }
+
+    [Fact]
+    public async Task RemoveProperty_Should_Return_False_For_Nonexistent_Property()
+    {
+        var (mapping, context) = await BuildScriptAsync(
+            """
+            dynamic obj = CreateObject();
+            SetProperty(obj, "name", "test");
+            var removed = RemoveProperty(obj, "nonExistent");
+            return Task.FromResult(new ScriptResponse { Data = removed });
+            """);
+
+        var response = await mapping.InputHandler(WorkflowTaskFactory.CreateHttpTask(), context);
+
+        Assert.False((bool)response.Data);
+    }
+
+    [Fact]
+    public async Task ToDictionary_Should_Contain_All_Set_Properties()
+    {
+        var (mapping, context) = await BuildScriptAsync(
+            """
+            dynamic obj = CreateObject();
+            SetProperty(obj, "name", "test");
+            SetProperty(obj, "value", 42);
+            var dict = ToDictionary(obj);
+            return Task.FromResult(new ScriptResponse { Data = dict.ContainsKey("name") && dict.ContainsKey("value") });
+            """);
+
+        var response = await mapping.InputHandler(WorkflowTaskFactory.CreateHttpTask(), context);
+
+        Assert.True((bool)response.Data);
+    }
+
+    #endregion
+}

--- a/workers/BBT.Workflow.DbMigrator/appsettings.json
+++ b/workers/BBT.Workflow.DbMigrator/appsettings.json
@@ -1,7 +1,7 @@
 {
   "ApplicationName": "vnext-db-migrator",
   "ConnectionStrings": {
-    "Default": "Host=localhost;Port=5432;Database=vNext_MorphIdm;Username=postgres;Password=postgres;"
+    "Default": "Host=localhost;Port=5432;Database=Aether_WorkflowDb;Username=postgres;Password=postgres;"
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
## Summary
Support returning mapped instance data in the start and transition response when using synchronous flows (`sync=true`).

## Changes
- **Domain**: Introduce `InstanceOutputBase` as shared base for instance operation responses; `StartInstanceOutput` and `TransitionOutput` now inherit from it (Id, Key, Status, Attributes, ETag, EntityEtag, Extensions).
- **Application**: Add `Extensions` support in `StartInstanceInput` and `TransitionInput` so callers can request which extension data to evaluate and include in the sync response.
- **Application/Infrastructure**: Command and query app services (local and remote) populate full instance data (attributes, ETag, entityEtag, extensions) when `sync=true`.
- **API**: InstanceController updated to pass through sync and extension options.
- **Scripting**: Updates in `ScriptBase`; add `DynamicHelperFunctionsTests`.
- **Chore**: `.gitignore` entries for Claude/Cursor; add `CLAUDE.md`, `.claudeignore`, `.cursorignore` for AI/tooling.

## Related
Closes #393 (or references issue #393).

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Support enriched synchronous instance start and transition responses with schema-filtered attributes, ETags, and extensions, and add dynamic scripting helpers and tests.

New Features:
- Allow callers to request extension evaluation in synchronous start and transition operations via new Extensions options on inputs and API endpoints.
- Return enriched instance data (key, schema-filtered attributes, representation ETag, entity ETag, and computed extensions) in sync=true start and transition responses using a shared InstanceOutputBase DTO.
- Introduce dynamic collection and object helper functions in ScriptBase for easier manipulation of Instance.Data in scripts.

Enhancements:
- Extract schema field-level visibility logic into a reusable ISchemaFieldFilterService and wire it into command/query services for consistent attribute filtering.
- Propagate requested extensions through remote instance command/query services and HTTP controllers via a standardized extensions query parameter.

Documentation:
- Add CLAUDE.md and related ignore files to document project architecture, workflows, and AI/tooling guidance.

Tests:
- Add DynamicHelperFunctionsTests to cover the new ScriptBase dynamic helper functions end-to-end.

Chores:
- Update .gitignore and add .claudeignore/.cursorignore entries for AI and editor tooling artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support passing multiple extensions for instance start/transition/retrieval (query params).
  * Capture and persist raw task invocation results for richer diagnostics.

* **Refactor**
  * Standardized instance operation outputs with a shared base (consistent ETag/entity metadata).
  * Consolidated field-level schema filtering into a reusable service for authorized visibility.

* **Tests**
  * Added extensive tests for dynamic scripting helper functions.

* **Documentation**
  * Added tooling and usage documentation for AI/code assistants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->