### PR TITLE
fix(pipeline): defer instance Active status until post-commit jobs complete

### DIFF
--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ClearBusyOnResumeStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ClearBusyOnResumeStep.cs
@@ -14,15 +14,14 @@ namespace BBT.Workflow.Execution.Pipeline.Steps;
 /// 2. Skips status update if target state is Busy SubType (ChangeState will handle it)
 /// 3. Implements idempotency - only updates DB if status actually changes
 /// </summary>
-public sealed class ClearBusyOnResumeStep(
-    IInstanceRepository instanceRepository) : ITransitionStep
+public sealed class ClearBusyOnResumeStep() : ITransitionStep
 {
     /// <inheritdoc />
     public int Order => LifecycleOrder.ClearBusyOnResumeStep;
 
     /// <inheritdoc />
     [Trace]
-    public async Task<Result<StepOutcome>> ExecuteAsync(TransitionExecutionContext context,
+    public Task<Result<StepOutcome>> ExecuteAsync(TransitionExecutionContext context,
         CancellationToken cancellationToken)
     {
         Activity.Current?.SetDisplayName($"[{Order}] {nameof(ClearBusyOnResumeStep)}");
@@ -30,21 +29,21 @@ public sealed class ClearBusyOnResumeStep(
         // Only process this step if resuming from SubFlow completion
         if (!context.Directives.IsSubFlowResume)
         {
-            return Result<StepOutcome>.Ok(StepOutcome.Continue());
+            return Task.FromResult(Result<StepOutcome>.Ok(StepOutcome.Continue()));
         }
 
-        // Railway chain: Resolve target state first, then conditionally clear busy
-        return await Result.Ok(context)
-            .Bind(UpdateTargetStateInContext)  // 1. Resolve target state first
-            .BindAsync(ctx => ClearBusyIfNeededAsync(ctx, cancellationToken))  // 2. Conditional clear
-            .Map(_ => StepOutcome.Continue());
+        // Resolve target state first, then conditionally defer status
+        var stateResult = UpdateTargetStateInContext(context);
+        if (!stateResult.IsSuccess)
+            return Task.FromResult(Result<StepOutcome>.Fail(stateResult.Error));
+
+        ClearBusyIfNeeded(context);
+        return Task.FromResult(Result<StepOutcome>.Ok(StepOutcome.Continue()));
     }
 
     /// <summary>
     /// Updates target state in context by resolving the current state from workflow definition.
     /// </summary>
-    /// <param name="context">Transition execution context</param>
-    /// <returns>Result containing the context with resolved target state</returns>
     private static Result<TransitionExecutionContext> UpdateTargetStateInContext(TransitionExecutionContext context)
     {
         return context.Workflow.GetState(context.Instance.GetCurrentState)
@@ -56,34 +55,20 @@ public sealed class ClearBusyOnResumeStep(
     }
 
     /// <summary>
-    /// Conditionally clears busy status and updates repository.
-    /// Implements two optimizations:
-    /// 1. Skip if target state SubType is Busy (ChangeState will handle it)
-    /// 2. Skip if instance is already Active (idempotency)
+    /// Conditionally defers the Active status update via PipelineDirectives.
+    /// Skips if target state SubType is Busy (ChangeState will handle it).
+    /// Skips if instance is already Active or Completed (idempotency).
     /// </summary>
-    /// <param name="context">Transition execution context with resolved target state</param>
-    /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>Result containing the context</returns>
-    private async Task<Result<TransitionExecutionContext>> ClearBusyIfNeededAsync(
-        TransitionExecutionContext context, 
-        CancellationToken cancellationToken)
+    private static void ClearBusyIfNeeded(TransitionExecutionContext context)
     {
-        var targetState = context.Target;
-        
-        // Optimization 1: If target state is Busy subtype, ChangeState will handle status
-        // No need to set Active here (would be immediately overridden to Busy anyway)
-        if (targetState?.SubType == StateSubType.Busy)
-        {
-            return Result<TransitionExecutionContext>.Ok(context);
-        }
-        
-        // Optimization 2: Idempotency - only update if status actually needs to change
+        // If target state is Busy subtype, ChangeState will handle status
+        if (context.Target?.SubType == StateSubType.Busy)
+            return;
+
+        // Defer status update to after post-commit jobs complete
         if (context.Instance is { IsActive: false, IsCompleted: false })
         {
-            context.Instance.Active();
-            await instanceRepository.UpdateAsync(context.Instance, true, cancellationToken);
+            context.Directives.SetResolvedStatus(InstanceStatus.Active);
         }
-        
-        return Result<TransitionExecutionContext>.Ok(context);
     }
 }

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ResolveAvailableStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ResolveAvailableStep.cs
@@ -10,14 +10,15 @@ namespace BBT.Workflow.Execution.Pipeline.Steps;
 
 /// <summary>
 /// Pipeline step that resolves the Available (Active) status at the end of transition processing.
-/// Sets instance to Active when all conditions are met:
+/// Defers the actual status update to PipelineDirectives.ResolvedStatus so that the status
+/// is only applied after all post-commit jobs complete (in TransitionPipeline).
+/// Conditions for deferring Active status:
 /// - Auto transition chain is not continuing (NextTransition is null)
 /// - Not a terminal state (SubFlow entry point for parent)
 /// - Target state is not a Finish state
 /// - Target state has only manual/event transitions or no transitions
 /// </summary>
 public sealed class ResolveAvailableStep(
-    IInstanceRepository instanceRepository,
     ILogger<ResolveAvailableStep> logger) : ITransitionStep
 {
     /// <inheritdoc />
@@ -37,15 +38,13 @@ public sealed class ResolveAvailableStep(
             return Result<StepOutcome>.Ok(StepOutcome.Continue());
         }
 
-        // Set instance to Active and persist
-        return await Result.Ok(context)
-            .Tap(ctx => ctx.Instance.Active())
-            .TapAsync(ctx => instanceRepository.UpdateAsync(ctx.Instance, true, cancellationToken))
-            .Tap(ctx => logger.LogDebug(
-                "Instance {InstanceId} set to Available after transition to state {TargetState}",
-                ctx.InstanceId,
-                ctx.Target?.Key ?? "unknown"))
-            .Map(_ => StepOutcome.Continue());
+        // Defer status update to after post-commit jobs complete
+        context.Directives.SetResolvedStatus(InstanceStatus.Active);
+        logger.LogDebug(
+            "Instance {InstanceId} deferred Available status after transition to state {TargetState}",
+            context.InstanceId,
+            context.Target?.Key ?? "unknown");
+        return Result<StepOutcome>.Ok(StepOutcome.Continue());
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/TransitionPipeline.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/TransitionPipeline.cs
@@ -177,12 +177,15 @@ public class TransitionPipeline
                 }
             }
 
-            // 6) Check for next transition in sync dispatch chain
+            // 6) Apply deferred resolved status after all work is done
+            await ApplyResolvedStatusAsync(context, cancellationToken);
+
+            // 7) Check for next transition in sync dispatch chain
             var nextTransition = context.Directives.ConsumeNextTransition();
             if (nextTransition is null)
                 return Result<TransitionExecutionContext>.Ok(context);
 
-            // 7) Create new WorkflowExecutionContext for next transition
+            // 8) Create new WorkflowExecutionContext for next transition
             currentWorkflowContext = CreateNextWorkflowContext(context, nextTransition);
             pipelineFaulted = false; // Reset for next iteration
         }
@@ -528,6 +531,58 @@ public class TransitionPipeline
         {
             _logger.LogError(
                 "Failed to acquire lock for marking instance {InstanceId} as faulted",
+                context.InstanceId);
+        }
+    }
+
+    /// <summary>
+    /// Applies the deferred resolved status to the instance after all pipeline work
+    /// (including post-commit jobs) has completed.
+    /// Re-acquires the distributed lock to ensure consistent state update.
+    /// Guards against applying Active when:
+    /// - Auto chain is continuing (NextTransition is set)
+    /// - Instance has reached a terminal status (Completed/Faulted)
+    /// - Target state SubType is Busy (ChangeState already set Busy)
+    /// </summary>
+    private async Task ApplyResolvedStatusAsync(
+        TransitionExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        var resolvedStatus = context.Directives.ConsumeResolvedStatus();
+        if (resolvedStatus is null)
+            return;
+
+        // Auto chain is continuing — instance should stay Busy
+        if (context.Directives.NextTransition is not null)
+            return;
+
+        // Terminal status reached (Completed/Faulted/Passive) — don't override
+        if (context.Instance.IsCompleted)
+            return;
+
+        // Target state SubType is Busy — ChangeState already set Busy
+        if (context.Target?.SubType == StateSubType.Busy)
+            return;
+
+        // All guards passed — re-acquire lock and apply the resolved status
+        var lockAcquired = await _distributedLockService.ExecuteWithLockAsync(
+            context.LockKey,
+            async () =>
+            {
+                context.Instance.Active();
+                await _instanceRepository.UpdateAsync(context.Instance, true, cancellationToken);
+
+                _logger.LogDebug(
+                    "Instance {InstanceId} resolved to Active after post-commit completion",
+                    context.InstanceId);
+            },
+            DefaultLockLeaseSeconds,
+            cancellationToken);
+
+        if (!lockAcquired)
+        {
+            _logger.LogWarning(
+                "Failed to acquire lock for applying resolved status on instance {InstanceId}",
                 context.InstanceId);
         }
     }

--- a/src/BBT.Workflow.Application/Instances/Managers/InstanceCancellationService.cs
+++ b/src/BBT.Workflow.Application/Instances/Managers/InstanceCancellationService.cs
@@ -49,9 +49,16 @@ public sealed class InstanceCancellationService(
             // Process all jobs in parallel for better performance
             var processingTasks = jobs.Select(async job =>
             {
-                await backgroundJobService.DeleteAsync(job.JobId, cancellationToken);
-                job.MarkAsProcessed();
-                await instanceJobRepository.UpdateAsync(job, true, cancellationToken);
+                try
+                {
+                    await backgroundJobService.DeleteAsync(job.JobId, cancellationToken);
+                    job.MarkAsProcessed();
+                    await instanceJobRepository.UpdateAsync(job, true, cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    logger.InstanceJobDeletionFailed(ex, job.JobId, instanceId);
+                }
             });
 
             await Task.WhenAll(processingTasks);
@@ -102,9 +109,16 @@ public sealed class InstanceCancellationService(
             // Process filtered jobs in parallel
             var processingTasks = jobsToCancel.Select(async job =>
             {
-                await backgroundJobService.DeleteAsync(job.JobId, cancellationToken);
-                job.MarkAsProcessed();
-                await instanceJobRepository.UpdateAsync(job, true, cancellationToken);
+                try
+                {
+                    await backgroundJobService.DeleteAsync(job.JobId, cancellationToken);
+                    job.MarkAsProcessed();
+                    await instanceJobRepository.UpdateAsync(job, true, cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    logger.InstanceJobDeletionFailed(ex, job.JobId, instanceId);
+                }
             });
 
             await Task.WhenAll(processingTasks);

--- a/src/BBT.Workflow.Domain/Execution/Transitions/Context/PipelineDirectives.cs
+++ b/src/BBT.Workflow.Domain/Execution/Transitions/Context/PipelineDirectives.cs
@@ -1,4 +1,5 @@
 using BBT.Workflow.Execution.PostCommit;
+using BBT.Workflow.Instances;
 
 namespace BBT.Workflow.Execution;
 
@@ -138,6 +139,33 @@ public sealed class PipelineDirectives
         var key = _errorTransitionKey;
         _errorTransitionKey = null;
         return key;
+    }
+
+    /// <summary>
+    /// Gets the deferred instance status to be applied after all pipeline work
+    /// (including post-commit jobs) completes.
+    /// When set, the actual status update is deferred until the pipeline
+    /// returns control to the caller.
+    /// </summary>
+    public InstanceStatus? ResolvedStatus { get; private set; }
+
+    /// <summary>
+    /// Sets the deferred resolved status.
+    /// The status will be applied after post-commit jobs complete.
+    /// </summary>
+    /// <param name="status">The status to defer.</param>
+    public void SetResolvedStatus(InstanceStatus status) => ResolvedStatus = status;
+
+    /// <summary>
+    /// Consumes and clears the resolved status.
+    /// Called by the pipeline after post-commit jobs complete.
+    /// </summary>
+    /// <returns>The deferred status, or null if none was set.</returns>
+    public InstanceStatus? ConsumeResolvedStatus()
+    {
+        var s = ResolvedStatus;
+        ResolvedStatus = null;
+        return s;
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
@@ -1030,6 +1030,19 @@ public static partial class WorkflowLogs
         Exception exception,
         Guid instanceId);
 
+    /// <summary>
+    /// Logs when a single job deletion fails during instance cancellation.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 40103,
+        Level = LogLevel.Error,
+        Message = "Failed to delete job {JobId} during cancellation for instance {InstanceId}")]
+    public static partial void InstanceJobDeletionFailed(
+        this ILogger logger,
+        Exception exception,
+        Guid jobId,
+        Guid instanceId);
+
     #endregion
 
     #region Instance Completion Cleanup

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/Steps/ResolveAvailableStepTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/Steps/ResolveAvailableStepTests.cs
@@ -21,15 +21,13 @@ namespace BBT.Workflow.Application.Tests.Execution.Transitions.Pipeline.Steps;
 /// </summary>
 public class ResolveAvailableStepTests
 {
-    private readonly IInstanceRepository _mockInstanceRepository;
     private readonly ILogger<ResolveAvailableStep> _mockLogger;
     private readonly ResolveAvailableStep _step;
 
     public ResolveAvailableStepTests()
     {
-        _mockInstanceRepository = Substitute.For<IInstanceRepository>();
         _mockLogger = Substitute.For<ILogger<ResolveAvailableStep>>();
-        _step = new ResolveAvailableStep(_mockInstanceRepository, _mockLogger);
+        _step = new ResolveAvailableStep(_mockLogger);
     }
 
     [Fact]
@@ -40,7 +38,7 @@ public class ResolveAvailableStepTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_WhenAllConditionsMet_ShouldSetToActive()
+    public async Task ExecuteAsync_WhenAllConditionsMet_ShouldDeferActiveStatus()
     {
         // Arrange
         var context = CreateTransitionExecutionContext(hasOnlyManualTransitions: true);
@@ -51,12 +49,12 @@ public class ResolveAvailableStepTests
 
         // Assert
         result.IsSuccess.ShouldBeTrue();
-        context.Instance.IsActive.ShouldBeTrue();
-        await _mockInstanceRepository.Received(1).UpdateAsync(context.Instance, true, CancellationToken.None);
+        context.Instance.IsBusy.ShouldBeTrue(); // Instance stays Busy — not updated directly
+        context.Directives.ResolvedStatus.ShouldBe(InstanceStatus.Active); // Deferred to directives
     }
 
     [Fact]
-    public async Task ExecuteAsync_WhenInstanceNotBusy_ShouldSkipAndNotUpdate()
+    public async Task ExecuteAsync_WhenInstanceNotBusy_ShouldSkipAndNotDeferStatus()
     {
         // Arrange
         var context = CreateTransitionExecutionContext(hasOnlyManualTransitions: true);
@@ -67,11 +65,11 @@ public class ResolveAvailableStepTests
 
         // Assert
         result.IsSuccess.ShouldBeTrue();
-        await _mockInstanceRepository.DidNotReceive().UpdateAsync(Arg.Any<Instance>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        context.Directives.ResolvedStatus.ShouldBeNull();
     }
 
     [Fact]
-    public async Task ExecuteAsync_WhenInstanceIsCompleted_ShouldSkipAndNotUpdate()
+    public async Task ExecuteAsync_WhenInstanceIsCompleted_ShouldSkipAndNotDeferStatus()
     {
         // Arrange
         var context = CreateTransitionExecutionContext(hasOnlyManualTransitions: true);
@@ -82,11 +80,11 @@ public class ResolveAvailableStepTests
 
         // Assert
         result.IsSuccess.ShouldBeTrue();
-        await _mockInstanceRepository.DidNotReceive().UpdateAsync(Arg.Any<Instance>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        context.Directives.ResolvedStatus.ShouldBeNull();
     }
 
     [Fact]
-    public async Task ExecuteAsync_WhenNextTransitionRequested_ShouldStayBusy()
+    public async Task ExecuteAsync_WhenNextTransitionRequested_ShouldNotDeferStatus()
     {
         // Arrange
         var context = CreateTransitionExecutionContext(hasOnlyManualTransitions: true);
@@ -99,11 +97,11 @@ public class ResolveAvailableStepTests
         // Assert
         result.IsSuccess.ShouldBeTrue();
         context.Instance.IsBusy.ShouldBeTrue();
-        await _mockInstanceRepository.DidNotReceive().UpdateAsync(Arg.Any<Instance>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        context.Directives.ResolvedStatus.ShouldBeNull();
     }
 
     [Fact]
-    public async Task ExecuteAsync_WhenTerminalReached_ShouldStayBusy()
+    public async Task ExecuteAsync_WhenTerminalReached_ShouldNotDeferStatus()
     {
         // Arrange
         var context = CreateTransitionExecutionContext(hasOnlyManualTransitions: true);
@@ -116,11 +114,11 @@ public class ResolveAvailableStepTests
         // Assert
         result.IsSuccess.ShouldBeTrue();
         context.Instance.IsBusy.ShouldBeTrue();
-        await _mockInstanceRepository.DidNotReceive().UpdateAsync(Arg.Any<Instance>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        context.Directives.ResolvedStatus.ShouldBeNull();
     }
 
     [Fact]
-    public async Task ExecuteAsync_WhenTargetIsFinishState_ShouldStayBusy()
+    public async Task ExecuteAsync_WhenTargetIsFinishState_ShouldNotDeferStatus()
     {
         // Arrange
         var context = CreateTransitionExecutionContextWithFinishState();
@@ -132,11 +130,11 @@ public class ResolveAvailableStepTests
         // Assert
         result.IsSuccess.ShouldBeTrue();
         context.Instance.IsBusy.ShouldBeTrue();
-        await _mockInstanceRepository.DidNotReceive().UpdateAsync(Arg.Any<Instance>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        context.Directives.ResolvedStatus.ShouldBeNull();
     }
 
     [Fact]
-    public async Task ExecuteAsync_WhenTargetHasAutoTransitions_ShouldStayBusy()
+    public async Task ExecuteAsync_WhenTargetHasAutoTransitions_ShouldNotDeferStatus()
     {
         // Arrange
         var context = CreateTransitionExecutionContext(hasOnlyManualTransitions: false);
@@ -148,11 +146,11 @@ public class ResolveAvailableStepTests
         // Assert
         result.IsSuccess.ShouldBeTrue();
         context.Instance.IsBusy.ShouldBeTrue();
-        await _mockInstanceRepository.DidNotReceive().UpdateAsync(Arg.Any<Instance>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        context.Directives.ResolvedStatus.ShouldBeNull();
     }
 
     [Fact]
-    public async Task ExecuteAsync_WhenTargetIsNull_ShouldSkipAndNotUpdate()
+    public async Task ExecuteAsync_WhenTargetIsNull_ShouldSkipAndNotDeferStatus()
     {
         // Arrange
         var context = CreateTransitionExecutionContext(hasOnlyManualTransitions: true);
@@ -165,11 +163,11 @@ public class ResolveAvailableStepTests
         // Assert
         result.IsSuccess.ShouldBeTrue();
         context.Instance.IsBusy.ShouldBeTrue();
-        await _mockInstanceRepository.DidNotReceive().UpdateAsync(Arg.Any<Instance>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        context.Directives.ResolvedStatus.ShouldBeNull();
     }
 
     [Fact]
-    public async Task ExecuteAsync_WhenTargetHasNoTransitions_ShouldSetToActive()
+    public async Task ExecuteAsync_WhenTargetHasNoTransitions_ShouldDeferActiveStatus()
     {
         // Arrange - state with no transitions should be Available
         var context = CreateTransitionExecutionContextWithNoTransitions();
@@ -180,8 +178,8 @@ public class ResolveAvailableStepTests
 
         // Assert
         result.IsSuccess.ShouldBeTrue();
-        context.Instance.IsActive.ShouldBeTrue();
-        await _mockInstanceRepository.Received(1).UpdateAsync(context.Instance, true, CancellationToken.None);
+        context.Instance.IsBusy.ShouldBeTrue(); // Instance stays Busy — not updated directly
+        context.Directives.ResolvedStatus.ShouldBe(InstanceStatus.Active); // Deferred to directives
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Fix a race condition where clients polling instance state during async (`sync=false`) execution received a premature `Active` status before the pipeline had fully completed
- `ResolveAvailableStep` and `ClearBusyOnResumeStep` previously wrote `Active` directly to the DB mid-pipeline, before post-commit jobs (SubFlow starts, remote task calls) finished
- Status updates are now deferred via `PipelineDirectives.SetResolvedStatus` and applied in the new `TransitionPipeline.ApplyResolvedStatusAsync` method, which runs after all post-commit jobs complete
- Guards ensure `Active` is never applied when an auto-chain is continuing, the instance is in a terminal state, or the target state has a `Busy` subtype

## Changes
- `src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ResolveAvailableStep.cs` — removed `IInstanceRepository` dependency; defers status via directives
- `src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ClearBusyOnResumeStep.cs` — same refactor; removed `IInstanceRepository`
- `src/BBT.Workflow.Application/Execution/Transitions/Pipeline/TransitionPipeline.cs` — added `ApplyResolvedStatusAsync` (step 6 in pipeline loop)
- `src/BBT.Workflow.Domain/Execution/Transitions/Context/PipelineDirectives.cs` — added `ResolvedStatus`, `SetResolvedStatus`, `ConsumeResolvedStatus`
- `src/BBT.Workflow.Application/Instances/Managers/InstanceCancellationService.cs` — added per-job exception handling with `InstanceJobDeletionFailed` logging
- `src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs` — added `InstanceJobDeletionFailed` log method (EventId 40103)
- `test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/Steps/ResolveAvailableStepTests.cs` — updated assertions to verify deferred status pattern

## Test Plan
- [ ] Trigger a transition with `sync=false` and poll instance state during execution — verify status stays `Busy` until pipeline fully completes
- [ ] Trigger a transition that chains an automatic transition — verify instance stays `Busy` throughout the chain and becomes `Active` only at the end
- [ ] Trigger a transition leading to a `Finish` state — verify instance becomes `Completed`, not `Active`
- [ ] Run `dotnet test test/BBT.Workflow.Application.Tests` — all `ResolveAvailableStepTests` should pass

## Notes
Closes #535

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Defer instance status resolution to the end of the transition pipeline to avoid reporting Active before post-commit work completes and improve cancellation robustness.

Bug Fixes:
- Prevent instances from being marked Active before post-commit jobs complete by deferring status updates through pipeline directives and applying them after the pipeline finishes.

Enhancements:
- Route Available/Active resolution through PipelineDirectives and a new ApplyResolvedStatusAsync step in the transition pipeline, decoupling status decisions from mid-pipeline steps.
- Simplify ClearBusyOnResumeStep and ResolveAvailableStep to set deferred status instead of writing directly to the database, and adjust pipeline ordering accordingly.
- Add per-job exception handling and structured logging when background job deletion fails during instance cancellation.

Tests:
- Update ResolveAvailableStep tests to assert the new deferred-status behavior via PipelineDirectives instead of immediate instance updates.