### PR TITLE
fix: prevent OOM and cache gaps in definition cache initialization

### DIFF
--- a/init/VNext.Init.Host/package-api-server.js
+++ b/init/VNext.Init.Host/package-api-server.js
@@ -204,7 +204,7 @@ function generateVersion(artifactVersion, packageVersion, domain) {
 
 /**
  * Update version fields in a component object
- * Updates version and flowVersion at root level only
+ * Updates version at root level only
  * 
  * NOTE: data[] items are processed separately by processSysFileData,
  * so we don't process them here to avoid double-processing.
@@ -225,12 +225,6 @@ function updateComponentVersions(component, packageVersion, domain) {
     if (updated.version && typeof updated.version === 'string') {
         const newVersion = generateVersion(updated.version, packageVersion, domain);
         updated.version = newVersion;
-    }
-    
-    // Update flowVersion if present (same logic as version)
-    if (updated.flowVersion && typeof updated.flowVersion === 'string') {
-        const newFlowVersion = generateVersion(updated.flowVersion, packageVersion, domain);
-        updated.flowVersion = newFlowVersion;
     }
     
     // NOTE: data[] items are NOT processed here - they are processed separately

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Definitions/DefinitionController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Definitions/DefinitionController.cs
@@ -29,9 +29,10 @@ public sealed class DefinitionController(
     [HttpGet("re-initialize")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     public async Task<IActionResult> ReInitializeAsync(
+        [FromQuery] bool fullLoad = false,
         CancellationToken cancellationToken = default)
     {
-        var result = await appService.ReInitializeAsync(cancellationToken);
+        var result = await appService.ReInitializeAsync(fullLoad, cancellationToken);
         return FromResult(result);
     }
 } 

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/DataFunctionHandler.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/DataFunctionHandler.cs
@@ -26,7 +26,8 @@ public sealed class DataFunctionHandler(
             IfNoneMatch = request.IfNoneMatch,
             Extensions = request.Parameters.Extensions,
             Headers = request.Headers,
-            QueryParameters = request.QueryParameters
+            QueryParameters = request.QueryParameters,
+            Version = request.QueryParameters.GetOrDefault("version"),
         };
 
         var result = await queryAppService.GetInstanceDataAsync(input, cancellationToken);

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Utilities/UtilityController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Utilities/UtilityController.cs
@@ -117,7 +117,7 @@ public sealed class UtilityController(
                 eventData.RequestedBy);
 
             // Update only in-memory cache (distributed cache already updated by initiating pod)
-            await runtimeCacheInitializer.InitializeAsync(cancellationToken);
+            await runtimeCacheInitializer.InitializeAsync(eventData.FullLoad, cancellationToken);
 
             logger.DefinitionCacheInvalidationSucceeded(podInstance);
 

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/HostedServices/Caching/CacheInitializationHostedService.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/HostedServices/Caching/CacheInitializationHostedService.cs
@@ -19,7 +19,7 @@ public class CacheInitializationHostedService(
             
             await using var scope = scopeFactory.CreateAsyncScope();
             var initializer = scope.ServiceProvider.GetRequiredService<IRuntimeCacheInitializer>();
-            await initializer.InitializeAsync(stoppingToken);
+            await initializer.InitializeAsync(fullLoad: true, stoppingToken);
             
             logger.LogInformation("Cache initialization completed successfully");
         }

--- a/scripts/set-domain.sh
+++ b/scripts/set-domain.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# set-domain.sh — Switch debug domain across all launchSettings.json and appsettings.json files.
+#
+# Usage:
+#   ./scripts/set-domain.sh set <domain>   — Set APP_DOMAIN and Database=vNext_<domain>
+#   ./scripts/set-domain.sh reset          — Reset to defaults (core / Aether_WorkflowDb)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+DEFAULT_DOMAIN="core"
+DEFAULT_DB="Aether_WorkflowDb"
+
+LAUNCH_SETTINGS=(
+  "orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Properties/launchSettings.json"
+  "execution/BBT.Workflow.Execution.HttpApi.Host/Properties/launchSettings.json"
+  "workers/BBT.Workflow.Workers.Inbox/Properties/launchSettings.json"
+  "workers/BBT.Workflow.Workers.Outbox/Properties/launchSettings.json"
+  "workers/BBT.Workflow.DbMigrator/Properties/launchSettings.json"
+)
+
+APP_SETTINGS=(
+  "orchestration/BBT.Workflow.Orchestration.HttpApi.Host/appsettings.json"
+  "workers/BBT.Workflow.Workers.Inbox/appsettings.json"
+  "workers/BBT.Workflow.Workers.Outbox/appsettings.json"
+  "workers/BBT.Workflow.DbMigrator/appsettings.json"
+)
+
+usage() {
+  echo "Usage:"
+  echo "  $0 set <domain>   Set APP_DOMAIN=<domain> and Database=vNext_<domain>"
+  echo "  $0 reset          Reset to defaults (APP_DOMAIN=core, Database=Aether_WorkflowDb)"
+  exit 1
+}
+
+apply() {
+  local domain="$1"
+  local db_name="$2"
+
+  echo "APP_DOMAIN  → $domain"
+  echo "Database    → $db_name"
+  echo ""
+
+  for rel in "${LAUNCH_SETTINGS[@]}"; do
+    local path="$ROOT/$rel"
+    if [ -f "$path" ]; then
+      sed -i '' "s/\"APP_DOMAIN\": \"[^\"]*\"/\"APP_DOMAIN\": \"$domain\"/g" "$path"
+      echo "  [launchSettings] $rel"
+    else
+      echo "  [SKIP] Not found: $rel"
+    fi
+  done
+
+  for rel in "${APP_SETTINGS[@]}"; do
+    local path="$ROOT/$rel"
+    if [ -f "$path" ]; then
+      sed -i '' "/Port=5432/s/Database=[^;]*/Database=$db_name/g" "$path"
+      echo "  [appsettings]   $rel"
+    else
+      echo "  [SKIP] Not found: $rel"
+    fi
+  done
+
+  echo ""
+  echo "Done."
+}
+
+case "${1:-}" in
+  set)
+    [ -z "${2:-}" ] && { echo "ERROR: domain name is required."; echo ""; usage; }
+    apply "$2" "vNext_$2"
+    ;;
+  reset)
+    apply "$DEFAULT_DOMAIN" "$DEFAULT_DB"
+    ;;
+  *)
+    usage
+    ;;
+esac

--- a/src/BBT.Workflow.Application/Caching/CacheInitializationGate.cs
+++ b/src/BBT.Workflow.Application/Caching/CacheInitializationGate.cs
@@ -1,0 +1,29 @@
+namespace BBT.Workflow.Caching;
+
+/// <summary>
+/// Singleton per-pod gate that prevents concurrent cache initializations and tracks
+/// the last successful initialization time for incremental (delta) loads.
+/// </summary>
+public sealed class CacheInitializationGate
+{
+    private readonly SemaphoreSlim _semaphore = new(1, 1);
+    private DateTime? _lastInitializedAt;
+
+    /// <summary>
+    /// Attempts to acquire the initialization lock without blocking.
+    /// Returns <c>true</c> if the lock was acquired; <c>false</c> if initialization is already in progress.
+    /// </summary>
+    public bool TryAcquire() => _semaphore.Wait(0);
+
+    /// <summary>Releases the initialization lock.</summary>
+    public void Release() => _semaphore.Release();
+
+    /// <summary>
+    /// UTC timestamp of the last successful cache initialization, or <c>null</c> if
+    /// the cache has never been initialized on this pod instance.
+    /// </summary>
+    public DateTime? LastInitializedAt => _lastInitializedAt;
+
+    /// <summary>Records a successful initialization at the given UTC time.</summary>
+    public void SetLastInitializedAt(DateTime utcNow) => _lastInitializedAt = utcNow;
+}

--- a/src/BBT.Workflow.Application/Caching/CacheSet.cs
+++ b/src/BBT.Workflow.Application/Caching/CacheSet.cs
@@ -394,6 +394,24 @@ public class CacheSet<T>(
         }
     }
 
+    public async Task MergeAllAsync(object data, CancellationToken cancellationToken = default)
+    {
+        if (data is not IEnumerable<T> entities)
+            throw new ArgumentException($"Invalid data type for {typeof(T).Name}");
+
+        var count = 0;
+        foreach (var entity in entities)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await UpsertLocalAsync(entity, cancellationToken);
+            count++;
+        }
+
+        _logger.LogInformation(
+            "CacheSet<{Type}> merged {Count} item(s) incrementally.",
+            typeof(T).Name, count);
+    }
+
     /// <summary>
     /// Performs cleanup of expired and least-used items based on TTL and capacity.
     /// </summary>

--- a/src/BBT.Workflow.Application/Caching/DomainCacheContext.cs
+++ b/src/BBT.Workflow.Application/Caching/DomainCacheContext.cs
@@ -92,6 +92,19 @@ public class DomainCacheContext : CacheContext, IDomainCacheContext, IDisposable
         }
     }
 
+    public async Task MergeAsync(Dictionary<Type, object> deltaData, CancellationToken cancellationToken = default)
+    {
+        foreach (var cacheSet in CacheSets)
+        {
+            var cacheSetType = cacheSet.GetType().GetGenericArguments()[0];
+
+            if (deltaData.TryGetValue(cacheSetType, out var data))
+            {
+                await cacheSet.MergeAllAsync(data, cancellationToken);
+            }
+        }
+    }
+
     public int CleanupAll(
         TimeSpan? ttl = null,
         int? maxItemsPerSet = null,

--- a/src/BBT.Workflow.Application/Caching/ICacheSet.cs
+++ b/src/BBT.Workflow.Application/Caching/ICacheSet.cs
@@ -19,6 +19,12 @@ public interface ICacheSet : IDisposable
     /// Used when initiating cache refresh that should propagate to all pods.
     /// </summary>
     Task LoadAllWithDistributedCacheAsync(object data, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Upserts the provided entities into the existing in-memory snapshot without replacing entries
+    /// that are not present in <paramref name="data"/>. Used for incremental (delta) cache updates.
+    /// </summary>
+    Task MergeAllAsync(object data, CancellationToken cancellationToken = default);
 }
 
 /// <summary>

--- a/src/BBT.Workflow.Application/Caching/IDomainCacheContext.cs
+++ b/src/BBT.Workflow.Application/Caching/IDomainCacheContext.cs
@@ -28,6 +28,15 @@ public interface IDomainCacheContext
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Upserts only the provided (delta) entities into the existing in-memory cache without
+    /// replacing entries absent from <paramref name="deltaData"/>. Used for incremental updates.
+    /// </summary>
+    /// <param name="deltaData">Dictionary mapping entity types to the changed/new entities</param>
+    /// <param name="cancellationToken">Token to monitor for cancellation requests</param>
+    Task MergeAsync(Dictionary<Type, object> deltaData,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets the cache set for the specified entity type.
     /// </summary>
     /// <typeparam name="T">The entity type</typeparam>

--- a/src/BBT.Workflow.Application/Caching/IRuntimeCacheInitializer.cs
+++ b/src/BBT.Workflow.Application/Caching/IRuntimeCacheInitializer.cs
@@ -12,17 +12,26 @@ public interface IRuntimeCacheInitializer
     /// This includes workflows, tasks, functions, views, schemas, and extensions.
     /// Updates only in-memory cache (used by receiving pods).
     /// </summary>
+    /// <param name="fullLoad">
+    /// When <c>true</c>, all records are fetched regardless of previous initialization state (used at startup).
+    /// When <c>false</c> (default), only records modified since the last successful initialization are fetched
+    /// and merged into the existing cache (incremental update).
+    /// </param>
     /// <param name="cancellationToken">Token to monitor for cancellation requests</param>
     /// <returns>A task representing the asynchronous initialization operation</returns>
-    Task InitializeAsync(CancellationToken cancellationToken = default);
+    Task InitializeAsync(bool fullLoad = false, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Initializes both in-memory and distributed cache by loading all workflow components from the database.
     /// This includes workflows, tasks, functions, views, schemas, and extensions.
     /// Use this when triggering cache refresh that should propagate to all pods.
     /// </summary>
+    /// <param name="fullLoad">
+    /// When <c>true</c>, all records are fetched (full reload).
+    /// When <c>false</c> (default), only records modified since the last initialization are fetched.
+    /// </param>
     /// <param name="cancellationToken">Token to monitor for cancellation requests</param>
     /// <returns>A task representing the asynchronous initialization operation</returns>
-    Task InitializeWithDistributedCacheAsync(CancellationToken cancellationToken = default);
+    Task InitializeWithDistributedCacheAsync(bool fullLoad = false, CancellationToken cancellationToken = default);
 }
 

--- a/src/BBT.Workflow.Application/Caching/RuntimeCacheInitializer.cs
+++ b/src/BBT.Workflow.Application/Caching/RuntimeCacheInitializer.cs
@@ -1,6 +1,7 @@
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Runtime;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace BBT.Workflow.Caching;
 
@@ -11,52 +12,110 @@ namespace BBT.Workflow.Caching;
 /// </summary>
 public sealed class RuntimeCacheInitializer(
     IServiceScopeFactory scopeFactory,
-    IDomainCacheContext domainCacheContext) : IRuntimeCacheInitializer
+    IDomainCacheContext domainCacheContext,
+    CacheInitializationGate gate,
+    ILogger<RuntimeCacheInitializer> logger) : IRuntimeCacheInitializer
 {
     /// <inheritdoc />
-    public async Task InitializeAsync(CancellationToken cancellationToken = default)
+    public async Task InitializeAsync(bool fullLoad = false, CancellationToken cancellationToken = default)
     {
-        var initialData = await LoadAllEntitiesFromDatabaseAsync(cancellationToken);
-        await domainCacheContext.InitializeAsync(initialData, cancellationToken);
+        if (!gate.TryAcquire())
+        {
+            logger.LogWarning(
+                "Cache initialization already in progress on this pod. Skipping concurrent request. (fullLoad={FullLoad})",
+                fullLoad);
+            return;
+        }
+
+        try
+        {
+            var since = ResolveLoadSince(fullLoad);
+            var capturedAt = DateTime.UtcNow;
+            var data = await LoadAllEntitiesFromDatabaseAsync(since, cancellationToken);
+
+            if (since.HasValue)
+                await domainCacheContext.MergeAsync(data, cancellationToken);
+            else
+                await domainCacheContext.InitializeAsync(data, cancellationToken);
+
+            gate.SetLastInitializedAt(capturedAt);
+        }
+        finally
+        {
+            gate.Release();
+        }
     }
 
     /// <inheritdoc />
-    public async Task InitializeWithDistributedCacheAsync(CancellationToken cancellationToken = default)
+    public async Task InitializeWithDistributedCacheAsync(bool fullLoad = false, CancellationToken cancellationToken = default)
     {
-        var initialData = await LoadAllEntitiesFromDatabaseAsync(cancellationToken);
-        await domainCacheContext.InitializeWithDistributedCacheAsync(initialData, cancellationToken);
-    }
-
-    private async Task<Dictionary<Type, object>> LoadAllEntitiesFromDatabaseAsync(CancellationToken cancellationToken)
-    {
-        async Task<IEnumerable<T?>> LoadAsync<T>(CancellationToken ct)
-            where T : class, IDomainEntity, IReferenceSetter
+        if (!gate.TryAcquire())
         {
-            await using var scope = scopeFactory.CreateAsyncScope();
-            var runtimeService = scope.ServiceProvider.GetRequiredService<IRuntimeService>();
-            return await runtimeService.GetAsync<T>(ct);
+            logger.LogWarning(
+                "Cache initialization already in progress on this pod. Skipping concurrent request. (fullLoad={FullLoad})",
+                fullLoad);
+            return;
         }
 
-        // Load all entity types in parallel for better performance
-        var flowsTask = LoadAsync<Definitions.Workflow>(cancellationToken);
-        var tasksTask = LoadAsync<WorkflowTask>(cancellationToken);
-        var functionsTask = LoadAsync<Function>(cancellationToken);
-        var viewsTask = LoadAsync<View>(cancellationToken);
-        var schemasTask = LoadAsync<SchemaDefinition>(cancellationToken);
-        var extensionsTask = LoadAsync<Extension>(cancellationToken);
+        try
+        {
+            var since = ResolveLoadSince(fullLoad);
+            var capturedAt = DateTime.UtcNow;
+            var data = await LoadAllEntitiesFromDatabaseAsync(since, cancellationToken);
 
-        // Wait for all tasks to complete
-        await Task.WhenAll(flowsTask, tasksTask, functionsTask, viewsTask, schemasTask, extensionsTask);
+            if (since.HasValue)
+                await domainCacheContext.MergeAsync(data, cancellationToken);
+            else
+                await domainCacheContext.InitializeWithDistributedCacheAsync(data, cancellationToken);
 
-        // Build and return the initial data dictionary
+            gate.SetLastInitializedAt(capturedAt);
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Returns the <c>since</c> timestamp to use for this load:
+    /// <c>null</c> → full load (replace all); non-null → incremental (merge delta).
+    /// </summary>
+    private DateTime? ResolveLoadSince(bool fullLoad)
+    {
+        if (fullLoad)
+            return null;
+
+        return gate.LastInitializedAt;
+    }
+
+    private async Task<Dictionary<Type, object>> LoadAllEntitiesFromDatabaseAsync(
+        DateTime? since,
+        CancellationToken cancellationToken)
+    {
+        // Load entity types sequentially to avoid concurrent DB connection pressure.
+        var flows = await LoadAsync<Definitions.Workflow>(since, cancellationToken);
+        var tasks = await LoadAsync<WorkflowTask>(since, cancellationToken);
+        var functions = await LoadAsync<Function>(since, cancellationToken);
+        var views = await LoadAsync<View>(since, cancellationToken);
+        var schemas = await LoadAsync<SchemaDefinition>(since, cancellationToken);
+        var extensions = await LoadAsync<Extension>(since, cancellationToken);
+
         return new Dictionary<Type, object>
         {
-            { typeof(Definitions.Workflow), flowsTask.Result ?? [] },
-            { typeof(WorkflowTask), tasksTask.Result ?? [] },
-            { typeof(SchemaDefinition), schemasTask.Result ?? [] },
-            { typeof(Function), functionsTask.Result ?? [] },
-            { typeof(View), viewsTask.Result ?? [] },
-            { typeof(Extension), extensionsTask.Result ?? [] }
+            { typeof(Definitions.Workflow), flows },
+            { typeof(WorkflowTask), tasks },
+            { typeof(SchemaDefinition), schemas },
+            { typeof(Function), functions },
+            { typeof(View), views },
+            { typeof(Extension), extensions }
         };
+    }
+
+    private async Task<IEnumerable<T?>> LoadAsync<T>(DateTime? since, CancellationToken ct)
+        where T : class, IDomainEntity, IReferenceSetter
+    {
+        await using var scope = scopeFactory.CreateAsyncScope();
+        var runtimeService = scope.ServiceProvider.GetRequiredService<IRuntimeService>();
+        return await runtimeService.GetAsync<T>(since, ct);
     }
 }

--- a/src/BBT.Workflow.Application/Definitions/DefinitionAppService.cs
+++ b/src/BBT.Workflow.Application/Definitions/DefinitionAppService.cs
@@ -183,7 +183,7 @@ public sealed class DefinitionAppService(
             input.Version,
             false
         );
-
+        instance.ModifiedAt = DateTime.UtcNow;
         await instanceRepository.UpdateAsync(instance, true, cancellationToken);
 
         // Cast to cache via CastProcessor
@@ -270,6 +270,7 @@ public sealed class DefinitionAppService(
         }
         else
         {
+            instance.ModifiedAt = DateTime.UtcNow;
             await instanceRepo.UpdateAsync(instance, true, cancellationToken);
         }
 
@@ -352,26 +353,27 @@ public sealed class DefinitionAppService(
     }
 
     /// <inheritdoc />
-    public async Task<Result> ReInitializeAsync(CancellationToken cancellationToken = default)
+    public async Task<Result> ReInitializeAsync(bool fullLoad = false, CancellationToken cancellationToken = default)
     {
         // First, update both in-memory and distributed cache on this initiating pod
-        await runtimeCacheInitializer.InitializeWithDistributedCacheAsync(cancellationToken);
-        
+        await runtimeCacheInitializer.InitializeWithDistributedCacheAsync(fullLoad, cancellationToken);
+
         // Then, publish broadcast event to all pods using Dapr client directly
         var cacheInvalidationEvent = new DefinitionCacheInvalidationEvent
         {
             Domain = runtimeInfoProvider.Domain,
             RequestedBy = "System",
             RequestedAt = DateTime.UtcNow,
-            Environment = configuration["ASPNETCORE_ENVIRONMENT"]!
+            Environment = configuration["ASPNETCORE_ENVIRONMENT"]!,
+            FullLoad = fullLoad
         };
-        
+
         await daprClient.PublishEventAsync(
             pubsubName: configuration["DAPR_PUBSUB_BROADCAST_STORE_NAME"]!,
             topicName: DefinitionCacheInvalidationEvent.TopicName,
             data: cacheInvalidationEvent,
             cancellationToken: cancellationToken);
-        
+
         return Result.Ok();
     }
 }

--- a/src/BBT.Workflow.Application/Definitions/IDefinitionAppService.cs
+++ b/src/BBT.Workflow.Application/Definitions/IDefinitionAppService.cs
@@ -43,5 +43,10 @@ public interface IDefinitionAppService : IApplicationService
     /// Reloads all system components including workflows, tasks, functions, 
     /// views, schemas, and extensions from the runtime system schema.
     /// </remarks>
-    Task<Result> ReInitializeAsync(CancellationToken cancellationToken = default);
+    /// <param name="fullLoad">
+    /// When <c>true</c>, all records are reloaded (full cache rebuild).
+    /// When <c>false</c> (default), only records modified since the last initialization are fetched
+    /// and merged into the existing cache.
+    /// </param>
+    Task<Result> ReInitializeAsync(bool fullLoad = false, CancellationToken cancellationToken = default);
 }

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -57,12 +57,14 @@ public sealed class InstanceQueryAppService(
             .MatchAsync(
                 onSuccess: async instance =>
                 {
+                    var instanceData = instance.FindData(input.Version);
+                    
                     var result = await BuildInstanceOutputAsync(
                         input.Domain,
                         input.Extensions,
                         input.Workflow,
                         instance,
-                        instance.LatestData,
+                        instanceData,
                         ExtensionScope.GetInstance,
                         input.Headers,
                         input.QueryParameters,
@@ -497,11 +499,12 @@ public sealed class InstanceQueryAppService(
                 onSuccess: async data =>
                 {
                     var (flow, instance) = data;
-                    var entityEtag = instance.LatestData?.ETag ?? string.Empty;
+                    var instanceData = instance.FindData(input.Version);
+                    var entityEtag = instanceData?.ETag ?? string.Empty;
 
                     var result = new GetInstanceDataOutput
                     {
-                        Data = instance.LatestData?.Data.JsonElement
+                        Data = instanceData?.Data.JsonElement
                     };
 
                     result.Data = await schemaFieldFilterService.ApplyAsync(flow, result.Data, instance, cancellationToken) ??
@@ -526,7 +529,7 @@ public sealed class InstanceQueryAppService(
                             .WithInstance(instance)
                             .WithRuntime(runtimeInfoProvider)
                             .WithTransition(string.Empty)
-                            .WithBody(instance.LatestData?.Data ?? new JsonData("{}"))
+                            .WithBody(instanceData?.Data ?? new JsonData("{}"))
                             .WithHeaders(input.Headers)
                             .WithQueryParameters(input.QueryParameters)
                             .BuildAsync(cancellationToken);

--- a/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
@@ -73,6 +73,7 @@ public static class WorkflowApplicationModuleServiceCollectionExtensions
         // Runtime Services
         services.AddScoped<IRuntimeService, RuntimeService>();
         services.AddScoped<IRuntimeCacheInitializer, RuntimeCacheInitializer>();
+        services.AddSingleton<CacheInitializationGate>();
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Application/Runtime/IRuntimeService.cs
+++ b/src/BBT.Workflow.Application/Runtime/IRuntimeService.cs
@@ -17,6 +17,14 @@ public interface IRuntimeService
         where T : class, IDomainEntity, IReferenceSetter;
 
     /// <summary>
+    /// Retrieves active entities of the specified type modified at or after <paramref name="since"/>.
+    /// When <paramref name="since"/> is <c>null</c>, all active entities are returned (full load).
+    /// The schema is automatically inferred from the entity type.
+    /// </summary>
+    Task<IEnumerable<T?>> GetAsync<T>(DateTime? since, CancellationToken cancellationToken = default)
+        where T : class, IDomainEntity, IReferenceSetter;
+
+    /// <summary>
     /// Retrieves a specific entity by key and version.
     /// The schema is automatically inferred from the entity type.
     /// </summary>

--- a/src/BBT.Workflow.Application/Runtime/RuntimeService.cs
+++ b/src/BBT.Workflow.Application/Runtime/RuntimeService.cs
@@ -14,7 +14,13 @@ public sealed class RuntimeService(
     IRuntimeInfoProvider runtimeInfoProvider,
     ILogger<RuntimeService> logger) : IRuntimeService
 {
+    private const int PageSize = 100;
+
     public async Task<IEnumerable<T?>> GetAsync<T>(CancellationToken cancellationToken = default)
+        where T : class, IDomainEntity, IReferenceSetter
+        => await GetAsync<T>(since: null, cancellationToken);
+
+    public async Task<IEnumerable<T?>> GetAsync<T>(DateTime? since, CancellationToken cancellationToken = default)
         where T : class, IDomainEntity, IReferenceSetter
     {
         var schemaName = runtimeOptions.Value.GetSchemaNameByType(typeof(T));
@@ -22,10 +28,17 @@ public sealed class RuntimeService(
 
         using (currentSchema.Use(schemaInfo.Schema))
         {
-            var results = await instanceRepository.GetActiveDataListAsync(cancellationToken);
-            
-            var flows = results
-                .Select(item =>
+            var result = new List<T?>();
+            int skip = 0;
+            List<InstanceAndDataModel> page;
+
+            do
+            {
+                page = since.HasValue
+                    ? await instanceRepository.GetActiveDataListSinceAsync(since.Value, skip, PageSize, cancellationToken)
+                    : await instanceRepository.GetActiveDataListPagedAsync(skip, PageSize, cancellationToken);
+
+                foreach (var item in page)
                 {
                     try
                     {
@@ -42,22 +55,23 @@ public sealed class RuntimeService(
                             ));
                         }
 
-                        return flow;
+                        result.Add(flow);
                     }
                     catch (JsonException ex)
                     {
                         logger.InstanceDeserializationFailed(ex, schemaName, item.Instance.Key, item.InstanceData.Version);
-                        return null;
                     }
                     catch (Exception ex)
                     {
                         logger.InstanceDeserializationFailed(ex, schemaName, item.Instance.Key, item.InstanceData.Version);
-                        return null;
                     }
-                })
-                .Where(flow => flow != null)
-                .ToList();
-            return flows;
+                }
+
+                skip += PageSize;
+            }
+            while (page.Count == PageSize);
+
+            return result.Where(f => f != null);
         }
     }
 

--- a/src/BBT.Workflow.Domain/Instances/IInstanceRepository.cs
+++ b/src/BBT.Workflow.Domain/Instances/IInstanceRepository.cs
@@ -17,6 +17,10 @@ public interface IInstanceRepository : IRepository<Instance, Guid>
     
     Task<List<InstanceAndDataModel>> GetActiveDataListAsync(CancellationToken cancellationToken = default);
 
+    Task<List<InstanceAndDataModel>> GetActiveDataListPagedAsync(int skip, int take, CancellationToken cancellationToken = default);
+
+    Task<List<InstanceAndDataModel>> GetActiveDataListSinceAsync(DateTime since, int skip, int take, CancellationToken cancellationToken = default);
+
     Task<InstanceAndDataModel?> FindActiveDataAsync(string key, string version,
         CancellationToken cancellationToken = default);
         

--- a/src/BBT.Workflow.Domain/Instances/Instance.cs
+++ b/src/BBT.Workflow.Domain/Instances/Instance.cs
@@ -25,6 +25,7 @@ public sealed class Instance : AggregateRoot<Guid>, ICreationAuditedObject, IMod
     {
         IsTransient = true;
         CreatedAt = DateTime.UtcNow;
+        ModifiedAt = DateTime.UtcNow;
         Flow = Check.NotNullOrWhiteSpace(flow, nameof(Flow), WorkflowConstants.MaxKeyLength);
         FlowVersion = Check.NotNullOrWhiteSpace(flowVersion, nameof(FlowVersion), WorkflowConstants.MaxVersionLength);
         Key = Check.Length(key, nameof(Key), InstanceConstants.MaxKeyLength);

--- a/src/BBT.Workflow.Events.Contracts/Definitions/Events/DefinitionCacheInvalidationEvent.cs
+++ b/src/BBT.Workflow.Events.Contracts/Definitions/Events/DefinitionCacheInvalidationEvent.cs
@@ -34,4 +34,11 @@ public class DefinitionCacheInvalidationEvent : IDistributedEvent
     /// When the cache invalidation was requested.
     /// </summary>
     public required DateTime RequestedAt { get; init; }
+
+    /// <summary>
+    /// When <c>true</c>, receiving pods perform a full cache reload (replace all).
+    /// When <c>false</c> (default), only records modified since the last initialization are fetched
+    /// and merged into the existing cache (incremental update).
+    /// </summary>
+    public bool FullLoad { get; init; } = false;
 }

--- a/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceRepository.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceRepository.cs
@@ -853,6 +853,49 @@ public sealed class EfCoreInstanceRepository(
             .ToListAsync(cancellationToken);
     }
 
+    public async Task<List<InstanceAndDataModel>> GetActiveDataListPagedAsync(
+        int skip, int take, CancellationToken cancellationToken = default)
+    {
+        var context = await GetDbContextAsync();
+
+        return await (from instance in context.Instances
+                      where instance.Status == InstanceStatus.Active
+                      orderby instance.Id
+                      join data in context.InstancesData on instance.Id equals data.InstanceId
+                      select new InstanceAndDataModel
+                      {
+                          Instance = instance,
+                          InstanceData = data
+                      })
+            .AsNoTracking()
+            .AsSplitQuery()
+            .Skip(skip)
+            .Take(take)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<List<InstanceAndDataModel>> GetActiveDataListSinceAsync(
+        DateTime since, int skip, int take, CancellationToken cancellationToken = default)
+    {
+        var context = await GetDbContextAsync();
+
+        return await (from instance in context.Instances
+                      where instance.Status == InstanceStatus.Active
+                            && (instance.ModifiedAt ?? instance.CreatedAt) >= since
+                      orderby instance.Id
+                      join data in context.InstancesData on instance.Id equals data.InstanceId
+                      select new InstanceAndDataModel
+                      {
+                          Instance = instance,
+                          InstanceData = data
+                      })
+            .AsNoTracking()
+            .AsSplitQuery()
+            .Skip(skip)
+            .Take(take)
+            .ToListAsync(cancellationToken);
+    }
+
     /// <inheritdoc />
     public async Task<bool> AnyActiveByKeyAsync(string key, Guid excludeInstanceId,
         CancellationToken cancellationToken = default)

--- a/workers/BBT.Workflow.Workers.Inbox/Controllers/UtilityController.cs
+++ b/workers/BBT.Workflow.Workers.Inbox/Controllers/UtilityController.cs
@@ -59,7 +59,7 @@ public sealed class UtilityController(
         logger.DefinitionCacheInvalidationReceived(podInstance, eventData.Domain, eventData.RequestedBy);
         
         // Update only in-memory cache (distributed cache already updated by initiating pod)
-        await runtimeCacheInitializer.InitializeAsync(cancellationToken);
+        await runtimeCacheInitializer.InitializeAsync(eventData.FullLoad, cancellationToken);
         
         logger.DefinitionCacheInvalidationSucceeded(podInstance);
                 


### PR DESCRIPTION
## Summary

Fixes #487. The definition cache invalidation was reloading the entire active instance table on every broadcast event, causing `OutOfMemoryException` in environments with large datasets.

- **Add `CacheInitializationGate`** — per-pod singleton that prevents concurrent cache initializations via a `SemaphoreSlim` and tracks `LastInitializedAt` for delta load boundary
- **Introduce incremental (delta) loading** — subsequent cache refreshes query only records where `(ModifiedAt ?? CreatedAt) >= LastInitializedAt` via `GetActiveDataListSinceAsync`, instead of reloading the full table
- **Fix `_lastInitializedAt` timestamp capture** — timestamp is now captured *before* the DB query starts (not after `MergeAsync` completes), eliminating a race window where a concurrent `PublishAsync` could be missed by both the current and the next delta load
- **Support `fullLoad=true` flag** — `ReInitializeAsync` and the broadcast event carry a `fullLoad` parameter to force a complete reload when needed (e.g. after a cold start or explicit admin request)
- **Broadcast-driven multi-pod refresh** — `DefinitionCacheInvalidationEvent` is published via Dapr so every pod independently refreshes its in-memory cache using its own `LastInitializedAt` as the delta boundary; the initiating pod also updates the distributed cache

## Test plan

- [ ] Trigger `POST /api/v1/definitions/publish` for several components, then call `GET /api/v1/definitions/re-initialize` — verify all published components appear in cache
- [ ] Trigger `re-initialize` while a concurrent publish is in progress — verify no component is silently dropped from cache on the next delta load
- [ ] Trigger `re-initialize?fullLoad=true` — verify the entire cache is rebuilt from scratch regardless of `LastInitializedAt`
- [ ] Confirm memory usage does not spike on repeated cache invalidation events in a large dataset environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Implement incremental, per-pod gated definition cache initialization with optional full reloads to prevent OOM and missed updates in large datasets.

New Features:
- Add per-pod CacheInitializationGate to serialize cache initialization and track last successful initialization timestamp.
- Introduce incremental (delta) cache loading based on instance modification timestamps with a fullLoad override flag.
- Expose a version-aware instance data query path so callers can request specific historical versions of instance data.
- Add a set-domain.sh helper script to switch APP_DOMAIN and database names across local configs.

Bug Fixes:
- Prevent OutOfMemory conditions by paging active instance reads and avoiding full-table reloads on every cache invalidation.
- Ensure instance modification timestamps are updated on publish and data changes so incremental loads pick up new versions.
- Fix cache initialization race windows by capturing the delta boundary timestamp before database reads.
- Correct instance query handlers to respect the requested data version instead of always using the latest snapshot.

Enhancements:
- Add merge-based cache update APIs to support incremental in-memory cache upserts without clearing existing entries.
- Update cache initialization flows and hosted services to honor the fullLoad flag and integrate with broadcast invalidation events.
- Adjust RuntimeService to use paged reads from the instance repository for better scalability on large datasets.
- Simplify package-api-server version update behavior by no longer rewriting flowVersion at the root level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for retrieving specific versions of instance data, enabling access to historical snapshots instead of only the latest version.
  * Introduced flexible cache refresh modes: full cache reload or incremental merge of recent changes, optimizing performance based on your needs.

* **Chores**
  * Added domain configuration utility for development environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->