### PR TITLE
fix: version query parameter ignored in GetInstance and GetInstanceData endpoints

### DIFF
--- a/init/VNext.Init.Host/package-api-server.js
+++ b/init/VNext.Init.Host/package-api-server.js
@@ -204,7 +204,7 @@ function generateVersion(artifactVersion, packageVersion, domain) {
 
 /**
  * Update version fields in a component object
- * Updates version and flowVersion at root level only
+ * Updates version at root level only
  * 
  * NOTE: data[] items are processed separately by processSysFileData,
  * so we don't process them here to avoid double-processing.
@@ -225,12 +225,6 @@ function updateComponentVersions(component, packageVersion, domain) {
     if (updated.version && typeof updated.version === 'string') {
         const newVersion = generateVersion(updated.version, packageVersion, domain);
         updated.version = newVersion;
-    }
-    
-    // Update flowVersion if present (same logic as version)
-    if (updated.flowVersion && typeof updated.flowVersion === 'string') {
-        const newFlowVersion = generateVersion(updated.flowVersion, packageVersion, domain);
-        updated.flowVersion = newFlowVersion;
     }
     
     // NOTE: data[] items are NOT processed here - they are processed separately

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/DataFunctionHandler.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/DataFunctionHandler.cs
@@ -26,7 +26,8 @@ public sealed class DataFunctionHandler(
             IfNoneMatch = request.IfNoneMatch,
             Extensions = request.Parameters.Extensions,
             Headers = request.Headers,
-            QueryParameters = request.QueryParameters
+            QueryParameters = request.QueryParameters,
+            Version = request.QueryParameters.GetOrDefault("version"),
         };
 
         var result = await queryAppService.GetInstanceDataAsync(input, cancellationToken);

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -57,12 +57,14 @@ public sealed class InstanceQueryAppService(
             .MatchAsync(
                 onSuccess: async instance =>
                 {
+                    var instanceData = instance.FindData(input.Version);
+                    
                     var result = await BuildInstanceOutputAsync(
                         input.Domain,
                         input.Extensions,
                         input.Workflow,
                         instance,
-                        instance.LatestData,
+                        instanceData,
                         ExtensionScope.GetInstance,
                         input.Headers,
                         input.QueryParameters,
@@ -497,11 +499,12 @@ public sealed class InstanceQueryAppService(
                 onSuccess: async data =>
                 {
                     var (flow, instance) = data;
-                    var entityEtag = instance.LatestData?.ETag ?? string.Empty;
+                    var instanceData = instance.FindData(input.Version);
+                    var entityEtag = instanceData?.ETag ?? string.Empty;
 
                     var result = new GetInstanceDataOutput
                     {
-                        Data = instance.LatestData?.Data.JsonElement
+                        Data = instanceData?.Data.JsonElement
                     };
 
                     result.Data = await schemaFieldFilterService.ApplyAsync(flow, result.Data, instance, cancellationToken) ??
@@ -526,7 +529,7 @@ public sealed class InstanceQueryAppService(
                             .WithInstance(instance)
                             .WithRuntime(runtimeInfoProvider)
                             .WithTransition(string.Empty)
-                            .WithBody(instance.LatestData?.Data ?? new JsonData("{}"))
+                            .WithBody(instanceData?.Data ?? new JsonData("{}"))
                             .WithHeaders(input.Headers)
                             .WithQueryParameters(input.QueryParameters)
                             .BuildAsync(cancellationToken);


### PR DESCRIPTION
## Summary

- Map `version` query parameter to `GetInstanceDataInput.Version` in `DataFunctionHandler` — it was never populated, so version-scoped requests always resolved to latest
- Replace `instance.LatestData` with `instance.FindData(input.Version)` in both `GetInstanceAsync` and `GetInstanceDataAsync` — the domain method already supported semantic/partial version matching but was never called from the application layer
- Remove erroneous `flowVersion` rewrite from `updateComponentVersions` in `package-api-server.js` — `flowVersion` has different semantics and should not be rewritten with artifact/package version logic

Closes #490

## Test plan

- [ ] `GET /instance/{id}?version=1.0.0` returns data for version `1.0.0`, not latest
- [ ] `GET /instance/{id}/data?version=1.0.0` returns data for version `1.0.0`, not latest
- [ ] Partial version `?version=1` resolves to the highest `1.x.x` version
- [ ] Omitting `version` still returns latest data (no regression)
- [ ] ETag in `If-None-Match` conditional response is computed from the version-resolved data, not latest
- [ ] `flowVersion` field is not modified during `package-api-server.js` packaging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Respect requested instance data versions in query endpoints and stop rewriting flowVersion during packaging.

Bug Fixes:
- Ensure GetInstanceAsync uses version-resolved instance data instead of always using the latest data.
- Ensure GetInstanceDataAsync uses version-resolved instance data and ETags rather than always using the latest data.

Chores:
- Stop updating flowVersion in package-api-server.js so it is no longer rewritten with artifact/package version logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now retrieve specific versions of instance data by specifying the version parameter in requests, enabling access to historical instance data versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->