### PR TITLE
v0.0.44

### DIFF
--- a/src/BBT.Workflow.Domain/Instances/Instance.cs
+++ b/src/BBT.Workflow.Domain/Instances/Instance.cs
@@ -456,12 +456,12 @@ public sealed class Instance : AggregateRoot<Guid>, ICreationAuditedObject, IMod
         }
 
         correlation.Completed();
-        
-        // If this is a SubFlow (blocking), set instance to Active
-        if (correlation.SubFlowType.Equals(SubFlowType.SubFlow))
-        {
-            Active();
-        }
+
+        // NOTE: Do NOT call Active() here for SubFlow type.
+        // The parent must remain Busy until ClearBusyOnResumeStep runs in ResumePipelineAsync.
+        // Transitioning to Active here would cause the state endpoint to return Active
+        // during the processing window between correlation completion and pipeline resume,
+        // falsely signaling to clients that the flow is no longer busy.
 
         return correlation;
     }

--- a/test/BBT.Workflow.Domain.Tests/Instances/InstanceTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Instances/InstanceTests.cs
@@ -905,6 +905,32 @@ public class InstanceTests : DomainTestBase<DomainEntryPoint>
     }
 
     [Fact]
+    public void CompleteCorrelation_SubFlow_ShouldRemainBusy()
+    {
+        // Arrange
+        var subInstanceId = Guid.NewGuid();
+        var instance = InstanceFactory.CreateDefault();
+        var correlation = InstanceCorrelation.Create(
+            Guid.NewGuid(),
+            instance.Id,
+            "parent-state",
+            subInstanceId,
+            "S", // SubFlow
+            "domain",
+            "flow",
+            null
+        );
+        instance.AddCorrelation(correlation); // sets instance to Busy
+
+        // Act
+        instance.CompleteCorrelation(subInstanceId);
+
+        // Assert — must remain Busy; ClearBusyOnResumeStep will transition to Active
+        Assert.Equal(InstanceStatus.Busy, instance.Status);
+        Assert.True(instance.IsBusy);
+    }
+
+    [Fact]
     public void HasActiveSubFlow_ShouldReturnTrue_WhenActiveSubFlowExists()
     {
         // Arrange


### PR DESCRIPTION
When a SubFlow correlation was marked as completed, Instance.CompleteCorrelation() was immediately calling Active() on the parent instance and persisting it. This caused the state endpoint to return Active during the window between correlation completion and ResumePipelineAsync execution, falsely signaling to clients that the flow was no longer busy.

The parent instance now remains Busy after SubFlow correlation completion. ClearBusyOnResumeStep (Order 79) is responsible for transitioning it to Active once the resume pipeline has finished processing.

## Summary by Sourcery

Ensure parent workflow instances remain busy after SubFlow correlation completion until the resume pipeline finishes processing.

Bug Fixes:
- Prevent parent instances from briefly reporting an Active state between SubFlow correlation completion and resume pipeline processing, avoiding false non-busy signals to clients.

Tests:
- Add a unit test verifying that completing a SubFlow correlation keeps the parent instance in Busy status until the resume pipeline clears it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Parent workflow instances now correctly maintain "Busy" status while sub-workflow operations complete, with the active state restored during final resumption.

* **Tests**
  * Added test verifying parent instance state management after sub-workflow completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->