### PR TITLE
ci(workflows): scope app token to vnext-helm-charts for cross-repo dispatch

### DIFF
--- a/.github/workflows/build-and-publish-images.yml
+++ b/.github/workflows/build-and-publish-images.yml
@@ -48,6 +48,9 @@ jobs:
       with:
         app-id: ${{ secrets.APP_ID }}
         private-key: ${{ secrets.APP_PRIVATE_KEY }}
+        repositories: |
+          vnext
+          vnext-helm-charts
     
     - name: Checkout code
       uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- The GitHub App token was generated without an explicit `repositories` scope, covering only the current repo (`vnext`) by default
- `peter-evans/repository-dispatch` was failing with "Resource not accessible by integration" when attempting to trigger the Helm chart release in `burgan-tech/vnext-helm-charts`
- Added `repositories` parameter to `actions/create-github-app-token@v1` to include both `vnext` and `vnext-helm-charts`

## Changes
- `.github/workflows/build-and-publish-images.yml` — `Generate GitHub App Token` step: added `repositories: vnext\nvnext-helm-charts`

## Test Plan
- [ ] Trigger the `build-and-publish-images` workflow on a `release-v*` branch
- [ ] Verify the "Trigger Helm Chart Release" step completes without error
- [ ] Confirm a `repository_dispatch` event is received in `burgan-tech/vnext-helm-charts`

## Notes
Prerequisite: GitHub App must have **Contents: Read & Write** permission installed on `vnext-helm-charts` (Organization Settings → GitHub Apps → App → Repository permissions).

Closes #541

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

CI:
- Update build-and-publish-images workflow to generate a GitHub App token scoped to both vnext and vnext-helm-charts repositories for repository_dispatch events.