### PR TITLE
fix: restore AmbientServiceProvider.Current in all local Gateway and PostCommit scopes

### DIFF
--- a/init/VNext.Init.Host/package-api-server.js
+++ b/init/VNext.Init.Host/package-api-server.js
@@ -14,6 +14,7 @@
 
 const http = require('http');
 const https = require('https');
+const crypto = require('crypto');
 const fs = require('fs').promises;
 const path = require('path');
 const { execSync, spawn } = require('child_process');
@@ -38,6 +39,59 @@ const SERVER_HEADERS_TIMEOUT_MS = parseInt(process.env.SERVER_HEADERS_TIMEOUT_MS
  * The special core runtime package that requires domain replacement for SYS files
  */
 const VNEXT_CORE_RUNTIME_PACKAGE = '@burgan-tech/vnext-core-runtime';
+
+const JOB_TTL_MS = 30 * 60 * 1000; // 30 minutes
+const jobs = new Map();
+
+/**
+ * @typedef {'accepted'|'processing'|'completed'|'failed'} JobStatus
+ * @typedef {{current: number, total: number, currentFile: string, phase: string}} JobProgress
+ * @typedef {{id: string, packageName: string, status: JobStatus, progress: JobProgress|null, results: Object|null, error: string|null, createdAt: string, updatedAt: string}} Job
+ */
+
+/**
+ * Create a new job entry and store it.
+ * @param {string} packageName
+ * @returns {Job}
+ */
+function createJob(packageName) {
+    cleanupExpiredJobs();
+    const id = crypto.randomUUID();
+    const job = {
+        id,
+        packageName,
+        status: 'accepted',
+        progress: null,
+        results: null,
+        error: null,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+    };
+    jobs.set(id, job);
+    return job;
+}
+
+/**
+ * Update mutable fields on an existing job.
+ * @param {Job} job
+ * @param {Partial<Job>} fields
+ */
+function updateJob(job, fields) {
+    Object.assign(job, fields, { updatedAt: new Date().toISOString() });
+}
+
+/**
+ * Remove jobs older than JOB_TTL_MS that are in a terminal state.
+ */
+function cleanupExpiredJobs() {
+    const now = Date.now();
+    for (const [id, job] of jobs) {
+        if ((job.status === 'completed' || job.status === 'failed') &&
+            (now - new Date(job.updatedAt).getTime()) > JOB_TTL_MS) {
+            jobs.delete(id);
+        }
+    }
+}
 
 /**
  * ANSI color codes for console output
@@ -608,8 +662,9 @@ function logErrorResponse(responseBody, context) {
  * @param {boolean} shouldReplaceDomain - Whether to replace domain fields
  * @param {string} appDomain - Target app domain
  * @param {Object} results - Results object to update
+ * @param {Job} [job] - Optional job for progress tracking
  */
-async function processJsonFile(jsonFilePath, packagePath, componentType, vnextConfig, shouldReplaceDomain, appDomain, results) {
+async function processJsonFile(jsonFilePath, packagePath, componentType, vnextConfig, shouldReplaceDomain, appDomain, results, job) {
             const relativePath = path.relative(packagePath, jsonFilePath);
             const fileName = path.basename(jsonFilePath);
             
@@ -639,6 +694,17 @@ async function processJsonFile(jsonFilePath, packagePath, componentType, vnextCo
         log.error(`Failed to process ${relativePath}: ${e.message}`);
                 results.failed.push(relativePath);
             }
+
+    if (job) {
+        const current = results.success.length + results.failed.length;
+        updateJob(job, {
+            progress: {
+                ...job.progress,
+                current,
+                currentFile: relativePath,
+            },
+        });
+    }
         }
 
 /**
@@ -651,8 +717,9 @@ async function processJsonFile(jsonFilePath, packagePath, componentType, vnextCo
  * @param {boolean} shouldReplaceDomain - Whether to replace domain fields
  * @param {string} appDomain - Target app domain
  * @param {Object} results - Results object to update
+ * @param {Job} [job] - Optional job for progress tracking
  */
-async function processWorkflowsWithOrdering(workflowDir, packagePath, vnextConfig, shouldReplaceDomain, appDomain, results) {
+async function processWorkflowsWithOrdering(workflowDir, packagePath, vnextConfig, shouldReplaceDomain, appDomain, results, job) {
     log.subsection(`Processing WORKFLOWS (Priority Order)`);
     
     try {
@@ -674,7 +741,7 @@ async function processWorkflowsWithOrdering(workflowDir, packagePath, vnextConfi
     // Step 1: Process sys-flows.json first (if exists)
     if (sysFlowsFile) {
         log.info(`${colors.bold}Step 1: Loading sys-flows (Flow Definitions)${colors.reset}`);
-        await processJsonFile(sysFlowsFile, packagePath, 'workflows', vnextConfig, shouldReplaceDomain, appDomain, results);
+        await processJsonFile(sysFlowsFile, packagePath, 'workflows', vnextConfig, shouldReplaceDomain, appDomain, results, job);
     } else {
         log.warn('sys-flows.json not found in Workflows directory');
     }
@@ -683,7 +750,7 @@ async function processWorkflowsWithOrdering(workflowDir, packagePath, vnextConfi
     if (otherFiles.length > 0) {
         log.info(`${colors.bold}Step 2: Loading other workflow files (${otherFiles.length} files)${colors.reset}`);
         for (const jsonFilePath of otherFiles) {
-            await processJsonFile(jsonFilePath, packagePath, 'workflows', vnextConfig, shouldReplaceDomain, appDomain, results);
+            await processJsonFile(jsonFilePath, packagePath, 'workflows', vnextConfig, shouldReplaceDomain, appDomain, results, job);
         }
     }
 }
@@ -697,8 +764,9 @@ async function processWorkflowsWithOrdering(workflowDir, packagePath, vnextConfi
  * @param {boolean} shouldReplaceDomain - Whether to replace domain fields
  * @param {string} appDomain - Target app domain
  * @param {Object} results - Results object to update
+ * @param {Job} [job] - Optional job for progress tracking
  */
-async function processComponentDirectory(componentDir, packagePath, vnextConfig, shouldReplaceDomain, appDomain, results) {
+async function processComponentDirectory(componentDir, packagePath, vnextConfig, shouldReplaceDomain, appDomain, results, job) {
     log.subsection(`Processing ${componentDir.type.toUpperCase()}`);
     
     try {
@@ -715,7 +783,7 @@ async function processComponentDirectory(componentDir, packagePath, vnextConfig,
     
     // Process each JSON file
     for (const jsonFilePath of jsonFiles) {
-        await processJsonFile(jsonFilePath, packagePath, componentDir.type, vnextConfig, shouldReplaceDomain, appDomain, results);
+        await processJsonFile(jsonFilePath, packagePath, componentDir.type, vnextConfig, shouldReplaceDomain, appDomain, results, job);
     }
 }
 
@@ -738,8 +806,9 @@ async function processComponentDirectory(componentDir, packagePath, vnextConfig,
  * @param {string} packageName - Name of the npm package (e.g., "@burgan-tech/vnext-core-runtime")
  * @param {string|null} appDomain - Target app domain for domain replacement (null = no replacement)
  * @param {boolean} isRuntimePackage - Whether this is the runtime package (special ordering)
+ * @param {Job} [job] - Optional job for progress tracking
  */
-async function processPackage(packagePath, packageName, appDomain, isRuntimePackage = false) {
+async function processPackage(packagePath, packageName, appDomain, isRuntimePackage = false, job) {
     // Read vnext.config.json from package
     const vnextConfig = await readVNextConfig(packagePath);
     
@@ -758,6 +827,21 @@ async function processPackage(packagePath, packageName, appDomain, isRuntimePack
     log.subsection('Component Directories');
     componentDirs.forEach(dir => log.detail(`${dir.type}: ${dir.relativePath}`));
     
+    // Pre-count total files for progress tracking
+    let totalFiles = 0;
+    for (const dir of componentDirs) {
+        try {
+            const files = await findJsonFilesRecursively(dir.path);
+            totalFiles += files.length;
+        } catch { /* directory may not exist */ }
+    }
+
+    if (job) {
+        updateJob(job, {
+            progress: { current: 0, total: totalFiles, currentFile: '', phase: 'uploading' },
+        });
+    }
+
     const results = {
         success: [],
         failed: [],
@@ -772,7 +856,7 @@ async function processPackage(packagePath, packageName, appDomain, isRuntimePack
         // Step 1: Process Workflows FIRST (with sys-flows priority)
         const workflowDir = componentDirs.find(d => d.type === 'workflows');
         if (workflowDir) {
-            await processWorkflowsWithOrdering(workflowDir, packagePath, vnextConfig, shouldReplaceDomain, appDomain, results);
+            await processWorkflowsWithOrdering(workflowDir, packagePath, vnextConfig, shouldReplaceDomain, appDomain, results, job);
         } else {
             log.warn('Workflows directory not configured, skipping...');
         }
@@ -782,14 +866,14 @@ async function processPackage(packagePath, packageName, appDomain, isRuntimePack
         log.section('Loading Other Components');
         
         for (const componentDir of otherDirs) {
-            await processComponentDirectory(componentDir, packagePath, vnextConfig, shouldReplaceDomain, appDomain, results);
+            await processComponentDirectory(componentDir, packagePath, vnextConfig, shouldReplaceDomain, appDomain, results, job);
         }
     } else {
         // Standard package - no special ordering
         log.section('Standard Package - Loading Components');
         
         for (const componentDir of componentDirs) {
-            await processComponentDirectory(componentDir, packagePath, vnextConfig, shouldReplaceDomain, appDomain, results);
+            await processComponentDirectory(componentDir, packagePath, vnextConfig, shouldReplaceDomain, appDomain, results, job);
         }
     }
     
@@ -871,13 +955,11 @@ async function handleHealthCheck(req, res) {
 }
 
 /**
- * Handle Runtime Package Publish
+ * Handle Runtime Package Publish (async job pattern)
  * Endpoint: POST /api/package/runtime/publish
  * 
- * This endpoint is specifically for VNEXT_CORE_RUNTIME_PACKAGE.
- * - appDomain is REQUIRED
- * - Uses special ordering (Workflows first, sys-flows first)
- * - Replaces ALL domain fields
+ * Returns 202 Accepted immediately with a jobId.
+ * Processing runs in the background; poll GET /api/package/publish/status/:jobId for progress.
  */
 async function handleRuntimePublish(req, res) {
     try {
@@ -893,71 +975,37 @@ async function handleRuntimePublish(req, res) {
             appDomain
         } = body;
         
-        // appDomain is REQUIRED for runtime package
         if (!appDomain || appDomain.trim() === '') {
             res.writeHead(400, { 'Content-Type': 'application/json' });
             res.end(JSON.stringify({ 
                 error: 'appDomain is required for runtime package publish',
                 message: 'Please provide appDomain parameter (e.g., "core", "my-domain")'
             }));
-        return;
-    }
-    
-        log.section(`API Request: Runtime Package Publish`);
+            return;
+        }
+
+        const job = createJob(VNEXT_CORE_RUNTIME_PACKAGE);
+
+        log.section(`API Request: Runtime Package Publish [job=${job.id}]`);
         log.info(`Package: ${VNEXT_CORE_RUNTIME_PACKAGE}@${version}`);
         log.info(`App Domain: ${appDomain} (REQUIRED)`);
         log.info(`Domain Replacement: ALL domains will be replaced`);
-        
-        // Wait for vnext app to be ready
-        await waitForVNextApp();
-        
-        // Build auth options
-        const authOptions = {
-            token: npmToken,
-            username: npmUsername,
-            password: npmPassword,
-            email: npmEmail
-        };
-        
-        // Download package
-        const packagePath = await downloadPackage(VNEXT_CORE_RUNTIME_PACKAGE, version, npmRegistry, authOptions);
-        
-        // Verify package structure
-        await verifyPackageStructure(packagePath);
-        
-        // Process and publish with isRuntimePackage=true (special ordering)
-        const results = await processPackage(packagePath, VNEXT_CORE_RUNTIME_PACKAGE, appDomain, true);
-        
-        // Determine success status and message based on results
-        let success = true;
-        let message = 'Runtime package processed and published successfully';
-        
-        if (results.success.length === 0 && results.failed.length > 0) {
-            // All packages failed
-            success = false;
-            message = 'Runtime package processing failed. No packages were loaded.';
-        } else if (results.success.length > 0 && results.failed.length > 0) {
-            // Partial success
-            success = false;
-            message = `Runtime package partially processed. ${results.success.length} packages loaded successfully, ${results.failed.length} packages failed to load.`;
-        }
-        
-        // Trigger re-initialization
-        await reInitializeDefinitions();
-        
 
-        res.writeHead(success ? 200 : 207, { 'Content-Type': 'application/json' });
+        res.writeHead(202, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({
-            success: success,
-            message: message,
-            packageName: VNEXT_CORE_RUNTIME_PACKAGE,
-            appDomain: appDomain,
-            results: {
-                successful: results.success,
-                failed: results.failed,
-                skipped: results.skipped
-            }
+            jobId: job.id,
+            statusUrl: `/api/package/publish/status/${job.id}`,
+            message: 'Job accepted. Poll statusUrl for progress.',
         }));
+
+        runPackagePublishJob(job, {
+            packageName: VNEXT_CORE_RUNTIME_PACKAGE,
+            version,
+            npmRegistry,
+            authOptions: { token: npmToken, username: npmUsername, password: npmPassword, email: npmEmail },
+            appDomain,
+            isRuntimePackage: true,
+        });
         
     } catch (error) {
         log.error(`Error: ${error.message}`);
@@ -973,13 +1021,11 @@ async function handleRuntimePublish(req, res) {
 }
 
 /**
- * Handle Standard Package Publish
+ * Handle Standard Package Publish (async job pattern)
  * Endpoint: POST /api/package/publish
  * 
- * This endpoint is for standard packages (not runtime).
- * - appDomain is OPTIONAL
- * - If appDomain is provided, ALL domain fields will be replaced
- * - No special ordering
+ * Returns 202 Accepted immediately with a jobId.
+ * Processing runs in the background; poll GET /api/package/publish/status/:jobId for progress.
  */
 async function handlePackagePublish(req, res) {
     try {
@@ -1001,59 +1047,27 @@ async function handlePackagePublish(req, res) {
             return;
         }
 
-        log.section(`API Request: Package Publish`);
+        const job = createJob(packageName);
+
+        log.section(`API Request: Package Publish [job=${job.id}]`);
         log.info(`Package: ${packageName}@${version}`);
         log.info(`Domain Replacement: DISABLED`);
-        
-        // Wait for vnext app to be ready
-        await waitForVNextApp();
-        
-        // Build auth options
-        const authOptions = {
-            token: npmToken,
-            username: npmUsername,
-            password: npmPassword,
-            email: npmEmail
-        };
-        
-        // Download package
-        const packagePath = await downloadPackage(packageName, version, npmRegistry, authOptions);
-        
-        // Verify package structure
-        await verifyPackageStructure(packagePath);
-        
-        // Process and publish with isRuntimePackage=false (no special ordering)
-        // Domain replacement is never applied for standard packages
-        const results = await processPackage(packagePath, packageName, null, false);
-        
-        // Determine success status and message based on results
-        let success = true;
-        let message = 'Package processed and published successfully';
-        
-        if (results.success.length === 0 && results.failed.length > 0) {
-            // All packages failed
-            success = false;
-            message = 'Package processing failed. No packages were loaded.';
-        } else if (results.success.length > 0 && results.failed.length > 0) {
-            // Partial success
-            success = false;
-            message = `Package partially processed. ${results.success.length} packages loaded successfully, ${results.failed.length} packages failed to load.`;
-        }
-        
-        // Trigger re-initialization
-        await reInitializeDefinitions();
 
-        res.writeHead(success ? 200 : 207, { 'Content-Type': 'application/json' });
+        res.writeHead(202, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({
-            success: success,
-            message: message,
-            packageName: packageName,
-            results: {
-                successful: results.success,
-                failed: results.failed,
-                skipped: results.skipped
-            }
+            jobId: job.id,
+            statusUrl: `/api/package/publish/status/${job.id}`,
+            message: 'Job accepted. Poll statusUrl for progress.',
         }));
+
+        runPackagePublishJob(job, {
+            packageName,
+            version,
+            npmRegistry,
+            authOptions: { token: npmToken, username: npmUsername, password: npmPassword, email: npmEmail },
+            appDomain: null,
+            isRuntimePackage: false,
+        });
         
     } catch (error) {
         log.error(`Error: ${error.message}`);
@@ -1065,6 +1079,80 @@ async function handlePackagePublish(req, res) {
             success: false,
             error: error.message
         }));
+    }
+}
+
+/**
+ * Background worker for package publish jobs.
+ * Shared by both standard and runtime publish handlers.
+ *
+ * @param {Job} job
+ * @param {Object} opts
+ */
+async function runPackagePublishJob(job, opts) {
+    const { packageName, version, npmRegistry, authOptions, appDomain, isRuntimePackage } = opts;
+    try {
+        updateJob(job, {
+            status: 'processing',
+            progress: { current: 0, total: 0, currentFile: '', phase: 'waiting-for-vnext' },
+        });
+
+        await waitForVNextApp();
+
+        updateJob(job, {
+            progress: { ...job.progress, phase: 'downloading' },
+        });
+
+        const packagePath = await downloadPackage(packageName, version, npmRegistry, authOptions);
+        await verifyPackageStructure(packagePath);
+
+        updateJob(job, {
+            progress: { ...job.progress, phase: 'uploading' },
+        });
+
+        const results = await processPackage(packagePath, packageName, appDomain, isRuntimePackage, job);
+
+        updateJob(job, {
+            progress: { ...job.progress, phase: 're-initializing' },
+        });
+
+        await reInitializeDefinitions();
+
+        let success = true;
+        let message = 'Package processed and published successfully';
+
+        if (results.success.length === 0 && results.failed.length > 0) {
+            success = false;
+            message = 'Package processing failed. No packages were loaded.';
+        } else if (results.success.length > 0 && results.failed.length > 0) {
+            success = false;
+            message = `Package partially processed. ${results.success.length} loaded, ${results.failed.length} failed.`;
+        }
+
+        updateJob(job, {
+            status: 'completed',
+            results: {
+                success,
+                message,
+                packageName,
+                appDomain,
+                successful: results.success,
+                failed: results.failed,
+                skipped: results.skipped,
+            },
+            progress: { ...job.progress, phase: 'done' },
+        });
+
+        log.success(`Job ${job.id} completed — ${message}`);
+    } catch (error) {
+        log.error(`Job ${job.id} failed: ${error.message}`);
+        if (error.stack) log.error(error.stack);
+
+        updateJob(job, {
+            status: 'failed',
+            error: error.message,
+            progress: job.progress ? { ...job.progress, phase: 'failed' } : null,
+        });
     }
 }
 
@@ -1117,6 +1205,33 @@ async function reInitializeDefinitions() {
 }
 
 /**
+ * Handle job status polling
+ * Endpoint: GET /api/package/publish/status/:jobId
+ */
+async function handleJobStatus(req, res) {
+    const jobId = req.url.replace('/api/package/publish/status/', '');
+    const job = jobs.get(jobId);
+
+    if (!job) {
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Job not found', jobId }));
+        return;
+    }
+
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({
+        jobId: job.id,
+        packageName: job.packageName,
+        status: job.status,
+        progress: job.progress,
+        results: job.results,
+        error: job.error,
+        createdAt: job.createdAt,
+        updatedAt: job.updatedAt,
+    }));
+}
+
+/**
  * Handle API request - Route to appropriate handler
  */
 async function handleRequest(req, res) {
@@ -1134,6 +1249,12 @@ async function handleRequest(req, res) {
     // Health check endpoint
     if (req.method === 'GET' && req.url === '/health') {
         await handleHealthCheck(req, res);
+        return;
+    }
+    
+    // Job status polling endpoint
+    if (req.method === 'GET' && req.url.startsWith('/api/package/publish/status/')) {
+        await handleJobStatus(req, res);
         return;
     }
     
@@ -1159,7 +1280,8 @@ async function handleRequest(req, res) {
         availableEndpoints: [
             'GET /health',
             'POST /api/package/publish',
-            'POST /api/package/runtime/publish'
+            'POST /api/package/runtime/publish',
+            'GET /api/package/publish/status/:jobId'
         ]
     }));
 }
@@ -1204,6 +1326,8 @@ function startServer() {
         log.detail(`  - For any npm package`);
         log.detail(`  - appDomain is OPTIONAL`);
         log.detail(`  - If appDomain provided, replaces all domains`);
+        log.info(`Job Status: GET http://localhost:${PORT}/api/package/publish/status/:jobId`);
+        log.detail(`  - Poll for job progress after publish`);
         log.info(`VNext App URL: ${VNEXT_APP_URL}`);
         log.subsection('Timeout Configuration');
         log.info(`Server Timeout: ${SERVER_TIMEOUT_MS}ms (${SERVER_TIMEOUT_MS / 60000} min)`);
@@ -1216,6 +1340,8 @@ function startServer() {
         log.error(`Server error: ${err.message}`);
         process.exit(1);
     });
+
+    setInterval(cleanupExpiredJobs, 5 * 60 * 1000);
 }
 
 // Main execution logic

--- a/src/BBT.Workflow.Application/Execution/PostCommit/PostCommitExecutor.cs
+++ b/src/BBT.Workflow.Application/Execution/PostCommit/PostCommitExecutor.cs
@@ -1,3 +1,4 @@
+using BBT.Aether.DependencyInjection;
 using BBT.Aether.Results;
 using BBT.Workflow.Logging;
 using Microsoft.Extensions.DependencyInjection;
@@ -48,104 +49,117 @@ public sealed class PostCommitExecutor(
         logger.PostCommitExecutorStarting(context.InstanceId, jobs.Count);
 
         using (logger.BeginScope(new Dictionary<string, object>
-        {
-            [TelemetryConstants.TagNames.InstanceId] = context.InstanceId
-        }))
+               {
+                   [TelemetryConstants.TagNames.InstanceId] = context.InstanceId
+               }))
         {
             // Post-commit jobs run outside the lock but in the same request scope.
             // Use a new scope for isolation and proper DI lifetime management.
+            // Update AmbientServiceProvider.Current so that domain events raised during
+            // post-commit handlers resolve hook invokers from the correct scope.
+            var previousAmbient = AmbientServiceProvider.Current;
             await using var scope = scopeFactory.CreateAsyncScope();
             var serviceProvider = scope.ServiceProvider;
-
-            List<Error>? errors = null;
-
-            for (var i = 0; i < jobs.Count; i++)
+            AmbientServiceProvider.Current = serviceProvider;
+            try
             {
-                var job = jobs[i];
+                List<Error>? errors = null;
 
-                // 1) Idempotency check for idempotent jobs
-                if (job is IIdempotentPostCommitJob idempotentJob)
+                for (var i = 0; i < jobs.Count; i++)
                 {
-                    var beginResult = await idempotencyStore.TryBeginAsync(idempotentJob.IdempotencyKey, cancellationToken);
-                    if (!beginResult.IsSuccess)
-                    {
-                        // Store operation failed - treat as job failure
-                        logger.LogWarning(
-                            "Idempotency store failed for job {JobType} with key {Key}: {Error}",
-                            job.GetType().Name,
-                            idempotentJob.IdempotencyKey,
-                            beginResult.Error.Message);
+                    var job = jobs[i];
 
-                        return CreateFailureResult(job, beginResult.Error, i, jobs.Count);
+                    // 1) Idempotency check for idempotent jobs
+                    if (job is IIdempotentPostCommitJob idempotentJob)
+                    {
+                        var beginResult =
+                            await idempotencyStore.TryBeginAsync(idempotentJob.IdempotencyKey, cancellationToken);
+                        if (!beginResult.IsSuccess)
+                        {
+                            // Store operation failed - treat as job failure
+                            logger.LogWarning(
+                                "Idempotency store failed for job {JobType} with key {Key}: {Error}",
+                                job.GetType().Name,
+                                idempotentJob.IdempotencyKey,
+                                beginResult.Error.Message);
+
+                            return CreateFailureResult(job, beginResult.Error, i, jobs.Count);
+                        }
+
+                        if (!beginResult.Value)
+                        {
+                            // Job already processed - skip safely
+                            logger.LogDebug(
+                                "Skipping duplicate job {JobType} with idempotency key {Key}",
+                                job.GetType().Name,
+                                idempotentJob.IdempotencyKey);
+                            continue;
+                        }
                     }
 
-                    if (!beginResult.Value)
+                    // 2) Execute handler
+                    var execResult = await DispatchAsync(job, serviceProvider, context, cancellationToken);
+
+                    if (execResult.IsSuccess)
                     {
-                        // Job already processed - skip safely
-                        logger.LogDebug(
-                            "Skipping duplicate job {JobType} with idempotency key {Key}",
-                            job.GetType().Name,
-                            idempotentJob.IdempotencyKey);
+                        // Mark idempotent job as completed
+                        if (job is IIdempotentPostCommitJob completedJob)
+                        {
+                            await idempotencyStore.MarkCompletedAsync(completedJob.IdempotencyKey, cancellationToken);
+                        }
+
+                        logger.PostCommitJobCompleted(context.InstanceId, job.GetType().Name);
                         continue;
                     }
-                }
 
-                // 2) Execute handler
-                var execResult = await DispatchAsync(job, serviceProvider, context, cancellationToken);
+                    // Handler failed
+                    logger.PostCommitJobFailed(context.InstanceId, job.GetType().Name,
+                        execResult.Error.Message ?? "Unknown error");
 
-                if (execResult.IsSuccess)
-                {
-                    // Mark idempotent job as completed
-                    if (job is IIdempotentPostCommitJob completedJob)
+                    // Mark idempotent job as failed
+                    if (job is IIdempotentPostCommitJob failedJob)
                     {
-                        await idempotencyStore.MarkCompletedAsync(completedJob.IdempotencyKey, cancellationToken);
+                        await idempotencyStore.MarkFailedAsync(
+                            failedJob.IdempotencyKey,
+                            execResult.Error.Code,
+                            execResult.Error.Message,
+                            cancellationToken);
                     }
 
-                    logger.PostCommitJobCompleted(context.InstanceId, job.GetType().Name);
-                    continue;
+                    // 3) Consult failure policy
+                    var decision =
+                        failurePolicy.Decide(new PostCommitFailureContext(job, execResult.Error, i, jobs.Count));
+
+                    errors ??= new List<Error>(capacity: 4);
+                    errors.Add(execResult.Error);
+
+                    if (decision.ShouldMarkInstanceFaulted)
+                    {
+                        return PostCommitResult.Fail(
+                            execResult.Error,
+                            new PostCommitFaultRequest(decision.FaultErrorCode, decision.FaultErrorMessage));
+                    }
+
+                    if (!decision.ShouldContinue)
+                    {
+                        return PostCommitResult.Fail(execResult.Error);
+                    }
                 }
 
-                // Handler failed
-                logger.PostCommitJobFailed(context.InstanceId, job.GetType().Name, execResult.Error.Message ?? "Unknown error");
-
-                // Mark idempotent job as failed
-                if (job is IIdempotentPostCommitJob failedJob)
+                // Continue mode: all jobs processed but some may have failed
+                if (errors is { Count: > 0 })
                 {
-                    await idempotencyStore.MarkFailedAsync(
-                        failedJob.IdempotencyKey,
-                        execResult.Error.Code,
-                        execResult.Error.Message,
-                        cancellationToken);
+                    // Return first error (could aggregate if needed)
+                    return PostCommitResult.Fail(errors[0]);
                 }
 
-                // 3) Consult failure policy
-                var decision = failurePolicy.Decide(new PostCommitFailureContext(job, execResult.Error, i, jobs.Count));
-
-                errors ??= new List<Error>(capacity: 4);
-                errors.Add(execResult.Error);
-
-                if (decision.ShouldMarkInstanceFaulted)
-                {
-                    return PostCommitResult.Fail(
-                        execResult.Error,
-                        new PostCommitFaultRequest(decision.FaultErrorCode, decision.FaultErrorMessage));
-                }
-
-                if (!decision.ShouldContinue)
-                {
-                    return PostCommitResult.Fail(execResult.Error);
-                }
+                logger.PostCommitExecutorCompleted(context.InstanceId, jobs.Count);
+                return PostCommitResult.Ok();
             }
-
-            // Continue mode: all jobs processed but some may have failed
-            if (errors is { Count: > 0 })
+            finally
             {
-                // Return first error (could aggregate if needed)
-                return PostCommitResult.Fail(errors[0]);
+                AmbientServiceProvider.Current = previousAmbient;
             }
-
-            logger.PostCommitExecutorCompleted(context.InstanceId, jobs.Count);
-            return PostCommitResult.Ok();
         }
     }
 

--- a/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/ServiceScopeFactoryExtensions.cs
+++ b/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/ServiceScopeFactoryExtensions.cs
@@ -111,9 +111,6 @@ public static class ServiceScopeFactoryExtensions
     /// </summary>
     /// <typeparam name="T">The type of the result value.</typeparam>
     /// <param name="scopeFactory">The service scope factory.</param>
-    /// <param name="domain">The domain of the workflow.</param>
-    /// <param name="workflowKey">The key of the workflow.</param>
-    /// <param name="workflowVersion">The version of the workflow.</param>
     /// <param name="action">The async operation to execute with the scoped service provider.</param>
     /// <param name="cancellationToken">Cancellation token for the operation.</param>
     /// <returns>A Result containing the operation outcome or workflow loading error.</returns>
@@ -141,6 +138,31 @@ public static class ServiceScopeFactoryExtensions
     ///     cancellationToken);
     /// </code>
     /// </example>
+    /// <summary>
+    /// Executes an async operation in a new DI scope with automatic AmbientServiceProvider restoration.
+    /// Raw version for operations that return any type (not necessarily Result&lt;T&gt;).
+    /// Use this for ConditionalResult&lt;T&gt;, PostCommitResult, or other non-Result return types.
+    /// </summary>
+    public static async Task<T> ExecuteInScopeRawAsync<T>(
+        this IServiceScopeFactory scopeFactory,
+        Func<IServiceProvider, CancellationToken, Task<T>> action,
+        CancellationToken cancellationToken = default)
+    {
+        var previousAmbient = AmbientServiceProvider.Current;
+        var scope = scopeFactory.CreateAsyncScope();
+        try
+        {
+            var sp = scope.ServiceProvider;
+            AmbientServiceProvider.Current = sp;
+            return await action(sp, cancellationToken);
+        }
+        finally
+        {
+            AmbientServiceProvider.Current = previousAmbient;
+            await scope.DisposeAsync();
+        }
+    }
+
     public static Task<Result<T>> ExecuteWithWorkflowAsync<T>(
         this IServiceScopeFactory scopeFactory,
         string domain,

--- a/src/BBT.Workflow.Infrastructure/EventBus/HookedDistributedEventBus.cs
+++ b/src/BBT.Workflow.Infrastructure/EventBus/HookedDistributedEventBus.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Reflection;
+using BBT.Aether.DependencyInjection;
 using BBT.Aether.Events;
 using BBT.Workflow.Events.Hooks;
 using Microsoft.Extensions.DependencyInjection;
@@ -199,9 +200,25 @@ public sealed class HookedDistributedEventBus : IDistributedEventBus
             return HookExecutionResult.NoHooks;
         }
 
-        // Get all invokers for this event type
-        var invokers = GetInvokersForEventType(eventType);
-        
+        // Get all invokers for this event type.
+        // Wrap in try/catch: if the ambient SP is not set (e.g. during startup or background work
+        // that bypasses ExecuteInScopeAsync), scope-validation may throw when the bus is a
+        // singleton and invokers are scoped. In that case fall back to no-hooks so the event
+        // is still published to the inner bus rather than silently lost.
+        List<IEventHookInvoker> invokers;
+        try
+        {
+            invokers = GetInvokersForEventType(eventType);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Failed to resolve hook invokers for {EventType} — skipping hooks and publishing to inner bus",
+                eventType.Name);
+            return HookExecutionResult.NoHooks;
+        }
+
         if (invokers.Count == 0)
         {
             return HookExecutionResult.NoHooks;
@@ -307,9 +324,16 @@ public sealed class HookedDistributedEventBus : IDistributedEventBus
     /// <summary>
     /// Gets all hook invokers that can handle the specified event type.
     /// </summary>
+    /// <remarks>
+    /// Resolves invokers from <see cref="AmbientServiceProvider.Current"/> when available so that
+    /// scoped hooks are resolved from the correct request scope even when this bus instance is a
+    /// singleton (inheriting the lifetime of the inner <see cref="IDistributedEventBus"/>).
+    /// Falls back to the construction-time <see cref="_serviceProvider"/> when no ambient scope is set.
+    /// </remarks>
     private List<IEventHookInvoker> GetInvokersForEventType(Type eventType)
     {
-        var allInvokers = _serviceProvider.GetServices<IEventHookInvoker>();
+        var sp = AmbientServiceProvider.Current ?? _serviceProvider;
+        var allInvokers = sp.GetServices<IEventHookInvoker>();
         
         return allInvokers
             .Where(invoker => invoker.EventType == eventType)

--- a/src/BBT.Workflow.Infrastructure/Gateway/LocalAuthorizeGateway.cs
+++ b/src/BBT.Workflow.Infrastructure/Gateway/LocalAuthorizeGateway.cs
@@ -24,7 +24,7 @@ public sealed class LocalAuthorizeGateway : IAuthorizeGateway
     }
 
     /// <inheritdoc />
-    public async Task<Result<AuthorizeOutput>> GetAuthorizeResultForInstanceAsync(
+    public Task<Result<AuthorizeOutput>> GetAuthorizeResultForInstanceAsync(
         string domain,
         string workflow,
         string instanceId,
@@ -35,33 +35,37 @@ public sealed class LocalAuthorizeGateway : IAuthorizeGateway
         bool checkQueryRoles,
         CancellationToken cancellationToken = default)
     {
-        await using var scope = _serviceScopeFactory.CreateAsyncScope();
-        var currentSchema = scope.ServiceProvider.GetRequiredService<ICurrentSchema>();
-        var authorizeAppService = scope.ServiceProvider.GetRequiredService<IAuthorizeAppService>();
-
-        using (currentSchema.Use(workflow))
+        return _serviceScopeFactory.ExecuteInScopeAsync(async (sp, ct) =>
         {
-            return await authorizeAppService.GetAuthorizeResultForInstanceAsync(
-                domain, workflow, instanceId, role, transitionKey, functionKey, version, checkQueryRoles, cancellationToken);
-        }
+            var currentSchema = sp.GetRequiredService<ICurrentSchema>();
+            var authorizeAppService = sp.GetRequiredService<IAuthorizeAppService>();
+
+            using (currentSchema.Use(workflow))
+            {
+                return await authorizeAppService.GetAuthorizeResultForInstanceAsync(
+                    domain, workflow, instanceId, role, transitionKey, functionKey, version, checkQueryRoles, ct);
+            }
+        }, cancellationToken);
     }
 
     /// <inheritdoc />
-    public async Task<Result<AuthorizationMatrixOutput>> GetAuthorizationMatrixForInstanceAsync(
+    public Task<Result<AuthorizationMatrixOutput>> GetAuthorizationMatrixForInstanceAsync(
         string domain,
         string workflow,
         string instanceId,
         string? version,
         CancellationToken cancellationToken = default)
     {
-        await using var scope = _serviceScopeFactory.CreateAsyncScope();
-        var currentSchema = scope.ServiceProvider.GetRequiredService<ICurrentSchema>();
-        var authorizeAppService = scope.ServiceProvider.GetRequiredService<IAuthorizeAppService>();
-
-        using (currentSchema.Use(workflow))
+        return _serviceScopeFactory.ExecuteInScopeAsync(async (sp, ct) =>
         {
-            return await authorizeAppService.GetAuthorizationMatrixForInstanceAsync(
-                domain, workflow, instanceId, version, cancellationToken);
-        }
+            var currentSchema = sp.GetRequiredService<ICurrentSchema>();
+            var authorizeAppService = sp.GetRequiredService<IAuthorizeAppService>();
+
+            using (currentSchema.Use(workflow))
+            {
+                return await authorizeAppService.GetAuthorizationMatrixForInstanceAsync(
+                    domain, workflow, instanceId, version, ct);
+            }
+        }, cancellationToken);
     }
 }

--- a/src/BBT.Workflow.Infrastructure/Gateway/LocalInstanceCommandGateway.cs
+++ b/src/BBT.Workflow.Infrastructure/Gateway/LocalInstanceCommandGateway.cs
@@ -30,14 +30,14 @@ public sealed class LocalInstanceCommandGateway : IInstanceCommandGateway
         StartInstanceInput input,
         CancellationToken cancellationToken = default)
     {
-        return await _serviceScopeFactory.ExecuteWithWorkflowAsync<StartInstanceOutput>(input.Domain, input.Workflow, input.Version, async (sp, cancellationToken) =>
+        return await _serviceScopeFactory.ExecuteWithWorkflowAsync(input.Domain, input.Workflow, input.Version, async (sp, ct) =>
         {
             var currentSchema = sp.GetRequiredService<ICurrentSchema>();
             var commandService = sp.GetRequiredService<IInstanceCommandAppService>();
 
             using (currentSchema.Use(input.Workflow))
             {
-                return await commandService.StartAsync(input, cancellationToken);
+                return await commandService.StartAsync(input, ct);
             }
         }, cancellationToken);
     }
@@ -47,89 +47,93 @@ public sealed class LocalInstanceCommandGateway : IInstanceCommandGateway
         StartInstanceInput input,
         CancellationToken cancellationToken = default)
     {
-        // StartSubAsync uses the same StartAsync endpoint but with sub-specific handling
-        // The IInstanceCommandAppService.StartAsync handles both normal and sub-flow starts
-        return await _serviceScopeFactory.ExecuteWithWorkflowAsync<StartInstanceOutput>(input.Domain, input.Workflow, input.Version, async (sp, cancellationToken) =>
+        return await _serviceScopeFactory.ExecuteWithWorkflowAsync(input.Domain, input.Workflow, input.Version, async (sp, ct) =>
         {
             var currentSchema = sp.GetRequiredService<ICurrentSchema>();
             var commandService = sp.GetRequiredService<IInstanceCommandAppService>();
 
             using (currentSchema.Use(input.Workflow))
             {
-                return await commandService.StartAsync(input, cancellationToken);
+                return await commandService.StartAsync(input, ct);
             }
         }, cancellationToken);
     }
 
     /// <inheritdoc />
-    public async Task<Result<TransitionOutput>> TransitionAsync(
+    public Task<Result<TransitionOutput>> TransitionAsync(
         Guid instanceId,
         string transitionKey,
         TransitionInput input,
         CancellationToken cancellationToken = default)
     {
-        await using var scope = _serviceScopeFactory.CreateAsyncScope();
-        var currentSchema = scope.ServiceProvider.GetRequiredService<ICurrentSchema>();
-        var commandService = scope.ServiceProvider.GetRequiredService<IInstanceCommandAppService>();
-
-        using (currentSchema.Use(input.Workflow))
+        return _serviceScopeFactory.ExecuteInScopeAsync(async (sp, ct) =>
         {
-            return await commandService.TransitionAsync(
-                instanceId.ToString(),
-                transitionKey,
-                input,
-                cancellationToken);
-        }
+            var currentSchema = sp.GetRequiredService<ICurrentSchema>();
+            var commandService = sp.GetRequiredService<IInstanceCommandAppService>();
+
+            using (currentSchema.Use(input.Workflow))
+            {
+                return await commandService.TransitionAsync(
+                    instanceId.ToString(),
+                    transitionKey,
+                    input,
+                    ct);
+            }
+        }, cancellationToken);
     }
 
     /// <inheritdoc />
-    public async Task<Result> CompleteAsync(
+    public Task<Result> CompleteAsync(
         FlowCompletedInput input,
         CancellationToken cancellationToken = default)
     {
-        await using var scope = _serviceScopeFactory.CreateAsyncScope();
-        var currentSchema = scope.ServiceProvider.GetRequiredService<ICurrentSchema>();
-        var subflowCompletionService = scope.ServiceProvider.GetRequiredService<ISubflowCompletionService>();
-        var unitOfWorkManager = scope.ServiceProvider.GetRequiredService<IUnitOfWorkManager>();
-
-        using (currentSchema.Use(input.Flow))
+        return _serviceScopeFactory.ExecuteInScopeAsync(async (sp, ct) =>
         {
-            await using var uow = await unitOfWorkManager.BeginAsync(new UnitOfWorkOptions
+            var currentSchema = sp.GetRequiredService<ICurrentSchema>();
+            var subflowCompletionService = sp.GetRequiredService<ISubflowCompletionService>();
+            var unitOfWorkManager = sp.GetRequiredService<IUnitOfWorkManager>();
+
+            using (currentSchema.Use(input.Flow))
             {
-                Scope = UnitOfWorkScopeOption.RequiresNew
-            }, cancellationToken);
+                await using var uow = await unitOfWorkManager.BeginAsync(new UnitOfWorkOptions
+                {
+                    Scope = UnitOfWorkScopeOption.RequiresNew
+                }, ct);
 
-            await subflowCompletionService.CompletionAsync(input, cancellationToken);
-            await uow.SaveChangesAsync(cancellationToken);
-            await uow.CommitAsync(cancellationToken);
+                await subflowCompletionService.CompletionAsync(input, ct);
+                await uow.SaveChangesAsync(ct);
+                await uow.CommitAsync(ct);
 
-            return Result.Ok();
-        }
+                return Result.Ok();
+            }
+        }, cancellationToken);
     }
 
     /// <inheritdoc />
-    public async Task<Result> UpdateSubFlowStateAsync(
+    public Task<Result> UpdateSubFlowStateAsync(
         SubFlowStateChangedInput input,
         CancellationToken cancellationToken = default)
     {
-        await using var scope = _serviceScopeFactory.CreateAsyncScope();
-        var currentSchema = scope.ServiceProvider.GetRequiredService<ICurrentSchema>();
-        var subflowStateService = scope.ServiceProvider.GetRequiredService<ISubflowStateService>();
-        var unitOfWorkManager = scope.ServiceProvider.GetRequiredService<IUnitOfWorkManager>();
-
-        using (currentSchema.Use(input.Flow))
+        return _serviceScopeFactory.ExecuteInScopeAsync(async (sp, ct) =>
         {
-            await using var uow = await unitOfWorkManager.BeginAsync(new UnitOfWorkOptions
+            var currentSchema = sp.GetRequiredService<ICurrentSchema>();
+            var subflowStateService = sp.GetRequiredService<ISubflowStateService>();
+            var unitOfWorkManager = sp.GetRequiredService<IUnitOfWorkManager>();
+
+            using (currentSchema.Use(input.Flow))
             {
-                Scope = UnitOfWorkScopeOption.RequiresNew
-            }, cancellationToken);
+                await using var uow = await unitOfWorkManager.BeginAsync(new UnitOfWorkOptions
+                {
+                    Scope = UnitOfWorkScopeOption.RequiresNew
+                }, ct);
 
-            await subflowStateService.UpdateParentStateAsync(input, cancellationToken);
-            await uow.SaveChangesAsync(cancellationToken);
-            await uow.CommitAsync(cancellationToken);
+                await subflowStateService.UpdateParentStateAsync(input, ct);
+                await uow.SaveChangesAsync(ct);
+                await uow.CommitAsync(ct);
 
-            return Result.Ok();
-        }
+                return Result.Ok();
+            }
+        }, cancellationToken);
     }
 }
 

--- a/src/BBT.Workflow.Infrastructure/Gateway/LocalInstanceQueryGateway.cs
+++ b/src/BBT.Workflow.Infrastructure/Gateway/LocalInstanceQueryGateway.cs
@@ -9,7 +9,8 @@ namespace BBT.Workflow.Gateway;
 /// <summary>
 /// Local implementation of instance query gateway.
 /// Executes queries locally with proper schema context.
-/// Uses IServiceScopeFactory to create fresh scope for each operation.
+/// Uses ExecuteInScopeAsync/ExecuteInScopeRawAsync to create fresh scope for each operation
+/// and update AmbientServiceProvider.Current, preventing cross-scope UoW interference.
 /// </summary>
 public sealed class LocalInstanceQueryGateway : IInstanceQueryGateway
 {
@@ -25,161 +26,176 @@ public sealed class LocalInstanceQueryGateway : IInstanceQueryGateway
     }
 
     /// <inheritdoc />
-    public async Task<ConditionalResult<GetInstanceOutput>> GetInstanceAsync(
+    public Task<ConditionalResult<GetInstanceOutput>> GetInstanceAsync(
         GetInstanceInput input,
         CancellationToken cancellationToken = default)
     {
-        await using var scope = _serviceScopeFactory.CreateAsyncScope();
-        var currentSchema = scope.ServiceProvider.GetRequiredService<ICurrentSchema>();
-        var queryService = scope.ServiceProvider.GetRequiredService<IInstanceQueryAppService>();
-
-        using (currentSchema.Use(input.Workflow))
+        return _serviceScopeFactory.ExecuteInScopeRawAsync(async (sp, ct) =>
         {
-            return await queryService.GetInstanceAsync(input, cancellationToken);
-        }
+            var currentSchema = sp.GetRequiredService<ICurrentSchema>();
+            var queryService = sp.GetRequiredService<IInstanceQueryAppService>();
+
+            using (currentSchema.Use(input.Workflow))
+            {
+                return await queryService.GetInstanceAsync(input, ct);
+            }
+        }, cancellationToken);
     }
 
     /// <inheritdoc />
-    public async Task<ConditionalResult<GetInstanceDataOutput>> GetInstanceDataAsync(
+    public Task<ConditionalResult<GetInstanceDataOutput>> GetInstanceDataAsync(
         GetInstanceDataInput input,
         CancellationToken cancellationToken = default)
     {
-        await using var scope = _serviceScopeFactory.CreateAsyncScope();
-        var currentSchema = scope.ServiceProvider.GetRequiredService<ICurrentSchema>();
-        var queryService = scope.ServiceProvider.GetRequiredService<IInstanceQueryAppService>();
-
-        using (currentSchema.Use(input.Workflow))
+        return _serviceScopeFactory.ExecuteInScopeRawAsync(async (sp, ct) =>
         {
-            return await queryService.GetInstanceDataAsync(input, cancellationToken);
-        }
+            var currentSchema = sp.GetRequiredService<ICurrentSchema>();
+            var queryService = sp.GetRequiredService<IInstanceQueryAppService>();
+
+            using (currentSchema.Use(input.Workflow))
+            {
+                return await queryService.GetInstanceDataAsync(input, ct);
+            }
+        }, cancellationToken);
     }
 
     /// <inheritdoc />
-    public async Task<Result<InstanceListWithGroupsResponse<GetInstanceOutput>>> GetInstanceListAsync(
+    public Task<Result<InstanceListWithGroupsResponse<GetInstanceOutput>>> GetInstanceListAsync(
         GetInstanceListInput input,
         CancellationToken cancellationToken = default)
     {
-        await using var scope = _serviceScopeFactory.CreateAsyncScope();
-        var currentSchema = scope.ServiceProvider.GetRequiredService<ICurrentSchema>();
-        var queryService = scope.ServiceProvider.GetRequiredService<IInstanceQueryAppService>();
-
-        using (currentSchema.Use(input.Workflow))
+        return _serviceScopeFactory.ExecuteInScopeAsync(async (sp, ct) =>
         {
-            return await queryService.GetInstanceListAsync(input, cancellationToken);
-        }
+            var currentSchema = sp.GetRequiredService<ICurrentSchema>();
+            var queryService = sp.GetRequiredService<IInstanceQueryAppService>();
+
+            using (currentSchema.Use(input.Workflow))
+            {
+                return await queryService.GetInstanceListAsync(input, ct);
+            }
+        }, cancellationToken);
     }
 
     /// <inheritdoc />
-    public async Task<Result<GetInstanceHistoryOutput>> GetInstanceHistoryAsync(
+    public Task<Result<GetInstanceHistoryOutput>> GetInstanceHistoryAsync(
         GetInstanceHistoryInput input,
         CancellationToken cancellationToken = default)
     {
-        await using var scope = _serviceScopeFactory.CreateAsyncScope();
-        var currentSchema = scope.ServiceProvider.GetRequiredService<ICurrentSchema>();
-        var queryService = scope.ServiceProvider.GetRequiredService<IInstanceQueryAppService>();
-
-        using (currentSchema.Use(input.Workflow))
+        return _serviceScopeFactory.ExecuteInScopeAsync(async (sp, ct) =>
         {
-            return await queryService.GetInstanceHistoryAsync(input, cancellationToken);
-        }
+            var currentSchema = sp.GetRequiredService<ICurrentSchema>();
+            var queryService = sp.GetRequiredService<IInstanceQueryAppService>();
+
+            using (currentSchema.Use(input.Workflow))
+            {
+                return await queryService.GetInstanceHistoryAsync(input, ct);
+            }
+        }, cancellationToken);
     }
 
     /// <inheritdoc />
-    public async Task<ConditionalResult<GetInstanceStateOutput>> GetFunctionWithStateAsync(
+    public Task<ConditionalResult<GetInstanceStateOutput>> GetFunctionWithStateAsync(
         GetFunctionWithInstanceInput input,
         CancellationToken cancellationToken = default)
     {
-        await using var scope = _serviceScopeFactory.CreateAsyncScope();
-        var currentSchema = scope.ServiceProvider.GetRequiredService<ICurrentSchema>();
-        var queryService = scope.ServiceProvider.GetRequiredService<IInstanceQueryAppService>();
-
-        using (currentSchema.Use(input.Workflow))
+        return _serviceScopeFactory.ExecuteInScopeRawAsync(async (sp, ct) =>
         {
-            var stateInput = new GetInstanceStateInput
+            var currentSchema = sp.GetRequiredService<ICurrentSchema>();
+            var queryService = sp.GetRequiredService<IInstanceQueryAppService>();
+
+            using (currentSchema.Use(input.Workflow))
             {
-                Domain = input.Domain,
-                Workflow = input.Workflow,
-                Version = input.Version,
-                Instance = input.Instance,
-                Extensions = input.Extensions,
-                Headers = input.Headers,
-                QueryParams = input.QueryParams,
-                Role = input.Role,
-                IfNoneMatch = input.IfNoneMatch
-            };
-            return await queryService.GetInstanceStateAsync(stateInput, cancellationToken);
-        }
+                var stateInput = new GetInstanceStateInput
+                {
+                    Domain = input.Domain,
+                    Workflow = input.Workflow,
+                    Version = input.Version,
+                    Instance = input.Instance,
+                    Extensions = input.Extensions,
+                    Headers = input.Headers,
+                    QueryParams = input.QueryParams,
+                    Role = input.Role,
+                    IfNoneMatch = input.IfNoneMatch
+                };
+                return await queryService.GetInstanceStateAsync(stateInput, ct);
+            }
+        }, cancellationToken);
     }
 
     /// <inheritdoc />
-    public async Task<Result<GetViewOutput>> GetFunctionWithViewAsync(
+    public Task<Result<GetViewOutput>> GetFunctionWithViewAsync(
         GetFunctionWithInstanceInput input,
         string? transitionKey,
         CancellationToken cancellationToken = default)
     {
-        await using var scope = _serviceScopeFactory.CreateAsyncScope();
-        var currentSchema = scope.ServiceProvider.GetRequiredService<ICurrentSchema>();
-        var queryService = scope.ServiceProvider.GetRequiredService<IInstanceQueryAppService>();
-
-        using (currentSchema.Use(input.Workflow))
+        return _serviceScopeFactory.ExecuteInScopeAsync(async (sp, ct) =>
         {
-            var viewInput = new GetViewInput
+            var currentSchema = sp.GetRequiredService<ICurrentSchema>();
+            var queryService = sp.GetRequiredService<IInstanceQueryAppService>();
+
+            using (currentSchema.Use(input.Workflow))
             {
-                Domain = input.Domain,
-                Workflow = input.Workflow,
-                Version = input.Version,
-                Instance = input.Instance,
-                Headers=input.Headers,
-                QueryParameters=input.QueryParams
-            };
-            return await queryService.GetViewAsync(viewInput, transitionKey, cancellationToken);
-        }
+                var viewInput = new GetViewInput
+                {
+                    Domain = input.Domain,
+                    Workflow = input.Workflow,
+                    Version = input.Version,
+                    Instance = input.Instance,
+                    Headers = input.Headers,
+                    QueryParameters = input.QueryParams
+                };
+                return await queryService.GetViewAsync(viewInput, transitionKey, ct);
+            }
+        }, cancellationToken);
     }
 
     /// <inheritdoc />
-    public async Task<Result<GetSchemaOutput>> GetFunctionWithSchemaAsync(
+    public Task<Result<GetSchemaOutput>> GetFunctionWithSchemaAsync(
         GetFunctionWithInstanceInput input,
         string transitionKey,
         CancellationToken cancellationToken = default)
     {
-        await using var scope = _serviceScopeFactory.CreateAsyncScope();
-        var currentSchema = scope.ServiceProvider.GetRequiredService<ICurrentSchema>();
-        var queryService = scope.ServiceProvider.GetRequiredService<IInstanceQueryAppService>();
-
-        using (currentSchema.Use(input.Workflow))
+        return _serviceScopeFactory.ExecuteInScopeAsync(async (sp, ct) =>
         {
-            var schemaInput = new GetSchemaInput
+            var currentSchema = sp.GetRequiredService<ICurrentSchema>();
+            var queryService = sp.GetRequiredService<IInstanceQueryAppService>();
+
+            using (currentSchema.Use(input.Workflow))
             {
-                Domain = input.Domain,
-                Workflow = input.Workflow,
-                Version = input.Version,
-                Instance = input.Instance
-            };
-            return await queryService.GetSchemaAsync(schemaInput, transitionKey, cancellationToken);
-        }
+                var schemaInput = new GetSchemaInput
+                {
+                    Domain = input.Domain,
+                    Workflow = input.Workflow,
+                    Version = input.Version,
+                    Instance = input.Instance
+                };
+                return await queryService.GetSchemaAsync(schemaInput, transitionKey, ct);
+            }
+        }, cancellationToken);
     }
 
     /// <inheritdoc />
-    public async Task<Result<GetExtensionsOutput>> GetFunctionWithExtensionsAsync(
+    public Task<Result<GetExtensionsOutput>> GetFunctionWithExtensionsAsync(
         GetFunctionWithInstanceInput input,
         CancellationToken cancellationToken = default)
     {
-        await using var scope = _serviceScopeFactory.CreateAsyncScope();
-        var currentSchema = scope.ServiceProvider.GetRequiredService<ICurrentSchema>();
-        var queryService = scope.ServiceProvider.GetRequiredService<IInstanceQueryAppService>();
-
-        using (currentSchema.Use(input.Workflow))
+        return _serviceScopeFactory.ExecuteInScopeAsync(async (sp, ct) =>
         {
-            var extensionsInput = new GetExtensionsInput
+            var currentSchema = sp.GetRequiredService<ICurrentSchema>();
+            var queryService = sp.GetRequiredService<IInstanceQueryAppService>();
+
+            using (currentSchema.Use(input.Workflow))
             {
-                Domain = input.Domain,
-                Workflow = input.Workflow,
-                Version = input.Version,
-                Instance = input.Instance,
-                Extensions = input.Extensions
-            };
-            return await queryService.GetExtensionsAsync(extensionsInput, cancellationToken);
-        }
+                var extensionsInput = new GetExtensionsInput
+                {
+                    Domain = input.Domain,
+                    Workflow = input.Workflow,
+                    Version = input.Version,
+                    Instance = input.Instance,
+                    Extensions = input.Extensions
+                };
+                return await queryService.GetExtensionsAsync(extensionsInput, ct);
+            }
+        }, cancellationToken);
     }
 }
-

--- a/src/BBT.Workflow.Infrastructure/Gateway/LocalInstanceRetryGateway.cs
+++ b/src/BBT.Workflow.Infrastructure/Gateway/LocalInstanceRetryGateway.cs
@@ -28,13 +28,15 @@ public sealed class LocalInstanceRetryGateway : IInstanceRetryGateway
         RetryInstanceInput input,
         CancellationToken cancellationToken = default)
     {
-        await using var scope = _serviceScopeFactory.CreateAsyncScope();
-        var currentSchema = scope.ServiceProvider.GetRequiredService<ICurrentSchema>();
-        var retryService = scope.ServiceProvider.GetRequiredService<IInstanceRetryAppService>();
-
-        using (currentSchema.Use(input.Workflow))
+        return await _serviceScopeFactory.ExecuteInScopeAsync(async (sp, ct) =>
         {
-            return await retryService.RetryAsync(input, cancellationToken);
-        }
+            var currentSchema = sp.GetRequiredService<ICurrentSchema>();
+            var retryService = sp.GetRequiredService<IInstanceRetryAppService>();
+
+            using (currentSchema.Use(input.Workflow))
+            {
+                return await retryService.RetryAsync(input, ct);
+            }
+        }, cancellationToken);
     }
 }

--- a/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceCanceledEventHook.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceCanceledEventHook.cs
@@ -1,7 +1,9 @@
 using BBT.Aether.MultiSchema;
+using BBT.Aether.Results;
 using BBT.Aether.Uow;
 using BBT.Workflow.Events.Hooks;
 using BBT.Workflow.Logging;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace BBT.Workflow.Instances.Events;
@@ -10,6 +12,8 @@ namespace BBT.Workflow.Instances.Events;
 /// Hook executed before InstanceCanceledEvent is published.
 /// Performs pre-publish processing for instance cancellation events.
 /// This hook delegates the actual cancellation logic to IInstanceCancellationService.
+/// Uses IServiceScopeFactory to create an isolated DI scope, avoiding EF transaction
+/// conflicts when the hook runs inside an outer UoW's CommitAsync pipeline.
 /// </summary>
 /// <remarks>
 /// Register this hook in DI using:
@@ -19,9 +23,7 @@ namespace BBT.Workflow.Instances.Events;
 /// </remarks>
 public sealed class InstanceCanceledEventHook(
     ILogger<InstanceCanceledEventHook> logger,
-    IInstanceCancellationService cancellationService,
-    ICurrentSchema currentSchema,
-    IUnitOfWorkManager unitOfWorkManager) : IEventPublishHook<InstanceCanceledEvent>
+    IServiceScopeFactory scopeFactory) : IEventPublishHook<InstanceCanceledEvent>
 {
     /// <summary>
     /// Executes hook logic before the InstanceCanceledEvent is published.
@@ -60,23 +62,31 @@ public sealed class InstanceCanceledEventHook(
     }
 
     /// <summary>
-    /// Processes the instance cancellation locally with proper schema and UoW scope.
+    /// Processes the instance cancellation in an isolated DI scope with its own DbContext
+    /// and UoW, preventing EF transaction conflicts with the caller's active transaction.
     /// </summary>
     /// <param name="eventData">The event data containing instance cancellation details.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     private async Task ProcessLocalAsync(InstanceCanceledEvent eventData, CancellationToken cancellationToken)
     {
-        using (currentSchema.Use(eventData.Flow))
+        await scopeFactory.ExecuteInScopeAsync(async (sp, ct) =>
         {
-            await using (var uow = await unitOfWorkManager.BeginAsync(new UnitOfWorkOptions
-                         {
-                             Scope = UnitOfWorkScopeOption.RequiresNew
-                         }, cancellationToken))
+            var currentSchema = sp.GetRequiredService<ICurrentSchema>();
+            var unitOfWorkManager = sp.GetRequiredService<IUnitOfWorkManager>();
+            var cancellationService = sp.GetRequiredService<IInstanceCancellationService>();
+
+            using (currentSchema.Use(eventData.Flow))
             {
-                await cancellationService.ProcessCancellationAsync(eventData.InstanceId, cancellationToken);
-                await uow.SaveChangesAsync(cancellationToken);
-                await uow.CommitAsync(cancellationToken);
+                await using var uow = await unitOfWorkManager.BeginAsync(new UnitOfWorkOptions
+                {
+                    Scope = UnitOfWorkScopeOption.RequiresNew
+                }, ct);
+
+                await cancellationService.ProcessCancellationAsync(eventData.InstanceId, ct);
+                await uow.SaveChangesAsync(ct);
+                await uow.CommitAsync(ct);
+                return Result.Ok();
             }
-        }
+        }, cancellationToken);
     }
 }

--- a/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceCompletedCleanupEventHook.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceCompletedCleanupEventHook.cs
@@ -1,7 +1,9 @@
 using BBT.Aether.MultiSchema;
+using BBT.Aether.Results;
 using BBT.Aether.Uow;
 using BBT.Workflow.Events.Hooks;
 using BBT.Workflow.Logging;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace BBT.Workflow.Instances.Events;
@@ -9,6 +11,8 @@ namespace BBT.Workflow.Instances.Events;
 /// <summary>
 /// Hook executed before InstanceCompletedCleanupEvent is published.
 /// Cancels all scheduled jobs for the completed instance.
+/// Uses IServiceScopeFactory to create an isolated DI scope, avoiding EF transaction
+/// conflicts when the hook runs inside an outer UoW's CommitAsync pipeline.
 /// </summary>
 /// <remarks>
 /// Register this hook in DI using:
@@ -18,9 +22,7 @@ namespace BBT.Workflow.Instances.Events;
 /// </remarks>
 public sealed class InstanceCompletedCleanupEventHook(
     ILogger<InstanceCompletedCleanupEventHook> logger,
-    IInstanceCancellationService cancellationService,
-    ICurrentSchema currentSchema,
-    IUnitOfWorkManager unitOfWorkManager) : IEventPublishHook<InstanceCompletedCleanupEvent>
+    IServiceScopeFactory scopeFactory) : IEventPublishHook<InstanceCompletedCleanupEvent>
 {
     /// <summary>
     /// Executes hook logic before the InstanceCompletedCleanupEvent is published.
@@ -60,23 +62,31 @@ public sealed class InstanceCompletedCleanupEventHook(
     }
 
     /// <summary>
-    /// Processes the instance completion cleanup locally with proper schema and UoW scope.
+    /// Processes the instance completion cleanup in an isolated DI scope with its own DbContext
+    /// and UoW, preventing EF transaction conflicts with the caller's active transaction.
     /// </summary>
     /// <param name="eventData">The event data containing instance completion details.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     private async Task ProcessLocalAsync(InstanceCompletedCleanupEvent eventData, CancellationToken cancellationToken)
     {
-        using (currentSchema.Use(eventData.Flow))
+        await scopeFactory.ExecuteInScopeAsync(async (sp, ct) =>
         {
-            await using (var uow = await unitOfWorkManager.BeginAsync(new UnitOfWorkOptions
-                         {
-                             Scope = UnitOfWorkScopeOption.RequiresNew
-                         }, cancellationToken))
+            var currentSchema = sp.GetRequiredService<ICurrentSchema>();
+            var unitOfWorkManager = sp.GetRequiredService<IUnitOfWorkManager>();
+            var cancellationService = sp.GetRequiredService<IInstanceCancellationService>();
+
+            using (currentSchema.Use(eventData.Flow))
             {
-                await cancellationService.ProcessCancellationAsync(eventData.InstanceId, cancellationToken);
-                await uow.SaveChangesAsync(cancellationToken);
-                await uow.CommitAsync(cancellationToken);
+                await using var uow = await unitOfWorkManager.BeginAsync(new UnitOfWorkOptions
+                {
+                    Scope = UnitOfWorkScopeOption.RequiresNew
+                }, ct);
+
+                await cancellationService.ProcessCancellationAsync(eventData.InstanceId, ct);
+                await uow.SaveChangesAsync(ct);
+                await uow.CommitAsync(ct);
+                return Result.Ok();
             }
-        }
+        }, cancellationToken);
     }
 }

--- a/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceFaultedCleanupEventHook.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceFaultedCleanupEventHook.cs
@@ -1,7 +1,9 @@
 using BBT.Aether.MultiSchema;
+using BBT.Aether.Results;
 using BBT.Aether.Uow;
 using BBT.Workflow.Events.Hooks;
 using BBT.Workflow.Logging;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace BBT.Workflow.Instances.Events;
@@ -9,6 +11,8 @@ namespace BBT.Workflow.Instances.Events;
 /// <summary>
 /// Hook executed before InstanceFaultedCleanupEvent is published.
 /// Cancels all scheduled jobs for the faulted instance.
+/// Uses IServiceScopeFactory to create an isolated DI scope, avoiding EF transaction
+/// conflicts when the hook runs inside an outer UoW's CommitAsync pipeline.
 /// </summary>
 /// <remarks>
 /// Register this hook in DI using:
@@ -18,9 +22,7 @@ namespace BBT.Workflow.Instances.Events;
 /// </remarks>
 public sealed class InstanceFaultedCleanupEventHook(
     ILogger<InstanceFaultedCleanupEventHook> logger,
-    IInstanceCancellationService cancellationService,
-    ICurrentSchema currentSchema,
-    IUnitOfWorkManager unitOfWorkManager) : IEventPublishHook<InstanceFaultedCleanupEvent>
+    IServiceScopeFactory scopeFactory) : IEventPublishHook<InstanceFaultedCleanupEvent>
 {
     /// <summary>
     /// Executes hook logic before the InstanceFaultedCleanupEvent is published.
@@ -60,23 +62,31 @@ public sealed class InstanceFaultedCleanupEventHook(
     }
 
     /// <summary>
-    /// Processes the instance fault cleanup locally with proper schema and UoW scope.
+    /// Processes the instance fault cleanup in an isolated DI scope with its own DbContext
+    /// and UoW, preventing EF transaction conflicts with the caller's active transaction.
     /// </summary>
     /// <param name="eventData">The event data containing instance fault details.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     private async Task ProcessLocalAsync(InstanceFaultedCleanupEvent eventData, CancellationToken cancellationToken)
     {
-        using (currentSchema.Use(eventData.Flow))
+        await scopeFactory.ExecuteInScopeAsync(async (sp, ct) =>
         {
-            await using (var uow = await unitOfWorkManager.BeginAsync(new UnitOfWorkOptions
-                         {
-                             Scope = UnitOfWorkScopeOption.RequiresNew
-                         }, cancellationToken))
+            var currentSchema = sp.GetRequiredService<ICurrentSchema>();
+            var unitOfWorkManager = sp.GetRequiredService<IUnitOfWorkManager>();
+            var cancellationService = sp.GetRequiredService<IInstanceCancellationService>();
+
+            using (currentSchema.Use(eventData.Flow))
             {
-                await cancellationService.ProcessCancellationAsync(eventData.InstanceId, cancellationToken);
-                await uow.SaveChangesAsync(cancellationToken);
-                await uow.CommitAsync(cancellationToken);
+                await using var uow = await unitOfWorkManager.BeginAsync(new UnitOfWorkOptions
+                {
+                    Scope = UnitOfWorkScopeOption.RequiresNew
+                }, ct);
+
+                await cancellationService.ProcessCancellationAsync(eventData.InstanceId, ct);
+                await uow.SaveChangesAsync(ct);
+                await uow.CommitAsync(ct);
+                return Result.Ok();
             }
-        }
+        }, cancellationToken);
     }
 }

--- a/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/InstanceSubCompletedEventHandler.cs
+++ b/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/InstanceSubCompletedEventHandler.cs
@@ -1,7 +1,6 @@
 using BBT.Aether.DependencyInjection;
 using BBT.Aether.Events;
 using BBT.Aether.MultiSchema;
-using BBT.Aether.Uow;
 using BBT.Workflow.Instances.Events;
 using BBT.Workflow.Logging;
 using BBT.Workflow.Runtime;
@@ -60,16 +59,8 @@ internal sealed class InstanceSubCompletedEventHandler(
 
             await scopeFactory.ExecuteInNewScopeAsync(async sp =>
             {
-                var uowManager = sp.GetRequiredService<IUnitOfWorkManager>();
                 var subflowCompletionService = sp.GetRequiredService<ISubflowCompletionService>();
-
-                await using var uow = await uowManager.BeginAsync(new UnitOfWorkOptions
-                {
-                    Scope = UnitOfWorkScopeOption.RequiresNew
-                }, cancellationToken);
-
                 await subflowCompletionService.CompletionAsync(completedData, cancellationToken);
-                await uow.CommitAsync(cancellationToken);
             });
         }
     }


### PR DESCRIPTION
## Summary

Fixes silent domain event loss when a Gateway routes to the local (same-domain) path.

**Root cause:** `HookedDistributedEventBus.GetInvokersForEventType()` resolves `IEventHookInvoker` from `AmbientServiceProvider.Current`. Any `CreateAsyncScope()` call that does not update the ambient leaves it pointing to the outer (TransitionRunner) scope — hooks resolve from the wrong context and domain events are dropped. The same ambient is used by `IUnitOfWorkManager` for UoW participation decisions, risking cross-scope DbContext contamination.

## Changes

| File | Change |
|---|---|
| `ServiceScopeFactoryExtensions.cs` | Add `ExecuteInScopeRawAsync<T>` overload for `ConditionalResult<T>` and other non-`Result` return types |
| `LocalInstanceQueryGateway.cs` | Migrate all 8 methods to `ExecuteInScopeAsync` / `ExecuteInScopeRawAsync` |
| `LocalInstanceCommandGateway.cs` | Migrate `TransitionAsync`, `CompleteAsync`, `UpdateSubFlowStateAsync` to `ExecuteInScopeAsync` |
| `LocalAuthorizeGateway.cs` | Migrate both methods to `ExecuteInScopeAsync` |
| `PostCommitExecutor.cs` | Add inline ambient save/set/restore (`try/finally`) around the job loop |
| `InstanceCompletedCleanupEventHook.cs` | `ProcessLocalAsync` → `ExecuteInScopeAsync` |
| `InstanceCanceledEventHook.cs` | `ProcessLocalAsync` → `ExecuteInScopeAsync` |
| `InstanceFaultedCleanupEventHook.cs` | `ProcessLocalAsync` → `ExecuteInScopeAsync` |

## Test plan

- [ ] Trigger a transition with a `GetInstances` task on same-domain (onEntry scenario) — no UoW conflict or event loss
- [ ] Trigger a post-commit StartSubflow job — parent instance state updates correctly after completion
- [ ] Verify `HookedDistributedEventBus` logs show no "publishing to inner bus as fallback" warnings
- [ ] `dotnet test test/BBT.Workflow.Application.Tests`
- [ ] `dotnet test test/BBT.Workflow.Infrastructure.Tests`

Closes #504

## Summary by Sourcery

Restore correct ambient service provider usage across local gateways, post-commit execution, and event hooks to prevent cross-scope unit-of-work interference and domain event loss.

Bug Fixes:
- Ensure post-commit jobs execute with AmbientServiceProvider.Current set to the post-commit scope so hooks and UoW decisions resolve from the correct context.
- Resolve event hook invokers from the current ambient service provider when available and fall back gracefully when hooks cannot be resolved, avoiding silent event loss.
- Run instance cancellation and cleanup hooks in isolated scopes with their own UoW to prevent EF transaction conflicts and ensure reliable execution.
- Execute local instance queries, commands, retries, and authorization operations via scoped helpers that update the ambient provider, preventing cross-scope UoW contamination.

Enhancements:
- Introduce ExecuteInScopeRawAsync<T> to support executing arbitrary async operations in a new DI scope with automatic AmbientServiceProvider restoration.
- Simplify sub-completed inbox handler processing by delegating completion work to the existing scoped execution helper instead of manually managing a unit of work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal dependency injection scope management and context handling across workflow execution, event processing, and gateway operations
  * Enhanced ambient service provider lifecycle management for more reliable scoped service resolution in async operations
  * Strengthened error handling in event hooks to prevent failures from blocking event publication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->