### PR TITLE
feat(auth): instance data based authorization with dynamic role grants and request context

### DIFF
--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/AuthorizeFunctionHandler.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/AuthorizeFunctionHandler.cs
@@ -2,6 +2,7 @@ using BBT.Aether.AspNetCore.Results;
 using BBT.Workflow.Authorization;
 using BBT.Workflow.Definitions.Functions;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
 
 namespace BBT.Workflow.Controllers.Instances;
 
@@ -33,6 +34,13 @@ public sealed class AuthorizeFunctionHandler(
                 "true",
                 StringComparison.OrdinalIgnoreCase);
 
+        var routeValues = request.HttpContext.GetRouteData()?.Values
+            .ToDictionary(kv => kv.Key, kv => kv.Value?.ToString());
+        var requestContext = new AuthorizationRequestContext(
+            request.Headers,
+            request.QueryParameters,
+            routeValues);
+
         var result = await authorizeAppService.GetAuthorizeResultForInstanceAsync(
             request.Domain,
             request.Workflow,
@@ -42,6 +50,7 @@ public sealed class AuthorizeFunctionHandler(
             request.Parameters.FunctionKey,
             version,
             checkQueryRoles,
+            requestContext,
             cancellationToken);
 
         if (!result.IsSuccess)

--- a/src/BBT.Workflow.Application/Authorization/AuthorizationRequestContext.cs
+++ b/src/BBT.Workflow.Application/Authorization/AuthorizationRequestContext.cs
@@ -1,0 +1,12 @@
+namespace BBT.Workflow.Authorization;
+
+/// <summary>
+/// HTTP request context available at authorization time.
+/// Populated from the HTTP request and passed through the authorize pipeline.
+/// Enables dynamic role grants to reference <c>$.context.Headers.*</c>,
+/// <c>$.context.QueryParameters.*</c>, and <c>$.context.RouteValues.*</c> paths.
+/// </summary>
+public sealed record AuthorizationRequestContext(
+    IReadOnlyDictionary<string, string?>? Headers = null,
+    IReadOnlyDictionary<string, string?>? QueryParameters = null,
+    IReadOnlyDictionary<string, string?>? RouteValues = null);

--- a/src/BBT.Workflow.Application/Authorization/AuthorizeAppService.cs
+++ b/src/BBT.Workflow.Application/Authorization/AuthorizeAppService.cs
@@ -29,34 +29,6 @@ public sealed class AuthorizeAppService(
     ILogger<AuthorizeAppService> logger) : ApplicationService(serviceProvider), IAuthorizeAppService
 {
     /// <inheritdoc />
-    public async Task<Result<AuthorizeOutput>> GetAuthorizeResultAsync(
-        string domain,
-        string workflow,
-        string role,
-        string? transitionKey,
-        string? functionKey,
-        string? version = null,
-        bool checkQueryRoles = false,
-        CancellationToken cancellationToken = default)
-    {
-        var validation = ValidateAuthorizeTargetWorkflow(transitionKey, functionKey, checkQueryRoles);
-        if (validation.HasValue)
-            return validation.Value;
-
-        runtimeInfoProvider.Check(domain);
-        var workflowVersion = NormalizeVersion(version);
-        var workflowResult = await componentCacheStore.GetFlowAsync(domain, workflow, workflowVersion, cancellationToken);
-        if (!workflowResult.IsSuccess)
-            return Result<AuthorizeOutput>.Fail(workflowResult.Error);
-
-        var wf = workflowResult.Value!;
-        var callerRoles = GetCallerRoles(role);
-        var allowed = await EvaluateAuthorizeAsync(wf, callerRoles, transitionKey, functionKey, null, checkQueryRoles, domain, workflowVersion, cancellationToken);
-        logger.AuthorizeRequest(domain, workflow, role, allowed);
-        return Result<AuthorizeOutput>.Ok(new AuthorizeOutput { Allowed = allowed });
-    }
-
-    /// <inheritdoc />
     public async Task<Result<AuthorizeOutput>> GetAuthorizeResultForInstanceAsync(
         string domain,
         string workflow,
@@ -66,6 +38,7 @@ public sealed class AuthorizeAppService(
         string? functionKey,
         string? version = null,
         bool checkQueryRoles = false,
+        AuthorizationRequestContext? requestContext = null,
         CancellationToken cancellationToken = default)
     {
         var validation = ValidateAuthorizeTargetInstance(transitionKey, functionKey, checkQueryRoles);
@@ -98,7 +71,7 @@ public sealed class AuthorizeAppService(
                 if (IsParentOwnedTransition(wf, transitionKey))
                 {
                     var parentCallerRoles = GetCallerRoles(role);
-                    var parentAllowed = await EvaluateAuthorizeAsync(wf, parentCallerRoles, transitionKey, null, instance, false, domain, workflowVersion, cancellationToken);
+                    var parentAllowed = await EvaluateAuthorizeAsync(wf, parentCallerRoles, transitionKey, null, instance, false, domain, workflowVersion, requestContext, cancellationToken);
                     logger.AuthorizeRequest(domain, workflow, role, parentAllowed);
                     return Result<AuthorizeOutput>.Ok(new AuthorizeOutput { Allowed = parentAllowed });
                 }
@@ -109,7 +82,7 @@ public sealed class AuthorizeAppService(
                     transitionOverride.Roles is { Count: > 0 })
                 {
                     var overrideCallerRoles = GetCallerRoles(role);
-                    var overrideAllowed = await EvaluateWithGrantsAsync(overrideCallerRoles, transitionOverride.Roles!, instance, cancellationToken);
+                    var overrideAllowed = await EvaluateWithGrantsAsync(overrideCallerRoles, transitionOverride.Roles!, instance, requestContext, cancellationToken);
                     logger.AuthorizeRequest(domain, workflow, role, overrideAllowed);
                     return Result<AuthorizeOutput>.Ok(new AuthorizeOutput { Allowed = overrideAllowed });
                 }
@@ -124,7 +97,7 @@ public sealed class AuthorizeAppService(
                     stateOverride.QueryRoles is { Count: > 0 })
                 {
                     var overrideCallerRoles = GetCallerRoles(role);
-                    var overrideAllowed = await EvaluateWithGrantsAsync(overrideCallerRoles, stateOverride.QueryRoles!, instance, cancellationToken);
+                    var overrideAllowed = await EvaluateWithGrantsAsync(overrideCallerRoles, stateOverride.QueryRoles!, instance, requestContext, cancellationToken);
                     logger.AuthorizeRequest(domain, workflow, role, overrideAllowed);
                     return Result<AuthorizeOutput>.Ok(new AuthorizeOutput { Allowed = overrideAllowed });
                 }
@@ -141,11 +114,12 @@ public sealed class AuthorizeAppService(
                 functionKey,
                 version,
                 checkQueryRoles,
+                requestContext,
                 cancellationToken);
         }
 
         var callerRoles = GetCallerRoles(role);
-        var allowed = await EvaluateAuthorizeAsync(wf, callerRoles, transitionKey, functionKey, instance, checkQueryRoles, domain, workflowVersion, cancellationToken);
+        var allowed = await EvaluateAuthorizeAsync(wf, callerRoles, transitionKey, functionKey, instance, checkQueryRoles, domain, workflowVersion, requestContext, cancellationToken);
         logger.AuthorizeRequest(domain, workflow, role, allowed);
         return Result<AuthorizeOutput>.Ok(new AuthorizeOutput { Allowed = allowed });
     }
@@ -161,9 +135,8 @@ public sealed class AuthorizeAppService(
             return [roleParameter.Trim()];
         return null;
     }
-
-    /// <inheritdoc />
-    public async Task<Result<AuthorizationMatrixOutput>> GetAuthorizationMatrixAsync(
+    
+    private async Task<Result<AuthorizationMatrixOutput>> GetAuthorizationMatrixAsync(
         string domain,
         string workflow,
         string? version = null,
@@ -338,20 +311,6 @@ public sealed class AuthorizeAppService(
         string.IsNullOrWhiteSpace(version) ? null : version.Trim();
 
     /// <summary>
-    /// Validates workflow-level authorize: exactly one of transitionKey or functionKey; checkQueryRoles true → error.
-    /// </summary>
-    private static Result<AuthorizeOutput>? ValidateAuthorizeTargetWorkflow(string? transitionKey, string? functionKey, bool checkQueryRoles)
-    {
-        if (checkQueryRoles)
-            return Result<AuthorizeOutput>.Fail(WorkflowErrors.AuthorizeQueryRolesRequiresInstance());
-        var hasTransition = !string.IsNullOrWhiteSpace(transitionKey);
-        var hasFunction = !string.IsNullOrWhiteSpace(functionKey);
-        if (hasTransition == hasFunction)
-            return Result<AuthorizeOutput>.Fail(WorkflowErrors.AuthorizeRequiresExactlyOneTarget());
-        return null;
-    }
-
-    /// <summary>
     /// Validates instance-level authorize: exactly one of transitionKey, functionKey, or checkQueryRoles.
     /// </summary>
     private static Result<AuthorizeOutput>? ValidateAuthorizeTargetInstance(string? transitionKey, string? functionKey, bool checkQueryRoles)
@@ -378,16 +337,17 @@ public sealed class AuthorizeAppService(
         bool checkQueryRoles,
         string domain,
         string? workflowVersion,
+        AuthorizationRequestContext? requestContext,
         CancellationToken cancellationToken)
     {
         if (callerRoles is null || callerRoles.Count == 0)
-            return await EvaluateAuthorizeForSingleRoleAsync(workflow, null, transitionKey, functionKey, instance, checkQueryRoles, domain, workflowVersion, cancellationToken);
+            return await EvaluateAuthorizeForSingleRoleAsync(workflow, null, transitionKey, functionKey, instance, checkQueryRoles, domain, workflowVersion, requestContext, cancellationToken);
 
         foreach (var role in callerRoles)
         {
             if (string.IsNullOrWhiteSpace(role))
                 continue;
-            var allowed = await EvaluateAuthorizeForSingleRoleAsync(workflow, role.Trim(), transitionKey, functionKey, instance, checkQueryRoles, domain, workflowVersion, cancellationToken);
+            var allowed = await EvaluateAuthorizeForSingleRoleAsync(workflow, role.Trim(), transitionKey, functionKey, instance, checkQueryRoles, domain, workflowVersion, requestContext, cancellationToken);
             if (allowed)
                 return true;
         }
@@ -403,17 +363,18 @@ public sealed class AuthorizeAppService(
         bool checkQueryRoles,
         string domain,
         string? workflowVersion,
+        AuthorizationRequestContext? requestContext,
         CancellationToken cancellationToken)
     {
         if (checkQueryRoles)
-            return await EvaluateQueryRolesAsync(workflow, role, instance, cancellationToken);
+            return await EvaluateQueryRolesAsync(workflow, role, instance, requestContext, cancellationToken);
 
         if (!string.IsNullOrWhiteSpace(transitionKey))
         {
             var transition = workflow.FindTransitionInContext(transitionKey);
             if (transition == null)
                 return false;
-            return await transitionAuthorizationManager.IsTransitionAllowedForRoleAsync(workflow, transition, instance, role, cancellationToken);
+            return await transitionAuthorizationManager.IsTransitionAllowedForRoleAsync(workflow, transition, instance, role, requestContext, cancellationToken);
         }
 
         if (!string.IsNullOrWhiteSpace(functionKey))
@@ -423,7 +384,7 @@ public sealed class AuthorizeAppService(
                 return false;
             if (fnResult.Value!.Roles.Count == 0)
                 return true; // No roles defined on function → allow
-            return await transitionAuthorizationManager.IsRoleAllowedForGrantsAsync(role, fnResult.Value!.Roles, instance, cancellationToken);
+            return await transitionAuthorizationManager.IsRoleAllowedForGrantsAsync(role, fnResult.Value!.Roles, instance, requestContext, cancellationToken);
         }
 
         return false;
@@ -437,6 +398,7 @@ public sealed class AuthorizeAppService(
         IReadOnlyList<string>? callerRoles,
         IReadOnlyCollection<RoleGrant> grants,
         Instance instance,
+        AuthorizationRequestContext? requestContext,
         CancellationToken cancellationToken)
     {
         if (callerRoles is null || callerRoles.Count == 0)
@@ -445,7 +407,7 @@ public sealed class AuthorizeAppService(
         {
             if (string.IsNullOrWhiteSpace(r))
                 continue;
-            if (await transitionAuthorizationManager.IsRoleAllowedForGrantsAsync(r, grants, instance, cancellationToken))
+            if (await transitionAuthorizationManager.IsRoleAllowedForGrantsAsync(r, grants, instance, requestContext, cancellationToken))
                 return true;
         }
         return false;
@@ -459,6 +421,7 @@ public sealed class AuthorizeAppService(
         Definitions.Workflow workflow,
         string? role,
         Instance? instance,
+        AuthorizationRequestContext? requestContext,
         CancellationToken cancellationToken)
     {
         if (instance == null)
@@ -470,6 +433,6 @@ public sealed class AuthorizeAppService(
         var queryRoles = state is { QueryRoles.Count: > 0 } ? state.QueryRoles : workflow.QueryRoles;
         if (queryRoles.Count == 0)
             return true; // No query roles defined → allow
-        return await transitionAuthorizationManager.IsRoleAllowedForGrantsAsync(role, queryRoles, instance, cancellationToken);
+        return await transitionAuthorizationManager.IsRoleAllowedForGrantsAsync(role, queryRoles, instance, requestContext, cancellationToken);
     }
 }

--- a/src/BBT.Workflow.Application/Authorization/IAuthorizeAppService.cs
+++ b/src/BBT.Workflow.Application/Authorization/IAuthorizeAppService.cs
@@ -10,27 +10,9 @@ namespace BBT.Workflow.Authorization;
 public interface IAuthorizeAppService : IApplicationService
 {
     /// <summary>
-    /// Returns whether the given role is allowed for the requested transition or function (workflow-level).
-    /// Exactly one of transitionKey or functionKey must be provided. If checkQueryRoles is true, returns validation error (query roles only valid at instance level).
-    /// </summary>
-    /// <param name="version">Optional component version (workflow version when transitionKey, function version when functionKey). Empty/null = latest.</param>
-    /// <param name="checkQueryRoles">When true, returns error; query roles check is only valid for instance-level authorize.</param>
-    Task<Result<AuthorizeOutput>> GetAuthorizeResultAsync(
-        string domain,
-        string workflow,
-        string role,
-        string? transitionKey,
-        string? functionKey,
-        string? version = null,
-        bool checkQueryRoles = false,
-        CancellationToken cancellationToken = default);
-
-    /// <summary>
     /// Returns whether the given role is allowed for the requested transition, function, or state-based query roles for the specified instance.
     /// Exactly one of transitionKey, functionKey, or checkQueryRoles must be provided.
     /// </summary>
-    /// <param name="version">Optional component version. Empty/null = latest.</param>
-    /// <param name="checkQueryRoles">When true, evaluates state-based query roles (instance current state); mutually exclusive with transitionKey and functionKey.</param>
     Task<Result<AuthorizeOutput>> GetAuthorizeResultForInstanceAsync(
         string domain,
         string workflow,
@@ -40,22 +22,12 @@ public interface IAuthorizeAppService : IApplicationService
         string? functionKey,
         string? version = null,
         bool checkQueryRoles = false,
-        CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Returns the authorization matrix for the workflow (queryRoles, states, transitions, functions).
-    /// </summary>
-    /// <param name="version">Optional workflow version. Empty/null = latest.</param>
-    Task<Result<AuthorizationMatrixOutput>> GetAuthorizationMatrixAsync(
-        string domain,
-        string workflow,
-        string? version = null,
+        AuthorizationRequestContext? requestContext = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Returns the authorization matrix in instance context. When instance has active subflow, returns subflow's matrix; otherwise returns workflow's matrix.
     /// </summary>
-    /// <param name="version">Optional workflow version. Empty/null = latest.</param>
     Task<Result<AuthorizationMatrixOutput>> GetAuthorizationMatrixForInstanceAsync(
         string domain,
         string workflow,

--- a/src/BBT.Workflow.Application/Authorization/ITransitionAuthorizationManager.cs
+++ b/src/BBT.Workflow.Application/Authorization/ITransitionAuthorizationManager.cs
@@ -5,21 +5,33 @@ using WorkflowDefinition = BBT.Workflow.Definitions.Workflow;
 namespace BBT.Workflow.Authorization;
 
 /// <summary>
-/// Encapsulates transition-level role grant evaluation (static roles + $InstanceStarter / $PreviousUser).
+/// Encapsulates transition-level role grant evaluation: static roles, predefined instance roles, and dynamic context references.
 /// Used by AuthorizeAppService for single-transition checks and by InstanceQueryAppService for filtering available transitions.
+/// <para>
+/// Role types supported in <see cref="RoleGrant.Role"/>:
+/// <list type="bullet">
+///   <item>Static roles: e.g. <c>morph-idm.maker</c> — matched case-insensitively against <c>ICurrentUser.Roles</c>.</item>
+///   <item><c>$InstanceStarter</c> — matched against <c>Instance.CreatedBy</c> via <c>ICurrentUser.ActorUserName</c>.</item>
+///   <item><c>$PreviousUser</c> — matched against last manual <c>InstanceTransition.CreatedBy</c> via <c>ICurrentUser.ActorUserName</c>.</item>
+///   <item><c>$InstanceBehalfOfStarter</c> — matched against <c>Instance.CreatedByBehalfOf</c> via <c>ICurrentUser.UserName</c>.</item>
+///   <item><c>$PreviousBehalfOfUser</c> — matched against last manual <c>InstanceTransition.CreatedByBehalfOf</c> via <c>ICurrentUser.UserName</c>.</item>
+///   <item>Dynamic: <c>$user.$.context.&lt;path&gt;</c>, <c>$userBehalfOf.$.context.&lt;path&gt;</c>, <c>$role.$.context.&lt;path&gt;</c>
+///     — value resolved from the authorization context (Instance, Transition, Workflow) at evaluation time.</item>
+/// </list>
+/// </para>
 /// </summary>
 public interface ITransitionAuthorizationManager
 {
     /// <summary>
     /// Evaluates whether the given role is allowed for the transition using transition.Roles.
-    /// When instance is present, predefined roles ($InstanceStarter, $PreviousUser) are resolved and matched against current user.
-    /// When role is null, only predefined role grants are evaluated (via ICurrentUser.ActorUserName); regular role grants yield no match.
+    /// When instance is present, predefined and dynamic role grants are resolved and matched against current user.
+    /// When role is null, only predefined/dynamic role grants are evaluated; regular role grants yield no match.
     /// DENY always wins; if no DENY match, any ALLOW match yields true.
     /// </summary>
-    /// <param name="workflow">The workflow definition (for context).</param>
-    /// <param name="transition">The transition whose Roles are evaluated.</param>
-    /// <param name="instance">Optional instance for resolving $InstanceStarter and $PreviousUser.</param>
-    /// <param name="role">The caller's role to check. Null is allowed; predefined roles are still evaluated.</param>
+    /// <param name="workflow">The workflow definition (provides Workflow context for dynamic role evaluation).</param>
+    /// <param name="transition">The transition whose Roles are evaluated (provides Transition context for dynamic role evaluation).</param>
+    /// <param name="instance">Optional instance for resolving predefined and dynamic roles.</param>
+    /// <param name="role">The caller's role to check. Null is allowed; predefined/dynamic roles are still evaluated.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>True if the role is allowed for the transition; false otherwise.</returns>
     Task<bool> IsTransitionAllowedForRoleAsync(
@@ -27,18 +39,19 @@ public interface ITransitionAuthorizationManager
         Transition transition,
         Instance? instance,
         string? role,
+        AuthorizationRequestContext? requestContext = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Filters a list of transition keys to only those allowed for the given role.
     /// Uses the same evaluation as <see cref="IsTransitionAllowedForRoleAsync"/> per transition.
-    /// When role is null, only predefined role grants ($InstanceStarter, $PreviousUser) are evaluated; transitions with no roles pass through.
+    /// When role is null, only predefined/dynamic role grants are evaluated; transitions with no roles pass through.
     /// </summary>
     /// <param name="workflow">The workflow definition.</param>
     /// <param name="currentState">Current state (used to resolve transition by key via workflow context).</param>
-    /// <param name="instance">Optional instance for predefined role resolution.</param>
+    /// <param name="instance">Optional instance for predefined and dynamic role resolution.</param>
     /// <param name="transitionKeys">Candidate transition keys to filter.</param>
-    /// <param name="role">The caller's role. Null is allowed; predefined roles are still evaluated.</param>
+    /// <param name="role">The caller's role. Null is allowed; predefined/dynamic roles are still evaluated.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>List of transition keys that are allowed for the role.</returns>
     Task<IReadOnlyList<string>> FilterAuthorizedTransitionKeysAsync(
@@ -51,20 +64,22 @@ public interface ITransitionAuthorizationManager
 
     /// <summary>
     /// Evaluates whether the given role is allowed for a set of role grants (e.g. function or state queryRoles).
-    /// When instance is present, predefined roles ($InstanceStarter, $PreviousUser) are resolved.
-    /// When role is null, only predefined role grants are evaluated.
+    /// When instance is present, predefined and dynamic role grants are resolved.
+    /// When role is null, only predefined/dynamic role grants are evaluated.
     /// DENY always wins; if no DENY match, any ALLOW match yields true.
     /// </summary>
     Task<bool> IsRoleAllowedForGrantsAsync(
         string? role,
         IReadOnlyCollection<RoleGrant> roleGrants,
         Instance? instance,
+        AuthorizationRequestContext? requestContext = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Builds the effective caller roles list for schema field-level visibility.
-    /// Returns static roles (ICurrentUser.Roles); when instance is present, adds $InstanceStarter if
-    /// CurrentUser.ActorUserName equals Instance.CreatedBy, and $PreviousUser if it equals the last manual transition's CreatedBy.
+    /// Returns static roles (ICurrentUser.Roles); when instance is present, adds applicable predefined roles:
+    /// <c>$InstanceStarter</c>, <c>$PreviousUser</c> (matched via ActorUserName),
+    /// <c>$InstanceBehalfOfStarter</c>, <c>$PreviousBehalfOfUser</c> (matched via UserName).
     /// </summary>
     /// <param name="instance">Optional instance for resolving predefined roles.</param>
     /// <param name="cancellationToken">Cancellation token.</param>

--- a/src/BBT.Workflow.Application/Authorization/Remote/IRemoteAuthorizeAppService.cs
+++ b/src/BBT.Workflow.Application/Authorization/Remote/IRemoteAuthorizeAppService.cs
@@ -32,6 +32,7 @@ public interface IRemoteAuthorizeAppService
         string? functionKey,
         string? version,
         bool checkQueryRoles,
+        AuthorizationRequestContext? requestContext = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/BBT.Workflow.Application/Authorization/SchemaFieldVisibilityService.cs
+++ b/src/BBT.Workflow.Application/Authorization/SchemaFieldVisibilityService.cs
@@ -1,6 +1,4 @@
-using System.Collections.Generic;
 using BBT.Workflow.Definitions;
-using BBT.Workflow.Definitions.Schemas;
 
 namespace BBT.Workflow.Authorization;
 

--- a/src/BBT.Workflow.Application/Authorization/TransitionAuthorizationManager.cs
+++ b/src/BBT.Workflow.Application/Authorization/TransitionAuthorizationManager.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using BBT.Aether.Users;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Instances;
@@ -6,8 +7,13 @@ using WorkflowDefinition = BBT.Workflow.Definitions.Workflow;
 namespace BBT.Workflow.Authorization;
 
 /// <summary>
-/// Evaluates transition-level role grants (static + $InstanceStarter / $PreviousUser).
+/// Evaluates transition-level role grants (static + predefined + dynamic context references).
 /// DENY always wins; if no DENY match, any ALLOW match yields allowed.
+/// <para>
+/// Predefined actor roles ($InstanceStarter, $PreviousUser) are matched against <c>ICurrentUser.ActorUserName</c>.
+/// Predefined behalf-of roles ($InstanceBehalfOfStarter, $PreviousBehalfOfUser) are matched against <c>ICurrentUser.UserName</c>.
+/// Dynamic roles ($user, $userBehalfOf, $role) resolve values from the authorization context via a ScriptContext-compatible path.
+/// </para>
 /// </summary>
 public sealed class TransitionAuthorizationManager(
     ICurrentUser currentUser,
@@ -19,6 +25,7 @@ public sealed class TransitionAuthorizationManager(
         Transition transition,
         Instance? instance,
         string? role,
+        AuthorizationRequestContext? requestContext = null,
         CancellationToken cancellationToken = default)
     {
         var roleGrants = transition.Roles;
@@ -26,7 +33,7 @@ public sealed class TransitionAuthorizationManager(
             return true; // No roles defined → allow
 
         if (instance != null)
-            return await EvaluateRolesWithPredefinedAsync(role, roleGrants, instance, cancellationToken);
+            return await EvaluateRolesWithPredefinedAsync(role, roleGrants, instance, cancellationToken, transition, workflow, requestContext);
 
         return EvaluateRolesStatic(role, roleGrants);
     }
@@ -49,7 +56,7 @@ public sealed class TransitionAuthorizationManager(
             var transition = workflow.FindTransitionInContext(key);
             if (transition == null)
                 continue;
-            var allowed = await IsTransitionAllowedForRoleAsync(workflow, transition, instance, role, cancellationToken);
+            var allowed = await IsTransitionAllowedForRoleAsync(workflow, transition, instance, role, cancellationToken: cancellationToken);
             if (allowed)
                 result.Add(key);
         }
@@ -61,12 +68,13 @@ public sealed class TransitionAuthorizationManager(
         string? role,
         IReadOnlyCollection<RoleGrant> roleGrants,
         Instance? instance,
+        AuthorizationRequestContext? requestContext = null,
         CancellationToken cancellationToken = default)
     {
         if (roleGrants.Count == 0)
             return true; // No roles defined → allow
         if (instance != null)
-            return await EvaluateRolesWithPredefinedAsync(role, roleGrants, instance, cancellationToken);
+            return await EvaluateRolesWithPredefinedAsync(role, roleGrants, instance, cancellationToken, requestContext: requestContext);
         return EvaluateRolesStatic(role, roleGrants);
     }
 
@@ -83,42 +91,85 @@ public sealed class TransitionAuthorizationManager(
             return roles;
 
         var actorUserName = currentUser.ActorUserName?.Trim();
+        var subjectUserName = currentUser.UserName?.Trim();
+
+        // Single repository fetch used by both actor and behalf-of checks
+        InstanceTransition? lastManual = null;
+        if (!string.IsNullOrEmpty(actorUserName) || !string.IsNullOrEmpty(subjectUserName))
+            lastManual = await instanceTransitionRepository.GetLastCompletedManualTransitionAsync(instance.Id, cancellationToken);
+
+        // Actor-based predefined roles
         if (!string.IsNullOrEmpty(actorUserName))
         {
             if (string.Equals(actorUserName, instance.CreatedBy?.Trim(), StringComparison.Ordinal))
                 roles.Add(PredefinedInstanceRoles.InstanceStarter);
 
-            var lastManual = await instanceTransitionRepository.GetLastCompletedManualTransitionAsync(instance.Id, cancellationToken);
             var previousUserCreatedBy = lastManual?.CreatedBy?.Trim();
             if (!string.IsNullOrEmpty(previousUserCreatedBy) && string.Equals(actorUserName, previousUserCreatedBy, StringComparison.Ordinal))
                 roles.Add(PredefinedInstanceRoles.PreviousUser);
+        }
+
+        // BehalfOf-based predefined roles
+        if (!string.IsNullOrEmpty(subjectUserName))
+        {
+            if (string.Equals(subjectUserName, instance.CreatedByBehalfOf?.Trim(), StringComparison.Ordinal))
+                roles.Add(PredefinedInstanceRoles.InstanceBehalfOfStarter);
+
+            var previousBehalfOf = lastManual?.CreatedByBehalfOf?.Trim();
+            if (!string.IsNullOrEmpty(previousBehalfOf) && string.Equals(subjectUserName, previousBehalfOf, StringComparison.Ordinal))
+                roles.Add(PredefinedInstanceRoles.PreviousBehalfOfUser);
         }
 
         return roles;
     }
 
     /// <summary>
-    /// Evaluates role grants with resolution of predefined instance roles ($InstanceStarter, $PreviousUser).
-    /// When role is null, only predefined role grants are evaluated (via ICurrentUser.ActorUserName); regular role grants yield no match.
+    /// Evaluates role grants with resolution of predefined instance roles and dynamic context references.
+    /// When role is null, only predefined/dynamic role grants are evaluated; regular role grants yield no match.
     /// </summary>
     private async Task<bool> EvaluateRolesWithPredefinedAsync(
         string? role,
         IReadOnlyCollection<RoleGrant> roleGrants,
         Instance instance,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        Transition? transition = null,
+        WorkflowDefinition? workflow = null,
+        AuthorizationRequestContext? requestContext = null)
     {
         var normalizedRole = role?.Trim() ?? string.Empty;
         var currentActorUserName = currentUser.ActorUserName?.Trim();
+        var currentSubjectUserName = currentUser.UserName?.Trim();
 
-        string? previousUserCreatedBy = null;
-        if (roleGrants.Any(g => string.Equals(g.Role, PredefinedInstanceRoles.PreviousUser, StringComparison.Ordinal)))
-            previousUserCreatedBy = (await instanceTransitionRepository.GetLastCompletedManualTransitionAsync(instance.Id, cancellationToken))?.CreatedBy;
+        // Fetch previous transition only if needed
+        InstanceTransition? previousTransition = null;
+        if (roleGrants.Any(g =>
+            string.Equals(g.Role, PredefinedInstanceRoles.PreviousUser, StringComparison.Ordinal) ||
+            string.Equals(g.Role, PredefinedInstanceRoles.PreviousBehalfOfUser, StringComparison.Ordinal)))
+        {
+            previousTransition = await instanceTransitionRepository.GetLastCompletedManualTransitionAsync(instance.Id, cancellationToken);
+        }
+
+        // Lazy-built authorization context element for dynamic roles
+        JsonElement? authContext = null;
+        JsonElement GetAuthContext()
+        {
+            authContext ??= BuildAuthorizationContextElement(instance, transition, workflow, requestContext);
+            return authContext.Value;
+        }
 
         bool IsMatch(RoleGrant g)
         {
-            var resolvedValue = ResolvePredefinedRole(g.Role, instance, previousUserCreatedBy);
-            if (resolvedValue != null)
-                return !string.IsNullOrEmpty(currentActorUserName) && string.Equals(currentActorUserName, resolvedValue, StringComparison.Ordinal);
+            // 1. Predefined role check
+            var predefinedResult = MatchPredefinedRole(g.Role, instance, previousTransition, currentActorUserName, currentSubjectUserName);
+            if (predefinedResult.HasValue)
+                return predefinedResult.Value;
+
+            // 2. Dynamic context reference
+            var dynamicGrant = DynamicRoleGrant.TryParse(g.Role);
+            if (dynamicGrant != null)
+                return ResolveDynamicRoleMatch(dynamicGrant, GetAuthContext, normalizedRole, currentActorUserName, currentSubjectUserName);
+
+            // 3. Static role comparison (OrdinalIgnoreCase)
             return string.Equals(g.Role, normalizedRole, StringComparison.OrdinalIgnoreCase);
         }
 
@@ -132,17 +183,192 @@ public sealed class TransitionAuthorizationManager(
     }
 
     /// <summary>
-    /// Resolves predefined role to the effective user identifier for comparison with CurrentUser.ActorUserName.
+    /// Matches a predefined role against the current user and instance/transition data.
+    /// Returns true/false for matched predefined roles; returns null if not a predefined role.
     /// </summary>
-    private static string? ResolvePredefinedRole(string? grantRole, Instance instance, string? previousUserCreatedBy)
+    private static bool? MatchPredefinedRole(
+        string? grantRole,
+        Instance instance,
+        InstanceTransition? previousTransition,
+        string? actorUserName,
+        string? subjectUserName)
     {
         if (string.IsNullOrWhiteSpace(grantRole))
             return null;
+
         if (string.Equals(grantRole, PredefinedInstanceRoles.InstanceStarter, StringComparison.Ordinal))
-            return instance.CreatedBy;
+            return !string.IsNullOrEmpty(actorUserName) &&
+                   string.Equals(actorUserName, instance.CreatedBy?.Trim(), StringComparison.Ordinal);
+
         if (string.Equals(grantRole, PredefinedInstanceRoles.PreviousUser, StringComparison.Ordinal))
-            return previousUserCreatedBy;
-        return null;
+        {
+            var prevCreatedBy = previousTransition?.CreatedBy?.Trim();
+            return !string.IsNullOrEmpty(actorUserName) &&
+                   !string.IsNullOrEmpty(prevCreatedBy) &&
+                   string.Equals(actorUserName, prevCreatedBy, StringComparison.Ordinal);
+        }
+
+        if (string.Equals(grantRole, PredefinedInstanceRoles.InstanceBehalfOfStarter, StringComparison.Ordinal))
+            return !string.IsNullOrEmpty(subjectUserName) &&
+                   string.Equals(subjectUserName, instance.CreatedByBehalfOf?.Trim(), StringComparison.Ordinal);
+
+        if (string.Equals(grantRole, PredefinedInstanceRoles.PreviousBehalfOfUser, StringComparison.Ordinal))
+        {
+            var prevBehalfOf = previousTransition?.CreatedByBehalfOf?.Trim();
+            return !string.IsNullOrEmpty(subjectUserName) &&
+                   !string.IsNullOrEmpty(prevBehalfOf) &&
+                   string.Equals(subjectUserName, prevBehalfOf, StringComparison.Ordinal);
+        }
+
+        return null; // Not a predefined role
+    }
+
+    /// <summary>
+    /// Resolves a dynamic role grant against the authorization context and compares to the current user.
+    /// </summary>
+    private static bool ResolveDynamicRoleMatch(
+        DynamicRoleGrant grant,
+        Func<JsonElement> getAuthContext,
+        string normalizedCallerRole,
+        string? actorUserName,
+        string? subjectUserName)
+    {
+        const string contextPrefix = "$.context.";
+        if (!grant.ContextPath.StartsWith(contextPrefix, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var navigationPath = grant.ContextPath[contextPrefix.Length..];
+        if (string.IsNullOrWhiteSpace(navigationPath))
+            return false;
+
+        var values = ContextPathResolver.Resolve(getAuthContext(), navigationPath);
+        if (values.Count == 0)
+            return false;
+
+        return grant.Qualifier switch
+        {
+            DynamicRoleQualifier.User =>
+                !string.IsNullOrEmpty(actorUserName) &&
+                values.Any(v => string.Equals(v, actorUserName, StringComparison.Ordinal)),
+
+            DynamicRoleQualifier.UserBehalfOf =>
+                !string.IsNullOrEmpty(subjectUserName) &&
+                values.Any(v => string.Equals(v, subjectUserName, StringComparison.Ordinal)),
+
+            DynamicRoleQualifier.Role =>
+                values.Any(v => string.Equals(v, normalizedCallerRole, StringComparison.OrdinalIgnoreCase)),
+
+            _ => false
+        };
+    }
+
+    /// <summary>
+    /// Builds a <see cref="JsonElement"/> representing the authorization context,
+    /// structured to match the <c>$.context.*</c> path namespace used in dynamic role grants.
+    /// <para>
+    /// Includes <c>Instance</c>, <c>Transition</c>, <c>Workflow</c> when available.
+    /// <c>Body</c> and <c>Headers</c> are empty objects (not available at authorization time).
+    /// </para>
+    /// </summary>
+    private static JsonElement BuildAuthorizationContextElement(
+        Instance? instance,
+        Transition? transition,
+        WorkflowDefinition? workflow,
+        AuthorizationRequestContext? requestContext = null)
+    {
+        using var buffer = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            writer.WriteStartObject();
+
+            // Instance
+            if (instance != null)
+            {
+                writer.WritePropertyName("Instance");
+                writer.WriteStartObject();
+                writer.WriteString("Id", instance.Id.ToString());
+                writer.WriteString("Key", instance.Key);
+                writer.WriteString("Flow", instance.Flow);
+                writer.WriteString("FlowVersion", instance.FlowVersion);
+                writer.WriteString("Status", instance.Status.ToString());
+                writer.WriteString("CurrentState", instance.CurrentState);
+                writer.WriteString("EffectiveState", instance.EffectiveState);
+                writer.WriteString("EffectiveStateType", instance.EffectiveStateType?.ToString());
+                writer.WriteString("EffectiveStateSubType", instance.EffectiveStateSubType?.ToString());
+                writer.WriteString("CreatedBy", instance.CreatedBy);
+                writer.WriteString("CreatedByBehalfOf", instance.CreatedByBehalfOf);
+                writer.WriteString("ModifiedBy", instance.ModifiedBy);
+                writer.WriteString("ModifiedByBehalfOf", instance.ModifiedByBehalfOf);
+                writer.WritePropertyName("Data");
+                var dataElement = instance.LatestData?.Data.JsonElement
+                    ?? JsonDocument.Parse("{}").RootElement;
+                dataElement.WriteTo(writer);
+                writer.WriteEndObject();
+            }
+            else
+            {
+                writer.WriteNull("Instance");
+            }
+
+            // Transition
+            if (transition != null)
+            {
+                writer.WritePropertyName("Transition");
+                writer.WriteStartObject();
+                writer.WriteString("Key", transition.Key);
+                writer.WriteString("From", transition.From);
+                writer.WriteString("Target", transition.Target);
+                writer.WriteString("TriggerType", transition.TriggerType.ToString());
+                writer.WriteEndObject();
+            }
+            else
+            {
+                writer.WriteNull("Transition");
+            }
+
+            // Workflow
+            if (workflow != null)
+            {
+                writer.WritePropertyName("Workflow");
+                writer.WriteStartObject();
+                writer.WriteString("Key", workflow.Key);
+                writer.WriteString("Domain", workflow.Domain);
+                writer.WriteString("Flow", workflow.Flow);
+                writer.WriteString("Version", workflow.Version);
+                writer.WriteEndObject();
+            }
+            else
+            {
+                writer.WriteNull("Workflow");
+            }
+
+            // Body: empty (request body is not available at authorization time)
+            writer.WriteStartObject("Body");
+            writer.WriteEndObject();
+
+            // Headers, QueryParameters, RouteValues: from request context when available
+            WriteStringDictionary(writer, "Headers", requestContext?.Headers);
+            WriteStringDictionary(writer, "QueryParameters", requestContext?.QueryParameters);
+            WriteStringDictionary(writer, "RouteValues", requestContext?.RouteValues);
+
+            writer.WriteEndObject();
+        }
+
+        return JsonDocument.Parse(buffer.ToArray()).RootElement;
+    }
+
+    private static void WriteStringDictionary(
+        Utf8JsonWriter writer,
+        string propertyName,
+        IReadOnlyDictionary<string, string?>? dict)
+    {
+        writer.WriteStartObject(propertyName);
+        if (dict != null)
+        {
+            foreach (var (key, value) in dict)
+                writer.WriteString(key, value);
+        }
+        writer.WriteEndObject();
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Application/Gateway/IAuthorizeGateway.cs
+++ b/src/BBT.Workflow.Application/Gateway/IAuthorizeGateway.cs
@@ -1,4 +1,5 @@
 using BBT.Aether.Results;
+using BBT.Workflow.Authorization;
 using BBT.Workflow.Instances;
 
 namespace BBT.Workflow.Gateway;
@@ -34,6 +35,7 @@ public interface IAuthorizeGateway
         string? functionKey,
         string? version,
         bool checkQueryRoles,
+        AuthorizationRequestContext? requestContext = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -707,7 +707,7 @@ public sealed class InstanceQueryAppService(
                     {
                         // Parent override (replace mode): use parent-defined grants
                         var allowed = await transitionAuthorizationManager
-                            .IsRoleAllowedForGrantsAsync(input.Role, tOverride.Roles!, instance, cancellationToken);
+                            .IsRoleAllowedForGrantsAsync(input.Role, tOverride.Roles!, instance, cancellationToken: cancellationToken);
                         if (allowed) filteredKeys.Add(key);
                     }
                     else

--- a/src/BBT.Workflow.Domain/Definitions/Authorization/ContextPathResolver.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Authorization/ContextPathResolver.cs
@@ -1,0 +1,116 @@
+using System.Text.Json;
+
+namespace BBT.Workflow.Definitions;
+
+/// <summary>
+/// Resolves a dot-notation path with optional array wildcard (<c>[*]</c>) against a <see cref="JsonElement"/> root.
+/// Used by the dynamic role evaluation to extract values from the authorization context.
+/// <para>
+/// Path examples:
+/// <list type="bullet">
+///   <item><c>Instance.Data.customer.ownerUserId</c></item>
+///   <item><c>Instance.Data.assignedUsers[*].userId</c></item>
+///   <item><c>Transition.Key</c></item>
+/// </list>
+/// </para>
+/// </summary>
+public static class ContextPathResolver
+{
+    private const string ArrayWildcard = "[*]";
+
+    /// <summary>
+    /// Resolves a path against the given <paramref name="root"/> and returns all matched string values.
+    /// Returns an empty list when the path does not exist or any segment is missing.
+    /// Never throws on missing properties — all navigation errors yield an empty result.
+    /// Property name matching is case-insensitive.
+    /// </summary>
+    /// <param name="root">The JSON root element representing the authorization context.</param>
+    /// <param name="path">Dot-notation path, e.g. <c>Instance.Data.assignedUsers[*].userId</c></param>
+    public static IReadOnlyList<string> Resolve(JsonElement root, string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return [];
+
+        var segments = SplitPath(path);
+        if (segments.Length == 0)
+            return [];
+
+        var results = new List<string>();
+        Walk(root, segments, 0, results);
+        return results;
+    }
+
+    /// <summary>
+    /// Splits a path string into segments, normalizing <c>[*]</c> as a dedicated segment.
+    /// Example: <c>"assignedUsers[*].userId"</c> → <c>["assignedUsers", "[*]", "userId"]</c>
+    /// </summary>
+    private static string[] SplitPath(string path)
+    {
+        // Replace [*] with a sentinel so we can split on dots
+        var normalized = path.Replace(ArrayWildcard, ".[*]", StringComparison.Ordinal);
+
+        return normalized
+            .Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(s => s.Length > 0)
+            .ToArray();
+    }
+
+    private static void Walk(JsonElement element, string[] segments, int index, List<string> results)
+    {
+        if (index >= segments.Length)
+        {
+            // Leaf: collect value
+            var value = GetStringValue(element);
+            if (value != null)
+                results.Add(value);
+            return;
+        }
+
+        var segment = segments[index];
+
+        if (segment == ArrayWildcard)
+        {
+            // Expand array: iterate all elements and continue
+            if (element.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in element.EnumerateArray())
+                    Walk(item, segments, index + 1, results);
+            }
+            return;
+        }
+
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            // Case-insensitive property lookup
+            if (TryGetPropertyIgnoreCase(element, segment, out var child))
+                Walk(child, segments, index + 1, results);
+        }
+    }
+
+    private static bool TryGetPropertyIgnoreCase(JsonElement obj, string name, out JsonElement value)
+    {
+        foreach (var prop in obj.EnumerateObject())
+        {
+            if (string.Equals(prop.Name, name, StringComparison.OrdinalIgnoreCase))
+            {
+                value = prop.Value;
+                return true;
+            }
+        }
+
+        value = default;
+        return false;
+    }
+
+    private static string? GetStringValue(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.String => element.GetString(),
+            JsonValueKind.Number => element.GetRawText(),
+            JsonValueKind.True => "true",
+            JsonValueKind.False => "false",
+            _ => null
+        };
+    }
+}

--- a/src/BBT.Workflow.Domain/Definitions/Authorization/DynamicRoleGrant.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Authorization/DynamicRoleGrant.cs
@@ -1,0 +1,97 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace BBT.Workflow.Definitions;
+
+/// <summary>
+/// Qualifier type for a dynamic role grant: determines what the resolved value is compared against.
+/// </summary>
+public enum DynamicRoleQualifier
+{
+    /// <summary>Resolved value is compared to <c>ICurrentUser.ActorUserName</c> (act_sub).</summary>
+    User,
+
+    /// <summary>Resolved value is compared to <c>ICurrentUser.UserName</c> (sub / behalf-of subject).</summary>
+    UserBehalfOf,
+
+    /// <summary>Resolved value is compared to the caller's static role string (OrdinalIgnoreCase).</summary>
+    Role
+}
+
+/// <summary>
+/// Represents a dynamic role grant where the compared value is resolved at evaluation time
+/// from the authorization context via a ScriptContext-compatible path.
+/// <para>
+/// Format: <c>$&lt;qualifier&gt;.$.context.&lt;path&gt;</c>
+/// </para>
+/// <para>
+/// Examples:
+/// <list type="bullet">
+///   <item><c>$user.$.context.Instance.Data.customer.ownerUserId</c></item>
+///   <item><c>$user.$.context.Instance.Data.assignedUsers[*].userId</c></item>
+///   <item><c>$userBehalfOf.$.context.Instance.Data.customer.behalfOfUserId</c></item>
+///   <item><c>$role.$.context.Instance.Data.permissions.requiredRole</c></item>
+///   <item><c>$role.$.context.Transition.Key</c></item>
+/// </list>
+/// </para>
+/// </summary>
+public sealed record DynamicRoleGrant(DynamicRoleQualifier Qualifier, string ContextPath)
+{
+    private const string ContextPrefix = "$.context.";
+    private const string UserBehalfOfPrefix = "$userBehalfOf.";
+    private const string UserPrefix = "$user.";
+    private const string RolePrefix = "$role.";
+
+    /// <summary>Returns true if the context path contains an array wildcard segment (<c>[*]</c>).</summary>
+    public bool IsArrayPath => ContextPath.Contains("[*]", StringComparison.Ordinal);
+
+    /// <summary>
+    /// Attempts to parse a role grant string as a dynamic role grant.
+    /// Returns null if the string is not a dynamic role grant pattern.
+    /// </summary>
+    /// <remarks>
+    /// Checks <c>$userBehalfOf</c> before <c>$user</c> to avoid prefix collision.
+    /// </remarks>
+    public static DynamicRoleGrant? TryParse(string? role)
+    {
+        if (string.IsNullOrWhiteSpace(role))
+            return null;
+
+        DynamicRoleQualifier qualifier;
+        string remainder;
+
+        // Check $userBehalfOf BEFORE $user to avoid prefix collision
+        if (role.StartsWith(UserBehalfOfPrefix, StringComparison.Ordinal))
+        {
+            qualifier = DynamicRoleQualifier.UserBehalfOf;
+            remainder = role[UserBehalfOfPrefix.Length..];
+        }
+        else if (role.StartsWith(UserPrefix, StringComparison.Ordinal))
+        {
+            qualifier = DynamicRoleQualifier.User;
+            remainder = role[UserPrefix.Length..];
+        }
+        else if (role.StartsWith(RolePrefix, StringComparison.Ordinal))
+        {
+            qualifier = DynamicRoleQualifier.Role;
+            remainder = role[RolePrefix.Length..];
+        }
+        else
+        {
+            return null;
+        }
+
+        if (!remainder.StartsWith(ContextPrefix, StringComparison.Ordinal))
+            return null;
+
+        // Validate that there is a non-empty navigation path after the "$.context." prefix
+        var navigationPath = remainder[ContextPrefix.Length..];
+        if (string.IsNullOrWhiteSpace(navigationPath))
+            return null;
+
+        // Store the full path including "$.context." — ResolveDynamicRoleMatch will strip the prefix during evaluation
+        return new DynamicRoleGrant(qualifier, remainder);
+    }
+
+    /// <summary>Returns true if the given role string matches the dynamic role grant pattern.</summary>
+    public static bool IsDynamicRole([NotNullWhen(true)] string? role) => TryParse(role) != null;
+}

--- a/src/BBT.Workflow.Domain/Definitions/Authorization/PredefinedInstanceRoles.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Authorization/PredefinedInstanceRoles.cs
@@ -2,7 +2,8 @@ namespace BBT.Workflow.Definitions;
 
 /// <summary>
 /// Predefined system role names for instance-level authorization.
-/// These roles are resolved from instance/transition audit data; matching is done against CurrentUser.ActorUserName.
+/// Actor roles (<c>$InstanceStarter</c>, <c>$PreviousUser</c>) are matched against <c>ICurrentUser.ActorUserName</c>.
+/// BehalfOf roles (<c>$InstanceBehalfOfStarter</c>, <c>$PreviousBehalfOfUser</c>) are matched against <c>ICurrentUser.UserName</c>.
 /// </summary>
 public static class PredefinedInstanceRoles
 {
@@ -22,16 +23,33 @@ public static class PredefinedInstanceRoles
     public const string PreviousUser = "$PreviousUser";
 
     /// <summary>
+    /// Role resolved to the behalf-of subject who started the instance (Instance.CreatedByBehalfOf).
+    /// When this role is in a grant: the subject on whose behalf the instance was started may perform the operation.
+    /// Matching: CurrentUser.UserName (sub) is compared to Instance.CreatedByBehalfOf.
+    /// </summary>
+    public const string InstanceBehalfOfStarter = "$InstanceBehalfOfStarter";
+
+    /// <summary>
+    /// Role resolved to the behalf-of subject who triggered the last completed manual transition (InstanceTransition.CreatedByBehalfOf).
+    /// When this role is in a grant: the subject who was represented during the previous manual transition may perform the operation.
+    /// Matching: CurrentUser.UserName (sub) is compared to the last manual transition's CreatedByBehalfOf.
+    /// Only manual transitions are considered; automatic/scheduled/event transitions are ignored.
+    /// </summary>
+    public const string PreviousBehalfOfUser = "$PreviousBehalfOfUser";
+
+    /// <summary>
     /// Determines whether the given role is a predefined instance role.
     /// </summary>
     /// <param name="role">Role identifier to check.</param>
-    /// <returns>True if the role is InstanceStarter or PreviousUser.</returns>
+    /// <returns>True if the role is one of the four predefined instance roles.</returns>
     public static bool IsPredefinedRole(string? role)
     {
         if (string.IsNullOrWhiteSpace(role))
             return false;
         var normalized = role.Trim();
         return string.Equals(normalized, InstanceStarter, StringComparison.Ordinal)
-            || string.Equals(normalized, PreviousUser, StringComparison.Ordinal);
+            || string.Equals(normalized, PreviousUser, StringComparison.Ordinal)
+            || string.Equals(normalized, InstanceBehalfOfStarter, StringComparison.Ordinal)
+            || string.Equals(normalized, PreviousBehalfOfUser, StringComparison.Ordinal);
     }
 }

--- a/src/BBT.Workflow.Domain/Definitions/Validators/WorkflowValidator.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Validators/WorkflowValidator.cs
@@ -33,11 +33,14 @@ public class WorkflowValidator
         ValidateUpdateDataTransition(workflow, result);
         ValidateTransitionInStates(workflow, result, stateKeys);
         ValidateStateCountAndTypes(workflow, result);
+        ValidateRoleGrants(workflow.QueryRoles, $"{nameof(Workflow)}.{nameof(Workflow.QueryRoles)}", result);
 
         // State level validations
         ValidateStateLabels(workflow, result);
         ValidateWizardStateTransitions(workflow, result);
         ValidateDefaultAutoTransitions(workflow, result);
+        foreach (var state in workflow.States)
+            ValidateRoleGrants(state.QueryRoles, $"{nameof(Workflow)}.States[{state.Key}].{nameof(State.QueryRoles)}", result);
 
         // Transition level validations
         ValidateTransitionLabels(workflow, result);
@@ -369,6 +372,8 @@ public class WorkflowValidator
                 [$"{basePath}.{nameof(Transition.AvailableIn)}"]));
         }
 
+        ValidateRoleGrants(transition.Roles, $"{basePath}.{nameof(Transition.Roles)}", result);
+
         switch (transition.TriggerType)
         {
             case TriggerType.Automatic:
@@ -545,6 +550,43 @@ public class WorkflowValidator
         }
 
         // Schema, View, Mapping are optional - no validation needed
+    }
+
+    /// <summary>
+    /// Validates a collection of role grants, checking dynamic role references for correct format.
+    /// </summary>
+    private static void ValidateRoleGrants(
+        IReadOnlyCollection<RoleGrant> roleGrants,
+        string context,
+        WorkflowValidationResult result)
+    {
+        if (roleGrants.Count == 0)
+            return;
+
+        foreach (var grant in roleGrants)
+        {
+            if (!DynamicRoleGrant.IsDynamicRole(grant.Role))
+                continue;
+
+            var dynamic = DynamicRoleGrant.TryParse(grant.Role)!;
+            const string contextPrefix = "$.context.";
+
+            if (!dynamic.ContextPath.StartsWith(contextPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                result.AddError(new ValidationResult(
+                    $"Dynamic role '{grant.Role}' in '{context}' has an invalid path. Path must start with '{contextPrefix}'.",
+                    [$"{context}"]));
+                continue;
+            }
+
+            var navPath = dynamic.ContextPath[contextPrefix.Length..];
+            if (string.IsNullOrWhiteSpace(navPath))
+            {
+                result.AddError(new ValidationResult(
+                    $"Dynamic role '{grant.Role}' in '{context}' has an empty navigation path after '{contextPrefix}'.",
+                    [$"{context}"]));
+            }
+        }
     }
 
     #endregion

--- a/src/BBT.Workflow.Infrastructure/Authorization/Remote/RemoteAuthorizeAppService.cs
+++ b/src/BBT.Workflow.Infrastructure/Authorization/Remote/RemoteAuthorizeAppService.cs
@@ -40,6 +40,7 @@ public sealed class RemoteAuthorizeAppService(
         string? functionKey,
         string? version,
         bool checkQueryRoles,
+        AuthorizationRequestContext? requestContext = null,
         CancellationToken cancellationToken = default)
     {
         try
@@ -69,7 +70,7 @@ public sealed class RemoteAuthorizeAppService(
             var requestUri = new Uri(endpoint.BaseUrl, relativePath.TrimStart('/'));
             using var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
             var forwardHeaders = currentUser.ToForwardHeaders();
-            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, null);
+            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, requestContext?.Headers);
             var response = await httpClient.SendAsync(requestMessage, cancellationToken);
 
             // 200 and 403 both return AuthorizeOutput body (allowed true/false)

--- a/src/BBT.Workflow.Infrastructure/Gateway/LocalAuthorizeGateway.cs
+++ b/src/BBT.Workflow.Infrastructure/Gateway/LocalAuthorizeGateway.cs
@@ -33,6 +33,7 @@ public sealed class LocalAuthorizeGateway : IAuthorizeGateway
         string? functionKey,
         string? version,
         bool checkQueryRoles,
+        AuthorizationRequestContext? requestContext = null,
         CancellationToken cancellationToken = default)
     {
         return _serviceScopeFactory.ExecuteInScopeAsync(async (sp, ct) =>
@@ -43,7 +44,7 @@ public sealed class LocalAuthorizeGateway : IAuthorizeGateway
             using (currentSchema.Use(workflow))
             {
                 return await authorizeAppService.GetAuthorizeResultForInstanceAsync(
-                    domain, workflow, instanceId, role, transitionKey, functionKey, version, checkQueryRoles, ct);
+                    domain, workflow, instanceId, role, transitionKey, functionKey, version, checkQueryRoles, requestContext, ct);
             }
         }, cancellationToken);
     }

--- a/src/BBT.Workflow.Infrastructure/Gateway/RemoteAuthorizeGateway.cs
+++ b/src/BBT.Workflow.Infrastructure/Gateway/RemoteAuthorizeGateway.cs
@@ -1,4 +1,5 @@
 using BBT.Aether.Results;
+using BBT.Workflow.Authorization;
 using BBT.Workflow.Authorization.Remote;
 using BBT.Workflow.Instances;
 
@@ -32,10 +33,11 @@ public sealed class RemoteAuthorizeGateway : IAuthorizeGateway
         string? functionKey,
         string? version,
         bool checkQueryRoles,
+        AuthorizationRequestContext? requestContext = null,
         CancellationToken cancellationToken = default)
     {
         return _remoteService.GetAuthorizeResultForInstanceAsync(
-            domain, workflow, instanceId, role, transitionKey, functionKey, version, checkQueryRoles, cancellationToken);
+            domain, workflow, instanceId, role, transitionKey, functionKey, version, checkQueryRoles, requestContext, cancellationToken);
     }
 
     /// <inheritdoc />

--- a/src/BBT.Workflow.Infrastructure/Gateway/RoutedAuthorizeGateway.cs
+++ b/src/BBT.Workflow.Infrastructure/Gateway/RoutedAuthorizeGateway.cs
@@ -1,4 +1,5 @@
 using BBT.Aether.Results;
+using BBT.Workflow.Authorization;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Runtime;
 
@@ -41,11 +42,12 @@ public sealed class RoutedAuthorizeGateway : IAuthorizeGateway
         string? functionKey,
         string? version,
         bool checkQueryRoles,
+        AuthorizationRequestContext? requestContext = null,
         CancellationToken cancellationToken = default)
     {
         return _runtimeInfoProvider.IsDomainMatch(domain)
-            ? _local.GetAuthorizeResultForInstanceAsync(domain, workflow, instanceId, role, transitionKey, functionKey, version, checkQueryRoles, cancellationToken)
-            : _remote.GetAuthorizeResultForInstanceAsync(domain, workflow, instanceId, role, transitionKey, functionKey, version, checkQueryRoles, cancellationToken);
+            ? _local.GetAuthorizeResultForInstanceAsync(domain, workflow, instanceId, role, transitionKey, functionKey, version, checkQueryRoles, requestContext, cancellationToken)
+            : _remote.GetAuthorizeResultForInstanceAsync(domain, workflow, instanceId, role, transitionKey, functionKey, version, checkQueryRoles, requestContext, cancellationToken);
     }
 
     /// <inheritdoc />

--- a/src/BBT.Workflow.Infrastructure/Remote/CurrentUserForwardHeadersHelper.cs
+++ b/src/BBT.Workflow.Infrastructure/Remote/CurrentUserForwardHeadersHelper.cs
@@ -1,5 +1,3 @@
-using BBT.Workflow.CurrentUser;
-
 namespace BBT.Workflow.Remote;
 
 /// <summary>
@@ -10,7 +8,7 @@ public static class CurrentUserForwardHeadersHelper
 {
     // Content headers belong to HttpContent.Headers, not HttpRequestMessage.Headers.
     // Attempting Remove/Add on request.Headers for these throws InvalidOperationException.
-    private static readonly HashSet<string> _contentHeaders = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly HashSet<string> ContentHeaders = new(StringComparer.OrdinalIgnoreCase)
     {
         "Content-Type", "Content-Length", "Content-Encoding", "Content-Language",
         "Content-Location", "Content-Disposition", "Content-Range", "Content-MD5",
@@ -26,7 +24,7 @@ public static class CurrentUserForwardHeadersHelper
         isRestrictedHeader ??= _ => false;
         foreach (var kv in forwardHeaders)
         {
-            if (string.IsNullOrEmpty(kv.Value) || isRestrictedHeader(kv.Key) || _contentHeaders.Contains(kv.Key))
+            if (string.IsNullOrEmpty(kv.Value) || isRestrictedHeader(kv.Key) || ContentHeaders.Contains(kv.Key))
                 continue;
             request.Headers.TryAddWithoutValidation(kv.Key, kv.Value);
         }
@@ -34,7 +32,7 @@ public static class CurrentUserForwardHeadersHelper
         {
             foreach (var kv in inputHeaders)
             {
-                if (isRestrictedHeader(kv.Key) || _contentHeaders.Contains(kv.Key))
+                if (isRestrictedHeader(kv.Key) || ContentHeaders.Contains(kv.Key))
                     continue;
                 request.Headers.Remove(kv.Key);
                 if (!string.IsNullOrEmpty(kv.Value))

--- a/test/BBT.Workflow.Application.Tests/Authorization/TransitionAuthorizationManagerBehalfOfTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Authorization/TransitionAuthorizationManagerBehalfOfTests.cs
@@ -1,0 +1,318 @@
+using System;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.Users;
+using BBT.Workflow.Authorization;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Instances;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+using WorkflowDefinition = BBT.Workflow.Definitions.Workflow;
+
+namespace BBT.Workflow.Authorization;
+
+/// <summary>
+/// Unit tests for BehalfOf predefined role evaluation:
+/// $InstanceBehalfOfStarter and $PreviousBehalfOfUser.
+/// </summary>
+public sealed class TransitionAuthorizationManagerBehalfOfTests
+{
+    private readonly ICurrentUser _currentUser;
+    private readonly IInstanceTransitionRepository _repo;
+    private readonly TransitionAuthorizationManager _sut;
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    public TransitionAuthorizationManagerBehalfOfTests()
+    {
+        _currentUser = Substitute.For<ICurrentUser>();
+        _repo = Substitute.For<IInstanceTransitionRepository>();
+        _repo.GetLastCompletedManualTransitionAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+             .Returns((InstanceTransition?)null);
+        _sut = new TransitionAuthorizationManager(_currentUser, _repo);
+    }
+
+    private static Transition BuildTransition(string roleValue) =>
+        JsonSerializer.Deserialize<Transition>($$"""
+            {
+              "key": "t1",
+              "from": null,
+              "target": "state2",
+              "triggerType": "Manual",
+              "versionStrategy": "None",
+              "labels": [],
+              "onExecutionTasks": [],
+              "roles": [{"role": "{{roleValue}}", "grant": "allow"}]
+            }
+            """, JsonOptions)!;
+
+    private static WorkflowDefinition BuildWorkflow() =>
+        JsonSerializer.Deserialize<WorkflowDefinition>("""
+            {
+              "type": "F",
+              "timeout": null,
+              "labels": [],
+              "functions": [],
+              "features": [],
+              "states": [],
+              "sharedTransitions": [],
+              "extensions": [],
+              "queryRoles": []
+            }
+            """, JsonOptions)!;
+
+    #region $InstanceBehalfOfStarter
+
+    [Fact]
+    public async Task InstanceBehalfOfStarter_WhenSubjectMatchesCreatedByBehalfOf_Allows()
+    {
+        var instance = Instance.Create(Guid.NewGuid(), "flow", "1.0.0", "key");
+        instance.CreatedByBehalfOf = "behalf-alice";
+        _currentUser.UserName.Returns("behalf-alice");
+
+        var result = await _sut.IsTransitionAllowedForRoleAsync(
+            BuildWorkflow(),
+            BuildTransition(PredefinedInstanceRoles.InstanceBehalfOfStarter),
+            instance, null, cancellationToken: CancellationToken.None);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task InstanceBehalfOfStarter_WhenSubjectDoesNotMatchCreatedByBehalfOf_Denies()
+    {
+        var instance = Instance.Create(Guid.NewGuid(), "flow", "1.0.0", "key");
+        instance.CreatedByBehalfOf = "behalf-alice";
+        _currentUser.UserName.Returns("behalf-bob");
+
+        var result = await _sut.IsTransitionAllowedForRoleAsync(
+            BuildWorkflow(),
+            BuildTransition(PredefinedInstanceRoles.InstanceBehalfOfStarter),
+            instance, null, cancellationToken: CancellationToken.None);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task InstanceBehalfOfStarter_WhenInstanceCreatedByBehalfOfIsNull_Denies()
+    {
+        var instance = Instance.Create(Guid.NewGuid(), "flow", "1.0.0", "key");
+        instance.CreatedByBehalfOf = null;
+        _currentUser.UserName.Returns("behalf-alice");
+
+        var result = await _sut.IsTransitionAllowedForRoleAsync(
+            BuildWorkflow(),
+            BuildTransition(PredefinedInstanceRoles.InstanceBehalfOfStarter),
+            instance, null, cancellationToken: CancellationToken.None);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task InstanceBehalfOfStarter_WhenUserNameIsNull_Denies()
+    {
+        var instance = Instance.Create(Guid.NewGuid(), "flow", "1.0.0", "key");
+        instance.CreatedByBehalfOf = "behalf-alice";
+        _currentUser.UserName.Returns((string?)null);
+
+        var result = await _sut.IsTransitionAllowedForRoleAsync(
+            BuildWorkflow(),
+            BuildTransition(PredefinedInstanceRoles.InstanceBehalfOfStarter),
+            instance, null, cancellationToken: CancellationToken.None);
+
+        result.ShouldBeFalse();
+    }
+
+    #endregion
+
+    #region $PreviousBehalfOfUser
+
+    [Fact]
+    public async Task PreviousBehalfOfUser_WhenSubjectMatchesPreviousTransitionBehalfOf_Allows()
+    {
+        var instanceId = Guid.NewGuid();
+        var instance = Instance.Create(instanceId, "flow", "1.0.0", "key");
+
+        var lastTransition = InstanceTransition.Create(
+            Guid.NewGuid(), instanceId, "t0", "state1",
+            TriggerType.Manual,
+            JsonData.CreateFrom("{}"), JsonData.CreateFrom("{}"));
+        lastTransition.CreatedByBehalfOf = "behalf-alice";
+
+        _repo.GetLastCompletedManualTransitionAsync(instanceId, Arg.Any<CancellationToken>())
+             .Returns(lastTransition);
+        _currentUser.UserName.Returns("behalf-alice");
+
+        var result = await _sut.IsTransitionAllowedForRoleAsync(
+            BuildWorkflow(),
+            BuildTransition(PredefinedInstanceRoles.PreviousBehalfOfUser),
+            instance, null, cancellationToken: CancellationToken.None);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task PreviousBehalfOfUser_WhenSubjectDoesNotMatchPreviousTransitionBehalfOf_Denies()
+    {
+        var instanceId = Guid.NewGuid();
+        var instance = Instance.Create(instanceId, "flow", "1.0.0", "key");
+
+        var lastTransition = InstanceTransition.Create(
+            Guid.NewGuid(), instanceId, "t0", "state1",
+            TriggerType.Manual,
+            JsonData.CreateFrom("{}"), JsonData.CreateFrom("{}"));
+        lastTransition.CreatedByBehalfOf = "behalf-alice";
+
+        _repo.GetLastCompletedManualTransitionAsync(instanceId, Arg.Any<CancellationToken>())
+             .Returns(lastTransition);
+        _currentUser.UserName.Returns("behalf-bob");
+
+        var result = await _sut.IsTransitionAllowedForRoleAsync(
+            BuildWorkflow(),
+            BuildTransition(PredefinedInstanceRoles.PreviousBehalfOfUser),
+            instance, null, cancellationToken: CancellationToken.None);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task PreviousBehalfOfUser_WhenNoPreviousTransition_Denies()
+    {
+        var instance = Instance.Create(Guid.NewGuid(), "flow", "1.0.0", "key");
+        _currentUser.UserName.Returns("behalf-alice");
+
+        var result = await _sut.IsTransitionAllowedForRoleAsync(
+            BuildWorkflow(),
+            BuildTransition(PredefinedInstanceRoles.PreviousBehalfOfUser),
+            instance, null, cancellationToken: CancellationToken.None);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task PreviousBehalfOfUser_WhenPreviousTransitionBehalfOfIsNull_Denies()
+    {
+        var instanceId = Guid.NewGuid();
+        var instance = Instance.Create(instanceId, "flow", "1.0.0", "key");
+
+        var lastTransition = InstanceTransition.Create(
+            Guid.NewGuid(), instanceId, "t0", "state1",
+            TriggerType.Manual,
+            JsonData.CreateFrom("{}"), JsonData.CreateFrom("{}"));
+        lastTransition.CreatedByBehalfOf = null;
+
+        _repo.GetLastCompletedManualTransitionAsync(instanceId, Arg.Any<CancellationToken>())
+             .Returns(lastTransition);
+        _currentUser.UserName.Returns("behalf-alice");
+
+        var result = await _sut.IsTransitionAllowedForRoleAsync(
+            BuildWorkflow(),
+            BuildTransition(PredefinedInstanceRoles.PreviousBehalfOfUser),
+            instance, null, cancellationToken: CancellationToken.None);
+
+        result.ShouldBeFalse();
+    }
+
+    #endregion
+
+    #region GetEffectiveCallerRolesForFieldVisibilityAsync - BehalfOf roles
+
+    [Fact]
+    public async Task GetEffectiveRoles_WhenSubjectIsInstanceBehalfOfStarter_AddsRole()
+    {
+        var instanceId = Guid.NewGuid();
+        var instance = Instance.Create(instanceId, "flow", "1.0.0", "key");
+        instance.CreatedByBehalfOf = "behalf-alice";
+
+        _currentUser.Roles.Returns(Array.Empty<string>());
+        _currentUser.UserName.Returns("behalf-alice");
+        _currentUser.ActorUserName.Returns((string?)null);
+
+        var result = await _sut.GetEffectiveCallerRolesForFieldVisibilityAsync(instance, CancellationToken.None);
+
+        result.ShouldContain(PredefinedInstanceRoles.InstanceBehalfOfStarter);
+    }
+
+    [Fact]
+    public async Task GetEffectiveRoles_WhenSubjectIsPreviousBehalfOfUser_AddsRole()
+    {
+        var instanceId = Guid.NewGuid();
+        var instance = Instance.Create(instanceId, "flow", "1.0.0", "key");
+
+        var lastTransition = InstanceTransition.Create(
+            Guid.NewGuid(), instanceId, "t0", "state1",
+            TriggerType.Manual,
+            JsonData.CreateFrom("{}"), JsonData.CreateFrom("{}"));
+        lastTransition.CreatedByBehalfOf = "behalf-alice";
+
+        _repo.GetLastCompletedManualTransitionAsync(instanceId, Arg.Any<CancellationToken>())
+             .Returns(lastTransition);
+
+        _currentUser.Roles.Returns(Array.Empty<string>());
+        _currentUser.UserName.Returns("behalf-alice");
+        _currentUser.ActorUserName.Returns((string?)null);
+
+        var result = await _sut.GetEffectiveCallerRolesForFieldVisibilityAsync(instance, CancellationToken.None);
+
+        result.ShouldContain(PredefinedInstanceRoles.PreviousBehalfOfUser);
+    }
+
+    [Fact]
+    public async Task GetEffectiveRoles_WhenBothActorAndSubjectMatch_AddsAllFourPredefinedRoles()
+    {
+        var instanceId = Guid.NewGuid();
+        var instance = Instance.Create(instanceId, "flow", "1.0.0", "key");
+        instance.CreatedBy = "alice";
+        instance.CreatedByBehalfOf = "behalf-alice";
+
+        var lastTransition = InstanceTransition.Create(
+            Guid.NewGuid(), instanceId, "t0", "state1",
+            TriggerType.Manual,
+            JsonData.CreateFrom("{}"), JsonData.CreateFrom("{}"));
+        lastTransition.CreatedBy = "alice";
+        lastTransition.CreatedByBehalfOf = "behalf-alice";
+
+        _repo.GetLastCompletedManualTransitionAsync(instanceId, Arg.Any<CancellationToken>())
+             .Returns(lastTransition);
+
+        _currentUser.Roles.Returns(Array.Empty<string>());
+        _currentUser.ActorUserName.Returns("alice");
+        _currentUser.UserName.Returns("behalf-alice");
+
+        var result = await _sut.GetEffectiveCallerRolesForFieldVisibilityAsync(instance, CancellationToken.None);
+
+        result.ShouldContain(PredefinedInstanceRoles.InstanceStarter);
+        result.ShouldContain(PredefinedInstanceRoles.PreviousUser);
+        result.ShouldContain(PredefinedInstanceRoles.InstanceBehalfOfStarter);
+        result.ShouldContain(PredefinedInstanceRoles.PreviousBehalfOfUser);
+        result.Count.ShouldBe(4);
+    }
+
+    [Fact]
+    public async Task GetEffectiveRoles_SingleRepositoryFetch_WhenBothActorAndSubjectPresent()
+    {
+        var instanceId = Guid.NewGuid();
+        var instance = Instance.Create(instanceId, "flow", "1.0.0", "key");
+        instance.CreatedBy = "alice";
+        instance.CreatedByBehalfOf = "behalf-alice";
+
+        _currentUser.Roles.Returns(Array.Empty<string>());
+        _currentUser.ActorUserName.Returns("alice");
+        _currentUser.UserName.Returns("behalf-alice");
+
+        _repo.GetLastCompletedManualTransitionAsync(instanceId, Arg.Any<CancellationToken>())
+             .Returns((InstanceTransition?)null);
+
+        await _sut.GetEffectiveCallerRolesForFieldVisibilityAsync(instance, CancellationToken.None);
+
+        // Repository should only be called once even though both actor and behalf-of checks need it
+        await _repo.Received(1).GetLastCompletedManualTransitionAsync(instanceId, Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+}

--- a/test/BBT.Workflow.Application.Tests/Authorization/TransitionAuthorizationManagerDynamicRoleTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Authorization/TransitionAuthorizationManagerDynamicRoleTests.cs
@@ -1,0 +1,325 @@
+using System;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.DependencyInjection;
+using BBT.Aether.Uow;
+using BBT.Aether.Users;
+using BBT.Workflow.Authorization;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Instances;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+using WorkflowDefinition = BBT.Workflow.Definitions.Workflow;
+
+namespace BBT.Workflow.Authorization;
+
+/// <summary>
+/// Unit tests for dynamic role grant evaluation in TransitionAuthorizationManager.
+/// Dynamic roles use the format: $user.$.context.*, $userBehalfOf.$.context.*, $role.$.context.*
+/// </summary>
+public sealed class TransitionAuthorizationManagerDynamicRoleTests : IDisposable
+{
+    private readonly ICurrentUser _currentUser;
+    private readonly IInstanceTransitionRepository _repo;
+    private readonly TransitionAuthorizationManager _sut;
+    private readonly IServiceProvider? _previousAmbientServiceProvider;
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    public TransitionAuthorizationManagerDynamicRoleTests()
+    {
+        _currentUser = Substitute.For<ICurrentUser>();
+        _repo = Substitute.For<IInstanceTransitionRepository>();
+        _repo.GetLastCompletedManualTransitionAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+             .Returns((InstanceTransition?)null);
+        _sut = new TransitionAuthorizationManager(_currentUser, _repo);
+
+        // Required for PostSharp SchemaValidation aspect used by Instance.AddData
+        var mockUoW = Substitute.For<IUnitOfWork>();
+        var mockUoWManager = Substitute.For<IUnitOfWorkManager>();
+        mockUoWManager.BeginAsync(Arg.Any<UnitOfWorkOptions>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(mockUoW));
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(mockUoWManager);
+        services.AddSingleton(Substitute.For<BBT.Workflow.Caching.IComponentCacheStore>());
+        services.AddSingleton(Substitute.For<BBT.Workflow.DefinitionContext.IWorkflowContext>());
+        _previousAmbientServiceProvider = AmbientServiceProvider.Current;
+        AmbientServiceProvider.Current = services.BuildServiceProvider();
+    }
+
+    public void Dispose()
+    {
+        AmbientServiceProvider.Current = _previousAmbientServiceProvider;
+    }
+
+    private static Instance CreateInstance(string dataJson)
+    {
+        var instance = Instance.Create(Guid.NewGuid(), "flow", "1.0.0", "key");
+        instance.AddData(Guid.NewGuid(), JsonData.CreateFrom(dataJson), VersionStrategy.None);
+        return instance;
+    }
+
+    private static Transition BuildTransition(string roleValue, string grant = "allow")
+    {
+        var json = $$"""
+            {
+              "key": "t1",
+              "from": null,
+              "target": "state2",
+              "triggerType": "Manual",
+              "versionStrategy": "None",
+              "labels": [],
+              "onExecutionTasks": [],
+              "roles": [{"role": "{{roleValue}}", "grant": "{{grant}}"}]
+            }
+            """;
+        return JsonSerializer.Deserialize<Transition>(json, JsonOptions)!;
+    }
+
+    private static WorkflowDefinition BuildWorkflow() =>
+        JsonSerializer.Deserialize<WorkflowDefinition>("""
+            {
+              "type": "F",
+              "timeout": null,
+              "labels": [],
+              "functions": [],
+              "features": [],
+              "states": [],
+              "sharedTransitions": [],
+              "extensions": [],
+              "queryRoles": []
+            }
+            """, JsonOptions)!;
+
+    #region $user qualifier
+
+    [Fact]
+    public async Task DynamicUser_WhenActorMatchesInstanceDataValue_Allows()
+    {
+        _currentUser.ActorUserName.Returns("alice");
+        var instance = CreateInstance("""{"customer": {"ownerUserId": "alice"}}""");
+
+        var result = await _sut.IsTransitionAllowedForRoleAsync(
+            BuildWorkflow(),
+            BuildTransition("$user.$.context.Instance.Data.customer.ownerUserId"),
+            instance, null, cancellationToken: CancellationToken.None);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task DynamicUser_WhenActorDoesNotMatchInstanceDataValue_Denies()
+    {
+        _currentUser.ActorUserName.Returns("bob");
+        var instance = CreateInstance("""{"customer": {"ownerUserId": "alice"}}""");
+
+        var result = await _sut.IsTransitionAllowedForRoleAsync(
+            BuildWorkflow(),
+            BuildTransition("$user.$.context.Instance.Data.customer.ownerUserId"),
+            instance, null, cancellationToken: CancellationToken.None);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task DynamicUser_WithArrayWildcard_WhenActorIsInArray_Allows()
+    {
+        _currentUser.ActorUserName.Returns("charlie");
+        var instance = CreateInstance("""{"assignedUsers": [{"userId": "alice"}, {"userId": "charlie"}]}""");
+
+        var result = await _sut.IsTransitionAllowedForRoleAsync(
+            BuildWorkflow(),
+            BuildTransition("$user.$.context.Instance.Data.assignedUsers[*].userId"),
+            instance, null, cancellationToken: CancellationToken.None);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task DynamicUser_WithArrayWildcard_WhenActorNotInArray_Denies()
+    {
+        _currentUser.ActorUserName.Returns("dave");
+        var instance = CreateInstance("""{"assignedUsers": [{"userId": "alice"}, {"userId": "charlie"}]}""");
+
+        var result = await _sut.IsTransitionAllowedForRoleAsync(
+            BuildWorkflow(),
+            BuildTransition("$user.$.context.Instance.Data.assignedUsers[*].userId"),
+            instance, null, cancellationToken: CancellationToken.None);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task DynamicUser_WhenPathNotFound_Denies()
+    {
+        _currentUser.ActorUserName.Returns("alice");
+        var instance = CreateInstance("""{"other": "value"}""");
+
+        var result = await _sut.IsTransitionAllowedForRoleAsync(
+            BuildWorkflow(),
+            BuildTransition("$user.$.context.Instance.Data.customer.ownerUserId"),
+            instance, null, cancellationToken: CancellationToken.None);
+
+        result.ShouldBeFalse();
+    }
+
+    #endregion
+
+    #region $userBehalfOf qualifier
+
+    [Fact]
+    public async Task DynamicUserBehalfOf_WhenSubjectMatchesInstanceDataValue_Allows()
+    {
+        _currentUser.UserName.Returns("behalf-user");
+        var instance = CreateInstance("""{"customer": {"behalfOfId": "behalf-user"}}""");
+
+        var result = await _sut.IsTransitionAllowedForRoleAsync(
+            BuildWorkflow(),
+            BuildTransition("$userBehalfOf.$.context.Instance.Data.customer.behalfOfId"),
+            instance, null, cancellationToken: CancellationToken.None);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task DynamicUserBehalfOf_WhenSubjectDoesNotMatch_Denies()
+    {
+        _currentUser.UserName.Returns("other-user");
+        var instance = CreateInstance("""{"customer": {"behalfOfId": "behalf-user"}}""");
+
+        var result = await _sut.IsTransitionAllowedForRoleAsync(
+            BuildWorkflow(),
+            BuildTransition("$userBehalfOf.$.context.Instance.Data.customer.behalfOfId"),
+            instance, null, cancellationToken: CancellationToken.None);
+
+        result.ShouldBeFalse();
+    }
+
+    #endregion
+
+    #region $role qualifier
+
+    [Fact]
+    public async Task DynamicRole_WhenCallerRoleMatchesInstanceDataValue_Allows()
+    {
+        var instance = CreateInstance("""{"permissions": {"requiredRole": "maker"}}""");
+
+        var result = await _sut.IsTransitionAllowedForRoleAsync(
+            BuildWorkflow(),
+            BuildTransition("$role.$.context.Instance.Data.permissions.requiredRole"),
+            instance, "maker", cancellationToken: CancellationToken.None);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task DynamicRole_CaseInsensitiveMatch_Allows()
+    {
+        var instance = CreateInstance("""{"permissions": {"requiredRole": "Maker"}}""");
+
+        var result = await _sut.IsTransitionAllowedForRoleAsync(
+            BuildWorkflow(),
+            BuildTransition("$role.$.context.Instance.Data.permissions.requiredRole"),
+            instance, "maker", cancellationToken: CancellationToken.None);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task DynamicRole_WithArrayWildcard_WhenAnyRoleMatches_Allows()
+    {
+        var instance = CreateInstance("""{"approvers": [{"role": "viewer"}, {"role": "approver"}]}""");
+
+        var result = await _sut.IsTransitionAllowedForRoleAsync(
+            BuildWorkflow(),
+            BuildTransition("$role.$.context.Instance.Data.approvers[*].role"),
+            instance, "approver", cancellationToken: CancellationToken.None);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task DynamicRole_WhenCallerRoleNotInArray_Denies()
+    {
+        var instance = CreateInstance("""{"approvers": [{"role": "viewer"}, {"role": "approver"}]}""");
+
+        var result = await _sut.IsTransitionAllowedForRoleAsync(
+            BuildWorkflow(),
+            BuildTransition("$role.$.context.Instance.Data.approvers[*].role"),
+            instance, "maker", cancellationToken: CancellationToken.None);
+
+        result.ShouldBeFalse();
+    }
+
+    #endregion
+
+    #region DENY semantics
+
+    [Fact]
+    public async Task DynamicUser_WithDenyGrant_WhenActorMatches_Denies()
+    {
+        _currentUser.ActorUserName.Returns("alice");
+        var instance = CreateInstance("""{"blockedUser": "alice"}""");
+
+        var result = await _sut.IsTransitionAllowedForRoleAsync(
+            BuildWorkflow(),
+            BuildTransition("$user.$.context.Instance.Data.blockedUser", grant: "deny"),
+            instance, "alice", cancellationToken: CancellationToken.None);
+
+        result.ShouldBeFalse();
+    }
+
+    #endregion
+
+    #region Transition path
+
+    [Fact]
+    public async Task DynamicRole_TransitionKeyPath_WhenMatchesCallerRole_Allows()
+    {
+        var instance = CreateInstance("{}");
+        var json = """
+            {
+              "key": "approve",
+              "from": null,
+              "target": "approved",
+              "triggerType": "Manual",
+              "versionStrategy": "None",
+              "labels": [],
+              "onExecutionTasks": [],
+              "roles": [{"role": "$role.$.context.Transition.Key", "grant": "allow"}]
+            }
+            """;
+        var transition = JsonSerializer.Deserialize<Transition>(json, JsonOptions)!;
+
+        var result = await _sut.IsTransitionAllowedForRoleAsync(
+            BuildWorkflow(), transition, instance, "approve", cancellationToken: CancellationToken.None);
+
+        result.ShouldBeTrue();
+    }
+
+    #endregion
+
+    #region Instance null - dynamic roles always deny
+
+    [Fact]
+    public async Task DynamicRole_WhenInstanceIsNull_Denies()
+    {
+        // Without instance, EvaluateRolesStatic is used, which won't match dynamic role strings
+        var transition = BuildTransition("$user.$.context.Instance.Data.owner");
+        _currentUser.ActorUserName.Returns("alice");
+
+        var result = await _sut.IsTransitionAllowedForRoleAsync(
+            BuildWorkflow(), transition, null, "alice", cancellationToken: CancellationToken.None);
+
+        result.ShouldBeFalse();
+    }
+
+    #endregion
+}

--- a/test/BBT.Workflow.Domain.Tests/Definitions/Authorization/ContextPathResolverTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Definitions/Authorization/ContextPathResolverTests.cs
@@ -1,0 +1,222 @@
+using System.Text.Json;
+using BBT.Workflow.Definitions;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Definitions;
+
+/// <summary>
+/// Unit tests for ContextPathResolver.
+/// </summary>
+public sealed class ContextPathResolverTests
+{
+    private static JsonElement Parse(string json) =>
+        JsonDocument.Parse(json).RootElement;
+
+    #region Simple property navigation
+
+    [Fact]
+    public void Resolve_SingleLevelProperty_ReturnsValue()
+    {
+        var root = Parse("""{"name": "alice"}""");
+        var result = ContextPathResolver.Resolve(root, "name");
+        result.ShouldBe(["alice"]);
+    }
+
+    [Fact]
+    public void Resolve_NestedProperty_ReturnsValue()
+    {
+        var root = Parse("""{"customer": {"ownerUserId": "alice"}}""");
+        var result = ContextPathResolver.Resolve(root, "customer.ownerUserId");
+        result.ShouldBe(["alice"]);
+    }
+
+    [Fact]
+    public void Resolve_DeeplyNestedProperty_ReturnsValue()
+    {
+        var root = Parse("""{"a": {"b": {"c": "deep"}}}""");
+        var result = ContextPathResolver.Resolve(root, "a.b.c");
+        result.ShouldBe(["deep"]);
+    }
+
+    #endregion
+
+    #region ScriptContext-like root (Instance.Data.*)
+
+    [Fact]
+    public void Resolve_InstanceDataPath_ReturnsValue()
+    {
+        var root = Parse("""
+            {
+              "Instance": {
+                "Id": "abc",
+                "Data": {
+                  "customer": { "ownerUserId": "alice" }
+                }
+              }
+            }
+            """);
+
+        var result = ContextPathResolver.Resolve(root, "Instance.Data.customer.ownerUserId");
+        result.ShouldBe(["alice"]);
+    }
+
+    [Fact]
+    public void Resolve_InstanceCurrentState_ReturnsValue()
+    {
+        var root = Parse("""{"Instance": {"CurrentState": "waiting"}}""");
+        var result = ContextPathResolver.Resolve(root, "Instance.CurrentState");
+        result.ShouldBe(["waiting"]);
+    }
+
+    [Fact]
+    public void Resolve_TransitionKey_ReturnsValue()
+    {
+        var root = Parse("""{"Transition": {"Key": "approve"}}""");
+        var result = ContextPathResolver.Resolve(root, "Transition.Key");
+        result.ShouldBe(["approve"]);
+    }
+
+    #endregion
+
+    #region Array wildcard [*]
+
+    [Fact]
+    public void Resolve_ArrayWildcard_ReturnsAllMatchingValues()
+    {
+        var root = Parse("""
+            {
+              "assignedUsers": [
+                {"userId": "alice"},
+                {"userId": "bob"},
+                {"userId": "charlie"}
+              ]
+            }
+            """);
+
+        var result = ContextPathResolver.Resolve(root, "assignedUsers[*].userId");
+        result.Count.ShouldBe(3);
+        result.ShouldContain("alice");
+        result.ShouldContain("bob");
+        result.ShouldContain("charlie");
+    }
+
+    [Fact]
+    public void Resolve_NestedArrayWildcard_ReturnsAllMatchingValues()
+    {
+        var root = Parse("""
+            {
+              "Instance": {
+                "Data": {
+                  "approvers": [
+                    {"role": "maker"},
+                    {"role": "approver"}
+                  ]
+                }
+              }
+            }
+            """);
+
+        var result = ContextPathResolver.Resolve(root, "Instance.Data.approvers[*].role");
+        result.Count.ShouldBe(2);
+        result.ShouldContain("maker");
+        result.ShouldContain("approver");
+    }
+
+    [Fact]
+    public void Resolve_ArrayWildcardOnEmptyArray_ReturnsEmpty()
+    {
+        var root = Parse("""{"items": []}""");
+        var result = ContextPathResolver.Resolve(root, "items[*].id");
+        result.ShouldBeEmpty();
+    }
+
+    #endregion
+
+    #region Case insensitivity
+
+    [Fact]
+    public void Resolve_PropertyNameCaseInsensitive_ReturnsValue()
+    {
+        var root = Parse("""{"CUSTOMER": {"OWNERUSERID": "alice"}}""");
+        var result = ContextPathResolver.Resolve(root, "customer.ownerUserId");
+        result.ShouldBe(["alice"]);
+    }
+
+    #endregion
+
+    #region Missing / null paths
+
+    [Fact]
+    public void Resolve_MissingProperty_ReturnsEmpty()
+    {
+        var root = Parse("""{"customer": {"name": "alice"}}""");
+        var result = ContextPathResolver.Resolve(root, "customer.ownerUserId");
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Resolve_MissingIntermediateProperty_ReturnsEmpty()
+    {
+        var root = Parse("""{"other": "value"}""");
+        var result = ContextPathResolver.Resolve(root, "customer.ownerUserId");
+        result.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Resolve_NullOrEmptyPath_ReturnsEmpty(string? path)
+    {
+        var root = Parse("""{"x": "y"}""");
+        var result = ContextPathResolver.Resolve(root, path!);
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Resolve_NullJsonValue_ReturnsEmpty()
+    {
+        var root = Parse("""{"owner": null}""");
+        var result = ContextPathResolver.Resolve(root, "owner");
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Resolve_ObjectAtLeaf_ReturnsEmpty()
+    {
+        var root = Parse("""{"customer": {"id": "123"}}""");
+        var result = ContextPathResolver.Resolve(root, "customer");
+        result.ShouldBeEmpty(); // Object itself is not a leaf string value
+    }
+
+    #endregion
+
+    #region Value type coercion
+
+    [Fact]
+    public void Resolve_NumberValue_ReturnsRawText()
+    {
+        var root = Parse("""{"amount": 42}""");
+        var result = ContextPathResolver.Resolve(root, "amount");
+        result.ShouldBe(["42"]);
+    }
+
+    [Fact]
+    public void Resolve_BooleanTrue_ReturnsTrue()
+    {
+        var root = Parse("""{"active": true}""");
+        var result = ContextPathResolver.Resolve(root, "active");
+        result.ShouldBe(["true"]);
+    }
+
+    [Fact]
+    public void Resolve_BooleanFalse_ReturnsFalse()
+    {
+        var root = Parse("""{"active": false}""");
+        var result = ContextPathResolver.Resolve(root, "active");
+        result.ShouldBe(["false"]);
+    }
+
+    #endregion
+}

--- a/test/BBT.Workflow.Domain.Tests/Definitions/Authorization/DynamicRoleGrantTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Definitions/Authorization/DynamicRoleGrantTests.cs
@@ -1,0 +1,143 @@
+using BBT.Workflow.Definitions;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Definitions;
+
+/// <summary>
+/// Unit tests for DynamicRoleGrant parsing.
+/// </summary>
+public sealed class DynamicRoleGrantTests
+{
+    #region TryParse - valid patterns
+
+    [Fact]
+    public void TryParse_UserQualifierWithSimplePath_ReturnsUserGrant()
+    {
+        var result = DynamicRoleGrant.TryParse("$user.$.context.Instance.Data.customer.ownerUserId");
+
+        result.ShouldNotBeNull();
+        result.Qualifier.ShouldBe(DynamicRoleQualifier.User);
+        result.ContextPath.ShouldBe("$.context.Instance.Data.customer.ownerUserId");
+    }
+
+    [Fact]
+    public void TryParse_UserQualifierWithArrayWildcard_ReturnsUserGrantWithIsArrayPath()
+    {
+        var result = DynamicRoleGrant.TryParse("$user.$.context.Instance.Data.assignedUsers[*].userId");
+
+        result.ShouldNotBeNull();
+        result.Qualifier.ShouldBe(DynamicRoleQualifier.User);
+        result.ContextPath.ShouldBe("$.context.Instance.Data.assignedUsers[*].userId");
+        result.IsArrayPath.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void TryParse_UserBehalfOfQualifier_ReturnsUserBehalfOfGrant()
+    {
+        var result = DynamicRoleGrant.TryParse("$userBehalfOf.$.context.Instance.Data.customer.behalfOfUserId");
+
+        result.ShouldNotBeNull();
+        result.Qualifier.ShouldBe(DynamicRoleQualifier.UserBehalfOf);
+        result.ContextPath.ShouldBe("$.context.Instance.Data.customer.behalfOfUserId");
+    }
+
+    [Fact]
+    public void TryParse_RoleQualifier_ReturnsRoleGrant()
+    {
+        var result = DynamicRoleGrant.TryParse("$role.$.context.Instance.Data.permissions.requiredRole");
+
+        result.ShouldNotBeNull();
+        result.Qualifier.ShouldBe(DynamicRoleQualifier.Role);
+        result.ContextPath.ShouldBe("$.context.Instance.Data.permissions.requiredRole");
+    }
+
+    [Fact]
+    public void TryParse_RoleQualifierWithArrayWildcard_ReturnsRoleGrantWithIsArrayPath()
+    {
+        var result = DynamicRoleGrant.TryParse("$role.$.context.Instance.Data.approvers[*].role");
+
+        result.ShouldNotBeNull();
+        result.Qualifier.ShouldBe(DynamicRoleQualifier.Role);
+        result.IsArrayPath.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void TryParse_TransitionPath_ReturnsGrant()
+    {
+        var result = DynamicRoleGrant.TryParse("$role.$.context.Transition.Key");
+
+        result.ShouldNotBeNull();
+        result.Qualifier.ShouldBe(DynamicRoleQualifier.Role);
+        result.ContextPath.ShouldBe("$.context.Transition.Key");
+    }
+
+    #endregion
+
+    #region TryParse - prefix collision
+
+    [Fact]
+    public void TryParse_UserBehalfOfPrefix_NotMistakenForUser()
+    {
+        // $userBehalfOf must not be parsed as $user with remainder "BehalfOf.$.context..."
+        var result = DynamicRoleGrant.TryParse("$userBehalfOf.$.context.Instance.Data.id");
+
+        result.ShouldNotBeNull();
+        result.Qualifier.ShouldBe(DynamicRoleQualifier.UserBehalfOf);
+    }
+
+    #endregion
+
+    #region TryParse - null / invalid inputs
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("$InstanceStarter")]
+    [InlineData("$PreviousUser")]
+    [InlineData("morph-idm.maker")]
+    [InlineData("$user.Instance.Data.field")]       // missing $.context.
+    [InlineData("$role.context.Instance.Data.f")]   // missing $. prefix
+    [InlineData("$user.$.context.")]                // empty path after prefix
+    public void TryParse_InvalidOrNonDynamicInputs_ReturnsNull(string? input)
+    {
+        DynamicRoleGrant.TryParse(input).ShouldBeNull();
+    }
+
+    #endregion
+
+    #region IsDynamicRole
+
+    [Theory]
+    [InlineData("$user.$.context.Instance.Data.id", true)]
+    [InlineData("$userBehalfOf.$.context.Instance.Data.id", true)]
+    [InlineData("$role.$.context.Instance.Data.id", true)]
+    [InlineData("$InstanceStarter", false)]
+    [InlineData("morph-idm.maker", false)]
+    [InlineData(null, false)]
+    public void IsDynamicRole_ReturnsExpected(string? role, bool expected)
+    {
+        DynamicRoleGrant.IsDynamicRole(role).ShouldBe(expected);
+    }
+
+    #endregion
+
+    #region IsArrayPath
+
+    [Fact]
+    public void IsArrayPath_WhenPathContainsWildcard_ReturnsTrue()
+    {
+        var grant = DynamicRoleGrant.TryParse("$user.$.context.Instance.Data.items[*].id")!;
+        grant.IsArrayPath.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsArrayPath_WhenPathHasNoWildcard_ReturnsFalse()
+    {
+        var grant = DynamicRoleGrant.TryParse("$user.$.context.Instance.Data.owner.id")!;
+        grant.IsArrayPath.ShouldBeFalse();
+    }
+
+    #endregion
+}

--- a/test/BBT.Workflow.Domain.Tests/Definitions/Authorization/PredefinedInstanceRolesTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Definitions/Authorization/PredefinedInstanceRolesTests.cs
@@ -20,15 +20,32 @@ public class PredefinedInstanceRolesTests
         Assert.Equal("$PreviousUser", PredefinedInstanceRoles.PreviousUser);
     }
 
+    [Fact]
+    public void InstanceBehalfOfStarter_ShouldBeDollarInstanceBehalfOfStarter()
+    {
+        Assert.Equal("$InstanceBehalfOfStarter", PredefinedInstanceRoles.InstanceBehalfOfStarter);
+    }
+
+    [Fact]
+    public void PreviousBehalfOfUser_ShouldBeDollarPreviousBehalfOfUser()
+    {
+        Assert.Equal("$PreviousBehalfOfUser", PredefinedInstanceRoles.PreviousBehalfOfUser);
+    }
+
     [Theory]
     [InlineData("$InstanceStarter", true)]
     [InlineData("$PreviousUser", true)]
+    [InlineData("$InstanceBehalfOfStarter", true)]
+    [InlineData("$PreviousBehalfOfUser", true)]
     [InlineData("$instancestarter", false)]
     [InlineData("$previoususer", false)]
+    [InlineData("$instancebehalfofstarter", false)]
+    [InlineData("$previousbehalfofuser", false)]
     [InlineData("role.maker", false)]
     [InlineData("", false)]
     [InlineData(null, false)]
     [InlineData("  $InstanceStarter  ", true)]
+    [InlineData("  $InstanceBehalfOfStarter  ", true)]
     public void IsPredefinedRole_ShouldReturnExpected(string? role, bool expected)
     {
         Assert.Equal(expected, PredefinedInstanceRoles.IsPredefinedRole(role));


### PR DESCRIPTION
## Summary

- **Dynamic role grants** (`$user`, `$userBehalfOf`, `$role` qualifiers): transition `roles` can now contain path expressions like `$user.$.context.Instance.Data.*` or `$role.$.context.Instance.Data.*`; values are resolved via `ContextPathResolver` with `[*]` array wildcard support
- **BehalfOf predefined roles**: added `$InstanceBehalfOfStarter` and `$PreviousBehalfOfUser`; matched against `ICurrentUser.UserName` (`sub` claim)
- **Request context pipeline**: `AuthorizationRequestContext` (Headers, QueryParameters, RouteValues) is threaded from `AuthorizeFunctionHandler` through the entire authorization pipeline (`AuthorizeAppService` → gateway chain → `TransitionAuthorizationManager`); `BuildAuthorizationContextElement` exposes these values under `$.context.Headers.*`, `$.context.QueryParameters.*`, and `$.context.RouteValues.*`
- **Gateway chain**: `LocalAuthorizeGateway`, `RemoteAuthorizeGateway`, `RoutedAuthorizeGateway`, and `RemoteAuthorizeAppService` updated; in remote scenarios, original request headers are forwarded safely via `CurrentUserForwardHeadersHelper.MergeIntoRequest` (content headers and empty values are filtered)
- **WorkflowValidator**: validation added for dynamic role format (`$qualifier.$.context.<path>`)

## New files

| File | Description |
|------|-------------|
| `DynamicRoleGrant.cs` | Qualifier + context path parse/model |
| `ContextPathResolver.cs` | `System.Text.Json`-based JSON path resolver with `[*]` wildcard support |
| `AuthorizationRequestContext.cs` | Record carrying HTTP request context through the pipeline |
| `TransitionAuthorizationManagerDynamicRoleTests.cs` | Dynamic role scenarios (25 tests) |
| `TransitionAuthorizationManagerBehalfOfTests.cs` | BehalfOf predefined role scenarios (12 tests) |
| `ContextPathResolverTests.cs` | Path resolver unit tests |
| `DynamicRoleGrantTests.cs` | Parse/model unit tests |

## Dynamic role format

```
$user.$.context.Instance.Data.customer.ownerUserId
$userBehalfOf.$.context.Instance.Data.assignedUsers[*].userId
$role.$.context.Instance.Data.permissions.requiredRole
$user.$.context.Headers.x-actor-id
$role.$.context.QueryParameters.requiredRole
$role.$.context.RouteValues.domain
```

## Test plan

- [ ] `dotnet test test/BBT.Workflow.Domain.Tests` — ContextPathResolver, DynamicRoleGrant, PredefinedInstanceRoles
- [ ] `dotnet test test/BBT.Workflow.Application.Tests --filter Authorization` — 42 tests, 0 failures
- [ ] Manual: `$user.$.context.Instance.Data.assignedUsers[*].userId` with matching `act_sub` header → ALLOW
- [ ] Manual: `$role.$.context.QueryParameters.requiredRole` with `?requiredRole=maker` and caller role `maker` → ALLOW
- [ ] Manual: cross-domain subflow scenario — request headers forwarded safely to remote service


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* **Dynamic role grants**: Roles can now be evaluated based on HTTP request context (headers, query parameters, route values) using dynamic role expressions like `$user.$.context.<path>`, `$userBehalfOf.$.context.<path>`, and `$role.$.context.<path>`.
* **Behalf-of authorization**: Added new predefined roles for on-behalf-of authorization scenarios.
* **Enhanced request context support**: HTTP request data is now available during authorization evaluation for more flexible access control decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->