### PR TITLE
fix(gateway): pass correct workflow parameter to ExecuteWithWorkflowA…

### DIFF
--- a/src/BBT.Workflow.Infrastructure/Gateway/LocalInstanceQueryGateway.cs
+++ b/src/BBT.Workflow.Infrastructure/Gateway/LocalInstanceQueryGateway.cs
@@ -1,4 +1,3 @@
-using BBT.Aether.MultiSchema;
 using BBT.Aether.Results;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Instances.DTOs;
@@ -43,7 +42,7 @@ public sealed class LocalInstanceQueryGateway : IInstanceQueryGateway
         GetInstanceDataInput input,
         CancellationToken cancellationToken = default)
     {
-        return _serviceScopeFactory.ExecuteWithWorkflowAsync(input.Domain, input.Version, input.Version,
+        return _serviceScopeFactory.ExecuteWithWorkflowAsync(input.Domain, input.Workflow, input.Version,
             async (sp, ct) =>
             {
                 var queryService = sp.GetRequiredService<IInstanceQueryAppService>();


### PR DESCRIPTION
…sync

The `input.Version` was incorrectly passed as the workflow argument. Replace with `input.Workflow` to match the intended parameter.

Also remove unused `BBT.Aether.MultiSchema` using directive.

## Summary by Sourcery

Fix instance query gateway to pass the correct workflow identifier when executing workflow-scoped operations.

Bug Fixes:
- Correct the workflow parameter passed to ExecuteWithWorkflowAsync when fetching instance data.

Enhancements:
- Remove an unused using directive from the local instance query gateway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workflow context selection in instance data retrieval to correctly use the workflow identifier, ensuring the proper workflow context is applied when processing instance data requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->