### PR TITLE
feat(graphql): enhance SQL aggregation with separated WHERE clauses f…

### DIFF
--- a/src/BBT.Workflow.Domain/BBT.Workflow.Domain.csproj
+++ b/src/BBT.Workflow.Domain/BBT.Workflow.Domain.csproj
@@ -22,4 +22,7 @@
   <ItemGroup>
     <EmbeddedResource Include="Tasks\Scripting\NotificationMapping.csx" LogicalName="BBT.Workflow.Tasks.Scripting.NotificationMapping.csx" />
   </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="BBT.Workflow.Domain.Tests" />
+  </ItemGroup>
 </Project>

--- a/src/BBT.Workflow.Domain/QueryExtensions/GraphQL/GraphQLAggregationService.cs
+++ b/src/BBT.Workflow.Domain/QueryExtensions/GraphQL/GraphQLAggregationService.cs
@@ -41,11 +41,10 @@ public static class GraphQLAggregationService
         var parameterIndex = 0;
 
         var (selectClause, _) = BuildAggregationSelectClause(aggregations, jsonColumnName);
-        var whereClause = filterNode != null 
-            ? GraphQLJsonFilterService.BuildWhereClause(filterNode, jsonColumnName, parameters, ref parameterIndex)
-            : string.Empty;
+        var (jsonWhereClause, instanceWhereClause) = GraphQLJsonFilterService.BuildSeparatedWhereClausesForSql(
+            filterNode, jsonColumnName, parameters, ref parameterIndex);
 
-        var sql = BuildAggregationSql(selectClause, whereClause, null, schema);
+        var sql = BuildAggregationSql(selectClause, jsonWhereClause, instanceWhereClause, null, schema);
 
         using var connection = dbContext.Database.GetDbConnection();
         if (connection.State != ConnectionState.Open)
@@ -109,12 +108,11 @@ public static class GraphQLAggregationService
 
         var (selectClause, groupByClause) = BuildGroupBySelectClause(
             groupByFields, groupBy.Aggregations ?? new AggregationRequest { Count = true }, jsonColumnName);
-        
-        var whereClause = filterNode != null 
-            ? GraphQLJsonFilterService.BuildWhereClause(filterNode, jsonColumnName, parameters, ref parameterIndex)
-            : string.Empty;
 
-        var sql = BuildAggregationSql(selectClause, whereClause, groupByClause, schema);
+        var (jsonWhereClause, instanceWhereClause) = GraphQLJsonFilterService.BuildSeparatedWhereClausesForSql(
+            filterNode, jsonColumnName, parameters, ref parameterIndex);
+
+        var sql = BuildAggregationSql(selectClause, jsonWhereClause, instanceWhereClause, groupByClause, schema);
 
         using var connection = dbContext.Database.GetDbConnection();
         if (connection.State != ConnectionState.Open)
@@ -274,22 +272,35 @@ public static class GraphQLAggregationService
         return (string.Join(", ", selectParts), string.Join(", ", groupByParts));
     }
 
-    private static string BuildAggregationSql(
+    internal static string BuildAggregationSql(
         string selectClause,
-        string whereClause,
+        string jsonWhereClause,
+        string? instanceWhereClause,
         string? groupByClause,
         string schema)
     {
         var sb = new StringBuilder();
 
         sb.AppendLine($@"SELECT {selectClause}");
-        sb.AppendLine($@"FROM ""{schema}"".""InstancesData""");
-        sb.AppendLine(@"WHERE ""IsLatest"" = true");
 
-        if (!string.IsNullOrEmpty(whereClause))
+        var hasInstanceJoin = !string.IsNullOrEmpty(instanceWhereClause);
+        if (hasInstanceJoin)
         {
-            sb.AppendLine($"AND ({whereClause})");
+            sb.AppendLine($@"FROM ""{schema}"".""InstancesData"" d");
+            sb.AppendLine($@"INNER JOIN ""{schema}"".""Instances"" s ON s.""Id"" = d.""InstanceId""");
+            sb.AppendLine(@"WHERE d.""IsLatest"" = true");
         }
+        else
+        {
+            sb.AppendLine($@"FROM ""{schema}"".""InstancesData""");
+            sb.AppendLine(@"WHERE ""IsLatest"" = true");
+        }
+
+        if (!string.IsNullOrEmpty(jsonWhereClause))
+            sb.AppendLine($"AND ({jsonWhereClause})");
+
+        if (!string.IsNullOrEmpty(instanceWhereClause))
+            sb.AppendLine($"AND ({instanceWhereClause})");
 
         if (!string.IsNullOrEmpty(groupByClause))
         {

--- a/src/BBT.Workflow.Domain/QueryExtensions/GraphQL/GraphQLJsonFilterService.cs
+++ b/src/BBT.Workflow.Domain/QueryExtensions/GraphQL/GraphQLJsonFilterService.cs
@@ -194,6 +194,23 @@ public static class GraphQLJsonFilterService
     }
 
     /// <summary>
+    /// Builds JSON and Instance WHERE fragments for raw SQL (e.g. aggregations with optional <c>Instances</c> join).
+    /// Instance fragments use alias <c>s</c>; JSON fragments reference the JSON column on <c>InstancesData</c>.
+    /// </summary>
+    public static (string jsonWhereClause, string instanceWhereClause) BuildSeparatedWhereClausesForSql(
+        GraphQLFilterNode? filterNode,
+        string jsonColumnName,
+        List<NpgsqlParameter> parameters,
+        ref int parameterIndex,
+        ILogger? logger = null)
+    {
+        if (filterNode == null || filterNode.NodeType == FilterNodeType.Empty)
+            return (string.Empty, string.Empty);
+
+        return BuildSeparatedWhereClauses(filterNode, jsonColumnName, parameters, ref parameterIndex, logger);
+    }
+
+    /// <summary>
     /// Build WHERE clauses recursively, separating Instance and JSON conditions
     /// </summary>
     private static void BuildSeparatedClauses(

--- a/test/BBT.Workflow.Domain.Tests/BBT.Workflow.Domain.Tests.csproj
+++ b/test/BBT.Workflow.Domain.Tests/BBT.Workflow.Domain.Tests.csproj
@@ -10,6 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkPackageVersion)" />
+        <PackageReference Include="Npgsql" Version="$(MicrosoftPackageVersion)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/BBT.Workflow.Domain.Tests/QueryExtensions/GraphQL/GraphQLAggregationInstanceFilterTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/QueryExtensions/GraphQL/GraphQLAggregationInstanceFilterTests.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using BBT.Workflow.Definitions.GraphQL;
+using Npgsql;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Domain.Tests.QueryExtensions.GraphQL;
+
+/// <summary>
+/// Ensures aggregation / groupBy SQL joins <c>Instances</c> when filters reference instance columns.
+/// </summary>
+public class GraphQLAggregationInstanceFilterTests
+{
+    [Fact]
+    public void BuildAggregationSql_WithInstanceColumnFilter_IncludesJoinAndInstanceAlias()
+    {
+        var filterJson = """{"key":{"eq":"1111"}}""";
+        var filterNode = GraphQLFilterParser.ParseFilter(filterJson);
+        filterNode.ShouldNotBeNull();
+
+        var parameters = new List<NpgsqlParameter>();
+        var index = 0;
+        var (jsonWhere, instanceWhere) = GraphQLJsonFilterService.BuildSeparatedWhereClausesForSql(
+            filterNode, "Data", parameters, ref index);
+
+        instanceWhere.ShouldNotBeNullOrWhiteSpace();
+        instanceWhere.ShouldContain("s.\"Key\"");
+        jsonWhere.ShouldBeEmpty();
+
+        var sql = GraphQLAggregationService.BuildAggregationSql(
+            "COUNT(*) AS count_result",
+            jsonWhere,
+            instanceWhere,
+            groupByClause: """(\"Data\" ->> 'region')""",
+            schema: "myschema");
+
+        sql.ShouldContain("INNER JOIN \"myschema\".\"Instances\" s");
+        sql.ShouldContain("FROM \"myschema\".\"InstancesData\" d");
+        sql.ShouldContain("WHERE d.\"IsLatest\" = true");
+        sql.ShouldContain("GROUP BY");
+    }
+
+    [Fact]
+    public void BuildAggregationSql_WithJsonOnlyFilter_DoesNotJoinInstances()
+    {
+        var filterJson = """{"attributes":{"clientId":{"eq":122}}}""";
+        var filterNode = GraphQLFilterParser.ParseFilter(filterJson);
+        filterNode.ShouldNotBeNull();
+
+        var parameters = new List<NpgsqlParameter>();
+        var index = 0;
+        var (jsonWhere, instanceWhere) = GraphQLJsonFilterService.BuildSeparatedWhereClausesForSql(
+            filterNode, "Data", parameters, ref index);
+
+        instanceWhere.ShouldBeEmpty();
+        jsonWhere.ShouldNotBeNullOrWhiteSpace();
+
+        var sql = GraphQLAggregationService.BuildAggregationSql(
+            "COUNT(*) AS count_result",
+            jsonWhere,
+            instanceWhere,
+            groupByClause: null,
+            schema: "public");
+
+        sql.ShouldNotContain("INNER JOIN");
+        sql.ShouldContain("FROM \"public\".\"InstancesData\"");
+        sql.ShouldContain("WHERE \"IsLatest\" = true");
+    }
+}


### PR DESCRIPTION
…or JSON and instance filters

- Introduced BuildSeparatedWhereClausesForSql method to generate distinct WHERE clauses for JSON and instance conditions.
- Updated BuildAggregationSql to utilize the new method, improving SQL query structure and clarity.
- Added unit tests to validate behavior of SQL joins based on filter types, ensuring correct aggregation logic.

Also, added InternalsVisibleTo for unit testing and included Npgsql package reference in test project.

## Summary by Sourcery

Separate JSON-based and instance-based filters in GraphQL aggregation SQL generation to enable conditional joining of the Instances table and improve query structure.

New Features:
- Expose a helper to build distinct JSON and instance WHERE fragments for raw SQL aggregation queries.

Enhancements:
- Update GraphQL aggregation and group-by execution to use separated JSON and instance WHERE clauses and conditionally join the Instances table based on filter usage.

Build:
- Add Npgsql reference and InternalsVisibleTo configuration to enable domain-level GraphQL aggregation testing from the test project.

Tests:
- Add unit tests verifying aggregation SQL includes an Instances join when instance columns are filtered and omits it for JSON-only filters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GraphQL aggregation query filtering to correctly handle filters targeting both instance properties and JSON attributes simultaneously.

* **Tests**
  * Added test coverage for GraphQL aggregation filtering with mixed instance-level and JSON-based filter scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->