### PR TITLE
feat: enhance GetInstancesTaskExecutor to support grouped instance da…

### DIFF
--- a/src/BBT.Workflow.Application/Tasks/Executors/Trigger/GetInstancesTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Trigger/GetInstancesTaskExecutor.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using BBT.Aether;
+using BBT.Workflow;
 using BBT.Aether.Results;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Discovery;
@@ -108,36 +109,76 @@ public sealed class GetInstancesTaskExecutor : TriggerTaskExecutorBase<GetInstan
                     taskType: TaskType.ToString()));
             }
 
-            // Step 2: Get data for each instance
+            var listResponse = instanceListResult.Value!;
+            var basePath = _urlTemplateBuilder.BuildFunctionListUrl(
+                task.TriggerDomain,
+                task.TriggerFlow,
+                "data");
+
+            var groupItems = TryMaterializeGroupSummaries(listResponse);
+            if (groupItems != null)
+            {
+                // groupBy: items are GroupSummary — do not call GetInstanceData per row
+                var currentPage = task.Page;
+                var pageSize = task.PageSize;
+                var totalEstimate = groupItems.Count;
+                var hasNext = (currentPage * pageSize) < totalEstimate;
+
+                var groupedResponseData = new
+                {
+                    links = new
+                    {
+                        self = $"{basePath}?page={currentPage}&pageSize={pageSize}",
+                        first = $"{basePath}?page=1&pageSize={pageSize}",
+                        next = hasNext
+                            ? $"{basePath}?page={currentPage + 1}&pageSize={pageSize}"
+                            : "",
+                        prev = currentPage > 1
+                            ? $"{basePath}?page={currentPage - 1}&pageSize={pageSize}"
+                            : ""
+                    },
+                    items = groupItems
+                };
+
+                return Result<TaskInvocationResult>.Ok(TaskInvocationResult.Success(
+                    data: groupedResponseData,
+                    statusCode: 200,
+                    taskType: TaskType.ToString(),
+                    metadata: new Dictionary<string, object>
+                    {
+                        ["Page"] = currentPage,
+                        ["PageSize"] = pageSize,
+                        ["HasNext"] = hasNext,
+                        ["ItemCount"] = groupItems.Count,
+                        ["Grouped"] = true
+                    }));
+            }
+
+            // Step 2: Get data for each instance (flat list)
             // Note: ToPagedList uses Items.Count as totalItems estimate since InstanceListWithGroupsResponse doesn't preserve total count
-            var pagedList = instanceListResult.Value!.ToPagedList(task.PageSize, task.Page, instanceListResult.Value.Items.Count);
+            var pagedList = listResponse.ToPagedList(task.PageSize, task.Page, listResponse.Items.Count);
             var instanceDataResults = await ProcessDataFunctionListAsync(
                 task.TriggerDomain,
                 task.TriggerFlow,
                 pagedList,
                 cancellationToken);
 
-            // Build HATEOAS-like response structure for consistency with remote execution
-            var basePath = _urlTemplateBuilder.BuildFunctionListUrl(
-                task.TriggerDomain, 
-                task.TriggerFlow, 
-                "data");
             var responseData = new
             {
                 links = new
                 {
                     self = $"{basePath}?page={pagedList.CurrentPage}&pageSize={pagedList.PageSize}",
                     first = $"{basePath}?page=1&pageSize={pagedList.PageSize}",
-                    next = pagedList.HasNext 
-                        ? $"{basePath}?page={pagedList.CurrentPage + 1}&pageSize={pagedList.PageSize}" 
+                    next = pagedList.HasNext
+                        ? $"{basePath}?page={pagedList.CurrentPage + 1}&pageSize={pagedList.PageSize}"
                         : "",
-                    prev = pagedList.CurrentPage > 1 
-                        ? $"{basePath}?page={pagedList.CurrentPage - 1}&pageSize={pagedList.PageSize}" 
+                    prev = pagedList.CurrentPage > 1
+                        ? $"{basePath}?page={pagedList.CurrentPage - 1}&pageSize={pagedList.PageSize}"
                         : ""
                 },
                 items = instanceDataResults
             };
-            
+
             return Result<TaskInvocationResult>.Ok(TaskInvocationResult.Success(
                 data: responseData,
                 statusCode: 200,
@@ -192,6 +233,46 @@ public sealed class GetInstancesTaskExecutor : TriggerTaskExecutorBase<GetInstan
         }
         
         return results;
+    }
+
+    /// <summary>
+    /// When the list API returns groupBy results, <see cref="InstanceListWithGroupsResponse{T}.Items"/> holds
+    /// <see cref="GroupSummary"/> (or JSON elements after deserialization). Returns null if the payload is not
+    /// a homogeneous group list so the flat instance path can run.
+    /// </summary>
+    private static List<GroupSummary>? TryMaterializeGroupSummaries(
+        InstanceListWithGroupsResponse<GetInstanceOutput> listResponse)
+    {
+        if (listResponse.Items.Count == 0)
+        {
+            return null;
+        }
+
+        var groups = new List<GroupSummary>(listResponse.Items.Count);
+        foreach (var item in listResponse.Items)
+        {
+            switch (item)
+            {
+                case GroupSummary groupSummary:
+                    groups.Add(groupSummary);
+                    break;
+                case JsonElement jsonElement:
+                    var deserialized = JsonSerializer.Deserialize<GroupSummary>(
+                        jsonElement,
+                        JsonSerializerConstants.JsonOptions);
+                    if (deserialized == null)
+                    {
+                        return null;
+                    }
+
+                    groups.Add(deserialized);
+                    break;
+                default:
+                    return null;
+            }
+        }
+
+        return groups;
     }
 
     private async Task<Result<TaskInvocationResult>> ExecuteRemoteAsync(

--- a/test/BBT.Workflow.Application.Tests/Tasks/Executors/GetInstancesTaskExecutorTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Tasks/Executors/GetInstancesTaskExecutorTests.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.Results;
+using BBT.Workflow;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Discovery;
+using BBT.Workflow.Execution;
+using BBT.Workflow.Gateway;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Runtime;
+using BBT.Workflow.Scripting;
+using BBT.Workflow.Tasks.Executors;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Application.Tests.Tasks.Executors;
+
+public sealed class GetInstancesTaskExecutorTests
+{
+    private static TaskExecutorContext CreateContext(GetInstancesTask task)
+    {
+        var onExecute = OnExecuteTask.Create(1, task, ScriptCode.FromNative(string.Empty));
+        var instance = Instance.Create(Guid.NewGuid(), "test-flow", "1.0", "ctx-key");
+        var scriptContext = new ScriptContext.Builder(NullLogger<ScriptContext>.Instance)
+            .SetRuntime(Substitute.For<IRuntimeInfoProvider>())
+            .SetInstance(instance)
+            .Build();
+
+        return new TaskExecutorContext(task, onExecute, scriptContext, null, TaskTrigger.OnExecute);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenListReturnsGroups_SkipsGetInstanceData_AndReturnsGroupedMetadata()
+    {
+        var task = WorkflowTaskFactory.CreateGetInstancesTask(
+            domain: "test-domain",
+            flow: "test-flow",
+            filter: """{"groupBy":["status"]}""");
+
+        var gateway = Substitute.For<IInstanceQueryGateway>();
+        var groups = new List<GroupSummary>
+        {
+            new() { Name = "open", Count = 2 },
+            new() { Name = "done", Count = 3 }
+        };
+        gateway.GetInstanceListAsync(Arg.Any<GetInstanceListInput>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok(InstanceListWithGroupsResponse<GetInstanceOutput>.FromGroups(groups)));
+
+        var runtime = Substitute.For<IRuntimeInfoProvider>();
+        runtime.Domain.Returns("test-domain");
+
+        var urlBuilder = Substitute.For<IUrlTemplateBuilder>();
+        urlBuilder.BuildFunctionListUrl("test-domain", "test-flow", "data")
+            .Returns("/api/test-domain/workflows/test-flow/functions/data");
+
+        var executor = new GetInstancesTaskExecutor(
+            Substitute.For<IScriptEngine>(),
+            runtime,
+            Substitute.For<IRemoteInvokerService>(),
+            gateway,
+            Substitute.For<IDomainDiscoveryResolver>(),
+            urlBuilder,
+            NullLogger<GetInstancesTaskExecutor>.Instance);
+
+        var result = await executor.ExecuteAsync(CreateContext(task), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await gateway.DidNotReceive()
+            .GetInstanceDataAsync(Arg.Any<GetInstanceDataInput>(), Arg.Any<CancellationToken>());
+
+        var response = result.Value!;
+        response.IsSuccess.ShouldBeTrue();
+        response.Metadata!["Grouped"].ShouldBe(true);
+        response.Metadata["ItemCount"].ShouldBe(2);
+
+        var dataJson = JsonSerializer.Serialize(response.Data, JsonSerializerConstants.JsonOptions);
+        using var doc = JsonDocument.Parse(dataJson);
+        Assert.Equal(2, doc.RootElement.GetProperty("items").GetArrayLength());
+        Assert.Equal("open", doc.RootElement.GetProperty("items")[0].GetProperty("name").GetString());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenListReturnsInstances_CallsGetInstanceDataPerItem()
+    {
+        var task = WorkflowTaskFactory.CreateGetInstancesTask(domain: "test-domain", flow: "test-flow");
+
+        var instanceRow = new GetInstanceOutput { Key = "inst-1" };
+        var listResponse = new InstanceListWithGroupsResponse<GetInstanceOutput>();
+        listResponse.Items.Add(instanceRow);
+
+        var gateway = Substitute.For<IInstanceQueryGateway>();
+        gateway.GetInstanceListAsync(Arg.Any<GetInstanceListInput>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok(listResponse));
+        gateway.GetInstanceDataAsync(
+                Arg.Is<GetInstanceDataInput>(i => i.Instance == "inst-1"),
+                Arg.Any<CancellationToken>())
+            .Returns(ConditionalResult<GetInstanceDataOutput>.Success(new GetInstanceDataOutput()));
+
+        var runtime = Substitute.For<IRuntimeInfoProvider>();
+        runtime.Domain.Returns("test-domain");
+
+        var urlBuilder = Substitute.For<IUrlTemplateBuilder>();
+        urlBuilder.BuildFunctionListUrl(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
+            .Returns("/fn/data");
+
+        var executor = new GetInstancesTaskExecutor(
+            Substitute.For<IScriptEngine>(),
+            runtime,
+            Substitute.For<IRemoteInvokerService>(),
+            gateway,
+            Substitute.For<IDomainDiscoveryResolver>(),
+            urlBuilder,
+            NullLogger<GetInstancesTaskExecutor>.Instance);
+
+        var result = await executor.ExecuteAsync(CreateContext(task), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await gateway.Received(1)
+            .GetInstanceDataAsync(
+                Arg.Is<GetInstanceDataInput>(i => i.Instance == "inst-1"),
+                Arg.Any<CancellationToken>());
+        result.Value!.Metadata!.ContainsKey("Grouped").ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenItemsAreJsonElements_DeserializesAsGroupSummaries()
+    {
+        var task = WorkflowTaskFactory.CreateGetInstancesTask(domain: "test-domain", flow: "test-flow");
+
+        var listResponse = new InstanceListWithGroupsResponse<GetInstanceOutput>
+        {
+            Items =
+            [
+                JsonSerializer.SerializeToElement(
+                    new GroupSummary { Name = "a", Count = 5 },
+                    JsonSerializerConstants.JsonOptions)
+            ]
+        };
+
+        var gateway = Substitute.For<IInstanceQueryGateway>();
+        gateway.GetInstanceListAsync(Arg.Any<GetInstanceListInput>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok(listResponse));
+
+        var runtime = Substitute.For<IRuntimeInfoProvider>();
+        runtime.Domain.Returns("test-domain");
+
+        var urlBuilder = Substitute.For<IUrlTemplateBuilder>();
+        urlBuilder.BuildFunctionListUrl(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
+            .Returns("/fn/data");
+
+        var executor = new GetInstancesTaskExecutor(
+            Substitute.For<IScriptEngine>(),
+            runtime,
+            Substitute.For<IRemoteInvokerService>(),
+            gateway,
+            Substitute.For<IDomainDiscoveryResolver>(),
+            urlBuilder,
+            NullLogger<GetInstancesTaskExecutor>.Instance);
+
+        var result = await executor.ExecuteAsync(CreateContext(task), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await gateway.DidNotReceive()
+            .GetInstanceDataAsync(Arg.Any<GetInstanceDataInput>(), Arg.Any<CancellationToken>());
+        result.Value!.Metadata!["Grouped"].ShouldBe(true);
+    }
+}


### PR DESCRIPTION
…ta retrieval

- Added logic to handle cases where the instance list API returns grouped results, allowing for optimized data retrieval without individual instance calls.
- Introduced TryMaterializeGroupSummaries method to deserialize group summaries from JSON elements.
- Updated ExecuteAsync method to return grouped metadata and pagination links when applicable.
- Added unit tests to validate behavior for both grouped and flat instance data retrieval scenarios.

## Summary by Sourcery

Support grouped instance list responses in GetInstancesTaskExecutor and add coverage for both grouped and flat retrieval paths.

New Features:
- Return grouped instance metadata directly when the instance list API is group-based, including pagination links and grouping metadata.

Enhancements:
- Add helper to materialize homogeneous group summaries from list API responses, falling back to flat instance processing when grouping is not applicable.

Tests:
- Add unit tests verifying grouped responses bypass per-instance data fetches, flat responses still call GetInstanceData, and JSON element items are deserialized into group summaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Instance list responses now support grouped result format with pagination metadata and additional response indicators.

* **Tests**
  * Added comprehensive test coverage for instance list executor, validating grouped and flat response scenarios with proper metadata handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->