### PR TITLE
fix(transitions): validate schema on async transition requests

### DIFF
--- a/src/BBT.Workflow.Application/Execution/Transitions/Strategy/AsyncTransitionStrategy.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Strategy/AsyncTransitionStrategy.cs
@@ -5,6 +5,7 @@ using BBT.Aether.DistributedLock;
 using BBT.Aether.Results;
 using BBT.Workflow.BackgroundJobs.Handlers;
 using BBT.Workflow.BackgroundJobs.Payloads;
+using BBT.Workflow.Execution.Validation;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Logging;
 using Dapr.Jobs.Models;
@@ -27,6 +28,7 @@ public sealed class AsyncTransitionStrategy(
     IInstanceJobRepository jobRepository,
     IInstanceRepository instanceRepository,
     IDistributedLockService distributedLockService,
+    ITransitionValidationService validationService,
     ILogger<AsyncTransitionStrategy> logger) : ITransitionStrategy
 {
     /// <summary>
@@ -38,8 +40,16 @@ public sealed class AsyncTransitionStrategy(
     /// <inheritdoc />
     /// <summary>
     /// Executes transition asynchronously by enqueuing a background job.
-    /// Railway chain: Create Context → Set Busy → Enqueue Job → Return Context
+    /// Railway chain: Create Context → Validate (schema + policy) → Set Busy → Enqueue Job → Return Context
     /// </summary>
+    /// <remarks>
+    /// Validation must run BEFORE lock acquisition and job enqueue so that callers
+    /// receive 400 Bad Request for invalid payloads instead of accepting the request,
+    /// flipping the instance to Busy, and discovering the schema violation later in
+    /// the background job (which would leave the instance in a Faulted state).
+    /// This also guarantees correct behavior when callers bypass the AppService
+    /// pre-validation guard and invoke the workflow execution service directly.
+    /// </remarks>
     [Trace]
     public Task<Result<TransitionExecutionContext>> ExecuteAsync(
         WorkflowExecutionContext context,
@@ -47,7 +57,23 @@ public sealed class AsyncTransitionStrategy(
     {
         var activity = Activity.Current;
         return ctxFactory.CreateAsync(context, cancellationToken)
+            .BindAsync(ctx => ValidateAsync(ctx, cancellationToken))
             .BindAsync(ctx => EnqueueJobAndReturnContextAsync(ctx, context, activity, cancellationToken));
+    }
+
+    /// <summary>
+    /// Validates the transition context (schema + state-machine policy) before
+    /// any side effects (Busy flip, lock acquisition, job enqueue).
+    /// Mirrors the guard in <c>TransitionPipeline.RunAsync</c> for the sync path.
+    /// </summary>
+    private async Task<Result<TransitionExecutionContext>> ValidateAsync(
+        TransitionExecutionContext ctx,
+        CancellationToken cancellationToken)
+    {
+        var validationResult = await validationService.ValidateAsync(ctx, cancellationToken);
+        return validationResult.IsSuccess
+            ? Result<TransitionExecutionContext>.Ok(ctx)
+            : Result<TransitionExecutionContext>.Fail(validationResult.Error);
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
@@ -44,6 +44,7 @@ public sealed class InstanceCommandAppService(
     IHeaderService headerService,
     ITransitionDataMapper transitionDataMapper,
     ITransitionValidationService transitionValidationService,
+    ITransitionContextFactory transitionContextFactory,
     IWorkflowContext workflowContext,
     IRepresentationEtagService representationEtagService,
     ISchemaFieldFilterService schemaFieldFilterService,
@@ -74,14 +75,19 @@ public sealed class InstanceCommandAppService(
             return existingInstanceResult.Value;
         }
 
-        // Step 3-6: Continue with normal railway flow for NEW instances
+        // Step 3-6: Continue with normal railway flow for NEW instances.
+        // Order matters: PrepareInstanceAsync runs schema validation before persisting the instance,
+        // ExecuteStartTransitionAsync dispatches the (sync or async) execution, and only after a
+        // successful dispatch do we schedule the workflow timeout — otherwise a failed enqueue or
+        // a 409 lock conflict would leave a dangling timeout job for an instance that never started.
         return await PrepareInstanceAsync(workflow, input, cancellationToken)
-            .ThenAsync(async data =>
-            {
-                await ScheduleWorkflowTimeoutIfConfiguredAsync(data.Workflow, data.Instance, input.Instance.ExtraProperties, cancellationToken);
-                return Result<(Definitions.Workflow Workflow, Instance Instance)>.Ok(data);
-            })
-            .ThenAsync(data => ExecuteStartTransitionAsync(data, input, cancellationToken))
+            .ThenAsync(data => ExecuteStartTransitionAsync(data, input, cancellationToken)
+                .ThenAsync(async output =>
+                {
+                    await ScheduleWorkflowTimeoutIfConfiguredAsync(
+                        data.Workflow, data.Instance, input.Instance.ExtraProperties, cancellationToken);
+                    return Result<StartInstanceOutput>.Ok(output);
+                }))
             .OnSuccess(output => AddWorkflowHeader(output, input));
     }
 
@@ -417,6 +423,20 @@ public sealed class InstanceCommandAppService(
 
         var workflowDefinition = workflowResult.Value;
 
+        // Pre-dispatch validation guard: validate schema + state-machine policy BEFORE
+        // dispatching to the execution service. This guarantees consistent 400 Bad Request
+        // behaviour for both sync=true and sync=false callers — the async path would otherwise
+        // accept the request, flip the instance to Busy and discover the schema violation
+        // later in the background job (leaving the instance Faulted). The same check is also
+        // performed inside AsyncTransitionStrategy as defense in depth for callers that
+        // bypass the AppService and invoke WorkflowExecutionService directly.
+        var preValidation = await ValidateTransitionRequestAsync(context, cancellationToken);
+        if (!preValidation.IsSuccess)
+        {
+            logger.TransitionValidationFailed(resolvedInstance.Id, transitionKey, preValidation.Error.Code);
+            return Result<TransitionOutput>.Fail(preValidation.Error);
+        }
+
         return await workflowExecutionService
             .ExecuteTransitionAsync(context, cancellationToken)
             .OnSuccess(output => AddTransitionHeader(output, resolvedInstance.Flow, resolvedInstance.FlowVersion))
@@ -427,6 +447,24 @@ public sealed class InstanceCommandAppService(
                 output.Key = resolvedInstance.Key;
                 return Task.FromResult(Result<TransitionOutput>.Ok(output));
             });
+    }
+
+    /// <summary>
+    /// Pre-dispatch schema + state-machine validation for a transition request.
+    /// Builds the execution context via <see cref="ITransitionContextFactory"/> (read-only,
+    /// no side effects) and runs the same <see cref="ITransitionValidationService.ValidateAsync"/>
+    /// that the sync pipeline uses, so both sync=true and sync=false callers get the same
+    /// validation error contract before any state mutation or background-job enqueue.
+    /// </summary>
+    private async Task<Result> ValidateTransitionRequestAsync(
+        WorkflowExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        var contextResult = await transitionContextFactory.CreateAsync(context, cancellationToken);
+        if (!contextResult.IsSuccess)
+            return Result.Fail(contextResult.Error);
+
+        return await transitionValidationService.ValidateAsync(contextResult.Value!, cancellationToken);
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Domain/Logging/WorkflowEventIds.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowEventIds.cs
@@ -89,6 +89,7 @@ public static class WorkflowEventIds
     public static readonly EventId JobCancelled = new(40048, nameof(JobCancelled));
     public static readonly EventId SubFlowTransitionsQueryFailed = new(40049, nameof(SubFlowTransitionsQueryFailed));
     public static readonly EventId ChildSubflowCancelFailed = new(40050, nameof(ChildSubflowCancelFailed));
+    public static readonly EventId TransitionValidationFailed = new(40051, nameof(TransitionValidationFailed));
 
     // Error (40070-40099)
     public static readonly EventId SubFlowCompletionFailed = new(40073, nameof(SubFlowCompletionFailed));

--- a/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
@@ -929,6 +929,21 @@ public static partial class WorkflowLogs
         string errorCode);
 
     /// <summary>
+    /// Logs when a transition request fails pre-dispatch validation (schema or policy).
+    /// Emitted by the AppService guard so both sync=true and sync=false callers see
+    /// the same 400 Bad Request behaviour for invalid payloads.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 40051,
+        Level = LogLevel.Warning,
+        Message = "Transition validation failed for instance {InstanceId} on transition {TransitionKey}: {ErrorCode}")]
+    public static partial void TransitionValidationFailed(
+        this ILogger logger,
+        Guid instanceId,
+        string transitionKey,
+        string errorCode);
+
+    /// <summary>
     /// Logs when workflow timeout is scheduled.
     /// </summary>
     [LoggerMessage(

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Strategy/AsyncTransitionStrategyTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Strategy/AsyncTransitionStrategyTests.cs
@@ -10,6 +10,7 @@ using BBT.Workflow.BackgroundJobs.Handlers;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Execution;
 using BBT.Workflow.Execution.Strategies;
+using BBT.Workflow.Execution.Validation;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Shared;
 using Microsoft.Extensions.Logging;
@@ -30,6 +31,7 @@ public class AsyncTransitionStrategyTests
     private readonly Mock<IInstanceJobRepository> _mockJobRepository;
     private readonly Mock<IInstanceRepository> _mockInstanceRepository;
     private readonly Mock<IDistributedLockService> _mockDistributedLockRepository;
+    private readonly Mock<ITransitionValidationService> _mockValidationService;
     private readonly Mock<ILogger<AsyncTransitionStrategy>> _mockLogger;
     private readonly AsyncTransitionStrategy _strategy;
 
@@ -40,7 +42,14 @@ public class AsyncTransitionStrategyTests
         _mockJobRepository = new Mock<IInstanceJobRepository>();
         _mockInstanceRepository = new Mock<IInstanceRepository>();
         _mockDistributedLockRepository = new Mock<IDistributedLockService>();
+        _mockValidationService = new Mock<ITransitionValidationService>();
         _mockLogger = new Mock<ILogger<AsyncTransitionStrategy>>();
+
+        // Default: validation passes — individual tests override this when they need to
+        // exercise the schema/policy rejection path.
+        _mockValidationService
+            .Setup(x => x.ValidateAsync(It.IsAny<TransitionExecutionContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Ok());
 
         _strategy = new AsyncTransitionStrategy(
             _mockBackgroundJobService.Object,
@@ -48,6 +57,7 @@ public class AsyncTransitionStrategyTests
             _mockJobRepository.Object,
             _mockInstanceRepository.Object,
             _mockDistributedLockRepository.Object,
+            _mockValidationService.Object,
             _mockLogger.Object);
     }
 
@@ -368,6 +378,73 @@ public class AsyncTransitionStrategyTests
                 It.IsAny<bool>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(It.IsAny<InstanceJob>());
+
+        // Default lock service behavior — execute the inner action and report acquisition success.
+        // Without this, ExecuteWithLockAsync returns false by default and the strategy short-circuits
+        // to InstanceLockConflict before any enqueue happens (which masked real signal in earlier runs).
+        _mockDistributedLockRepository
+            .Setup(x => x.ExecuteWithLockAsync(
+                It.IsAny<string>(),
+                It.IsAny<Func<Task>>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<string, Func<Task>, int, CancellationToken>(async (_, action, _, _) =>
+            {
+                await action();
+                return true;
+            });
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenSchemaValidationFails_ShouldReturnFailureWithoutEnqueue()
+    {
+        // Arrange — context creation succeeds but the validation service rejects the payload
+        // (mirrors the sync pipeline's schema-violation behaviour for the async path).
+        var workflowContext = CreateWorkflowExecutionContext();
+        var transitionContext = CreateTransitionExecutionContext();
+        SetupSuccessfulExecution(workflowContext, transitionContext);
+
+        var validationError = Error.Validation(
+            "schema.invalid",
+            "Field 'amount' is required");
+
+        _mockValidationService
+            .Setup(x => x.ValidateAsync(It.IsAny<TransitionExecutionContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Fail(validationError));
+
+        // Act
+        var result = await _strategy.ExecuteAsync(workflowContext, CancellationToken.None);
+
+        // Assert — request must be rejected with the validation error and NO side effects:
+        // no Busy flip, no lock attempt, no Dapr enqueue, no job record.
+        result.IsSuccess.ShouldBeFalse();
+        result.Error.ShouldBe(validationError);
+
+        _mockBackgroundJobService.Verify(
+            x => x.EnqueueAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<TransitionJobPayload>(),
+                It.IsAny<string>(),
+                It.IsAny<Dictionary<string, object>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        _mockJobRepository.Verify(
+            x => x.InsertAsync(It.IsAny<InstanceJob>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        _mockInstanceRepository.Verify(
+            x => x.UpdateAsync(It.IsAny<Instance>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        _mockDistributedLockRepository.Verify(
+            x => x.ExecuteWithLockAsync(
+                It.IsAny<string>(),
+                It.IsAny<Func<Task>>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     private WorkflowExecutionContext CreateWorkflowExecutionContext()


### PR DESCRIPTION
## Summary
- Async (`sync=false`) start-instance and transition requests previously skipped schema validation, accepting the request, flipping the instance to `Busy`, and only discovering the schema violation later in the background job — leaving the instance in a `Faulted` state.
- Applies defense in depth: pre-dispatch validation in the AppService AND a second guard inside `AsyncTransitionStrategy` so callers that bypass the AppService and call `WorkflowExecutionService` directly are still covered.
- Reorders `StartAsync` so the workflow timeout is scheduled only after a successful execute dispatch, preventing dangling timeout jobs when the async enqueue fails or hits a 409 lock conflict.

## Changes
- `src/BBT.Workflow.Application/Execution/Transitions/Strategy/AsyncTransitionStrategy.cs` — inject `ITransitionValidationService`; add `ValidateAsync` step between `CreateAsync` and lock/enqueue.
- `src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs` — inject `ITransitionContextFactory`; add pre-dispatch `ValidateTransitionRequestAsync` guard in `TransitionAsync`; reorder `StartAsync` so timeout fires after successful dispatch.
- `src/BBT.Workflow.Domain/Logging/WorkflowEventIds.cs`, `WorkflowLogs.cs` — add `TransitionValidationFailed` log event (`40051`).
- `test/BBT.Workflow.Application.Tests/Execution/Transitions/Strategy/AsyncTransitionStrategyTests.cs` — new test `ExecuteAsync_WhenSchemaValidationFails_ShouldReturnFailureWithoutEnqueue`; mock the missing `IDistributedLockService.ExecuteWithLockAsync` (also unblocks 5 pre-existing tests).

## Test Plan
- [ ] Define a workflow transition with a JSON schema; send a `sync=false` start-instance request with an invalid payload → expect `400 Bad Request` (was `200 OK` with `Status = Busy`).
- [ ] Same as above for the transition endpoint → expect `400 Bad Request`.
- [ ] Send a `sync=false` request with a valid payload → expect normal accept + background job enqueue.
- [ ] Send a `sync=true` request with an invalid payload → behaviour unchanged (`400 Bad Request`).
- [ ] Trigger an async start-instance lock conflict → verify no dangling \`timeout-{instanceId}\` job remains.
- [ ] \`dotnet test test/BBT.Workflow.Application.Tests --filter "FullyQualifiedName~AsyncTransitionStrategyTests"\` → new test passes; pre-existing test count improves.

## Notes
Closes #556. No API/contract changes; the only behavioural shift is that invalid \`sync=false\` payloads now return \`400\` instead of being accepted and silently faulting the instance.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Enforce schema and policy validation for asynchronous workflow transitions and adjust timeout scheduling to prevent invalid async requests from being accepted or leaving dangling jobs.

Bug Fixes:
- Ensure async transition and start-instance requests with invalid payloads are rejected upfront instead of faulting instances later in background processing.
- Prevent workflow timeout jobs from being scheduled when async start-instance dispatch or lock acquisition fails.

Enhancements:
- Add centralized pre-dispatch validation for transitions in the application service to align sync and async behaviors and emit structured logs on validation failures.
- Extend the async transition strategy to validate transition contexts before changing instance state or enqueuing background jobs.
- Introduce a dedicated log event for transition validation failures to aid observability and troubleshooting.

Tests:
- Expand async transition strategy tests to cover schema validation failure behavior and properly mock distributed locking to exercise enqueue paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transition requests are now validated for schema and policy compliance before execution. Invalid transitions are rejected immediately with appropriate error logging, preventing unnecessary lock acquisition and job enqueueing operations.
  * Enhanced instance startup process to schedule workflow timeouts only after successful transition dispatch.

* **Tests**
  * Added comprehensive tests covering transition validation failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->