### PR TITLE
perf(caching): redis version index, granular publish broadcast, no full DB scan

### DIFF
--- a/etc/orchestration/dapr/components/definition-component-published-subscription.yaml
+++ b/etc/orchestration/dapr/components/definition-component-published-subscription.yaml
@@ -1,0 +1,8 @@
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+  name: vnext-definition-component-published-subscription
+spec:
+  topic: definition.component.published
+  route: /api/v1/utilities/cache/component-published
+  pubsubname: vnext-pubsub-broadcast

--- a/etc/workers/inbox/dapr/components/definition-component-published-subscription.yaml
+++ b/etc/workers/inbox/dapr/components/definition-component-published-subscription.yaml
@@ -1,0 +1,8 @@
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+  name: vnext-definition-component-published-subscription
+spec:
+  topic: definition.component.published
+  route: /api/v1/utilities/cache/component-published
+  pubsubname: vnext-pubsub-broadcast

--- a/etc/workers/inbox/dapr/components/state.yaml
+++ b/etc/workers/inbox/dapr/components/state.yaml
@@ -13,4 +13,4 @@ spec:
     - name: actorStateStore
       value: "false"
     - name: keyPrefix
-      value: "vnext-outbox"
+      value: "vnext"

--- a/etc/workers/outbox/dapr/components/state.yaml
+++ b/etc/workers/outbox/dapr/components/state.yaml
@@ -13,4 +13,4 @@ spec:
     - name: actorStateStore
       value: "false"
     - name: keyPrefix
-      value: "vnext-outbox"
+      value: "vnext"

--- a/init/VNext.Init.Host/package-api-server.js
+++ b/init/VNext.Init.Host/package-api-server.js
@@ -44,10 +44,32 @@ const JOB_TTL_MS = 30 * 60 * 1000; // 30 minutes
 const jobs = new Map();
 
 /**
- * @typedef {'accepted'|'processing'|'completed'|'failed'} JobStatus
+ * @typedef {'accepted'|'processing'|'completed'|'failed'|'cancelled'} JobStatus
  * @typedef {{current: number, total: number, currentFile: string, phase: string}} JobProgress
- * @typedef {{id: string, packageName: string, status: JobStatus, progress: JobProgress|null, results: Object|null, error: string|null, createdAt: string, updatedAt: string}} Job
+ * @typedef {{id: string, packageName: string, status: JobStatus, progress: JobProgress|null, results: Object|null, error: string|null, cancelRequested: boolean, cancelledAt: string|null, createdAt: string, updatedAt: string}} Job
  */
+
+/**
+ * Error thrown when a job detects that cancellation has been requested.
+ * Caught by runPackagePublishJob to transition the job into the 'cancelled' state.
+ */
+class JobCancelledError extends Error {
+    constructor(jobId) {
+        super(`Job ${jobId} was cancelled`);
+        this.name = 'JobCancelledError';
+    }
+}
+
+/**
+ * Throw a JobCancelledError if the job has been flagged for cancellation.
+ * Used as a cooperative cancel checkpoint between work units.
+ * @param {Job} [job]
+ */
+function throwIfCancelled(job) {
+    if (job && job.cancelRequested) {
+        throw new JobCancelledError(job.id);
+    }
+}
 
 /**
  * Create a new job entry and store it.
@@ -64,6 +86,8 @@ function createJob(packageName) {
         progress: null,
         results: null,
         error: null,
+        cancelRequested: false,
+        cancelledAt: null,
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
     };
@@ -86,7 +110,7 @@ function updateJob(job, fields) {
 function cleanupExpiredJobs() {
     const now = Date.now();
     for (const [id, job] of jobs) {
-        if ((job.status === 'completed' || job.status === 'failed') &&
+        if ((job.status === 'completed' || job.status === 'failed' || job.status === 'cancelled') &&
             (now - new Date(job.updatedAt).getTime()) > JOB_TTL_MS) {
             jobs.delete(id);
         }
@@ -665,6 +689,8 @@ function logErrorResponse(responseBody, context) {
  * @param {Job} [job] - Optional job for progress tracking
  */
 async function processJsonFile(jsonFilePath, packagePath, componentType, vnextConfig, shouldReplaceDomain, appDomain, results, job) {
+    throwIfCancelled(job);
+
             const relativePath = path.relative(packagePath, jsonFilePath);
             const fileName = path.basename(jsonFilePath);
             
@@ -720,6 +746,7 @@ async function processJsonFile(jsonFilePath, packagePath, componentType, vnextCo
  * @param {Job} [job] - Optional job for progress tracking
  */
 async function processWorkflowsWithOrdering(workflowDir, packagePath, vnextConfig, shouldReplaceDomain, appDomain, results, job) {
+    throwIfCancelled(job);
     log.subsection(`Processing WORKFLOWS (Priority Order)`);
     
     try {
@@ -750,6 +777,7 @@ async function processWorkflowsWithOrdering(workflowDir, packagePath, vnextConfi
     if (otherFiles.length > 0) {
         log.info(`${colors.bold}Step 2: Loading other workflow files (${otherFiles.length} files)${colors.reset}`);
         for (const jsonFilePath of otherFiles) {
+            throwIfCancelled(job);
             await processJsonFile(jsonFilePath, packagePath, 'workflows', vnextConfig, shouldReplaceDomain, appDomain, results, job);
         }
     }
@@ -767,6 +795,7 @@ async function processWorkflowsWithOrdering(workflowDir, packagePath, vnextConfi
  * @param {Job} [job] - Optional job for progress tracking
  */
 async function processComponentDirectory(componentDir, packagePath, vnextConfig, shouldReplaceDomain, appDomain, results, job) {
+    throwIfCancelled(job);
     log.subsection(`Processing ${componentDir.type.toUpperCase()}`);
     
     try {
@@ -783,6 +812,7 @@ async function processComponentDirectory(componentDir, packagePath, vnextConfig,
     
     // Process each JSON file
     for (const jsonFilePath of jsonFiles) {
+        throwIfCancelled(job);
         await processJsonFile(jsonFilePath, packagePath, componentDir.type, vnextConfig, shouldReplaceDomain, appDomain, results, job);
     }
 }
@@ -972,7 +1002,8 @@ async function handleRuntimePublish(req, res) {
             npmUsername,
             npmPassword,
             npmEmail,
-            appDomain
+            appDomain,
+            reInitialize = false
         } = body;
         
         if (!appDomain || appDomain.trim() === '') {
@@ -990,6 +1021,7 @@ async function handleRuntimePublish(req, res) {
         log.info(`Package: ${VNEXT_CORE_RUNTIME_PACKAGE}@${version}`);
         log.info(`App Domain: ${appDomain} (REQUIRED)`);
         log.info(`Domain Replacement: ALL domains will be replaced`);
+        log.info(`Re-initialize after publish: ${reInitialize === true ? 'ENABLED' : 'DISABLED'}`);
 
         res.writeHead(202, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({
@@ -1005,6 +1037,7 @@ async function handleRuntimePublish(req, res) {
             authOptions: { token: npmToken, username: npmUsername, password: npmPassword, email: npmEmail },
             appDomain,
             isRuntimePackage: true,
+            reInitialize: reInitialize === true,
         });
         
     } catch (error) {
@@ -1038,7 +1071,8 @@ async function handlePackagePublish(req, res) {
             npmToken,
             npmUsername,
             npmPassword,
-            npmEmail
+            npmEmail,
+            reInitialize = false
         } = body;
 
         if (!packageName) {
@@ -1052,6 +1086,7 @@ async function handlePackagePublish(req, res) {
         log.section(`API Request: Package Publish [job=${job.id}]`);
         log.info(`Package: ${packageName}@${version}`);
         log.info(`Domain Replacement: DISABLED`);
+        log.info(`Re-initialize after publish: ${reInitialize === true ? 'ENABLED' : 'DISABLED'}`);
 
         res.writeHead(202, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({
@@ -1067,6 +1102,7 @@ async function handlePackagePublish(req, res) {
             authOptions: { token: npmToken, username: npmUsername, password: npmPassword, email: npmEmail },
             appDomain: null,
             isRuntimePackage: false,
+            reInitialize: reInitialize === true,
         });
         
     } catch (error) {
@@ -1090,33 +1126,43 @@ async function handlePackagePublish(req, res) {
  * @param {Object} opts
  */
 async function runPackagePublishJob(job, opts) {
-    const { packageName, version, npmRegistry, authOptions, appDomain, isRuntimePackage } = opts;
+    const { packageName, version, npmRegistry, authOptions, appDomain, isRuntimePackage, reInitialize = false } = opts;
+    let results = null;
     try {
         updateJob(job, {
             status: 'processing',
             progress: { current: 0, total: 0, currentFile: '', phase: 'waiting-for-vnext' },
         });
 
+        throwIfCancelled(job);
         await waitForVNextApp();
+        throwIfCancelled(job);
 
         updateJob(job, {
             progress: { ...job.progress, phase: 'downloading' },
         });
 
         const packagePath = await downloadPackage(packageName, version, npmRegistry, authOptions);
+        throwIfCancelled(job);
         await verifyPackageStructure(packagePath);
+        throwIfCancelled(job);
 
         updateJob(job, {
             progress: { ...job.progress, phase: 'uploading' },
         });
 
-        const results = await processPackage(packagePath, packageName, appDomain, isRuntimePackage, job);
+        results = await processPackage(packagePath, packageName, appDomain, isRuntimePackage, job);
+        throwIfCancelled(job);
 
-        updateJob(job, {
-            progress: { ...job.progress, phase: 're-initializing' },
-        });
+        if (reInitialize) {
+            updateJob(job, {
+                progress: { ...job.progress, phase: 're-initializing' },
+            });
 
-        await reInitializeDefinitions();
+            await reInitializeDefinitions();
+        } else {
+            log.info('Re-initialize step skipped (reInitialize=false)');
+        }
 
         let success = true;
         let message = 'Package processed and published successfully';
@@ -1145,6 +1191,30 @@ async function runPackagePublishJob(job, opts) {
 
         log.success(`Job ${job.id} completed — ${message}`);
     } catch (error) {
+        if (error instanceof JobCancelledError) {
+            log.warn(`Job ${job.id} cancelled by user`);
+            updateJob(job, {
+                status: 'cancelled',
+                cancelledAt: new Date().toISOString(),
+                progress: job.progress ? { ...job.progress, phase: 'cancelled' } : null,
+                results: results ? {
+                    success: false,
+                    message: 'Job cancelled by user. Partial uploads were left in place.',
+                    packageName,
+                    appDomain,
+                    successful: results.success,
+                    failed: results.failed,
+                    skipped: results.skipped,
+                } : {
+                    success: false,
+                    message: 'Job cancelled by user before any uploads occurred.',
+                    packageName,
+                    appDomain,
+                },
+            });
+            return;
+        }
+
         log.error(`Job ${job.id} failed: ${error.message}`);
         if (error.stack) log.error(error.stack);
 
@@ -1226,8 +1296,62 @@ async function handleJobStatus(req, res) {
         progress: job.progress,
         results: job.results,
         error: job.error,
+        cancelRequested: job.cancelRequested,
+        cancelledAt: job.cancelledAt,
         createdAt: job.createdAt,
         updatedAt: job.updatedAt,
+    }));
+}
+
+/**
+ * Handle job cancel request
+ * Endpoint: POST /api/package/publish/cancel/:jobId
+ *
+ * Sets a cooperative cancel flag on the job. The background worker checks this
+ * flag at well-defined checkpoints (between files, between stages) and stops
+ * gracefully. The currently in-flight upload (if any) is allowed to finish;
+ * partial uploads are NOT rolled back and reInitializeDefinitions() is skipped.
+ */
+async function handleJobCancel(req, res) {
+    const jobId = req.url.replace('/api/package/publish/cancel/', '');
+    const job = jobs.get(jobId);
+
+    if (!job) {
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Job not found', jobId }));
+        return;
+    }
+
+    if (job.status === 'completed' || job.status === 'failed' || job.status === 'cancelled') {
+        res.writeHead(409, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+            error: 'Job is already in a terminal state and cannot be cancelled',
+            jobId: job.id,
+            status: job.status,
+        }));
+        return;
+    }
+
+    if (job.cancelRequested) {
+        res.writeHead(202, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+            jobId: job.id,
+            status: job.status,
+            cancelRequested: true,
+            message: 'Cancel was already requested. Poll status endpoint to confirm completion.',
+        }));
+        return;
+    }
+
+    updateJob(job, { cancelRequested: true });
+    log.warn(`Cancel requested for job ${job.id}`);
+
+    res.writeHead(202, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({
+        jobId: job.id,
+        status: job.status,
+        cancelRequested: true,
+        message: 'Cancel signal sent. Job will stop at next checkpoint. Poll status endpoint to confirm.',
     }));
 }
 
@@ -1260,6 +1384,12 @@ async function handleRequest(req, res) {
     
     // Route POST requests
     if (req.method === 'POST') {
+        // Cancel a running publish job
+        if (req.url.startsWith('/api/package/publish/cancel/')) {
+            await handleJobCancel(req, res);
+            return;
+        }
+
         // Runtime package publish endpoint
         if (req.url === '/api/package/runtime/publish') {
             await handleRuntimePublish(req, res);
@@ -1281,7 +1411,8 @@ async function handleRequest(req, res) {
             'GET /health',
             'POST /api/package/publish',
             'POST /api/package/runtime/publish',
-            'GET /api/package/publish/status/:jobId'
+            'GET /api/package/publish/status/:jobId',
+            'POST /api/package/publish/cancel/:jobId'
         ]
     }));
 }
@@ -1328,6 +1459,9 @@ function startServer() {
         log.detail(`  - If appDomain provided, replaces all domains`);
         log.info(`Job Status: GET http://localhost:${PORT}/api/package/publish/status/:jobId`);
         log.detail(`  - Poll for job progress after publish`);
+        log.info(`Cancel Job: POST http://localhost:${PORT}/api/package/publish/cancel/:jobId`);
+        log.detail(`  - Cooperative cancel; job stops at next checkpoint`);
+        log.detail(`  - Partial uploads are NOT rolled back; reInitialize is skipped`);
         log.info(`VNext App URL: ${VNEXT_APP_URL}`);
         log.subsection('Timeout Configuration');
         log.info(`Server Timeout: ${SERVER_TIMEOUT_MS}ms (${SERVER_TIMEOUT_MS / 60000} min)`);

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Utilities/UtilityController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Utilities/UtilityController.cs
@@ -21,6 +21,7 @@ namespace BBT.Workflow.Orchestration.Controllers.Utilities;
 public sealed class UtilityController(
     IDefinitionAppService definitionAppService,
     IRuntimeCacheInitializer runtimeCacheInitializer,
+    IDomainCacheContext domainCacheContext,
     IRuntimeInfoProvider runtimeInfoProvider,
     IOptions<RuntimeOptions> runtimeOptions,
     IDomainDiscoveryResolver domainDiscoveryResolver,
@@ -126,6 +127,57 @@ public sealed class UtilityController(
         catch (Exception ex)
         {
             logger.DefinitionCacheInvalidationFailed(podInstance, ex.ToString());
+            return Ok();
+        }
+    }
+
+    /// <summary>
+    /// Handles granular per-component publish events. Each pod warms its local snapshot for
+    /// the affected component (snapshot &lt;- Redis body cache, with single-version DB fallback)
+    /// without performing a full cache reload. Complements the Redis version index by keeping
+    /// the snapshot hot so subsequent reads avoid the extra Redis hop.
+    /// </summary>
+    [ApiExplorerSettings(IgnoreApi = true)]
+    [HttpPost("utilities/cache/component-published")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<IActionResult> ComponentPublishedAsync(
+        [FromBody] ComponentPublishedEvent eventData,
+        CancellationToken cancellationToken = default)
+    {
+        var podInstance = Environment.GetEnvironmentVariable("HOSTNAME")
+            ?? Environment.GetEnvironmentVariable("POD_NAME")
+            ?? Environment.MachineName;
+        var hostEnvironment = configuration["ASPNETCORE_ENVIRONMENT"];
+
+        try
+        {
+            if (!string.Equals(eventData.Environment, hostEnvironment, StringComparison.OrdinalIgnoreCase))
+            {
+                logger.LogDebug(
+                    "ComponentPublishedEvent ignored - environment mismatch. Pod={PodInstance} EventEnv={EventEnv} HostEnv={HostEnv}",
+                    podInstance, eventData.Environment, hostEnvironment);
+                return Ok();
+            }
+
+            logger.LogInformation(
+                "ComponentPublishedEvent received. Pod={PodInstance} ComponentType={ComponentType} Domain={Domain} Key={Key} Version={Version}",
+                podInstance, eventData.ComponentType, eventData.Domain, eventData.Key, eventData.Version);
+
+            await domainCacheContext.WarmComponentAsync(
+                eventData.ComponentType,
+                eventData.Domain,
+                eventData.Key,
+                eventData.Version,
+                cancellationToken);
+
+            return Ok();
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(
+                ex,
+                "ComponentPublishedEvent handling failed. Pod={PodInstance} ComponentType={ComponentType} Domain={Domain} Key={Key} Version={Version}",
+                podInstance, eventData.ComponentType, eventData.Domain, eventData.Key, eventData.Version);
             return Ok();
         }
     }

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Utilities/UtilityController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Utilities/UtilityController.cs
@@ -116,8 +116,8 @@ public sealed class UtilityController(
                 eventData.Domain,
                 eventData.RequestedBy);
 
-            // Update only in-memory cache (distributed cache already updated by initiating pod)
-            await runtimeCacheInitializer.InitializeAsync(eventData.FullLoad, cancellationToken);
+            // Warm in-memory cache from distributed cache; no full DB scan on receiving pods
+            await runtimeCacheInitializer.InitializeFromDistributedCacheAsync(cancellationToken);
 
             logger.DefinitionCacheInvalidationSucceeded(podInstance);
 

--- a/src/BBT.Workflow.Application/Caching/CacheSet.cs
+++ b/src/BBT.Workflow.Application/Caching/CacheSet.cs
@@ -15,11 +15,18 @@ namespace BBT.Workflow.Caching;
 public class CacheSet<T>(
     IDistributedCacheService distributedCache,
     ICacheBackend<T> backend,
+    IComponentVersionIndex versionIndex,
     ILogger<CacheSet<T>> logger)
     : ICacheSet<T>
     where T : class, IDomainEntity, IReferenceSetter
 {
     private readonly ILogger _logger = logger;
+
+    // Logical component-type discriminator (e.g. "sys-flows", "sys-tasks") sourced from
+    // the entity's static abstract ComponentTypeKey. Used as the prefix for both the body
+    // cache key (CreateCacheKey) and the Redis version index key (vidx:{ComponentKeyName}:...)
+    // so the two systems stay aligned across pods.
+    private static readonly string ComponentKeyName = T.ComponentTypeKey;
 
     // Immutable snapshot holding all local cache state
     private CacheSnapshot<T> _snapshot = new(
@@ -110,6 +117,18 @@ public class CacheSet<T>(
             // Local cache is already updated, distributed cache failure is logged but not blocking
         }
 
+        // 3) Update version index in Redis (best-effort, errors are swallowed by the impl).
+        // Allows partial/"latest" lookups on other pods to resolve via Redis without a DB scan.
+        if (!string.IsNullOrEmpty(entity.Domain) && !string.IsNullOrEmpty(entity.Key) && !string.IsNullOrEmpty(entity.Version))
+        {
+            _ = versionIndex.AddVersionAsync(
+                ComponentKeyName,
+                entity.Domain,
+                entity.Key,
+                entity.Version,
+                cancellationToken);
+        }
+
         return Result.Ok();
     }
 
@@ -178,29 +197,43 @@ public class CacheSet<T>(
         var snap = _snapshot;
         var indexKey = CreateIndexKey(domain, name);
 
-        string? latestVersion = null;
+        string? localLatest = null;
 
         if (snap.Index.TryGetValue(indexKey, out var versions) && versions.Count > 0)
         {
-            latestVersion = versions
+            localLatest = versions
                 .OrderByDescending(v => v, new SemVersionComparer())
                 .FirstOrDefault();
         }
 
-        // If we have a latest version from the index, find it in the snapshot
-        if (!string.IsNullOrEmpty(latestVersion))
+        // Always consult the Redis version index first so a publish on another pod
+        // becomes visible immediately - even when the local snapshot already holds
+        // an older "latest" for this component. Falling back to a stale local value
+        // would otherwise mask freshly published versions until the next ReInitialize.
+        var redisVersions = await versionIndex.GetVersionsAsync(
+            ComponentKeyName, domain, name, cancellationToken);
+
+        var indexLatest = redisVersions is { Count: > 0 }
+            ? InstanceDataVersionComparer.FindBestMatch(redisVersions, null)
+            : null;
+
+        var authoritativeLatest = ChooseHigher(indexLatest, localLatest);
+
+        if (!string.IsNullOrEmpty(authoritativeLatest))
         {
-            foreach (var entry in snap.Entries.Values)
+            // Fast path: the authoritative version is already in the local snapshot.
+            // Direct O(1) dictionary lookup using the canonical cache-key format.
+            if (string.Equals(authoritativeLatest, localLatest, StringComparison.OrdinalIgnoreCase) &&
+                snap.Entries.TryGetValue(CreateCacheKey(domain, name, authoritativeLatest), out var entry))
             {
-                var entity = entry.Value;
-                if (string.Equals(entity.Domain, domain, StringComparison.OrdinalIgnoreCase) &&
-                    string.Equals(entity.Key, name, StringComparison.OrdinalIgnoreCase) &&
-                    string.Equals(entity.Version, latestVersion, StringComparison.OrdinalIgnoreCase))
-                {
-                    entry.UpdateAccess();
-                    return Result<T>.Ok(entity);
-                }
+                entry.UpdateAccess();
+                return Result<T>.Ok(entry.Value);
             }
+
+            // Resolved via Redis index (or local entry missing) - load body via the
+            // standard cacheKey path (snapshot -> Redis body -> single-version DB).
+            var resolvedKey = CreateCacheKey(domain, name, authoritativeLatest);
+            return await GetAsync(resolvedKey, cancellationToken);
         }
 
         // Not in snapshot: load ALL versions for this key from backend
@@ -247,35 +280,44 @@ public class CacheSet<T>(
         // 2) If full version → try exact match first from local snapshot
         if (InstanceDataVersionComparer.IsFullVersion(version))
         {
-            var cacheKey = $"{typeof(T).Name}:{domain}:{key}:{version}";
+            var cacheKey = CreateCacheKey(domain, key, version);
             return await GetAsync(cacheKey, cancellationToken);
         }
 
-        // 3) For artifact or partial version → use smart matching
+        // 3) For artifact or partial version → use smart matching.
+        // Always consult the Redis vidx alongside the local snapshot so a fresh publish
+        // on another pod is visible even when the local snapshot already has a match.
         var snap = _snapshot;
         var indexKey = CreateIndexKey(domain, key);
 
-        // Get all versions from index
+        string? localBest = null;
         if (snap.Index.TryGetValue(indexKey, out var versions) && versions.Count > 0)
         {
-            // Use InstanceDataVersionComparer.FindBestMatch to find the best matching version
-            var bestMatch = InstanceDataVersionComparer.FindBestMatch(versions, version);
+            localBest = InstanceDataVersionComparer.FindBestMatch(versions, version);
+        }
 
-            if (!string.IsNullOrEmpty(bestMatch))
+        var redisVersions = await versionIndex.GetVersionsAsync(
+            ComponentKeyName, domain, key, cancellationToken);
+
+        var indexBest = redisVersions is { Count: > 0 }
+            ? InstanceDataVersionComparer.FindBestMatch(redisVersions, version)
+            : null;
+
+        var authoritative = ChooseHigher(indexBest, localBest);
+
+        if (!string.IsNullOrEmpty(authoritative))
+        {
+            // Fast path: snapshot already has the authoritative version.
+            // Direct O(1) dictionary lookup using the canonical cache-key format.
+            if (string.Equals(authoritative, localBest, StringComparison.OrdinalIgnoreCase) &&
+                snap.Entries.TryGetValue(CreateCacheKey(domain, key, authoritative), out var entry))
             {
-                // Find the entity with the best matching version in snapshot
-                foreach (var entry in snap.Entries.Values)
-                {
-                    var entity = entry.Value;
-                    if (string.Equals(entity.Domain, domain, StringComparison.OrdinalIgnoreCase) &&
-                        string.Equals(entity.Key, key, StringComparison.OrdinalIgnoreCase) &&
-                        string.Equals(entity.Version, bestMatch, StringComparison.OrdinalIgnoreCase))
-                    {
-                        entry.UpdateAccess();
-                        return Result<T>.Ok(entity);
-                    }
-                }
+                entry.UpdateAccess();
+                return Result<T>.Ok(entry.Value);
             }
+
+            var resolvedKey = CreateCacheKey(domain, key, authoritative);
+            return await GetAsync(resolvedKey, cancellationToken);
         }
 
         // 4) Not in snapshot: load ALL versions for key from backend, cache them all, then smart match
@@ -323,6 +365,18 @@ public class CacheSet<T>(
         {
             _logger.LogError(ex, "Error removing from distributed cache for {CacheKey}", cacheKey);
             // Local cache is already removed, distributed cache failure is logged but not blocking
+        }
+
+        // Drop the version from the Redis index so other pods don't resolve to a missing body.
+        var parsed = TryParseCacheKey(cacheKey);
+        if (parsed is not null && !string.IsNullOrEmpty(parsed.Value.Version))
+        {
+            _ = versionIndex.RemoveVersionAsync(
+                ComponentKeyName,
+                parsed.Value.Domain,
+                parsed.Value.Key,
+                parsed.Value.Version!,
+                cancellationToken);
         }
 
         return Result.Ok();
@@ -538,7 +592,7 @@ public class CacheSet<T>(
                     if (parsed is null) continue;
 
                     var result = await backend.LoadAsync(parsed.Value.Domain, parsed.Value.Key, parsed.Value.Version, cancellationToken);
-                    if (result.IsSuccess && result.Value is not null)
+                    if (result is { IsSuccess: true, Value: not null })
                         SnapshotUpsert(CreateCacheKey(result.Value), result.Value);
                 }
             }
@@ -630,7 +684,22 @@ public class CacheSet<T>(
     // ----------------
 
     private static string CreateCacheKey(T entity)
-        => $"{(typeof(T) as IDomainEntity)?.ComponentKey}:{entity.Domain}:{entity.Key}:{entity.Version}";
+        => CreateCacheKey(entity.Domain, entity.Key, entity.Version);
+
+    private static string CreateCacheKey(string domain, string key, string? version)
+        => $"{ComponentKeyName}:{domain}:{key}:{version}";
+
+    /// <summary>
+    /// Picks the SemVer-higher of two candidate versions. Either may be null/empty.
+    /// Used to reconcile a local-snapshot resolution with the cross-pod Redis vidx
+    /// resolution so the freshest known version always wins.
+    /// </summary>
+    private static string? ChooseHigher(string? a, string? b)
+    {
+        if (string.IsNullOrEmpty(a)) return b;
+        if (string.IsNullOrEmpty(b)) return a;
+        return new SemVersionComparer().Compare(a, b) >= 0 ? a : b;
+    }
 
     private static string CreateIndexKey(string domain, string name)
         => $"{domain}:{name}";

--- a/src/BBT.Workflow.Application/Caching/CacheSet.cs
+++ b/src/BBT.Workflow.Application/Caching/CacheSet.cs
@@ -519,6 +519,36 @@ public class CacheSet<T>(
         return removedCount;
     }
 
+    public async Task LoadFromDistributedCacheAsync(IEnumerable<string> cacheKeys, CancellationToken cancellationToken = default)
+    {
+        foreach (var cacheKey in cacheKeys)
+        {
+            try
+            {
+                var entity = await distributedCache.GetAsync<T>(cacheKey, cancellationToken);
+                if (entity is not null)
+                {
+                    EnsureReferenceIsSet(entity, cacheKey);
+                    SnapshotUpsert(cacheKey, entity);
+                }
+                else
+                {
+                    // Distributed cache miss — fall back to per-key DB query, populate in-memory only
+                    var parsed = TryParseCacheKey(cacheKey);
+                    if (parsed is null) continue;
+
+                    var result = await backend.LoadAsync(parsed.Value.Domain, parsed.Value.Key, parsed.Value.Version, cancellationToken);
+                    if (result.IsSuccess && result.Value is not null)
+                        SnapshotUpsert(CreateCacheKey(result.Value), result.Value);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to warm in-memory cache for key {CacheKey}", cacheKey);
+            }
+        }
+    }
+
     public void Dispose()
     {
         // Snapshot only contains managed objects, no cleanup needed

--- a/src/BBT.Workflow.Application/Caching/DomainCacheContext.cs
+++ b/src/BBT.Workflow.Application/Caching/DomainCacheContext.cs
@@ -1,5 +1,6 @@
 using BBT.Aether.DistributedCache;
 using BBT.Workflow.Definitions;
+using BBT.Workflow.Runtime;
 using Microsoft.Extensions.Logging;
 
 namespace BBT.Workflow.Caching;
@@ -21,36 +22,43 @@ public class DomainCacheContext : CacheContext, IDomainCacheContext, IDisposable
         ICacheBackend<Function> functionBackend,
         ICacheBackend<View> viewBackend,
         ICacheBackend<Extension> extensionBackend,
+        IComponentVersionIndex versionIndex,
         ILoggerFactory loggerFactory)
     {
         Workflows = new CacheSet<Definitions.Workflow>(
             distributedCache,
             workflowBackend,
+            versionIndex,
             loggerFactory.CreateLogger<CacheSet<Definitions.Workflow>>());
 
         Tasks = new CacheSet<WorkflowTask>(
             distributedCache,
             taskBackend,
+            versionIndex,
             loggerFactory.CreateLogger<CacheSet<WorkflowTask>>());
 
         Schemas = new CacheSet<SchemaDefinition>(
             distributedCache,
             schemaBackend,
+            versionIndex,
             loggerFactory.CreateLogger<CacheSet<SchemaDefinition>>());
 
         Functions = new CacheSet<Function>(
             distributedCache,
             functionBackend,
+            versionIndex,
             loggerFactory.CreateLogger<CacheSet<Function>>());
 
         Views = new CacheSet<View>(
             distributedCache,
             viewBackend,
+            versionIndex,
             loggerFactory.CreateLogger<CacheSet<View>>());
 
         Extensions = new CacheSet<Extension>(
             distributedCache,
             extensionBackend,
+            versionIndex,
             loggerFactory.CreateLogger<CacheSet<Extension>>());
 
         CacheSets =
@@ -99,6 +107,35 @@ public class DomainCacheContext : CacheContext, IDomainCacheContext, IDisposable
             if (cacheKeysByType.TryGetValue(cacheSet.EntityType, out var keys))
                 await cacheSet.LoadFromDistributedCacheAsync(keys, cancellationToken);
         }
+    }
+
+    public Task WarmComponentAsync(
+        string componentType,
+        string domain,
+        string key,
+        string version,
+        CancellationToken cancellationToken = default)
+    {
+        ICacheSet? targetSet = componentType switch
+        {
+            RuntimeSysSchemaInfo.Flows => Workflows,
+            RuntimeSysSchemaInfo.Tasks => Tasks,
+            RuntimeSysSchemaInfo.Schemas => Schemas,
+            RuntimeSysSchemaInfo.Functions => Functions,
+            RuntimeSysSchemaInfo.Views => Views,
+            RuntimeSysSchemaInfo.Extensions => Extensions,
+            _ => null
+        };
+
+        if (targetSet is null)
+            return Task.CompletedTask;
+
+        // Mirror the cache-key format produced by CacheSet.CreateCacheKey
+        // ("{ComponentTypeKey}:{domain}:{key}:{version}") so the snapshot upsert key
+        // collides with the one written by the publishing pod.
+        var cacheKey = $"{componentType}:{domain}:{key}:{version}";
+
+        return targetSet.LoadFromDistributedCacheAsync(new[] { cacheKey }, cancellationToken);
     }
 
     public async Task MergeAsync(Dictionary<Type, object> deltaData, CancellationToken cancellationToken = default)

--- a/src/BBT.Workflow.Application/Caching/DomainCacheContext.cs
+++ b/src/BBT.Workflow.Application/Caching/DomainCacheContext.cs
@@ -92,6 +92,15 @@ public class DomainCacheContext : CacheContext, IDomainCacheContext, IDisposable
         }
     }
 
+    public async Task LoadFromDistributedCacheAsync(Dictionary<Type, IEnumerable<string>> cacheKeysByType, CancellationToken cancellationToken = default)
+    {
+        foreach (var cacheSet in CacheSets)
+        {
+            if (cacheKeysByType.TryGetValue(cacheSet.EntityType, out var keys))
+                await cacheSet.LoadFromDistributedCacheAsync(keys, cancellationToken);
+        }
+    }
+
     public async Task MergeAsync(Dictionary<Type, object> deltaData, CancellationToken cancellationToken = default)
     {
         foreach (var cacheSet in CacheSets)

--- a/src/BBT.Workflow.Application/Caching/ICacheSet.cs
+++ b/src/BBT.Workflow.Application/Caching/ICacheSet.cs
@@ -25,6 +25,14 @@ public interface ICacheSet : IDisposable
     /// that are not present in <paramref name="data"/>. Used for incremental (delta) cache updates.
     /// </summary>
     Task MergeAllAsync(object data, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Warms the local in-memory cache from the distributed cache for the given cache keys.
+    /// For each key: reads from distributed cache; if present upserts locally (no write-back).
+    /// On a distributed cache miss falls back to a per-key DB query and upserts locally.
+    /// Used by broadcast-receiving pods to avoid a full DB scan.
+    /// </summary>
+    Task LoadFromDistributedCacheAsync(IEnumerable<string> cacheKeys, CancellationToken cancellationToken = default);
 }
 
 /// <summary>

--- a/src/BBT.Workflow.Application/Caching/IComponentVersionIndex.cs
+++ b/src/BBT.Workflow.Application/Caching/IComponentVersionIndex.cs
@@ -1,0 +1,56 @@
+namespace BBT.Workflow.Caching;
+
+/// <summary>
+/// Two-tier Redis caching strategy: maintains a lightweight index of known versions
+/// per component (vidx:{componentKey}:{domain}:{key}) so that partial or "latest" version
+/// lookups can be resolved against Redis instead of falling through to the database
+/// to enumerate all versions. The component body itself is stored under a separate
+/// fully-versioned key by <see cref="ICacheSet{T}"/>.
+/// </summary>
+public interface IComponentVersionIndex
+{
+    /// <summary>
+    /// Returns all known versions of a component, ordered by SemVer.
+    /// Returns null when the index entry is missing in Redis - the caller is expected
+    /// to fall back to the backend (DB) and repopulate the index.
+    /// </summary>
+    /// <param name="componentKey">Logical component group (e.g. "workflow", "workflowtask").</param>
+    /// <param name="domain">Domain identifier.</param>
+    /// <param name="key">Component key.</param>
+    /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
+    Task<SortedSet<string>?> GetVersionsAsync(
+        string componentKey,
+        string domain,
+        string key,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Adds a version to the index when a new component version is published or
+    /// observed via a backend load.
+    /// </summary>
+    Task AddVersionAsync(
+        string componentKey,
+        string domain,
+        string key,
+        string version,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes a single version from the index (invalidation).
+    /// </summary>
+    Task RemoveVersionAsync(
+        string componentKey,
+        string domain,
+        string key,
+        string version,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes the entire index entry (used when the component is fully removed).
+    /// </summary>
+    Task RemoveAllVersionsAsync(
+        string componentKey,
+        string domain,
+        string key,
+        CancellationToken cancellationToken = default);
+}

--- a/src/BBT.Workflow.Application/Caching/IDomainCacheContext.cs
+++ b/src/BBT.Workflow.Application/Caching/IDomainCacheContext.cs
@@ -37,6 +37,15 @@ public interface IDomainCacheContext
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Warms each local in-memory cache set from the distributed cache using the provided keys.
+    /// On a distributed cache miss for a key, falls back to a per-key DB query.
+    /// No write-back to distributed cache is performed.
+    /// Used by broadcast-receiving pods to avoid a full DB scan.
+    /// </summary>
+    Task LoadFromDistributedCacheAsync(Dictionary<Type, IEnumerable<string>> cacheKeysByType,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets the cache set for the specified entity type.
     /// </summary>
     /// <typeparam name="T">The entity type</typeparam>

--- a/src/BBT.Workflow.Application/Caching/IDomainCacheContext.cs
+++ b/src/BBT.Workflow.Application/Caching/IDomainCacheContext.cs
@@ -53,6 +53,24 @@ public interface IDomainCacheContext
     ICacheSet<T> Set<T>() where T : class, IDomainEntity, IReferenceSetter;
 
     /// <summary>
+    /// Warms the local snapshot for a single (componentType, domain, key, version) triple
+    /// from the distributed cache. Falls back to a single-version DB load on Redis miss.
+    /// Used by the granular ComponentPublishedEvent handler so receiving pods stay hot
+    /// without a full <see cref="LoadFromDistributedCacheAsync"/> sweep.
+    /// </summary>
+    /// <param name="componentType">RuntimeSysSchemaInfo discriminator (e.g. "sys-flows").</param>
+    /// <param name="domain">Domain identifier.</param>
+    /// <param name="key">Component logical key.</param>
+    /// <param name="version">Concrete version that was just published.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task WarmComponentAsync(
+        string componentType,
+        string domain,
+        string key,
+        string version,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Performs cleanup on all cache sets, removing expired and least-used items.
     /// </summary>
     /// <param name="ttl">Time-to-live for cache items</param>

--- a/src/BBT.Workflow.Application/Caching/IRuntimeCacheInitializer.cs
+++ b/src/BBT.Workflow.Application/Caching/IRuntimeCacheInitializer.cs
@@ -33,5 +33,15 @@ public interface IRuntimeCacheInitializer
     /// <param name="cancellationToken">Token to monitor for cancellation requests</param>
     /// <returns>A task representing the asynchronous initialization operation</returns>
     Task InitializeWithDistributedCacheAsync(bool fullLoad = false, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Warms the local in-memory cache by reading from the distributed cache for all active entity
+    /// keys discovered via a lightweight DB metadata query (no <c>InstanceData.Data</c> loaded).
+    /// On a distributed cache miss, falls back to a per-key DB query and populates in-memory only.
+    /// No write-back to distributed cache is performed.
+    /// Intended for broadcast-receiving pods; the initiating pod should call
+    /// <see cref="InitializeWithDistributedCacheAsync"/> instead.
+    /// </summary>
+    Task InitializeFromDistributedCacheAsync(CancellationToken cancellationToken = default);
 }
 

--- a/src/BBT.Workflow.Application/Caching/RuntimeCacheInitializer.cs
+++ b/src/BBT.Workflow.Application/Caching/RuntimeCacheInitializer.cs
@@ -76,6 +76,29 @@ public sealed class RuntimeCacheInitializer(
         }
     }
 
+    /// <inheritdoc />
+    public async Task InitializeFromDistributedCacheAsync(CancellationToken cancellationToken = default)
+    {
+        if (!gate.TryAcquire())
+        {
+            logger.LogWarning(
+                "Cache initialization already in progress on this pod. Skipping concurrent request.");
+            return;
+        }
+
+        try
+        {
+            var capturedAt = DateTime.UtcNow;
+            var cacheKeysByType = await LoadAllEntityCacheKeysAsync(cancellationToken);
+            await domainCacheContext.LoadFromDistributedCacheAsync(cacheKeysByType, cancellationToken);
+            gate.SetLastInitializedAt(capturedAt);
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
     /// <summary>
     /// Returns the <c>since</c> timestamp to use for this load:
     /// <c>null</c> → full load (replace all); non-null → incremental (merge delta).
@@ -117,5 +140,34 @@ public sealed class RuntimeCacheInitializer(
         await using var scope = scopeFactory.CreateAsyncScope();
         var runtimeService = scope.ServiceProvider.GetRequiredService<IRuntimeService>();
         return await runtimeService.GetAsync<T>(since, ct);
+    }
+
+    private async Task<Dictionary<Type, IEnumerable<string>>> LoadAllEntityCacheKeysAsync(CancellationToken cancellationToken)
+    {
+        // Load sequentially to avoid concurrent DB connection pressure.
+        var flows      = await LoadCacheKeysAsync<Definitions.Workflow>(cancellationToken);
+        var tasks      = await LoadCacheKeysAsync<WorkflowTask>(cancellationToken);
+        var functions  = await LoadCacheKeysAsync<Function>(cancellationToken);
+        var views      = await LoadCacheKeysAsync<View>(cancellationToken);
+        var schemas    = await LoadCacheKeysAsync<SchemaDefinition>(cancellationToken);
+        var extensions = await LoadCacheKeysAsync<Extension>(cancellationToken);
+
+        return new Dictionary<Type, IEnumerable<string>>
+        {
+            { typeof(Definitions.Workflow), flows },
+            { typeof(WorkflowTask), tasks },
+            { typeof(SchemaDefinition), schemas },
+            { typeof(Function), functions },
+            { typeof(View), views },
+            { typeof(Extension), extensions }
+        };
+    }
+
+    private async Task<IEnumerable<string>> LoadCacheKeysAsync<T>(CancellationToken ct)
+        where T : class, IDomainEntity, IReferenceSetter
+    {
+        await using var scope = scopeFactory.CreateAsyncScope();
+        var runtimeService = scope.ServiceProvider.GetRequiredService<IRuntimeService>();
+        return await runtimeService.GetActiveCacheKeysAsync<T>(ct);
     }
 }

--- a/src/BBT.Workflow.Application/Definitions/DefinitionAppService.cs
+++ b/src/BBT.Workflow.Application/Definitions/DefinitionAppService.cs
@@ -139,6 +139,8 @@ public sealed class DefinitionAppService(
             cancellationToken
         );
 
+        await PublishComponentPublishedEventAsync(input.Domain, input.Flow, input.Key, input.Version, cancellationToken);
+
         if (input.Data?.Any() == true)
         {
             var seedDataResult = await HandleAdditionalDataVersionsAsync(input, cancellationToken);
@@ -193,6 +195,8 @@ public sealed class DefinitionAppService(
             input.Attributes,
             cancellationToken
         );
+
+        await PublishComponentPublishedEventAsync(input.Domain, input.Flow, input.Key, input.Version, cancellationToken);
 
         if (input.Data?.Any() == true)
         {
@@ -281,7 +285,49 @@ public sealed class DefinitionAppService(
             cancellationToken
         );
 
+        await PublishComponentPublishedEventAsync(input.Domain, input.Key, dataItem.Key, dataItem.Version, cancellationToken);
+
         return Result.Ok();
+    }
+
+    /// <summary>
+    /// Best-effort granular broadcast that lets every pod warm its local snapshot for the
+    /// just-published component. Failures are logged and swallowed so a publish is never
+    /// blocked by pubsub issues - the Redis version index keeps consumers correct in that case.
+    /// </summary>
+    private async Task PublishComponentPublishedEventAsync(
+        string domain,
+        string componentType,
+        string key,
+        string version,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var evt = new ComponentPublishedEvent
+            {
+                Domain = domain,
+                Environment = configuration["ASPNETCORE_ENVIRONMENT"]!,
+                ComponentType = componentType,
+                Key = key,
+                Version = version,
+                PublishedBy = "System",
+                PublishedAt = DateTime.UtcNow
+            };
+
+            await daprClient.PublishEventAsync(
+                pubsubName: configuration["DAPR_PUBSUB_BROADCAST_STORE_NAME"]!,
+                topicName: ComponentPublishedEvent.TopicName,
+                data: evt,
+                cancellationToken: cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(
+                ex,
+                "ComponentPublishedEvent broadcast failed for {ComponentType} {Domain}/{Key}@{Version}",
+                componentType, domain, key, version);
+        }
     }
 
     /// <summary>
@@ -355,9 +401,6 @@ public sealed class DefinitionAppService(
     /// <inheritdoc />
     public async Task<Result> ReInitializeAsync(bool fullLoad = false, CancellationToken cancellationToken = default)
     {
-        // First, update both in-memory and distributed cache on this initiating pod
-        await runtimeCacheInitializer.InitializeWithDistributedCacheAsync(fullLoad, cancellationToken);
-
         // Then, publish broadcast event to all pods using Dapr client directly
         var cacheInvalidationEvent = new DefinitionCacheInvalidationEvent
         {

--- a/src/BBT.Workflow.Application/Runtime/IRuntimeService.cs
+++ b/src/BBT.Workflow.Application/Runtime/IRuntimeService.cs
@@ -47,4 +47,12 @@ public interface IRuntimeService
     /// <returns>All active entities matching the given key</returns>
     Task<IEnumerable<T?>> GetAsync<T>(string key, CancellationToken cancellationToken = default)
         where T : class, IDomainEntity, IReferenceSetter;
+
+    /// <summary>
+    /// Returns the distributed cache keys for all active entities of the specified type without
+    /// loading the entity data. Used by broadcast-receiving pods to warm their in-memory cache
+    /// from the distributed cache without a full DB scan.
+    /// </summary>
+    Task<IEnumerable<string>> GetActiveCacheKeysAsync<T>(CancellationToken cancellationToken = default)
+        where T : class, IDomainEntity, IReferenceSetter;
 }

--- a/src/BBT.Workflow.Application/Runtime/RuntimeService.cs
+++ b/src/BBT.Workflow.Application/Runtime/RuntimeService.cs
@@ -119,6 +119,21 @@ public sealed class RuntimeService(
         }
     }
 
+    public async Task<IEnumerable<string>> GetActiveCacheKeysAsync<T>(CancellationToken cancellationToken = default)
+        where T : class, IDomainEntity, IReferenceSetter
+    {
+        var schemaName = runtimeOptions.Value.GetSchemaNameByType(typeof(T));
+        var schemaInfo = runtimeOptions.Value.Schemas[schemaName];
+
+        using (currentSchema.Use(schemaInfo.Schema))
+        {
+            var keys = await instanceRepository.GetActiveInstanceKeysAsync(cancellationToken);
+            return keys
+                .Select(k => $"{schemaInfo.Name}:{runtimeInfoProvider.Domain}:{k.Key}:{k.Version}")
+                .ToList();
+        }
+    }
+
     public async Task<T?> GetAsync<T>(string key, string version,
         CancellationToken cancellationToken = default) where T : class, IDomainEntity, IReferenceSetter
     {

--- a/src/BBT.Workflow.Domain/Definitions/Extensions/Extension.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Extensions/Extension.cs
@@ -58,7 +58,8 @@ public sealed class Extension : IDomainEntity, IExtensionReference, IReferenceSe
 
     [JsonInclude] public OnExecuteTask Task { get; private set; }
 
-    public string ComponentKey => RuntimeSysSchemaInfo.Extensions;
+    public static string ComponentTypeKey => RuntimeSysSchemaInfo.Extensions;
+    public string ComponentKey => ComponentTypeKey;
 
     public void SetReference(IReference reference)
     {

--- a/src/BBT.Workflow.Domain/Definitions/Functions/Function.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Functions/Function.cs
@@ -81,7 +81,8 @@ public sealed class Function : IDomainEntity, IFunctionReference, IReferenceSett
     [JsonIgnore]
     public IReadOnlyCollection<RoleGrant> Roles => roles.AsReadOnly();
 
-    public string ComponentKey => RuntimeSysSchemaInfo.Functions;
+    public static string ComponentTypeKey => RuntimeSysSchemaInfo.Functions;
+    public string ComponentKey => ComponentTypeKey;
 
     private void SetKey(string key)
     {

--- a/src/BBT.Workflow.Domain/Definitions/Schemas/SchemaDefinition.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Schemas/SchemaDefinition.cs
@@ -49,7 +49,8 @@ public sealed class SchemaDefinition : IDomainEntity, ISchemaReference, IReferen
     /// </summary>
     public JsonElement Schema { get; private set; }
 
-    public string ComponentKey => RuntimeSysSchemaInfo.Schemas;
+    public static string ComponentTypeKey => RuntimeSysSchemaInfo.Schemas;
+    public string ComponentKey => ComponentTypeKey;
 
     private void SetKey(string key)
     {

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/WorkflowTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/WorkflowTask.cs
@@ -69,7 +69,8 @@ public abstract class WorkflowTask : IDomainEntity, ITaskReference, IReferenceSe
     /// </summary>
     public JsonElement Config { get; private set; }
 
-    public string ComponentKey => RuntimeSysSchemaInfo.Tasks;
+    public static string ComponentTypeKey => RuntimeSysSchemaInfo.Tasks;
+    public string ComponentKey => ComponentTypeKey;
 
     private void SetKey(string key)
     {

--- a/src/BBT.Workflow.Domain/Definitions/Views/View.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Views/View.cs
@@ -75,7 +75,8 @@ public sealed class View : IDomainEntity, IViewReference, IReferenceSetter
     /// </summary>
     public LanguageLabel[]? Labels { get; private set; } = [];
     
-    public string ComponentKey => RuntimeSysSchemaInfo.Views;
+    public static string ComponentTypeKey => RuntimeSysSchemaInfo.Views;
+    public string ComponentKey => ComponentTypeKey;
 
     public static string GenerateCacheKey(
         string domain,

--- a/src/BBT.Workflow.Domain/Definitions/Workflow.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Workflow.cs
@@ -96,7 +96,8 @@ public sealed class Workflow : IDomainEntity, IReference, IReferenceSetter, IHas
     public string SemanticVersion =>
         Version.Contains('+') ? Regex.Match(Version, @"^([^+]+)").Groups[1].Value : Version;
 
-    public string ComponentKey => RuntimeSysSchemaInfo.Flows;
+    public static string ComponentTypeKey => RuntimeSysSchemaInfo.Flows;
+    public string ComponentKey => ComponentTypeKey;
     
     /// <summary>
     /// When the workflow starts, a timer counts down.

--- a/src/BBT.Workflow.Domain/Instances/IInstanceRepository.cs
+++ b/src/BBT.Workflow.Domain/Instances/IInstanceRepository.cs
@@ -68,4 +68,10 @@ public interface IInstanceRepository : IRepository<Instance, Guid>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>True if an active instance with the same key exists, false otherwise.</returns>
     Task<bool> AnyActiveByKeyAsync(string key, Guid excludeInstanceId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the key and version of every active instance without loading <c>InstanceData.Data</c>.
+    /// Used by broadcast-receiving pods to discover what to warm from the distributed cache.
+    /// </summary>
+    Task<List<InstanceKeyModel>> GetActiveInstanceKeysAsync(CancellationToken cancellationToken = default);
 }

--- a/src/BBT.Workflow.Domain/Instances/InstanceKeyModel.cs
+++ b/src/BBT.Workflow.Domain/Instances/InstanceKeyModel.cs
@@ -1,0 +1,3 @@
+namespace BBT.Workflow.Instances;
+
+public record InstanceKeyModel(string Key, string Version);

--- a/src/BBT.Workflow.Domain/Shared/IDomainEntity.cs
+++ b/src/BBT.Workflow.Domain/Shared/IDomainEntity.cs
@@ -2,5 +2,17 @@ namespace BBT.Workflow;
 
 public interface IDomainEntity : IHasKey, IHasVersion, IHasDomain
 {
+    /// <summary>
+    /// Logical component-type discriminator (e.g. "sys-flows", "sys-tasks").
+    /// Mirrors <see cref="ComponentTypeKey"/> on the instance side - exposed as a
+    /// static abstract so type-only consumers (like generic caches/indexers) can
+    /// resolve the key without constructing an instance.
+    /// </summary>
+    static abstract string ComponentTypeKey { get; }
+
+    /// <summary>
+    /// Instance-side accessor for the component-type discriminator. Implementations
+    /// typically forward to <see cref="ComponentTypeKey"/>.
+    /// </summary>
     string ComponentKey { get; }
 }

--- a/src/BBT.Workflow.Events.Contracts/Definitions/Events/ComponentPublishedEvent.cs
+++ b/src/BBT.Workflow.Events.Contracts/Definitions/Events/ComponentPublishedEvent.cs
@@ -1,0 +1,61 @@
+using BBT.Aether.Events;
+
+namespace BBT.Workflow.Definitions.Events;
+
+/// <summary>
+/// Granular broadcast event signaling that a single component (workflow, task, schema, etc.)
+/// has just been published. Published to vnext-pubsub-broadcast so every pod can warm
+/// its local snapshot for the affected component without a full <see cref="DefinitionCacheInvalidationEvent"/>
+/// reload and without a DB scan.
+/// </summary>
+/// <remarks>
+/// Receiving pods are expected to:
+///  1. Validate environment and domain match.
+///  2. Resolve the cache set for <see cref="ComponentType"/> (sys-flows, sys-tasks, ...).
+///  3. Warm the local snapshot from the distributed cache for the produced cache key
+///     (snapshot &lt;- Redis body cache, falling back to a single-version DB load on miss).
+/// This event complements the Redis version index: even though "vidx-authoritative latest"
+/// already guarantees correctness, this event proactively fills the snapshot so subsequent
+/// reads avoid the extra Redis hop.
+/// </remarks>
+public class ComponentPublishedEvent : IDistributedEvent
+{
+    public const string TopicName = "definition.component.published";
+
+    /// <summary>
+    /// Domain the component belongs to.
+    /// </summary>
+    public required string Domain { get; init; }
+
+    /// <summary>
+    /// Environment the publish happened in (e.g., "Development", "Production").
+    /// Receiving pods ignore the event when this does not match their own environment.
+    /// </summary>
+    public required string Environment { get; init; }
+
+    /// <summary>
+    /// System component type discriminator (e.g., "sys-flows", "sys-tasks", "sys-schemas",
+    /// "sys-functions", "sys-views", "sys-extensions"). Mirrors RuntimeSysSchemaInfo constants.
+    /// </summary>
+    public required string ComponentType { get; init; }
+
+    /// <summary>
+    /// Logical key of the published component.
+    /// </summary>
+    public required string Key { get; init; }
+
+    /// <summary>
+    /// Concrete (full) version that was published.
+    /// </summary>
+    public required string Version { get; init; }
+
+    /// <summary>
+    /// Who/what triggered the publish (CI/CD pipeline id, user, "System", ...).
+    /// </summary>
+    public required string PublishedBy { get; init; }
+
+    /// <summary>
+    /// When the component was published.
+    /// </summary>
+    public required DateTime PublishedAt { get; init; }
+}

--- a/src/BBT.Workflow.Infrastructure/Caching/RedisComponentVersionIndex.cs
+++ b/src/BBT.Workflow.Infrastructure/Caching/RedisComponentVersionIndex.cs
@@ -1,0 +1,155 @@
+using BBT.Aether.DistributedCache;
+using BBT.Workflow.Caching;
+using Microsoft.Extensions.Logging;
+
+namespace BBT.Workflow.Infrastructure.Caching;
+
+/// <summary>
+/// Redis-backed implementation of <see cref="IComponentVersionIndex"/>.
+/// Stores the list of known versions per component under "vidx:{componentKey}:{domain}:{key}".
+/// All failures are logged and swallowed so the system can self-heal via DB fallback.
+/// </summary>
+public sealed class RedisComponentVersionIndex(
+    IDistributedCacheService cache,
+    ILogger<RedisComponentVersionIndex> logger) : IComponentVersionIndex
+{
+    // Index TTL is intentionally longer than the body TTL (CacheSet uses 12h for items).
+    // Stale index entries are self-healing: a body cache miss will trigger a single-version
+    // DB load that re-populates the index.
+    private static readonly TimeSpan IndexTtl = TimeSpan.FromHours(24);
+
+    private static string BuildIndexKey(string componentKey, string domain, string key)
+        => $"vidx:{componentKey}:{domain}:{key}";
+
+    public async Task<SortedSet<string>?> GetVersionsAsync(
+        string componentKey,
+        string domain,
+        string key,
+        CancellationToken cancellationToken = default)
+    {
+        var indexKey = BuildIndexKey(componentKey, domain, key);
+
+        try
+        {
+            var raw = await cache.GetAsync<string[]>(indexKey, cancellationToken);
+            if (raw is null || raw.Length == 0)
+                return null;
+
+            return new SortedSet<string>(raw, new SemVersionComparer());
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(
+                ex,
+                "Version index read failed for {IndexKey}, falling through to DB",
+                indexKey);
+            return null;
+        }
+    }
+
+    public async Task AddVersionAsync(
+        string componentKey,
+        string domain,
+        string key,
+        string version,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+            return;
+
+        var indexKey = BuildIndexKey(componentKey, domain, key);
+
+        try
+        {
+            // Read-modify-write. A distributed lock would be safer, but the race window is
+            // tolerable here: the worst case is that a version is briefly missing from the
+            // index and a subsequent get falls back to the DB to repopulate it.
+            var existing = await cache.GetAsync<string[]>(indexKey, cancellationToken)
+                           ?? Array.Empty<string>();
+
+            if (existing.Contains(version, StringComparer.Ordinal))
+                return;
+
+            var updated = existing.Append(version).Distinct(StringComparer.Ordinal).ToArray();
+
+            await cache.SetAsync(
+                indexKey,
+                updated,
+                new DistributedCacheEntryOptions { AbsoluteExpiration = DateTimeOffset.UtcNow.Add(IndexTtl) },
+                cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(
+                ex,
+                "Version index add failed for {IndexKey} version {Version}",
+                indexKey,
+                version);
+        }
+    }
+
+    public async Task RemoveVersionAsync(
+        string componentKey,
+        string domain,
+        string key,
+        string version,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+            return;
+
+        var indexKey = BuildIndexKey(componentKey, domain, key);
+
+        try
+        {
+            var existing = await cache.GetAsync<string[]>(indexKey, cancellationToken);
+            if (existing is null || existing.Length == 0)
+                return;
+
+            var updated = existing
+                .Where(v => !string.Equals(v, version, StringComparison.Ordinal))
+                .ToArray();
+
+            if (updated.Length == 0)
+            {
+                await cache.RemoveAsync(indexKey, cancellationToken);
+                return;
+            }
+
+            if (updated.Length == existing.Length)
+                return;
+
+            await cache.SetAsync(
+                indexKey,
+                updated,
+                new DistributedCacheEntryOptions { AbsoluteExpiration = DateTimeOffset.UtcNow.Add(IndexTtl) },
+                cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(
+                ex,
+                "Version index remove failed for {IndexKey} version {Version}",
+                indexKey,
+                version);
+        }
+    }
+
+    public async Task RemoveAllVersionsAsync(
+        string componentKey,
+        string domain,
+        string key,
+        CancellationToken cancellationToken = default)
+    {
+        var indexKey = BuildIndexKey(componentKey, domain, key);
+
+        try
+        {
+            await cache.RemoveAsync(indexKey, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Version index remove-all failed for {IndexKey}", indexKey);
+        }
+    }
+}

--- a/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceRepository.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceRepository.cs
@@ -926,6 +926,19 @@ public sealed class EfCoreInstanceRepository(
                 cancellationToken);
     }
 
+    /// <inheritdoc />
+    public async Task<List<InstanceKeyModel>> GetActiveInstanceKeysAsync(CancellationToken cancellationToken = default)
+    {
+        var context = await GetDbContextAsync();
+        return await (from instance in context.Instances
+                      where instance.Status == InstanceStatus.Active
+                      join data in context.InstancesData on instance.Id equals data.InstanceId
+                      where data.IsLatest
+                      select new InstanceKeyModel(instance.Key!, data.Version))
+            .AsNoTracking()
+            .ToListAsync(cancellationToken);
+    }
+
     /// <summary>
     /// Loads DataList for instances (ordered by id list) and returns list in the same order. Used when ORDER BY must be preserved (EF Include breaks order).
     /// </summary>

--- a/src/BBT.Workflow.Infrastructure/Microsoft/Extensions/DependencyInjection/WorkflowInfrastructureModuleServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Infrastructure/Microsoft/Extensions/DependencyInjection/WorkflowInfrastructureModuleServiceCollectionExtensions.cs
@@ -1,6 +1,8 @@
 using BBT.Aether.MultiSchema;
+using BBT.Workflow.Caching;
 using BBT.Workflow.Data;
 using BBT.Workflow.Execution.PostCommit;
+using BBT.Workflow.Infrastructure.Caching;
 using BBT.Workflow.Infrastructure.DataSink;
 using BBT.Workflow.Infrastructure.Execution.PostCommit;
 using BBT.Workflow.Infrastructure.HostedServices;
@@ -131,6 +133,10 @@ public static class WorkflowInfrastructureModuleServiceCollectionExtensions
 
         // Post-Commit Idempotency Store (needs IDistributedCacheService)
         services.AddSingleton<IPostCommitIdempotencyStore, DistributedCacheIdempotencyStore>();
+
+        // Two-tier cache: Redis-backed component version index (vidx:* keys).
+        // Resolves "latest" / partial version requests against Redis instead of the DB.
+        services.AddSingleton<IComponentVersionIndex, RedisComponentVersionIndex>();
 
         // Embedded Script Services (needs IComponentCacheStore from Application layer)
         services.AddEmbeddedScriptServices();

--- a/workers/BBT.Workflow.Workers.Inbox/Controllers/UtilityController.cs
+++ b/workers/BBT.Workflow.Workers.Inbox/Controllers/UtilityController.cs
@@ -15,6 +15,7 @@ namespace BBT.Workflow.Workers.Inbox.Controllers;
 [Route("api/v{version:apiVersion}/utilities")]
 public sealed class UtilityController(
     IRuntimeCacheInitializer runtimeCacheInitializer,
+    IDomainCacheContext domainCacheContext,
     IRuntimeInfoProvider runtimeInfoProvider,
     IConfiguration configuration,
     ILogger<UtilityController> logger) : ControllerBase
@@ -64,5 +65,64 @@ public sealed class UtilityController(
         logger.DefinitionCacheInvalidationSucceeded(podInstance);
                 
         return Ok();
+    }
+
+    /// <summary>
+    /// Handles granular per-component publish events on Worker.Inbox pods. Warms the local
+    /// snapshot for the affected component without a full reload. See the orchestration
+    /// host's UtilityController for the full rationale.
+    /// </summary>
+    [ApiExplorerSettings(IgnoreApi = true)]
+    [HttpPost("cache/component-published")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<IActionResult> ComponentPublishedAsync(
+        [FromBody] ComponentPublishedEvent eventData,
+        CancellationToken cancellationToken = default)
+    {
+        var podInstance = Environment.GetEnvironmentVariable("HOSTNAME")
+            ?? Environment.GetEnvironmentVariable("POD_NAME")
+            ?? Environment.MachineName;
+        var hostEnvironment = configuration["ASPNETCORE_ENVIRONMENT"];
+
+        try
+        {
+            if (!string.Equals(eventData.Environment, hostEnvironment, StringComparison.OrdinalIgnoreCase))
+            {
+                logger.LogDebug(
+                    "ComponentPublishedEvent ignored - environment mismatch. Pod={PodInstance} EventEnv={EventEnv} HostEnv={HostEnv}",
+                    podInstance, eventData.Environment, hostEnvironment);
+                return Ok();
+            }
+
+            // Worker.Inbox is multi-tenant - drop events that target a different domain.
+            if (!runtimeInfoProvider.IsDomainMatch(eventData.Domain))
+            {
+                logger.LogDebug(
+                    "ComponentPublishedEvent ignored - domain mismatch. Pod={PodInstance} EventDomain={EventDomain}",
+                    podInstance, eventData.Domain);
+                return Ok();
+            }
+
+            logger.LogInformation(
+                "ComponentPublishedEvent received. Pod={PodInstance} ComponentType={ComponentType} Domain={Domain} Key={Key} Version={Version}",
+                podInstance, eventData.ComponentType, eventData.Domain, eventData.Key, eventData.Version);
+
+            await domainCacheContext.WarmComponentAsync(
+                eventData.ComponentType,
+                eventData.Domain,
+                eventData.Key,
+                eventData.Version,
+                cancellationToken);
+
+            return Ok();
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(
+                ex,
+                "ComponentPublishedEvent handling failed. Pod={PodInstance}",
+                podInstance);
+            return Ok();
+        }
     }
 }

--- a/workers/BBT.Workflow.Workers.Inbox/Controllers/UtilityController.cs
+++ b/workers/BBT.Workflow.Workers.Inbox/Controllers/UtilityController.cs
@@ -58,8 +58,8 @@ public sealed class UtilityController(
         
         logger.DefinitionCacheInvalidationReceived(podInstance, eventData.Domain, eventData.RequestedBy);
         
-        // Update only in-memory cache (distributed cache already updated by initiating pod)
-        await runtimeCacheInitializer.InitializeAsync(eventData.FullLoad, cancellationToken);
+        // Warm in-memory cache from distributed cache; no full DB scan on receiving pods
+        await runtimeCacheInitializer.InitializeFromDistributedCacheAsync(cancellationToken);
         
         logger.DefinitionCacheInvalidationSucceeded(podInstance);
                 


### PR DESCRIPTION
## Summary
- Add a Redis-backed component version index (`vidx:*`) so "latest"/partial version lookups resolve against Redis instead of falling through to the database.
- Broadcast a granular `ComponentPublishedEvent` on every definition publish so receiving pods warm only the affected component's local snapshot instead of doing a full reload.
- Replace the full paginated DB scan in broadcast cache-invalidation receivers with a lightweight metadata query plus distributed-cache reads, eliminating the expensive `LoadAllEntitiesFromDatabaseAsync` path on every pod.
- Misc: unify worker Dapr state `keyPrefix` to `vnext`, add cancellable publish jobs and opt-in `reInitialize` to the init host package server.

## Changes
- `src/BBT.Workflow.Application/Caching/` — new `IComponentVersionIndex`, updated `CacheSet` (consults Redis vidx alongside local snapshot, picks SemVer-higher), `DomainCacheContext.WarmComponentAsync`, `RuntimeCacheInitializer.InitializeFromDistributedCacheAsync`.
- `src/BBT.Workflow.Infrastructure/Caching/RedisComponentVersionIndex.cs` — Redis implementation with self-healing fallback.
- `src/BBT.Workflow.Events.Contracts/Definitions/Events/ComponentPublishedEvent.cs` — new broadcast contract.
- `src/BBT.Workflow.Application/Definitions/DefinitionAppService.cs` — publishes the new event on each component upsert; `ReInitializeAsync` no longer eagerly initializes the local pod.
- `src/BBT.Workflow.Domain/` — expose `ComponentTypeKey` as `static abstract` on `IDomainEntity`; add `InstanceKeyModel` and lightweight repository query.
- `src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceRepository.cs` — metadata-only key/version query.
- `orchestration/.../UtilityController.cs` and `workers/BBT.Workflow.Workers.Inbox/Controllers/UtilityController.cs` — handle `component-published` event and switch broadcast invalidation to the distributed-cache path.
- `etc/orchestration/dapr/components/` and `etc/workers/inbox/dapr/components/` — new `definition.component.published` subscription; `state.yaml` `keyPrefix` unified to `vnext`.
- `init/VNext.Init.Host/package-api-server.js` — cancellable publish jobs (`POST /api/package/publish/cancel/:jobId`) and opt-in `reInitialize` flag.

## Test Plan
- [ ] Publish a workflow on pod A; verify pod B resolves the new "latest" version on the next read without waiting for a full ReInitialize.
- [ ] Confirm `vidx:{componentType}:{domain}:{key}` entries appear/update in Redis on publish and are removed on delete.
- [ ] Trigger `ReInitializeAsync`; verify receiving pods do NOT execute `LoadAllEntitiesFromDatabaseAsync` and instead populate snapshots from the distributed cache (DB hit only on cache miss).
- [ ] Subscribe a pod to `definition.component.published`; publish a component and verify only that component's snapshot is warmed (logs show `WarmComponentAsync` for the matching key).
- [ ] Verify environment/domain mismatch events are ignored with a debug log on both Orchestration and Worker.Inbox controllers.
- [ ] In init host: start a package publish, call the cancel endpoint, confirm the job transitions to `cancelled` at the next checkpoint and `reInitializeDefinitions` is skipped.
- [ ] Publish with `reInitialize: false` and confirm the re-init step is skipped; with `true`, confirm it runs.
- [ ] Verify worker inbox/outbox state entries land under the unified `vnext` key prefix.

## Notes
- `IDomainEntity.ComponentTypeKey` is now a `static abstract` member — any external implementer of `IDomainEntity` must add it.
- `ReInitializeAsync` no longer initializes the initiating pod eagerly; propagation relies on the broadcast path. Pods that don't subscribe to `vnext-pubsub-broadcast` will not receive cache updates.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Introduce a Redis-backed component version index and granular publish events to make version resolution and cache warming cross-pod aware while eliminating full database scans on broadcast-driven cache invalidations.

New Features:
- Add a Redis-backed component version index used by cache sets to resolve latest and partial version requests without falling back to full database enumeration.
- Emit a ComponentPublishedEvent on definition publishes and handle it in orchestration and worker pods to warm only the affected component in local caches.
- Extend the init host package API server with cancellable publish jobs, job cancellation status reporting, and an optional reInitialize flag for post-publish cache refresh.

Enhancements:
- Refine cache initialization to support warming in-memory caches from distributed cache keys via lightweight instance key queries instead of full entity loads.
- Standardize domain entities on a static ComponentTypeKey for type-level cache key generation and align cache key formats across components and pods.
- Register the Redis component version index in infrastructure services and wire it into the domain cache context and cache sets for two-tier caching.

Build:
- Update Dapr component configuration to subscribe orchestration and worker inbox services to the new definition.component.published topic and unify worker state key prefixes to the vnext naming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added job cancellation for package publish operations—cancel in-progress jobs at any time
  * Added optional definition re-initialization during publish operations

* **Improvements**
  * Enhanced cache synchronization across system pods using event-driven component updates
  * Improved distributed cache warming mechanism for better performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->