### PR TITLE
feat(subflow): add role/timeout overrides and fix authorize/state routing for SubFlow

### DIFF
--- a/src/BBT.Workflow.Application/Authorization/AuthorizeAppService.cs
+++ b/src/BBT.Workflow.Application/Authorization/AuthorizeAppService.cs
@@ -85,10 +85,52 @@ public sealed class AuthorizeAppService(
 
         var wf = workflowResult.Value!;
 
-        // When instance has active subflow, forward authorize to subflow instance (local or remote via gateway)
+        // When instance has active subflow, distinguish parent-owned vs SubFlow-owned requests
         if (instance?.Subflow != null)
         {
             var subflow = instance.Subflow;
+            var parentState = wf.FindState(instance.CurrentState!);
+            var subFlowConfig = parentState?.SubFlow;
+
+            // transitionKey: parent-owned (shared/cancel/updateData/exit) → evaluate locally against parent workflow
+            if (!string.IsNullOrWhiteSpace(transitionKey))
+            {
+                if (IsParentOwnedTransition(wf, transitionKey))
+                {
+                    var parentCallerRoles = GetCallerRoles(role);
+                    var parentAllowed = await EvaluateAuthorizeAsync(wf, parentCallerRoles, transitionKey, null, instance, false, domain, workflowVersion, cancellationToken);
+                    logger.AuthorizeRequest(domain, workflow, role, parentAllowed);
+                    return Result<AuthorizeOutput>.Ok(new AuthorizeOutput { Allowed = parentAllowed });
+                }
+
+                // SubFlow-owned transition: check override first, then forward
+                if (subFlowConfig?.HasTransitionRoleOverrides == true &&
+                    subFlowConfig.Overrides!.Transitions!.TryGetValue(transitionKey, out var transitionOverride) &&
+                    transitionOverride.Roles is { Count: > 0 })
+                {
+                    var overrideCallerRoles = GetCallerRoles(role);
+                    var overrideAllowed = await EvaluateWithGrantsAsync(overrideCallerRoles, transitionOverride.Roles!, instance, cancellationToken);
+                    logger.AuthorizeRequest(domain, workflow, role, overrideAllowed);
+                    return Result<AuthorizeOutput>.Ok(new AuthorizeOutput { Allowed = overrideAllowed });
+                }
+            }
+            // checkQueryRoles: check state override first, then forward
+            else if (checkQueryRoles)
+            {
+                var subFlowCurrentState = subflow.SubFlowCurrentState;
+                if (subFlowConfig?.HasQueryRoleOverrides == true &&
+                    !string.IsNullOrWhiteSpace(subFlowCurrentState) &&
+                    subFlowConfig.Overrides!.States!.TryGetValue(subFlowCurrentState, out var stateOverride) &&
+                    stateOverride.QueryRoles is { Count: > 0 })
+                {
+                    var overrideCallerRoles = GetCallerRoles(role);
+                    var overrideAllowed = await EvaluateWithGrantsAsync(overrideCallerRoles, stateOverride.QueryRoles!, instance, cancellationToken);
+                    logger.AuthorizeRequest(domain, workflow, role, overrideAllowed);
+                    return Result<AuthorizeOutput>.Ok(new AuthorizeOutput { Allowed = overrideAllowed });
+                }
+            }
+
+            // Forward to SubFlow (functionKey, no-override transition, no-override queryRoles)
             var roleForForward = currentUser.Roles?.Length > 0 ? string.Join(",", currentUser.Roles) : role;
             return await authorizeGateway.GetAuthorizeResultForInstanceAsync(
                 subflow.SubFlowDomain,
@@ -190,6 +232,12 @@ public sealed class AuthorizeAppService(
     {
         runtimeInfoProvider.Check(domain);
 
+        var workflowVersion = NormalizeVersion(version);
+        var workflowResult = await componentCacheStore.GetFlowAsync(domain, workflow, workflowVersion, cancellationToken);
+        if (!workflowResult.IsSuccess)
+            return Result<AuthorizationMatrixOutput>.Fail(workflowResult.Error);
+        var wf = workflowResult.Value!;
+
         Instance? instance = null;
         var instanceResult = await instanceRepository.FindByIdentifierAsync(instanceId, cancellationToken);
         if (instanceResult is not null)
@@ -198,12 +246,53 @@ public sealed class AuthorizeAppService(
         if (instance?.Subflow != null)
         {
             var subflow = instance.Subflow;
-            return await authorizeGateway.GetAuthorizationMatrixForInstanceAsync(
+            var subFlowMatrixResult = await authorizeGateway.GetAuthorizationMatrixForInstanceAsync(
                 subflow.SubFlowDomain,
                 subflow.SubFlowName,
                 subflow.SubFlowInstanceId.ToString(),
                 version,
                 cancellationToken);
+
+            if (!subFlowMatrixResult.IsSuccess)
+                return subFlowMatrixResult;
+
+            var matrix = subFlowMatrixResult.Value!;
+            var parentState = wf.FindState(instance.CurrentState!);
+            var subFlowConfig = parentState?.SubFlow;
+
+            // Apply transition overrides from parent config (replace mode)
+            if (subFlowConfig?.HasTransitionRoleOverrides == true)
+            {
+                foreach (var t in matrix.Transitions)
+                {
+                    if (subFlowConfig.Overrides!.Transitions!.TryGetValue(t.Key, out var tOverride) &&
+                        tOverride.Roles is { Count: > 0 })
+                        t.Roles = ToRoleGrantDtos(tOverride.Roles!);
+                }
+            }
+
+            // Apply state queryRole overrides from parent config (replace mode)
+            if (subFlowConfig?.HasQueryRoleOverrides == true)
+            {
+                foreach (var s in matrix.States)
+                {
+                    if (subFlowConfig.Overrides!.States!.TryGetValue(s.Key, out var sOverride) &&
+                        sOverride.QueryRoles is { Count: > 0 })
+                        s.QueryRoles = ToRoleGrantDtos(sOverride.QueryRoles!);
+                }
+            }
+
+            // Merge parent-owned transitions (shared, cancel, updateData, exit) not already in SubFlow matrix
+            var existingTransitionKeys = new HashSet<string>(
+                matrix.Transitions.Select(t => t.Key), StringComparer.Ordinal);
+            foreach (var t in wf.SharedTransitions)
+                AddTransition(matrix.Transitions, existingTransitionKeys, t);
+            if (wf.Cancel != null) AddTransition(matrix.Transitions, existingTransitionKeys, wf.Cancel);
+            if (wf.UpdateData != null) AddTransition(matrix.Transitions, existingTransitionKeys, wf.UpdateData);
+            if (wf.Exit != null) AddTransition(matrix.Transitions, existingTransitionKeys, wf.Exit);
+
+            logger.AuthorizationMatrixRequest(domain, workflow);
+            return Result<AuthorizationMatrixOutput>.Ok(matrix);
         }
 
         return await GetAuthorizationMatrixAsync(domain, workflow, version, cancellationToken);
@@ -223,6 +312,16 @@ public sealed class AuthorizeAppService(
                 Roles = ToRoleGrantDtos(t.Roles)
             });
     }
+
+    /// <summary>
+    /// Returns true if the transition key belongs to the parent workflow's own transitions
+    /// (shared, cancel, updateData, exit) that should be evaluated locally regardless of active SubFlow.
+    /// </summary>
+    private static bool IsParentOwnedTransition(Definitions.Workflow wf, string transitionKey) =>
+        wf.SharedTransitions.Any(t => t.Key == transitionKey) ||
+        wf.Cancel?.Key == transitionKey ||
+        wf.UpdateData?.Key == transitionKey ||
+        wf.Exit?.Key == transitionKey;
 
     /// <summary>Maps role grants to DTOs; returns empty list when none (schema consistency).</summary>
     private static List<RoleGrantDto> ToRoleGrantDtos(IReadOnlyCollection<RoleGrant> roles)
@@ -282,7 +381,7 @@ public sealed class AuthorizeAppService(
         CancellationToken cancellationToken)
     {
         if (callerRoles is null || callerRoles.Count == 0)
-            return false;
+            return await EvaluateAuthorizeForSingleRoleAsync(workflow, null, transitionKey, functionKey, instance, checkQueryRoles, domain, workflowVersion, cancellationToken);
 
         foreach (var role in callerRoles)
         {
@@ -297,7 +396,7 @@ public sealed class AuthorizeAppService(
 
     private async Task<bool> EvaluateAuthorizeForSingleRoleAsync(
         Definitions.Workflow workflow,
-        string role,
+        string? role,
         string? transitionKey,
         string? functionKey,
         Instance? instance,
@@ -331,12 +430,34 @@ public sealed class AuthorizeAppService(
     }
 
     /// <summary>
+    /// Evaluates a list of role grants against the caller roles (multi-role: any allowed → allow).
+    /// Used to apply SubFlow override grants locally without forwarding to the SubFlow.
+    /// </summary>
+    private async Task<bool> EvaluateWithGrantsAsync(
+        IReadOnlyList<string>? callerRoles,
+        IReadOnlyCollection<RoleGrant> grants,
+        Instance instance,
+        CancellationToken cancellationToken)
+    {
+        if (callerRoles is null || callerRoles.Count == 0)
+            return false;
+        foreach (var r in callerRoles)
+        {
+            if (string.IsNullOrWhiteSpace(r))
+                continue;
+            if (await transitionAuthorizationManager.IsRoleAllowedForGrantsAsync(r, grants, instance, cancellationToken))
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
     /// Evaluates state-based query roles: instance effective state → state queryRoles or workflow root queryRoles.
     /// Resolves predefined instance roles ($InstanceStarter, $PreviousUser) when instance is present. DENY wins, else ALLOW.
     /// </summary>
     private async Task<bool> EvaluateQueryRolesAsync(
         Definitions.Workflow workflow,
-        string role,
+        string? role,
         Instance? instance,
         CancellationToken cancellationToken)
     {

--- a/src/BBT.Workflow.Application/Authorization/ITransitionAuthorizationManager.cs
+++ b/src/BBT.Workflow.Application/Authorization/ITransitionAuthorizationManager.cs
@@ -13,30 +13,32 @@ public interface ITransitionAuthorizationManager
     /// <summary>
     /// Evaluates whether the given role is allowed for the transition using transition.Roles.
     /// When instance is present, predefined roles ($InstanceStarter, $PreviousUser) are resolved and matched against current user.
+    /// When role is null, only predefined role grants are evaluated (via ICurrentUser.ActorUserName); regular role grants yield no match.
     /// DENY always wins; if no DENY match, any ALLOW match yields true.
     /// </summary>
     /// <param name="workflow">The workflow definition (for context).</param>
     /// <param name="transition">The transition whose Roles are evaluated.</param>
     /// <param name="instance">Optional instance for resolving $InstanceStarter and $PreviousUser.</param>
-    /// <param name="role">The caller's role to check.</param>
+    /// <param name="role">The caller's role to check. Null is allowed; predefined roles are still evaluated.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>True if the role is allowed for the transition; false otherwise.</returns>
     Task<bool> IsTransitionAllowedForRoleAsync(
         WorkflowDefinition workflow,
         Transition transition,
         Instance? instance,
-        string role,
+        string? role,
         CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Filters a list of transition keys to only those allowed for the given role.
     /// Uses the same evaluation as <see cref="IsTransitionAllowedForRoleAsync"/> per transition.
+    /// When role is null, only predefined role grants ($InstanceStarter, $PreviousUser) are evaluated; transitions with no roles pass through.
     /// </summary>
     /// <param name="workflow">The workflow definition.</param>
     /// <param name="currentState">Current state (used to resolve transition by key via workflow context).</param>
     /// <param name="instance">Optional instance for predefined role resolution.</param>
     /// <param name="transitionKeys">Candidate transition keys to filter.</param>
-    /// <param name="role">The caller's role.</param>
+    /// <param name="role">The caller's role. Null is allowed; predefined roles are still evaluated.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>List of transition keys that are allowed for the role.</returns>
     Task<IReadOnlyList<string>> FilterAuthorizedTransitionKeysAsync(
@@ -44,16 +46,17 @@ public interface ITransitionAuthorizationManager
         State currentState,
         Instance? instance,
         IReadOnlyList<string> transitionKeys,
-        string role,
+        string? role,
         CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Evaluates whether the given role is allowed for a set of role grants (e.g. function or state queryRoles).
     /// When instance is present, predefined roles ($InstanceStarter, $PreviousUser) are resolved.
+    /// When role is null, only predefined role grants are evaluated.
     /// DENY always wins; if no DENY match, any ALLOW match yields true.
     /// </summary>
     Task<bool> IsRoleAllowedForGrantsAsync(
-        string role,
+        string? role,
         IReadOnlyCollection<RoleGrant> roleGrants,
         Instance? instance,
         CancellationToken cancellationToken = default);

--- a/src/BBT.Workflow.Application/Authorization/TransitionAuthorizationManager.cs
+++ b/src/BBT.Workflow.Application/Authorization/TransitionAuthorizationManager.cs
@@ -18,12 +18,9 @@ public sealed class TransitionAuthorizationManager(
         WorkflowDefinition workflow,
         Transition transition,
         Instance? instance,
-        string role,
+        string? role,
         CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(role))
-            return false;
-
         var roleGrants = transition.Roles;
         if (roleGrants.Count == 0)
             return true; // No roles defined → allow
@@ -40,10 +37,10 @@ public sealed class TransitionAuthorizationManager(
         State currentState,
         Instance? instance,
         IReadOnlyList<string> transitionKeys,
-        string role,
+        string? role,
         CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(role) || transitionKeys.Count == 0)
+        if (transitionKeys.Count == 0)
             return transitionKeys;
 
         var result = new List<string>();
@@ -61,13 +58,11 @@ public sealed class TransitionAuthorizationManager(
 
     /// <inheritdoc />
     public async Task<bool> IsRoleAllowedForGrantsAsync(
-        string role,
+        string? role,
         IReadOnlyCollection<RoleGrant> roleGrants,
         Instance? instance,
         CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(role))
-            return false;
         if (roleGrants.Count == 0)
             return true; // No roles defined → allow
         if (instance != null)
@@ -104,14 +99,15 @@ public sealed class TransitionAuthorizationManager(
 
     /// <summary>
     /// Evaluates role grants with resolution of predefined instance roles ($InstanceStarter, $PreviousUser).
+    /// When role is null, only predefined role grants are evaluated (via ICurrentUser.ActorUserName); regular role grants yield no match.
     /// </summary>
     private async Task<bool> EvaluateRolesWithPredefinedAsync(
-        string role,
+        string? role,
         IReadOnlyCollection<RoleGrant> roleGrants,
         Instance instance,
         CancellationToken cancellationToken)
     {
-        var normalizedRole = role.Trim();
+        var normalizedRole = role?.Trim() ?? string.Empty;
         var currentActorUserName = currentUser.ActorUserName?.Trim();
 
         string? previousUserCreatedBy = null;
@@ -151,13 +147,14 @@ public sealed class TransitionAuthorizationManager(
 
     /// <summary>
     /// Evaluates role against role grants (static only). DENY always wins; else any ALLOW match → true.
+    /// When role is null, no regular role grants match; only the grant count check applies (empty grants → allow).
     /// Used by transition/function authorization and by schema field-level visibility.
     /// </summary>
-    public static bool EvaluateRolesStatic(string role, IReadOnlyCollection<RoleGrant> roleGrants)
+    public static bool EvaluateRolesStatic(string? role, IReadOnlyCollection<RoleGrant> roleGrants)
     {
         if (roleGrants.Count == 0)
             return true; // No roles defined → allow
-        var normalizedRole = role.Trim();
+        var normalizedRole = role?.Trim() ?? string.Empty;
         foreach (var g in roleGrants)
         {
             if (string.Equals(g.Role, normalizedRole, StringComparison.OrdinalIgnoreCase) && g.IsDeny)

--- a/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
@@ -78,7 +78,7 @@ public sealed class InstanceCommandAppService(
         return await PrepareInstanceAsync(workflow, input, cancellationToken)
             .ThenAsync(async data =>
             {
-                await ScheduleWorkflowTimeoutIfConfiguredAsync(data.Workflow, data.Instance, cancellationToken);
+                await ScheduleWorkflowTimeoutIfConfiguredAsync(data.Workflow, data.Instance, input.Instance.ExtraProperties, cancellationToken);
                 return Result<(Definitions.Workflow Workflow, Instance Instance)>.Ok(data);
             })
             .ThenAsync(data => ExecuteStartTransitionAsync(data, input, cancellationToken))
@@ -293,14 +293,26 @@ public sealed class InstanceCommandAppService(
 
     /// <summary>
     /// Schedules a workflow timeout job if the workflow has a timeout configuration.
+    /// When extraProperties contains a timeout override (set by SubflowStarter), it takes precedence over the workflow's own timeout.
     /// </summary>
     private async Task ScheduleWorkflowTimeoutIfConfiguredAsync(
         Definitions.Workflow workflow,
         Instance instance,
+        ExtraPropertyDictionary extraProperties,
         CancellationToken cancellationToken)
     {
-        // Check if workflow has timeout configuration
-        if (workflow.Timeout == null)
+        // Check for SubFlow timeout override in ExtraProperties
+        WorkflowTimeout? timeoutOverride = null;
+        if (extraProperties.TryGetValue(DomainConsts.MetaDataKeys.TimeoutOverride, out var overrideJson)
+            && !string.IsNullOrWhiteSpace(overrideJson?.ToString()))
+        {
+            timeoutOverride = JsonSerializer.Deserialize<WorkflowTimeout>(overrideJson!.ToString()!);
+        }
+
+        var effectiveTimeout = timeoutOverride ?? workflow.Timeout;
+
+        // Check if there is any timeout configuration to schedule
+        if (effectiveTimeout == null)
         {
             return;
         }
@@ -321,7 +333,7 @@ public sealed class InstanceCommandAppService(
             };
 
             // Parse ISO 8601 duration string to TimeSpan
-            var timeoutDuration = System.Xml.XmlConvert.ToTimeSpan(workflow.Timeout.Timer.Duration);
+            var timeoutDuration = System.Xml.XmlConvert.ToTimeSpan(effectiveTimeout.Timer.Duration);
 
             // Calculate timeout schedule - workflow timeout should be evaluated from creation time
             var timeoutDateTime = DateTime.UtcNow.Add(timeoutDuration);
@@ -357,7 +369,7 @@ public sealed class InstanceCommandAppService(
                 true,
                 cancellationToken);
 
-            logger.WorkflowTimeoutScheduled(instance.Id, workflow.Timeout.Timer.Duration, timeoutDateTime);
+            logger.WorkflowTimeoutScheduled(instance.Id, effectiveTimeout.Timer.Duration, timeoutDateTime);
         }
         catch (Exception ex)
         {

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -306,7 +306,7 @@ public sealed class InstanceQueryAppService(
                 subFlowInput,
                 cancellationToken);
 
-            if (subFlowResult.Result.IsSuccess && subFlowResult.Result.Value != null)
+            if (subFlowResult.Result is { IsSuccess: true, Value: not null })
             {
                 var subFlowValue = subFlowResult.Result.Value;
 
@@ -481,11 +481,11 @@ public sealed class InstanceQueryAppService(
     {
         runtimeInfoProvider.Check(input.Domain);
 
-        // Railway chain: Load Flow → Get Instance → Match to ConditionalResult
-        return await componentCacheStore.GetFlowAsync(input.Domain, input.Workflow, null, cancellationToken)
-            .BindAsync(workflow =>
-                GetInstanceByIdOrKeyAsync(input.Instance, cancellationToken)
-                    .MapAsync(instance => (flow: workflow, instance)))
+        // Railway chain: Get Instance → Load Flow (using instance.FlowVersion) → Match to ConditionalResult
+        return await GetInstanceByIdOrKeyAsync(input.Instance, cancellationToken)
+            .BindAsync(instance =>
+                componentCacheStore.GetFlowAsync(input.Domain, input.Workflow, instance.FlowVersion, cancellationToken)
+                    .MapAsync(workflow => (flow: workflow, instance)))
             .MatchAsync(
                 onSuccess: async data =>
                 {
@@ -603,7 +603,7 @@ public sealed class InstanceQueryAppService(
 
         return await GetInstanceByIdOrKeyAsync(input.Instance, cancellationToken)
             .BindAsync(instance =>
-                componentCacheStore.GetFlowAsync(input.Domain, input.Workflow, input.Version, cancellationToken)
+                componentCacheStore.GetFlowAsync(input.Domain, input.Workflow, instance.FlowVersion ?? input.Version, cancellationToken)
                     .MapAsync(workflow => (instance, workflow)))
             .MatchAsync(
                 onSuccess: async data =>
@@ -656,13 +656,75 @@ public sealed class InstanceQueryAppService(
                 Error.NotFound("notfound", $"State {instance.CurrentState} not found in workflow {input.Workflow}"));
         if (!stateResult.IsSuccess)
             return Result<GetInstanceStateOutput>.Fail(stateResult.Error);
-
+        
         var currentStateValue = stateResult.Value!;
         var keysForTransitions = subFlowStateInfo.AvailableTransitions;
-        if (!string.IsNullOrWhiteSpace(input.Role))
-            keysForTransitions = (await transitionAuthorizationManager.FilterAuthorizedTransitionKeysAsync(
-                    currentWorkflow, currentStateValue, instance, keysForTransitions, input.Role!, cancellationToken))
-                .ToList();
+        {
+            // Always evaluate authorization: predefined roles ($InstanceStarter, $PreviousUser) are checked via
+            // ICurrentUser.ActorUserName regardless of whether a role parameter was supplied.
+            // When this instance was started as a SubFlow with parent-defined transition overrides,
+            // apply combined filtering: parent override grants for overridden transitions,
+            // own role filtering for non-overridden transitions.
+            var parentTransitionOverrides = TryGetParentTransitionRoleOverrides(instance);
+            if (parentTransitionOverrides is { Count: > 0 })
+            {
+                var filteredKeys = new List<string>();
+                foreach (var key in keysForTransitions)
+                {
+                    if (parentTransitionOverrides.TryGetValue(key, out var tOverride) &&
+                        tOverride.Roles is { Count: > 0 })
+                    {
+                        // Parent override (replace mode): use parent-defined grants
+                        var allowed = await transitionAuthorizationManager
+                            .IsRoleAllowedForGrantsAsync(input.Role, tOverride.Roles!, instance, cancellationToken);
+                        if (allowed) filteredKeys.Add(key);
+                    }
+                    else
+                    {
+                        // No parent override: if the transition belongs to this workflow, apply own role filtering.
+                        // If not found (e.g. it came from a deeper SubFlow like C), pass through — already filtered by C.
+                        var ownTransition = currentWorkflow.FindTransitionInContext(key);
+                        if (ownTransition != null)
+                        {
+                            var result = await transitionAuthorizationManager.FilterAuthorizedTransitionKeysAsync(
+                                currentWorkflow, currentStateValue, instance, [key], input.Role, cancellationToken);
+                            filteredKeys.AddRange(result);
+                        }
+                        else
+                        {
+                            filteredKeys.Add(key);
+                        }
+                    }
+                }
+                keysForTransitions = filteredKeys;
+            }
+            else if (activeSubFlowCorrelation != null)
+            {
+                // Parent context with active SubFlow:
+                // SubFlow transitions are already correctly role-filtered by the SubFlow itself.
+                // Only apply parent-level filtering to parent-added shared transitions.
+                var subFlowTransitionKeys = subFlowStateInfo.SubFlowTransitionItems?
+                    .Select(t => t.Name).ToHashSet(StringComparer.Ordinal) ?? [];
+                var parentSharedKeys = keysForTransitions
+                    .Where(k => !subFlowTransitionKeys.Contains(k))
+                    .ToList();
+                var filteredParentSharedKeys = parentSharedKeys.Count > 0
+                    ? (await transitionAuthorizationManager.FilterAuthorizedTransitionKeysAsync(
+                            currentWorkflow, currentStateValue, instance, parentSharedKeys, input.Role, cancellationToken))
+                      .ToList()
+                    : parentSharedKeys;
+                keysForTransitions = keysForTransitions
+                    .Where(k => subFlowTransitionKeys.Contains(k))
+                    .Concat(filteredParentSharedKeys)
+                    .ToList();
+            }
+            else
+            {
+                keysForTransitions = (await transitionAuthorizationManager.FilterAuthorizedTransitionKeysAsync(
+                        currentWorkflow, currentStateValue, instance, keysForTransitions, input.Role, cancellationToken))
+                    .ToList();
+            }
+        }
 
         List<TransitionItem> transitionItems;
         if (subFlowStateInfo.SubFlowTransitionItems != null)
@@ -670,28 +732,43 @@ public sealed class InstanceQueryAppService(
             var subFlowItemsByName =
                 subFlowStateInfo.SubFlowTransitionItems.ToDictionary(t => t.Name, StringComparer.Ordinal);
             transitionItems = keysForTransitions
-                .Select(key => (Key: key, SubFlowItem: subFlowItemsByName.GetValueOrDefault(key)))
-                .Where(t => t.SubFlowItem is not null)
-                .Select(t => new TransitionItem
+                .Select(key =>
                 {
-                    Name = t.Key,
-                    Href = urlTemplateBuilder.BuildTransitionUrl(input.Domain, input.Workflow,
-                        instance.Id.ToString(),
-                        t.Key),
-                    View = new ViewHref
+                    var subFlowItem = subFlowItemsByName.GetValueOrDefault(key);
+                    bool hasView, loadData, hasSchema;
+                    if (subFlowItem != null)
                     {
-                        Href = urlTemplateBuilder.BuildViewUrl(input.Domain, input.Workflow, instance.Id.ToString(),
-                            t.Key),
-                        HasView = t.SubFlowItem!.View?.HasView ?? false,
-                        LoadData = t.SubFlowItem.View?.LoadData ?? false,
-                    },
-                    Schema = new SchemaHref
-                    {
-                        Href = urlTemplateBuilder.BuildSchemaUrl(input.Domain, input.Workflow,
-                            instance.Id.ToString(),
-                            t.Key),
-                        HasSchema = t.SubFlowItem.Schema?.HasSchema ?? false
+                        hasView = subFlowItem.View?.HasView ?? false;
+                        loadData = subFlowItem.View?.LoadData ?? false;
+                        hasSchema = subFlowItem.Schema?.HasSchema ?? false;
                     }
+                    else
+                    {
+                        // Parent-owned transition (e.g., shared transition not from SubFlow): resolve from parent workflow
+                        var transition = currentWorkflow.ResolveTransition(key, currentStateValue);
+                        hasView = transition?.View is { Views.Count: > 0 };
+                        loadData = false;
+                        hasSchema = transition?.Schema != null;
+                    }
+                    return new TransitionItem
+                    {
+                        Name = key,
+                        Href = urlTemplateBuilder.BuildTransitionUrl(input.Domain, input.Workflow,
+                            instance.Id.ToString(), key),
+                        View = new ViewHref
+                        {
+                            Href = urlTemplateBuilder.BuildViewUrl(input.Domain, input.Workflow,
+                                instance.Id.ToString(), key),
+                            HasView = hasView,
+                            LoadData = loadData,
+                        },
+                        Schema = new SchemaHref
+                        {
+                            Href = urlTemplateBuilder.BuildSchemaUrl(input.Domain, input.Workflow,
+                                instance.Id.ToString(), key),
+                            HasSchema = hasSchema
+                        }
+                    };
                 })
                 .ToList();
         }
@@ -816,7 +893,7 @@ public sealed class InstanceQueryAppService(
         // Railway chain: Get Instance → Get Workflow → Resolve State → Get View
         return await GetInstanceByIdOrKeyAsync(input.Instance, cancellationToken)
             .BindAsync(instance =>
-                componentCacheStore.GetFlowAsync(input.Domain, input.Workflow, input.Version, cancellationToken)
+                componentCacheStore.GetFlowAsync(input.Domain, input.Workflow, instance.FlowVersion ?? input.Version, cancellationToken)
                     .MapAsync(workflow => (instance, workflow)))
             .ThenAsync(data =>
                 ResolveViewAsync(data.instance, data.workflow, input, transitionKey, cancellationToken));
@@ -839,7 +916,7 @@ public sealed class InstanceQueryAppService(
         // Railway chain: Get Instance → Get Workflow → Build Schema Output
         return await GetInstanceByIdOrKeyAsync(input.Instance, cancellationToken)
             .BindAsync(instance =>
-                componentCacheStore.GetFlowAsync(input.Domain, input.Workflow, input.Version, cancellationToken)
+                componentCacheStore.GetFlowAsync(input.Domain, input.Workflow, instance.FlowVersion ?? input.Version, cancellationToken)
                     .MapAsync(workflow => (instance, workflow)))
             .ThenAsync(data =>
                 BuildSchemaOutputAsync(data.instance, data.workflow, input, transitionKey, cancellationToken));
@@ -860,7 +937,7 @@ public sealed class InstanceQueryAppService(
         // Railway chain: Get Instance → Get Workflow → Build Extensions Output
         return await GetInstanceByIdOrKeyAsync(input.Instance, cancellationToken)
             .BindAsync(instance =>
-                componentCacheStore.GetFlowAsync(input.Domain, input.Workflow, input.Version, cancellationToken)
+                componentCacheStore.GetFlowAsync(input.Domain, input.Workflow, instance.FlowVersion ?? input.Version, cancellationToken)
                     .MapAsync(workflow => (instance, workflow)))
             .ThenAsync(data =>
                 BuildExtensionsOutputAsync(data.instance, data.workflow, input, cancellationToken));
@@ -1176,9 +1253,10 @@ public sealed class InstanceQueryAppService(
         }
 
         // If current state has view overrides, resolve override view (local or remote) via service
+        // EffectiveViewOverrides: overrides.views takes precedence over legacy viewOverrides
         if (currentState.SubFlow!.HasViewOverrides)
         {
-            var overrideViewRef = currentState.SubFlow!.ViewOverrides!.GetOrDefault(subFlowViewResult.Value!.Key);
+            var overrideViewRef = currentState.SubFlow!.EffectiveViewOverrides!.GetOrDefault(subFlowViewResult.Value!.Key);
 
             if (overrideViewRef != null)
             {
@@ -1214,7 +1292,7 @@ public sealed class InstanceQueryAppService(
         }
 
         var instance = instanceResult.Value!;
-        var flowResult = await componentCacheStore.GetFlowAsync(input.Domain, input.Workflow, null, cancellationToken);
+        var flowResult = await componentCacheStore.GetFlowAsync(input.Domain, input.Workflow, instance.FlowVersion, cancellationToken);
         var flowVersion = flowResult.IsSuccess ? flowResult.Value?.Version : null;
 
         var rootNode = new InstanceHierarchyNode
@@ -1319,4 +1397,15 @@ public sealed class InstanceQueryAppService(
         ViewHref? SubFlowView = null,
         List<ActiveCorrelationHref>? SubFlowActiveCorrelations = null,
         List<TransitionItem>? SubFlowTransitionItems = null);
+
+    private static Dictionary<string, SubFlowTransitionOverride>? TryGetParentTransitionRoleOverrides(Instance instance)
+    {
+        if (!instance.ExtraProperties.TryGetValue(DomainConsts.MetaDataKeys.TransitionRoleOverrides, out var raw) ||
+            raw is null)
+            return null;
+        var json = raw.ToString();
+        if (string.IsNullOrWhiteSpace(json))
+            return null;
+        return JsonSerializer.Deserialize<Dictionary<string, SubFlowTransitionOverride>>(json);
+    }
 }

--- a/src/BBT.Workflow.Application/SubFlow/Services/SubflowStarter.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubflowStarter.cs
@@ -60,6 +60,8 @@ public sealed class SubflowStarter(
             correlation,
             subFlowConfig.Type.Code,
             inputMappingResult,
+            subFlowConfig.HasTimeoutOverride ? subFlowConfig.Overrides!.Timeout : null,
+            subFlowConfig.Overrides,
             cancellationToken);
     }
 
@@ -83,6 +85,8 @@ public sealed class SubflowStarter(
             correlation,
             subFlowType,
             inputMappingResult,
+            null, // no timeout override for task-triggered sub-processes
+            null, // no role overrides for task-triggered sub-processes
             cancellationToken);
     }
 
@@ -99,6 +103,8 @@ public sealed class SubflowStarter(
         InstanceCorrelation correlation,
         string subFlowTypeCode,
         ScriptResponse? inputMappingResult,
+        WorkflowTimeout? timeoutOverride,
+        Definitions.SubFlowOverrides? overrides,
         CancellationToken cancellationToken)
     {
         using var activity = SubFlowActivityHelper.StartActivity($"SubFlow.Start/{subFlowReference.Domain}/{subFlowReference.Key}");
@@ -145,6 +151,26 @@ public sealed class SubflowStarter(
                     [DomainConsts.MetaDataKeys.FlowType] = subFlowTypeCode
                 }
             };
+
+            // Apply timeout override from SubFlow config if present
+            if (timeoutOverride != null)
+            {
+                createInstanceInput.ExtraProperties[DomainConsts.MetaDataKeys.TimeoutOverride] =
+                    JsonSerializer.Serialize(timeoutOverride);
+            }
+
+            // Serialize parent-defined role overrides (transitions + states) for SubFlow to use during state queries.
+            // views are excluded as they are hosted/resolved on the parent side.
+            if (overrides?.Transitions is { Count: > 0 })
+            {
+                createInstanceInput.ExtraProperties[DomainConsts.MetaDataKeys.TransitionRoleOverrides] =
+                    JsonSerializer.Serialize(overrides.Transitions);
+            }
+            if (overrides?.States is { Count: > 0 })
+            {
+                createInstanceInput.ExtraProperties[DomainConsts.MetaDataKeys.StateRoleOverrides] =
+                    JsonSerializer.Serialize(overrides.States);
+            }
 
             // Apply additional properties from input mapping if available
             if (inputMappingResult != null)

--- a/src/BBT.Workflow.Domain/Definitions/SubFlow.cs
+++ b/src/BBT.Workflow.Domain/Definitions/SubFlow.cs
@@ -13,25 +13,63 @@ public sealed class SubFlow
         SubFlowType type,
         Reference process,
         ScriptCode mapping,
-        Dictionary<string, Reference>? viewOverrides)
+        Dictionary<string, Reference>? viewOverrides,
+        SubFlowOverrides? overrides = null)
     {
         Type = type;
         Process = process;
         Mapping = mapping;
         ViewOverrides = viewOverrides;
+        Overrides = overrides;
     }
 
     public SubFlowType Type { get; private set; }
     public Reference Process { get; private set; }
     public ScriptCode Mapping { get; private set; }
+
+    /// <summary>
+    /// Legacy view overrides. Kept for backward compatibility.
+    /// When Overrides.Views is also set, Overrides.Views takes precedence.
+    /// </summary>
     public Dictionary<string, Reference>? ViewOverrides { get; private set; }
-    
+
+    /// <summary>
+    /// Unified override configuration for this SubFlow state.
+    /// Supports views, transition roles, query roles, and timeout overrides (all replace mode).
+    /// </summary>
+    [JsonInclude]
+    [JsonPropertyName("overrides")]
+    public SubFlowOverrides? Overrides { get; private set; }
+
+    /// <summary>
+    /// Returns true if any view override is configured (either legacy ViewOverrides or Overrides.Views).
+    /// </summary>
     [NotMapped]
     [JsonIgnore]
-    public bool HasViewOverrides => this.ViewOverrides != null;
+    public bool HasViewOverrides => Overrides?.Views != null || ViewOverrides != null;
 
-    public static SubFlow Create(string type, IReference reference, ScriptCode mapping, Dictionary<string, Reference>? viewOverrides)
+    /// <summary>
+    /// Effective view overrides dictionary: Overrides.Views takes precedence over ViewOverrides.
+    /// </summary>
+    [NotMapped]
+    [JsonIgnore]
+    public Dictionary<string, Reference>? EffectiveViewOverrides => Overrides?.Views ?? ViewOverrides;
+
+    [NotMapped]
+    [JsonIgnore]
+    public bool HasTransitionRoleOverrides => Overrides?.Transitions is { Count: > 0 };
+
+    [NotMapped]
+    [JsonIgnore]
+    public bool HasQueryRoleOverrides => Overrides?.States is { Count: > 0 };
+
+    [NotMapped]
+    [JsonIgnore]
+    public bool HasTimeoutOverride => Overrides?.Timeout != null;
+
+    public static SubFlow Create(string type, IReference reference, ScriptCode mapping, Dictionary<string, Reference>? viewOverrides,
+        SubFlowOverrides? overrides = null)
     {
-        return new SubFlow(SubFlowType.FromCode(type), reference.ToReference(), mapping, viewOverrides);
+        return new SubFlow(SubFlowType.FromCode(type), reference.ToReference(), mapping, viewOverrides, overrides);
     }
 }

--- a/src/BBT.Workflow.Domain/Definitions/SubFlowOverrides.cs
+++ b/src/BBT.Workflow.Domain/Definitions/SubFlowOverrides.cs
@@ -1,0 +1,66 @@
+using System.Text.Json.Serialization;
+
+namespace BBT.Workflow.Definitions;
+
+/// <summary>
+/// Defines parent-level overrides for a SubFlow state.
+/// All overrides operate in replace mode: when an override is present, the SubFlow's own configuration
+/// is completely ignored for that specific entry.
+/// </summary>
+public sealed class SubFlowOverrides
+{
+    private SubFlowOverrides()
+    {
+    }
+
+    [JsonConstructor]
+    private SubFlowOverrides(
+        Dictionary<string, Reference>? views,
+        Dictionary<string, SubFlowTransitionOverride>? transitions,
+        Dictionary<string, SubFlowStateOverride>? states,
+        WorkflowTimeout? timeout)
+    {
+        Views = views;
+        Transitions = transitions;
+        States = states;
+        Timeout = timeout;
+    }
+
+    /// <summary>
+    /// View overrides: key = SubFlow view key, value = override Reference.
+    /// Takes precedence over SubFlow.ViewOverrides when both are set.
+    /// </summary>
+    [JsonInclude]
+    [JsonPropertyName("views")]
+    public Dictionary<string, Reference>? Views { get; private set; }
+
+    /// <summary>
+    /// Transition overrides: key = SubFlow transition key, value = per-transition override config.
+    /// Replace mode: when present, the SubFlow's own transition configuration is ignored for that transition.
+    /// </summary>
+    [JsonInclude]
+    [JsonPropertyName("transitions")]
+    public Dictionary<string, SubFlowTransitionOverride>? Transitions { get; private set; }
+
+    /// <summary>
+    /// State overrides: key = SubFlow state key, value = per-state override config.
+    /// Replace mode: when present, the SubFlow's own state configuration is ignored for that state.
+    /// </summary>
+    [JsonInclude]
+    [JsonPropertyName("states")]
+    public Dictionary<string, SubFlowStateOverride>? States { get; private set; }
+
+    /// <summary>
+    /// Timeout override: when set, replaces the SubFlow's own workflow-level timeout configuration.
+    /// </summary>
+    [JsonInclude]
+    [JsonPropertyName("timeout")]
+    public WorkflowTimeout? Timeout { get; private set; }
+
+    public static SubFlowOverrides Create(
+        Dictionary<string, Reference>? views = null,
+        Dictionary<string, SubFlowTransitionOverride>? transitions = null,
+        Dictionary<string, SubFlowStateOverride>? states = null,
+        WorkflowTimeout? timeout = null)
+        => new(views, transitions, states, timeout);
+}

--- a/src/BBT.Workflow.Domain/Definitions/SubFlowStateOverride.cs
+++ b/src/BBT.Workflow.Domain/Definitions/SubFlowStateOverride.cs
@@ -1,0 +1,29 @@
+using System.Text.Json.Serialization;
+
+namespace BBT.Workflow.Definitions;
+
+/// <summary>
+/// Per-state override configuration for a SubFlow state.
+/// Replace mode: when present, the SubFlow's own state configuration is ignored for that state.
+/// </summary>
+public sealed class SubFlowStateOverride
+{
+    private SubFlowStateOverride()
+    {
+    }
+
+    [JsonConstructor]
+    private SubFlowStateOverride(List<RoleGrant>? queryRoles)
+    {
+        QueryRoles = queryRoles;
+    }
+
+    /// <summary>
+    /// State query role overrides (replace mode). DENY always overrides ALLOW.
+    /// </summary>
+    [JsonInclude]
+    [JsonPropertyName("queryRoles")]
+    public List<RoleGrant>? QueryRoles { get; private set; }
+
+    public static SubFlowStateOverride Create(List<RoleGrant>? queryRoles = null) => new(queryRoles);
+}

--- a/src/BBT.Workflow.Domain/Definitions/SubFlowTransitionOverride.cs
+++ b/src/BBT.Workflow.Domain/Definitions/SubFlowTransitionOverride.cs
@@ -1,0 +1,29 @@
+using System.Text.Json.Serialization;
+
+namespace BBT.Workflow.Definitions;
+
+/// <summary>
+/// Per-transition override configuration for a SubFlow state.
+/// Replace mode: when present, the SubFlow's own transition configuration is ignored for that transition.
+/// </summary>
+public sealed class SubFlowTransitionOverride
+{
+    private SubFlowTransitionOverride()
+    {
+    }
+
+    [JsonConstructor]
+    private SubFlowTransitionOverride(List<RoleGrant>? roles)
+    {
+        Roles = roles;
+    }
+
+    /// <summary>
+    /// Transition role overrides (replace mode). DENY always overrides ALLOW.
+    /// </summary>
+    [JsonInclude]
+    [JsonPropertyName("roles")]
+    public List<RoleGrant>? Roles { get; private set; }
+
+    public static SubFlowTransitionOverride Create(List<RoleGrant>? roles = null) => new(roles);
+}

--- a/src/BBT.Workflow.Domain/DomainConsts.cs
+++ b/src/BBT.Workflow.Domain/DomainConsts.cs
@@ -16,5 +16,8 @@ public class DomainConsts
         public const string Transition = "parent.transition";
         public const string Sync = "sync";
         public const string Callback = "callback";
+        public const string TimeoutOverride = "subflow.timeout_override";
+        public const string TransitionRoleOverrides = "subflow.transition_role_overrides";
+        public const string StateRoleOverrides = "subflow.state_role_overrides";
     }
 }


### PR DESCRIPTION
## Summary

- **New domain types**: `SubFlowOverrides`, `SubFlowTransitionOverride`, `SubFlowStateOverride` — unified override configuration (transitions, states, views, timeout) attached to a SubFlow state definition
- **Authorize function refactoring**: parent-owned transitions (shared/cancel/updateData/exit) are now evaluated locally instead of being blindly forwarded to SubFlow; SubFlow-owned transitions check parent override grants first; `permissions` function merges parent shared transitions into the SubFlow matrix with overrides applied
- **Null role support**: `EvaluateAuthorizeAsync` and `ITransitionAuthorizationManager` now handle null/empty caller roles — transitions with no role grants allow through; predefined roles (`$InstanceStarter`, `$PreviousUser`) are evaluated via `ICurrentUser.ActorUserName` regardless of role parameter
- **State function fixes**: role guard removed so authorization always runs; nested SubFlow (A→B→C) transitions pass through correctly without being dropped; parent-owned shared transitions in `transitionItems` fall back to parent workflow resolution instead of being silently filtered
- **FlowVersion consistency**: all `GetFlowAsync` calls in `InstanceQueryAppService` now use `instance.FlowVersion` when an instance is available

## Test plan

- [ ] Transition with no role grants, no caller role → allowed
- [ ] Transition with `$InstanceStarter: ALLOW`, no role param, caller is instance creator → allowed
- [ ] Transition with regular role grant, no caller role → denied
- [ ] SubFlow active, authorize on parent shared transition → evaluated locally (not forwarded)
- [ ] SubFlow active, authorize on SubFlow transition with parent override → override grants applied
- [ ] SubFlow active, authorize on SubFlow transition without override → forwarded to SubFlow
- [ ] SubFlow active, `queryRoles` with state override → override applied locally
- [ ] `permissions` with SubFlow active → parent shared transitions visible, override roles applied
- [ ] Nested SubFlow (A→B→C): state function on B returns B's shared + C's transitions (no transitions dropped)
- [ ] `GetFlowAsync` uses `instance.FlowVersion` across state/view/schema/extensions/hierarchy endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add unified SubFlow override configuration and enhance authorization and timeout handling for SubFlow-driven workflows while ensuring instance-specific FlowVersion is consistently used.

New Features:
- Introduce SubFlowOverrides, SubFlowTransitionOverride, and SubFlowStateOverride domain types to configure parent-level overrides for SubFlow views, transitions, states, and timeouts.
- Allow SubFlow definitions to carry consolidated override metadata, including timeout overrides, that can be passed into SubFlow instances via ExtraProperties.

Bug Fixes:
- Ensure authorization is always evaluated for instance state transitions, including when no explicit role is provided, and correctly handles predefined roles for SubFlows.
- Fix SubFlow state/view/authorization routing so parent-owned transitions are evaluated in the parent workflow, SubFlow overrides are honored, and nested SubFlow transitions are no longer dropped.
- Make all instance-related flow queries consistently use the instance.FlowVersion (with fallback to requested version) across data, state, view, schema, and hierarchy endpoints to avoid version mismatches.

Enhancements:
- Extend authorization logic and transition filtering to support nullable roles and to evaluate predefined instance roles even when no role is supplied.
- Enrich the authorization matrix for instances with active SubFlows by applying parent-specified overrides and merging parent-owned transitions into the SubFlow matrix.
- Preserve backward compatibility for legacy SubFlow view overrides while giving precedence to the new unified overrides model.
- Improve SubFlow transition item construction so parent-owned shared transitions are resolved from the parent workflow rather than being filtered out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for parent workflow overrides of SubFlow timeouts, transition role authorizations, and state query role authorizations.
  * Enhanced authorization handling to support more flexible role evaluation in SubFlow contexts.

* **Improvements**
  * Improved SubFlow transition filtering and authorization evaluation when parent-level overrides are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->