### PR TITLE
fix(instance-state): return Busy during subflow completion propagation window

### DIFF
--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -645,10 +645,34 @@ public sealed class InstanceQueryAppService(
             .OrderByDescending(c => c.CorrelationId)
             .FirstOrDefault();
 
-        var subFlowStateInfo = activeSubFlowCorrelation != null
-            ? await GetSubFlowTransitionsAsync(activeSubFlowCorrelation, instance, currentWorkflow, input.Extensions,
-                input.Headers, input.QueryParams, input.Role, cancellationToken)
-            : GetMainFlowTransitions(instance, currentWorkflow, transitionInfo);
+        SubFlowStateInfo subFlowStateInfo;
+        if (activeSubFlowCorrelation != null)
+        {
+            subFlowStateInfo = await GetSubFlowTransitionsAsync(
+                activeSubFlowCorrelation, instance, currentWorkflow,
+                input.Extensions, input.Headers, input.QueryParams,
+                input.Role, cancellationToken);
+
+            // Guard: SubFlow has reached a terminal status but the parent correlation is still
+            // open (IsCompleted=false) — we are in the propagation window.
+            // The parent is Busy handling the SubFlow completion; returning the SubFlow's terminal
+            // status would falsely signal to clients that the whole flow is done.
+            // Fall back to the parent's own state so the client receives Status=Busy and retries.
+            var sfStatus = subFlowStateInfo.Status;
+            var subFlowIsTerminal = sfStatus != null
+                && (sfStatus.Equals(InstanceStatus.Completed)
+                    || sfStatus.Equals(InstanceStatus.Faulted)
+                    || sfStatus.Equals(InstanceStatus.Passive));
+
+            if (subFlowIsTerminal)
+            {
+                subFlowStateInfo = GetMainFlowTransitions(instance, currentWorkflow, transitionInfo);
+            }
+        }
+        else
+        {
+            subFlowStateInfo = GetMainFlowTransitions(instance, currentWorkflow, transitionInfo);
+        }
 
         var stateResult = currentWorkflow.GetState(instance.CurrentState!)
             .Ensure(

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -40,6 +40,13 @@ public sealed class InstanceQueryAppService(
     ILogger<InstanceQueryAppService> logger)
     : ApplicationService(serviceProvider), IInstanceQueryAppService
 {
+    private static readonly HashSet<InstanceStatus> TerminalStatuses =
+    [
+        InstanceStatus.Completed,
+        InstanceStatus.Faulted,
+        InstanceStatus.Passive
+    ];
+    
     public async Task<ConditionalResult<GetInstanceOutput>> GetInstanceAsync(
         GetInstanceInput input,
         CancellationToken cancellationToken = default)
@@ -659,10 +666,7 @@ public sealed class InstanceQueryAppService(
             // status would falsely signal to clients that the whole flow is done.
             // Fall back to the parent's own state so the client receives Status=Busy and retries.
             var sfStatus = subFlowStateInfo.Status;
-            var subFlowIsTerminal = sfStatus != null
-                && (sfStatus.Equals(InstanceStatus.Completed)
-                    || sfStatus.Equals(InstanceStatus.Faulted)
-                    || sfStatus.Equals(InstanceStatus.Passive));
+            var subFlowIsTerminal = sfStatus is not null && TerminalStatuses.Contains(sfStatus);
 
             if (subFlowIsTerminal)
             {

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceStateTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceStateTests.cs
@@ -1,0 +1,302 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.DependencyInjection;
+using BBT.Aether.Results;
+using BBT.Aether.MultiSchema;
+using BBT.Aether.Uow;
+using BBT.Workflow.Authorization;
+using BBT.Workflow.Caching;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Gateway;
+using BBT.Workflow.Instances.DTOs;
+using BBT.Workflow.RepresentationEtag;
+using BBT.Workflow.Runtime;
+using BBT.Workflow.Scripting;
+using BBT.Workflow.Tasks.Coordinator;
+using BBT.Workflow.Extentions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Instances;
+
+/// <summary>
+/// Unit tests for InstanceQueryAppService.GetInstanceStateAsync.
+/// Focuses on the propagation window race condition fix:
+/// when a SubFlow reports a terminal status but the parent correlation is not yet marked
+/// as completed (IsCompleted=false), the parent must return its own Busy status
+/// instead of the SubFlow's terminal status.
+/// </summary>
+public class InstanceQueryAppServiceStateTests : IDisposable
+{
+    private readonly IRuntimeInfoProvider _runtimeInfoProvider;
+    private readonly IComponentCacheStore _componentCacheStore;
+    private readonly IInstanceRepository _instanceRepository;
+    private readonly IInstanceQueryGateway _instanceQueryGateway;
+    private readonly IRepresentationEtagService _representationEtagService;
+    private readonly IUrlTemplateBuilder _urlTemplateBuilder;
+    private readonly InstanceQueryAppService _service;
+    private readonly IServiceProvider _ambientServiceProvider;
+    private readonly IServiceProvider? _previousAmbientServiceProvider;
+
+    private const string TestDomain = "test-domain";
+    private const string TestWorkflow = "test-flow";
+    private const string TestVersion = "1.0.0";
+    private const string TestState = "review";
+
+    public InstanceQueryAppServiceStateTests()
+    {
+        _runtimeInfoProvider = Substitute.For<IRuntimeInfoProvider>();
+        _componentCacheStore = Substitute.For<IComponentCacheStore>();
+        _instanceRepository = Substitute.For<IInstanceRepository>();
+        _instanceQueryGateway = Substitute.For<IInstanceQueryGateway>();
+        _representationEtagService = Substitute.For<IRepresentationEtagService>();
+        _urlTemplateBuilder = Substitute.For<IUrlTemplateBuilder>();
+
+        // Set up AmbientServiceProvider.Current needed by PostSharp UnitOfWorkAttribute
+        var mockUoW = Substitute.For<IUnitOfWork>();
+        var mockUoWManager = Substitute.For<IUnitOfWorkManager>();
+        mockUoWManager
+            .BeginAsync(Arg.Any<UnitOfWorkOptions>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(mockUoW));
+
+        var services = new ServiceCollection();
+        services.AddSingleton(mockUoWManager);
+        _ambientServiceProvider = services.BuildServiceProvider();
+
+        _previousAmbientServiceProvider = AmbientServiceProvider.Current;
+        AmbientServiceProvider.Current = _ambientServiceProvider;
+
+        _service = new InstanceQueryAppService(
+            serviceProvider: _ambientServiceProvider,
+            runtimeInfoProvider: _runtimeInfoProvider,
+            componentCacheStore: _componentCacheStore,
+            instanceRepository: _instanceRepository,
+            instanceCorrelationRepository: Substitute.For<IInstanceCorrelationRepository>(),
+            instanceExtensionService: Substitute.For<IInstanceExtensionService>(),
+            scriptContextFactory: Substitute.For<IScriptContextFactory>(),
+            instanceQueryGateway: _instanceQueryGateway,
+            viewContentResolutionService: Substitute.For<IViewContentResolutionService>(),
+            taskConditionService: Substitute.For<ITaskConditionService>(),
+            urlTemplateBuilder: _urlTemplateBuilder,
+            currentSchema: Substitute.For<ICurrentSchema>(),
+            transitionAuthorizationManager: Substitute.For<ITransitionAuthorizationManager>(),
+            representationEtagService: _representationEtagService,
+            schemaFieldFilterService: Substitute.For<ISchemaFieldFilterService>(),
+            logger: Substitute.For<ILogger<InstanceQueryAppService>>());
+    }
+
+    public void Dispose()
+    {
+        AmbientServiceProvider.Current = _previousAmbientServiceProvider;
+        (_ambientServiceProvider as IDisposable)?.Dispose();
+    }
+
+    /// <summary>
+    /// Verifies the propagation window guard:
+    /// when the SubFlow reports Completed but the parent correlation IsCompleted=false,
+    /// the parent returns its own Busy status — not the SubFlow's Completed status.
+    /// </summary>
+    [Fact]
+    public async Task GetInstanceStateAsync_WhenSubFlowCompletedButCorrelationStillActive_ReturnsBusy()
+    {
+        // Arrange
+        var (instance, workflow) = CreateParentWithActiveSubFlow();
+        SetupCommonMocks(instance, workflow);
+        SetupSubFlowGateway(InstanceStatus.Completed, "done");
+
+        var input = CreateInput(instance.Id.ToString());
+
+        // Act
+        var result = await _service.GetInstanceStateAsync(input, CancellationToken.None);
+
+        // Assert
+        result.IsNotModified.ShouldBeFalse();
+        result.Result.IsSuccess.ShouldBeTrue();
+
+        var output = result.Result.Value!;
+        output.Status.ShouldBe(InstanceStatus.Busy);
+        output.State.ShouldBe(TestState);
+        output.Transitions.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// Same guard applies when SubFlow is Faulted — parent returns its own Busy status.
+    /// </summary>
+    [Fact]
+    public async Task GetInstanceStateAsync_WhenSubFlowFaultedButCorrelationStillActive_ReturnsBusy()
+    {
+        // Arrange
+        var (instance, workflow) = CreateParentWithActiveSubFlow();
+        SetupCommonMocks(instance, workflow);
+        SetupSubFlowGateway(InstanceStatus.Faulted, "error-state");
+
+        var input = CreateInput(instance.Id.ToString());
+
+        // Act
+        var result = await _service.GetInstanceStateAsync(input, CancellationToken.None);
+
+        // Assert
+        result.Result.IsSuccess.ShouldBeTrue();
+        result.Result.Value!.Status.ShouldBe(InstanceStatus.Busy);
+        result.Result.Value!.Transitions.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// Same guard applies when SubFlow is Passive — parent returns its own Busy status.
+    /// </summary>
+    [Fact]
+    public async Task GetInstanceStateAsync_WhenSubFlowPassiveButCorrelationStillActive_ReturnsBusy()
+    {
+        // Arrange
+        var (instance, workflow) = CreateParentWithActiveSubFlow();
+        SetupCommonMocks(instance, workflow);
+        SetupSubFlowGateway(InstanceStatus.Passive, "suspended");
+
+        var input = CreateInput(instance.Id.ToString());
+
+        // Act
+        var result = await _service.GetInstanceStateAsync(input, CancellationToken.None);
+
+        // Assert
+        result.Result.IsSuccess.ShouldBeTrue();
+        result.Result.Value!.Status.ShouldBe(InstanceStatus.Busy);
+        result.Result.Value!.Transitions.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// When SubFlow is still Active, the existing behavior is preserved:
+    /// SubFlow's Active status and state are returned to the client.
+    /// </summary>
+    [Fact]
+    public async Task GetInstanceStateAsync_WhenSubFlowIsStillActive_ReturnsSubFlowActiveStatus()
+    {
+        // Arrange
+        var (instance, workflow) = CreateParentWithActiveSubFlow();
+        SetupCommonMocks(instance, workflow);
+        SetupSubFlowGateway(InstanceStatus.Active, "sub-review");
+
+        var input = CreateInput(instance.Id.ToString());
+
+        // Act
+        var result = await _service.GetInstanceStateAsync(input, CancellationToken.None);
+
+        // Assert
+        result.Result.IsSuccess.ShouldBeTrue();
+        result.Result.Value!.Status.ShouldBe(InstanceStatus.Active);
+        result.Result.Value!.State.ShouldBe("sub-review");
+    }
+
+    /// <summary>
+    /// When there is no active SubFlow correlation, the parent's own status is used normally.
+    /// </summary>
+    [Fact]
+    public async Task GetInstanceStateAsync_WhenNoActiveSubFlow_ReturnsParentActiveStatus()
+    {
+        // Arrange — instance has no SubFlow correlations
+        var instanceId = Guid.NewGuid();
+        var instance = Instance.Create(instanceId, TestWorkflow, TestVersion, "test-key");
+        var state = State.Create(TestState, StateType.Intermediate, StateSubType.None,
+            VersionStrategy.IncreaseMinor.Code);
+        instance.ChangeState(state);
+
+        var workflow = BuildWorkflow(state);
+        SetupCommonMocks(instance, workflow);
+
+        var input = CreateInput(instance.Id.ToString());
+
+        // Act
+        var result = await _service.GetInstanceStateAsync(input, CancellationToken.None);
+
+        // Assert
+        result.Result.IsSuccess.ShouldBeTrue();
+        result.Result.Value!.Status.ShouldBe(InstanceStatus.Active);
+        // Gateway should NOT have been called since there's no active subflow
+        await _instanceQueryGateway.DidNotReceive()
+            .GetFunctionWithStateAsync(Arg.Any<GetFunctionWithInstanceInput>(), Arg.Any<CancellationToken>());
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private (Instance instance, Definitions.Workflow workflow) CreateParentWithActiveSubFlow()
+    {
+        var instanceId = Guid.NewGuid();
+        var instance = Instance.Create(instanceId, TestWorkflow, TestVersion, "test-key");
+        var state = State.Create(TestState, StateType.Intermediate, StateSubType.None,
+            VersionStrategy.IncreaseMinor.Code);
+        instance.ChangeState(state);
+
+        // AddCorrelation with SubFlowType "S" sets instance.Status = Busy
+        var correlation = InstanceCorrelation.Create(
+            id: Guid.NewGuid(),
+            instanceId: instanceId,
+            parentState: TestState,
+            subFlowInstanceId: Guid.NewGuid(),
+            subFlowType: "S",
+            subFlowDomain: "sub-domain",
+            subFlowName: "sub-flow",
+            subFlowVersion: "1.0.0"
+        );
+        instance.AddCorrelation(correlation);
+
+        instance.Status.ShouldBe(InstanceStatus.Busy);
+
+        var workflow = BuildWorkflow(state);
+        return (instance, workflow);
+    }
+
+    private static Definitions.Workflow BuildWorkflow(State state)
+    {
+        var workflow = Definitions.Workflow.Create();
+        workflow.SetReference(new Reference(TestWorkflow, TestDomain, "sys-flows", TestVersion));
+        workflow.SetType("F");
+        workflow.AddState(state);
+        return workflow;
+    }
+
+    private void SetupCommonMocks(Instance instance, Definitions.Workflow workflow)
+    {
+        _instanceRepository
+            .FindByIdentifierAsReadOnlyAsync(instance.Id.ToString(), Arg.Any<CancellationToken>())
+            .Returns(instance);
+
+        _componentCacheStore
+            .GetFlowAsync(TestDomain, TestWorkflow, Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(Result<Definitions.Workflow>.Ok(workflow));
+
+        _urlTemplateBuilder.BuildDataUrl(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
+            .Returns("https://data-url");
+        _urlTemplateBuilder.BuildViewUrl(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
+            .Returns("https://view-url");
+
+        _representationEtagService.Generate(Arg.Any<object>()).Returns((string?)null);
+    }
+
+    private void SetupSubFlowGateway(InstanceStatus subFlowStatus, string subFlowState)
+    {
+        var subFlowOutput = new GetInstanceStateOutput
+        {
+            Status = subFlowStatus,
+            State = subFlowState,
+            Transitions = [],
+            ActiveCorrelations = []
+        };
+
+        _instanceQueryGateway
+            .GetFunctionWithStateAsync(Arg.Any<GetFunctionWithInstanceInput>(), Arg.Any<CancellationToken>())
+            .Returns(ConditionalResult<GetInstanceStateOutput>.Success(subFlowOutput));
+    }
+
+    private static GetInstanceStateInput CreateInput(string instanceId) => new()
+    {
+        Domain = TestDomain,
+        Workflow = TestWorkflow,
+        Instance = instanceId,
+        Headers = new Dictionary<string, string?>(),
+        QueryParams = new Dictionary<string, string?>()
+    };
+}


### PR DESCRIPTION
## Summary

- **Bug:** During the brief propagation window between a SubFlow completing and the parent correlation being marked `IsCompleted=true`, the parent's state function incorrectly returns `Status=Completed` (propagated from the SubFlow). Clients treat this as the whole flow being done and stop polling.
- **Fix:** Added a guard in `BuildInstanceStateOutputAsync` — when a SubFlow reports a terminal status (`Completed`, `Faulted`, or `Passive`) but the parent correlation is still open (`IsCompleted=false`), fall back to the parent's own status (`Busy`) instead of forwarding the SubFlow's status.
- **Tests:** 5 new unit tests in `InstanceQueryAppServiceStateTests` covering all terminal-status variants and verifying existing Active/no-subflow behavior is preserved.

## Root cause

```
SubFlow completes → publishes InstanceSubCompletedEvent
  ↓
Async handler starts CompleteAndPersistCorrelationAsync
  ↓  ← CLIENT HITS /state HERE
  ↓  Parent correlation: IsCompleted=false (still open)
  ↓  SubFlow gateway returns: Status=Completed
  ↓  → BuildInstanceStateOutputAsync returns Status=Completed  ← BUG
  ↓
Handler finishes → correlation.IsCompleted=true, parent → Active
```

**Invariant exploited by the fix:** if the parent correlation is still open (`IsCompleted=false`), the parent has not finished processing the SubFlow completion — its actual status is `Busy`. Returning `Busy` to the client is always correct in this state, prompting a retry that will resolve correctly after propagation.

## Test plan

- [x] `WhenSubFlowCompletedButCorrelationStillActive_ReturnsBusy`
- [x] `WhenSubFlowFaultedButCorrelationStillActive_ReturnsBusy`
- [x] `WhenSubFlowPassiveButCorrelationStillActive_ReturnsBusy`
- [x] `WhenSubFlowIsStillActive_ReturnsSubFlowActiveStatus` (existing behavior preserved)
- [x] `WhenNoActiveSubFlow_ReturnsParentActiveStatus` (existing behavior preserved)
- [ ] End-to-end: start a flow → enter SubFlow state → poll `/state` at high frequency around SubFlow completion → verify no `Status=Completed` is returned while parent is still `Busy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure instance state queries report the parent workflow as Busy during the subflow completion propagation window instead of prematurely reporting completion.

Bug Fixes:
- Prevent /state responses from returning a terminal subflow status while the parent correlation is still open, avoiding premature signaling that the overall flow has completed.

Tests:
- Add unit test coverage for instance state behavior across subflow terminal statuses, active subflow states, and flows without active subflows to validate the propagation window guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow state reporting so when a subflow ends while its parent is still active, clients see the parent as Busy instead of a premature terminal state.

* **Tests**
  * Added unit tests covering subflow/parent concurrency scenarios to ensure correct status propagation across Completed, Faulted, Passive, Active, and no-subflow cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->