### PR TITLE
fix: null-safety, ViewType enum, content-header forwarding, and StateSubType extensions

### DIFF
--- a/init/VNext.Init.Host/package-api-server.js
+++ b/init/VNext.Init.Host/package-api-server.js
@@ -998,27 +998,18 @@ async function handlePackagePublish(req, res) {
             npmToken,
             npmUsername,
             npmPassword,
-            npmEmail,
-            appDomain
+            npmEmail
         } = body;
-        
+
         if (!packageName) {
             res.writeHead(400, { 'Content-Type': 'application/json' });
             res.end(JSON.stringify({ error: 'packageName is required' }));
             return;
         }
-        
-        // Determine if domain replacement should happen
-        const shouldReplaceDomain = appDomain && appDomain.trim() !== '';
-        
+
         log.section(`API Request: Package Publish`);
         log.info(`Package: ${packageName}@${version}`);
-        if (shouldReplaceDomain) {
-            log.info(`App Domain: ${appDomain}`);
-            log.info(`Domain Replacement: ENABLED (all domains will be replaced)`);
-        } else {
-            log.info(`Domain Replacement: DISABLED (no appDomain provided)`);
-        }
+        log.info(`Domain Replacement: DISABLED`);
         
         // Wait for vnext app to be ready
         await waitForVNextApp();
@@ -1038,8 +1029,8 @@ async function handlePackagePublish(req, res) {
         await verifyPackageStructure(packagePath);
         
         // Process and publish with isRuntimePackage=false (no special ordering)
-        // appDomain is null if not provided (no replacement)
-        const results = await processPackage(packagePath, packageName, shouldReplaceDomain ? appDomain : null, false);
+        // Domain replacement is never applied for standard packages
+        const results = await processPackage(packagePath, packageName, null, false);
         
         // Determine success status and message based on results
         let success = true;
@@ -1063,8 +1054,6 @@ async function handlePackagePublish(req, res) {
             success: success,
             message: message,
             packageName: packageName,
-            appDomain: shouldReplaceDomain ? appDomain : null,
-            domainReplacement: shouldReplaceDomain,
             results: {
                 successful: results.success,
                 failed: results.failed,

--- a/src/BBT.Workflow.Application/Instances/DTOs/ViewInstanceAttributesDto.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/ViewInstanceAttributesDto.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using BBT.Workflow.Definitions;
 
 namespace BBT.Workflow.Instances;
 
@@ -18,7 +19,7 @@ public sealed class ViewInstanceAttributesDto
     /// View type.
     /// </summary>
     [JsonPropertyName("type")]
-    public string? Type { get; set; }
+    public ViewType? Type { get; set; }
 
     /// <summary>
     /// Display mode.

--- a/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
@@ -532,9 +532,9 @@ public sealed class InstanceCommandAppService(
                 cancellationToken);
 
             if (!extensionsResult.IsSuccess)
-                return Result<TOutput>.Fail(extensionsResult.Error);
-
-            extensions = extensionsResult.Value!;
+                logger.LogWarning("Extension processing failed but continuing. Error: {Error}", extensionsResult.Error);
+            else
+                extensions = extensionsResult.Value!;
         }
 
         if (output is StartInstanceOutput start)

--- a/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
@@ -532,7 +532,7 @@ public sealed class InstanceCommandAppService(
                 cancellationToken);
 
             if (!extensionsResult.IsSuccess)
-                logger.LogWarning("Extension processing failed but continuing. Error: {Error}", extensionsResult.Error);
+                logger.ExtensionProcessingFailedNonBlocking(extensionsResult.Error.Code);
             else
                 extensions = extensionsResult.Value!;
         }

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -1208,7 +1208,7 @@ public sealed class InstanceQueryAppService(
                 scriptContext,
                 cancellationToken);
 
-            if (ruleResult.IsSuccess && ruleResult.Value)
+            if (ruleResult is { IsSuccess: true, Value: true })
             {
                 selectedViewEntry = viewEntry;
                 break;

--- a/src/BBT.Workflow.Application/Instances/ViewContentResolutionService.cs
+++ b/src/BBT.Workflow.Application/Instances/ViewContentResolutionService.cs
@@ -120,12 +120,13 @@ public sealed class ViewContentResolutionService(
         var attrs = DeserializeAttributes(instanceOutput.Attributes);
         var contentRaw = attrs?.Content ?? string.Empty;
         var type = attrs?.Type;
-        var contentTyped = View.GetContentAsTypedFromObject(contentRaw, type);
+        var viewType = type ?? ViewType.Json;
+        var contentTyped = View.GetContentAsTypedFromObject(contentRaw, viewType);
         return new GetViewOutput
         {
             Key = instanceOutput.Key ?? viewKey,
             Content = contentTyped,
-            Type = type?.ToString() ?? "Json",
+            Type = viewType.ToString(),
             Display = attrs?.Display ?? string.Empty,
             Label = attrs?.Label ?? string.Empty
         };

--- a/src/BBT.Workflow.Application/Instances/ViewContentResolutionService.cs
+++ b/src/BBT.Workflow.Application/Instances/ViewContentResolutionService.cs
@@ -119,13 +119,13 @@ public sealed class ViewContentResolutionService(
     {
         var attrs = DeserializeAttributes(instanceOutput.Attributes);
         var contentRaw = attrs?.Content ?? string.Empty;
-        var type = attrs?.Type ?? string.Empty;
+        var type = attrs?.Type;
         var contentTyped = View.GetContentAsTypedFromObject(contentRaw, type);
         return new GetViewOutput
         {
             Key = instanceOutput.Key ?? viewKey,
             Content = contentTyped,
-            Type = type,
+            Type = type?.ToString() ?? "Json",
             Display = attrs?.Display ?? string.Empty,
             Label = attrs?.Label ?? string.Empty
         };

--- a/src/BBT.Workflow.Application/Tasks/Coordinator/TaskCoordinator.cs
+++ b/src/BBT.Workflow.Application/Tasks/Coordinator/TaskCoordinator.cs
@@ -131,15 +131,15 @@ public sealed class TaskCoordinator : ITaskCoordinatorExtended
         Activity.Current?.SetDisplayName("TaskCoordinator.Execute");
 
         var tasks = onExecuteTasks.ToList();
-        var completedSet = completedTaskIds.ToHashSet(StringComparer.OrdinalIgnoreCase) ?? [];
+        var completedSet = completedTaskIds.ToHashSet(StringComparer.OrdinalIgnoreCase);
         var executedTasks = new List<TaskExecutionSummary>();
         var totalStopwatch = Stopwatch.StartNew();
 
         var activity = Activity.Current;
         if (activity != null)
         {
-            activity.SetTag(TelemetryConstants.TagNames.InstanceId, context.Instance.Id.ToString());
-            activity.SetTag(TelemetryConstants.TagNames.Flow, context.Workflow.Key);
+            activity.SetTag(TelemetryConstants.TagNames.InstanceId, context.Instance?.Id.ToString());
+            activity.SetTag(TelemetryConstants.TagNames.Flow, context.Workflow?.Key);
             activity.SetTag("vnext.task.count", tasks.Count);
         }
 
@@ -158,7 +158,7 @@ public sealed class TaskCoordinator : ITaskCoordinatorExtended
         _logger.LogDebug(
             "Coordinating execution of {TaskCount} tasks for instance {InstanceId}. " +
             "Bypassing {BypassCount} already completed tasks.",
-            tasksToExecute.Count, context.Instance.Id, skippedCount);
+            tasksToExecute.Count, context.Instance?.Id, skippedCount);
 
         // Group tasks by Order for parallel/sequential execution
         var taskGroups = tasksToExecute
@@ -288,7 +288,7 @@ public sealed class TaskCoordinator : ITaskCoordinatorExtended
 
         _logger.LogDebug(
             "Executing {TaskCount} tasks in parallel for instance {InstanceId}",
-            tasks.Count, context.Instance.Id);
+            tasks.Count, context.Instance?.Id);
 
         // Track first failure for error boundary (thread-safe)
         TasksExecutionResult? firstFailure = null;

--- a/src/BBT.Workflow.Application/Tasks/Coordinator/TaskExecutionEngine.cs
+++ b/src/BBT.Workflow.Application/Tasks/Coordinator/TaskExecutionEngine.cs
@@ -74,15 +74,15 @@ public sealed class TaskExecutionEngine : ITaskExecutionEngine
         var boundaryChain = CompiledBoundaryChain.Compile(
             onExecuteTask.ErrorBoundary,
             GetStateBoundary(context),
-            context.Workflow.ErrorBoundary);
+            context.Workflow?.ErrorBoundary);
 
         Activity.Current?.SetDisplayName($"Task.Execute.{onExecuteTask.Task.Key}");
         var activity = Activity.Current;
         if (activity != null)
         {
             activity.SetTag(TelemetryConstants.TagNames.TaskKey, onExecuteTask.Task.Key);
-            activity.SetTag(TelemetryConstants.TagNames.InstanceId, context.Instance.Id.ToString());
-            activity.SetTag(TelemetryConstants.TagNames.Flow, context.Workflow.Key);
+            activity.SetTag(TelemetryConstants.TagNames.InstanceId, context.Instance?.Id.ToString());
+            activity.SetTag(TelemetryConstants.TagNames.Flow, context.Workflow?.Key);
         }
 
         _logger.LogInformation(
@@ -350,10 +350,10 @@ public sealed class TaskExecutionEngine : ITaskExecutionEngine
         var instance = context.Instance;
         var workflow = context.Workflow;
 
-        if (string.IsNullOrEmpty(instance.CurrentState))
+        if (string.IsNullOrEmpty(instance?.CurrentState))
             return null;
 
-        var state = workflow.FindState(instance.CurrentState);
+        var state = workflow?.FindState(instance.CurrentState);
         return state?.ErrorBoundary;
     }
 
@@ -437,7 +437,7 @@ public sealed class TaskExecutionEngine : ITaskExecutionEngine
     {
         if (taskTrigger != TaskTrigger.Extension && response.Data is not null)
         {
-            context.Instance.AddData(
+            context.Instance?.AddData(
                 _guidGenerator.Create(),
                 new JsonData(JsonSerializer.Serialize(response.Data, JsonSerializerConstants.JsonOptions)),
                 VersionStrategy.IncreasePatch);
@@ -476,7 +476,7 @@ public sealed class TaskExecutionEngine : ITaskExecutionEngine
         var task = taskResult.Value!;
         var taskType = task.GetTaskType();
         var taskTypeStr = taskType.ToString();
-        var workflowKey = context.Workflow.Key;
+        var workflowKey = context.Workflow?.Key ?? "N/A";
 
         Activity.Current?.SetTag(TelemetryConstants.TagNames.TaskType, taskTypeStr);
 
@@ -495,7 +495,7 @@ public sealed class TaskExecutionEngine : ITaskExecutionEngine
 
         _logger.LogDebug(
             "Executing task {TaskKey} of type {TaskType} for instance {InstanceId} (retry attempt)",
-            task.Key, taskType, context.Instance.Id);
+            task.Key, taskType, context.Instance?.Id);
 
         // 5. Persist creation
         await PersistCreationAsync(persistenceStrategy, instanceTask, cancellationToken);

--- a/src/BBT.Workflow.Domain/Definitions/States/StateEnums.cs
+++ b/src/BBT.Workflow.Domain/Definitions/States/StateEnums.cs
@@ -70,5 +70,9 @@ public enum StateSubType
     /// State requires human intervention (e.g., approval, manual review)
     /// Enables efficient querying of instances waiting for human action
     /// </summary>
-    Human = 6
+    Human = 6,
+    
+    Cancelled = 7,
+    
+    Timeout = 8
 }

--- a/src/BBT.Workflow.Domain/Definitions/Views/View.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Views/View.cs
@@ -123,7 +123,19 @@ public sealed class View : IDomainEntity, IViewReference, IReferenceSetter
 
         return content;
     }
-
+    
+    /// <summary>
+    /// Returns content typed by view type string: for Json, DeepLink, Http, URN attempts JSON parse (on failure returns original string);
+    /// for Html, Markdown or other types returns the content string. Shared logic for instance and remote view content.
+    /// </summary>
+    /// <param name="content">Raw view content (e.g. JSON string or markup).</param>
+    /// <param name="type">View type name (e.g. Json, Html, Markdown).</param>
+    /// <returns>Parsed JSON as <see cref="JsonElement"/> for JSON-structured types when parseable; otherwise the original content string.</returns>
+    public static object GetContentAsTypedFromObject(object? content, ViewType? type)
+    {
+        return GetContentAsTypedFromObject(content, type?.ToString());
+    }
+    
     private void SetKey(string key)
     {
         Key = Check.NotNullOrWhiteSpace(key, nameof(Key), ViewConstants.MaxKeyLength);

--- a/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
@@ -1608,4 +1608,19 @@ public static partial class WorkflowLogs
         string requestDomain);
 
     #endregion
+
+    #region Extensions
+
+    /// <summary>
+    /// Logs when extension processing fails but execution continues (non-blocking).
+    /// </summary>
+    [LoggerMessage(
+        EventId = 20101,
+        Level = LogLevel.Warning,
+        Message = "Extension processing failed but continuing. Error: {ErrorCode}")]
+    public static partial void ExtensionProcessingFailedNonBlocking(
+        this ILogger logger,
+        string errorCode);
+
+    #endregion
 }

--- a/src/BBT.Workflow.Domain/Scripting/Factory/Services/ScriptContextBuilder.cs
+++ b/src/BBT.Workflow.Domain/Scripting/Factory/Services/ScriptContextBuilder.cs
@@ -193,7 +193,12 @@ internal sealed class ScriptContextBuilder(
             var transition = ResolveTransition(workflow);
             builder.SetTransition(transition);
         }
-        
+        else
+        {
+            // If no workflow but transition was set directly, preserve it
+            builder.SetTransition(_transition);
+        }
+
         // Resolve instance if needed
         var instance = await ResolveInstanceAsync(cancellationToken);
         if (instance != null)

--- a/src/BBT.Workflow.Domain/Scripting/Factory/Services/ScriptContextBuilder.cs
+++ b/src/BBT.Workflow.Domain/Scripting/Factory/Services/ScriptContextBuilder.cs
@@ -182,23 +182,30 @@ internal sealed class ScriptContextBuilder(
 
     public async Task<ScriptContext> BuildAsync(CancellationToken cancellationToken = default)
     {
+        var builder = new ScriptContext.Builder(logger);
         // Resolve workflow if needed
         var workflow = await ResolveWorkflowAsync(cancellationToken);
 
+        if (workflow != null)
+        {
+            builder.SetWorkflow(workflow);
+            // Resolve transition if needed
+            var transition = ResolveTransition(workflow);
+            builder.SetTransition(transition);
+        }
+        
         // Resolve instance if needed
         var instance = await ResolveInstanceAsync(cancellationToken);
-
-        // Resolve transition if needed
-        var transition = ResolveTransition(workflow);
-
+        if (instance != null)
+        {
+            builder.SetInstance(instance);
+        }
+        
         var scriptTransitionRequest = BuildScriptTransitionRequest();
 
         // Build the ScriptContext using the domain builder
-        return new ScriptContext.Builder(logger)
+        return builder
             .SetRuntime(_runtimeInfoProvider!)
-            .SetWorkflow(workflow)
-            .SetInstance(instance)
-            .SetTransition(transition)
             .SetBody(_body)
             .SetHeaders(_headers)
             .SetRouteValues(_routeValues)
@@ -239,7 +246,7 @@ internal sealed class ScriptContextBuilder(
         return headerExpando;
     }
 
-    private async Task<Definitions.Workflow> ResolveWorkflowAsync(CancellationToken cancellationToken)
+    private async Task<Definitions.Workflow?> ResolveWorkflowAsync(CancellationToken cancellationToken)
     {
         if (_workflow != null)
             return _workflow;
@@ -257,10 +264,10 @@ internal sealed class ScriptContextBuilder(
             return result.GetValueOrThrow();
         }
 
-        throw new InvalidOperationException("Workflow must be set either directly or through domain/key parameters.");
+        return null;
     }
 
-    private async Task<Instance> ResolveInstanceAsync(CancellationToken cancellationToken)
+    private async Task<Instance?> ResolveInstanceAsync(CancellationToken cancellationToken)
     {
         if (_instance != null)
             return _instance;
@@ -279,7 +286,7 @@ internal sealed class ScriptContextBuilder(
             return _instance;
         }
 
-        throw new InvalidOperationException("Instance must be set either directly or through instance ID.");
+        return null;
     }
 
     private Transition? ResolveTransition(Definitions.Workflow workflow)

--- a/src/BBT.Workflow.Domain/Scripting/Models.cs
+++ b/src/BBT.Workflow.Domain/Scripting/Models.cs
@@ -290,7 +290,7 @@ public class ScriptContext(ILogger<ScriptContext> logger) : IDisposable, IAsyncD
     /// including its current state, accumulated data, and execution history. This is
     /// essential for making context-aware decisions in mapping implementations.
     /// </remarks>
-    public Instance Instance { get; private set; }
+    public Instance? Instance { get; private set; }
     
     /// <summary>
     /// The workflow definition that describes the structure, states, transitions, and tasks
@@ -308,7 +308,7 @@ public class ScriptContext(ILogger<ScriptContext> logger) : IDisposable, IAsyncD
     /// enabling mapping implementations to understand the workflow structure,
     /// available transitions, and task configurations for informed decision making.
     /// </remarks>
-    public Definitions.Workflow Workflow { get; private set; }
+    public Definitions.Workflow? Workflow { get; private set; }
 
     /// <summary>
     /// Provides runtime information and services for the current execution context,

--- a/src/BBT.Workflow.Infrastructure/Remote/CurrentUserForwardHeadersHelper.cs
+++ b/src/BBT.Workflow.Infrastructure/Remote/CurrentUserForwardHeadersHelper.cs
@@ -8,15 +8,25 @@ namespace BBT.Workflow.Remote;
 /// </summary>
 public static class CurrentUserForwardHeadersHelper
 {
+    // Content headers belong to HttpContent.Headers, not HttpRequestMessage.Headers.
+    // Attempting Remove/Add on request.Headers for these throws InvalidOperationException.
+    private static readonly HashSet<string> _contentHeaders = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Content-Type", "Content-Length", "Content-Encoding", "Content-Language",
+        "Content-Location", "Content-Disposition", "Content-Range", "Content-MD5",
+        "Expires", "Last-Modified", "Allow", "Host", "Connection", "Accept", "Accept-Encoding"
+    };
+
     /// <summary>
     /// Merges forward headers with input headers. Input headers take precedence (override) for the same key.
+    /// Content headers (e.g. Content-Type) are silently skipped as they cannot be set on HttpRequestMessage.Headers.
     /// </summary>
     public static void MergeIntoRequest(HttpRequestMessage request, Dictionary<string, string?> forwardHeaders, IReadOnlyDictionary<string, string?>? inputHeaders, Func<string, bool>? isRestrictedHeader = null)
     {
         isRestrictedHeader ??= _ => false;
         foreach (var kv in forwardHeaders)
         {
-            if (string.IsNullOrEmpty(kv.Value) || isRestrictedHeader(kv.Key))
+            if (string.IsNullOrEmpty(kv.Value) || isRestrictedHeader(kv.Key) || _contentHeaders.Contains(kv.Key))
                 continue;
             request.Headers.TryAddWithoutValidation(kv.Key, kv.Value);
         }
@@ -24,7 +34,7 @@ public static class CurrentUserForwardHeadersHelper
         {
             foreach (var kv in inputHeaders)
             {
-                if (isRestrictedHeader(kv.Key))
+                if (isRestrictedHeader(kv.Key) || _contentHeaders.Contains(kv.Key))
                     continue;
                 request.Headers.Remove(kv.Key);
                 if (!string.IsNullOrEmpty(kv.Value))

--- a/src/BBT.Workflow.Infrastructure/Remote/CurrentUserForwardHeadersHelper.cs
+++ b/src/BBT.Workflow.Infrastructure/Remote/CurrentUserForwardHeadersHelper.cs
@@ -14,7 +14,7 @@ public static class CurrentUserForwardHeadersHelper
     {
         "Content-Type", "Content-Length", "Content-Encoding", "Content-Language",
         "Content-Location", "Content-Disposition", "Content-Range", "Content-MD5",
-        "Expires", "Last-Modified", "Allow", "Host", "Connection", "Accept", "Accept-Encoding"
+        "Expires", "Last-Modified", "Allow"
     };
 
     /// <summary>

--- a/src/BBT.Workflow.Infrastructure/Remote/CurrentUserForwardHeadersHelper.cs
+++ b/src/BBT.Workflow.Infrastructure/Remote/CurrentUserForwardHeadersHelper.cs
@@ -14,7 +14,7 @@ public static class CurrentUserForwardHeadersHelper
     {
         "Content-Type", "Content-Length", "Content-Encoding", "Content-Language",
         "Content-Location", "Content-Disposition", "Content-Range", "Content-MD5",
-        "Expires", "Last-Modified", "Allow"
+        "Expires", "Last-Modified", "Allow", "Host", "Connection", "Accept", "Accept-Encoding"
     };
 
     /// <summary>

--- a/workers/BBT.Workflow.DbMigrator/appsettings.json
+++ b/workers/BBT.Workflow.DbMigrator/appsettings.json
@@ -14,6 +14,9 @@
   "Runtime": {
     "EnableSchemaMigration": true
   },
+  "Vault": {
+    "Enabled": false
+  },
   "Redis": {
     "Mode": "Standalone",
     "InstanceName": "workflow-api",

--- a/workers/BBT.Workflow.DbMigrator/appsettings.json
+++ b/workers/BBT.Workflow.DbMigrator/appsettings.json
@@ -14,9 +14,6 @@
   "Runtime": {
     "EnableSchemaMigration": true
   },
-  "Vault": {
-    "Enabled": false
-  },
   "Redis": {
     "Mode": "Standalone",
     "InstanceName": "workflow-api",

--- a/workers/BBT.Workflow.DbMigrator/appsettings.json
+++ b/workers/BBT.Workflow.DbMigrator/appsettings.json
@@ -15,7 +15,7 @@
     "EnableSchemaMigration": true
   },
   "Vault": {
-    "Enabled": true
+    "Enabled": false
   },
   "Redis": {
     "Mode": "Standalone",


### PR DESCRIPTION
## Summary

- Make `ScriptContext.Instance` and `ScriptContext.Workflow` nullable; `ScriptContextBuilder` returns `null` instead of throwing when workflow/instance cannot be resolved
- Add null-conditional operators in `TaskCoordinator` and `TaskExecutionEngine` to prevent `NullReferenceException` when context is partially populated
- Extension processing failure in `InstanceCommandAppService` is now non-blocking — logs a warning and continues instead of failing the entire operation
- Change `ViewInstanceAttributesDto.Type` from `string?` to `ViewType?`; add typed overload for `View.GetContentAsTypedFromObject(object?, ViewType?)`; fall back to `"Json"` when type is null in `ViewContentResolutionService`
- Add `StateSubType.Cancelled (7)` and `StateSubType.Timeout (8)` enum values
- Skip content headers (`Content-Type`, `Accept`, `Host`, etc.) in `CurrentUserForwardHeadersHelper` to prevent `InvalidOperationException` when merging into `HttpRequestMessage.Headers`
- Remove `appDomain` / domain-replacement logic from `package-api-server.js` publish endpoint
- Disable Vault in `DbMigrator` `appsettings.json` for local development

## Test plan

- [ ] Verify `ScriptContext.BuildAsync` does not throw when workflow or instance is unavailable
- [ ] Verify extension failure does not abort instance transitions — warning is logged
- [ ] Verify `ViewInstanceAttributesDto.Type` serializes/deserializes correctly as `ViewType` enum
- [ ] Verify `StateSubType.Cancelled` and `StateSubType.Timeout` are available and queryable
- [ ] Verify no `InvalidOperationException` when forwarding requests with `Content-Type` / `Accept` headers
- [ ] Verify package publish endpoint rejects / ignores `appDomain` parameter

Closes #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Relax script context requirements, harden task execution against partially populated context, and improve view and header handling while simplifying package publishing and local migration configuration.

Bug Fixes:
- Allow ScriptContextBuilder to return a context without resolved workflow or instance instead of throwing when they cannot be resolved.
- Guard TaskCoordinator and TaskExecutionEngine telemetry and state resolution against null workflow/instance to avoid NullReferenceException.
- Skip content and connection-related headers when forwarding current user headers to prevent InvalidOperationException on HttpRequestMessage headers.
- Treat extension processing failures in InstanceCommandAppService as non-blocking by logging a warning and continuing output enrichment.
- Ensure view content resolution falls back to a default Json type string when no view type is present, and support typed ViewType values in instance attributes.

Enhancements:
- Expose ScriptContext.Instance and ScriptContext.Workflow as nullable to support partially populated script contexts.
- Add a strongly-typed overload for View.GetContentAsTypedFromObject that accepts a ViewType enum.
- Extend StateSubType with Cancelled and Timeout values to better classify instance states.
- Refine view rule evaluation condition pattern matching in InstanceQueryAppService for clarity.

Build:
- Disable Vault by default in the DbMigrator appsettings for local development.

Deployment:
- Remove appDomain-based domain replacement from the package publish API and always publish standard packages without domain replacement metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Cancelled and Timeout state subtypes for improved workflow state tracking.

* **Bug Fixes**
  * Extension processing failures now emit a non-blocking warning and enrichment continues.
  * View handling now defaults missing types to Json and treats view type as a typed enum for consistent deserialization.
  * Strengthened null-safety across task execution and script context building.
  * Content-* headers are no longer forwarded when proxying requests.

* **Chores**
  * Vault integration disabled in the DB migrator configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->