### PR TITLE
feat(instances): replace history data versions with state transitions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
     <PropertyGroup>
 
         <!-- All Prism packages -->
-        <AetherPackageVersion>1.0.21</AetherPackageVersion>
+        <AetherPackageVersion>1.0.22</AetherPackageVersion>
         <!-- Elastic Apm packages -->
         <ElasticApmPackageVersion>1.31.0</ElasticApmPackageVersion>
         <!-- Microsoft packages -->

--- a/docs/implementation/application-services.md
+++ b/docs/implementation/application-services.md
@@ -107,6 +107,7 @@ Notes:
 - Supports ETag-based conditional reads.
 - Uses optimized GraphQL-style filtering with optional grouping/aggregations.
 - Extension processing is fail-fast (errors are propagated).
+- `GetInstanceHistoryAsync` returns the full list of state transitions (`InstanceTransitionDto`) for the instance — not the instance data versions. Each entry includes `transitionId`, `fromState`, `toState`, `startedAt`, `finishedAt`, `durationSeconds`, `triggerType`, `body`, `header`, and audit fields (`createdAt`, `createdBy`, `createdByBehalfOf`). Transitions are ordered by `startedAt` ascending. The endpoint accepts no `extensions` or `version` query parameters.
 
 ### 4. FunctionAppService
 

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
@@ -1,10 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using BBT.Aether;
 using BBT.Aether.AspNetCore.Controllers;
-using BBT.Aether.AspNetCore.Pagination;
 using BBT.Aether.AspNetCore.Results;
-using BBT.Aether.Results;
-using BBT.Workflow.Definitions;
 using BBT.Workflow.Domain.Shared;
 using BBT.Workflow.Instances;
 using BBT.Workflow.SubFlow;
@@ -23,9 +20,7 @@ public sealed class InstanceController(
     IInstanceRetryAppService retryAppService,
     IHttpContextAccessor httpContextAccessor,
     ISubflowCompletionService subflowCompletionService,
-    ISubflowStateService subflowStateService,
-    IPaginationLinkGenerator linkGenerator,
-    IUrlTemplateBuilder urlTemplateBuilder) : AetherControllerBase
+    ISubflowStateService subflowStateService) : AetherControllerBase
 {
     /// <summary>
     /// Starts a new workflow instance.
@@ -309,7 +304,6 @@ public sealed class InstanceController(
             Extensions = extensions,
             Page = page,
             PageSize = pageSize,
-            PageUrl = urlTemplateBuilder.BuildInstanceListUrl(domain, workflow),
             Filter = filter,
             Sort = orderBy ?? sort,
             Version = version,
@@ -318,42 +312,6 @@ public sealed class InstanceController(
         };
 
         var response = await queryAppService.GetInstanceListAsync(input, cancellationToken);
-        if (response.IsSuccess)
-        {
-            var route = urlTemplateBuilder.BuildInstanceListUrl(domain, workflow);
-
-            // Check if items contain GroupSummary objects (groupBy case) or GetInstanceOutput objects (normal case)
-            var firstItem = response.Value!.Items.FirstOrDefault();
-            var isGroupByResponse = firstItem is GroupSummary;
-
-            if (isGroupByResponse)
-            {
-                // For groupBy responses, create a simple paged list structure for HATEOAS links
-                var groupSummaries = response.Value!.Items.Cast<GroupSummary>().ToList();
-                var tempPagedList = new HateoasPagedList<GroupSummary>(
-                    groupSummaries,
-                    input.Page,
-                    input.PageSize,
-                    groupSummaries.Count == input.PageSize);
-
-                var hateoasResult = linkGenerator.CreateHateoasResult(tempPagedList, groupSummaries, route);
-                response.Value!.Links = hateoasResult.Links;
-            }
-            else
-            {
-                // Normal case: items are GetInstanceOutput objects
-                var instanceOutputs = response.Value!.Items.Cast<GetInstanceOutput>().ToList();
-                var tempPagedList = new HateoasPagedList<GetInstanceOutput>(
-                    instanceOutputs,
-                    input.Page,
-                    input.PageSize,
-                    instanceOutputs.Count == input.PageSize);
-
-                var hateoasResult = linkGenerator.CreateHateoasResult(tempPagedList, instanceOutputs, route);
-                response.Value!.Links = hateoasResult.Links;
-            }
-        }
-
         return response.ToActionResult(HttpContext);
     }
 
@@ -362,8 +320,6 @@ public sealed class InstanceController(
         [FromRoute] string domain,
         [FromRoute] string workflow,
         [FromRoute] string instance,
-        [FromQuery] string[]? extensions = null,
-        [FromQuery] string? version = null,
         CancellationToken cancellationToken = default)
     {
         var requestContext = HttpContext.GetRequestBindingContext();
@@ -373,8 +329,6 @@ public sealed class InstanceController(
             Domain = domain,
             Workflow = workflow,
             Instance = instance,
-            Extensions = extensions,
-            Version = version,
             Headers = requestContext.Headers,
             QueryParameters = requestContext.QueryParameters
         };

--- a/src/BBT.Workflow.Application/Instances/DTOs/GetInstanceInput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/GetInstanceInput.cs
@@ -82,8 +82,6 @@ public sealed class GetInstanceListInput : IHasDomain
     [Range(1, 100)]
     public int PageSize { get; set; } = 10;
 
-    public string PageUrl { get; set; } = string.Empty;
-
     /// <summary>
     /// OrderBy JSON for sorting. Single: {"field":"createdAt","direction":"desc"}.
     /// Multiple: {"fields":[{"field":"status","direction":"asc"},{"field":"createdAt","direction":"desc"}]}.
@@ -133,17 +131,6 @@ public sealed class GetInstanceHistoryInput : IHasDomain
 
     [Required]
     public string Instance { get; set; } = string.Empty;
-
-    /// <summary>
-    /// Extensions requested for data enrichment
-    /// </summary>
-    public string[]? Extensions { get; set; }
-
-    /// <summary>
-    /// Optional instance data version. When null or empty, latest data is used.
-    /// When set, instance data is resolved to that version (semantic/partial match supported).
-    /// </summary>
-    public string? Version { get; set; }
 
     /// <summary>
     /// HTTP headers from the request for script context binding

--- a/src/BBT.Workflow.Application/Instances/DTOs/InstanceListWithGroupsResponse.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/InstanceListWithGroupsResponse.cs
@@ -29,7 +29,7 @@ public sealed class InstanceListWithGroupsResponse<T>
     public static InstanceListWithGroupsResponse<T> FromPagedList(HateoasPagedList<T> pagedList, List<GroupSummary>? groups = null)
     {
         // If groups are provided, populate items with groups; otherwise use paged list items
-        if (groups != null && groups.Count > 0)
+        if (groups is { Count: > 0 })
         {
             return new InstanceListWithGroupsResponse<T>
             {

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -14,6 +14,7 @@ using BBT.Workflow.Scripting;
 using Microsoft.Extensions.Logging;
 using BBT.Workflow.Shared;
 using System.Text.Json;
+using BBT.Aether.Application.Pagination;
 using BBT.Workflow.Definitions.GraphQL;
 using BBT.Workflow.RepresentationEtag;
 using BBT.Workflow.Tasks.Coordinator;
@@ -26,6 +27,7 @@ public sealed class InstanceQueryAppService(
     IRuntimeInfoProvider runtimeInfoProvider,
     IComponentCacheStore componentCacheStore,
     IInstanceRepository instanceRepository,
+    IInstanceTransitionRepository instanceTransitionRepository,
     IInstanceCorrelationRepository instanceCorrelationRepository,
     IInstanceExtensionService instanceExtensionService,
     IScriptContextFactory scriptContextFactory,
@@ -37,6 +39,7 @@ public sealed class InstanceQueryAppService(
     ITransitionAuthorizationManager transitionAuthorizationManager,
     IRepresentationEtagService representationEtagService,
     ISchemaFieldFilterService schemaFieldFilterService,
+    IPaginationLinkGenerator paginationLinkGenerator,
     ILogger<InstanceQueryAppService> logger)
     : ApplicationService(serviceProvider), IInstanceQueryAppService
 {
@@ -167,10 +170,20 @@ public sealed class InstanceQueryAppService(
                     groups = result.Groups;
                 }
 
+                var route = urlTemplateBuilder.BuildInstanceListUrl(input.Domain, input.Workflow);
+                var linkGen = paginationLinkGenerator.Relative();
+
                 // If groups are present, populate items with groups instead of instances
-                if (groups != null && groups.Count > 0)
+                if (groups is { Count: > 0 })
                 {
-                    return InstanceListWithGroupsResponse<GetInstanceOutput>.FromGroups(groups);
+                    var groupPagedList = new HateoasPagedList<GroupSummary>(
+                        groups,
+                        input.Page,
+                        input.PageSize,
+                        hasNext: groups.Count == input.PageSize);
+                    var groupedResponse = InstanceListWithGroupsResponse<GetInstanceOutput>.FromGroups(groups);
+                    groupedResponse.Links = linkGen.GenerateLinks(groupPagedList, route);
+                    return groupedResponse;
                 }
 
                 // Normal flow: build instance outputs
@@ -205,7 +218,9 @@ public sealed class InstanceQueryAppService(
                     pagedList.PageSize,
                     pagedList.HasNext);
 
-                return InstanceListWithGroupsResponse<GetInstanceOutput>.FromPagedList(resultPagedList, null);
+                var response = InstanceListWithGroupsResponse<GetInstanceOutput>.FromPagedList(resultPagedList, null);
+                response.Links = linkGen.GenerateLinks(resultPagedList, route);
+                return response;
             },
             cancellationToken);
     }
@@ -219,32 +234,30 @@ public sealed class InstanceQueryAppService(
         return await GetInstanceByIdOrKeyAsync(input.Instance, cancellationToken)
             .ThenAsync(async instance =>
             {
-                var transitions = new List<GetInstanceOutput>();
-                foreach (var instanceData in instance.DataList.OrderBy(d => d.EnteredAt))
-                {
-                    var transitionOutputResult = await BuildInstanceOutputAsync(
-                        input.Domain,
-                        input.Extensions,
-                        input.Workflow,
-                        instance,
-                        instanceData,
-                        ExtensionScope.GetInstance,
-                        input.Headers,
-                        input.QueryParameters,
-                        cancellationToken);
+                var transitions = await instanceTransitionRepository.GetByInstanceIdAsync(instance.Id, cancellationToken);
 
-                    // Propagate extension errors - fail-fast behavior
-                    if (!transitionOutputResult.IsSuccess)
+                var dtoList = transitions
+                    .Select(t => new InstanceTransitionDto
                     {
-                        return Result<GetInstanceHistoryOutput>.Fail(transitionOutputResult.Error);
-                    }
-
-                    transitions.Add(transitionOutputResult.Value!);
-                }
+                        Id = t.Id,
+                        TransitionId = t.TransitionId,
+                        FromState = t.FromState,
+                        ToState = t.ToState,
+                        StartedAt = t.StartedAt,
+                        FinishedAt = t.FinishedAt,
+                        DurationSeconds = t.Duration?.TotalSeconds,
+                        TriggerType = t.TriggerType,
+                        Body = t.Body.JsonElement,
+                        Header = t.Header.JsonElement,
+                        CreatedAt = t.CreatedAt,
+                        CreatedBy = t.CreatedBy,
+                        CreatedByBehalfOf = t.CreatedByBehalfOf
+                    })
+                    .ToList();
 
                 return Result<GetInstanceHistoryOutput>.Ok(new GetInstanceHistoryOutput
                 {
-                    Transitions = transitions
+                    Transitions = dtoList
                 });
             });
     }

--- a/src/BBT.Workflow.Application/Instances/Managers/InstanceCancellationService.cs
+++ b/src/BBT.Workflow.Application/Instances/Managers/InstanceCancellationService.cs
@@ -46,8 +46,7 @@ public sealed class InstanceCancellationService(
                 return Result.Ok();
             }
 
-            // Process all jobs in parallel for better performance
-            var processingTasks = jobs.Select(async job =>
+            foreach (var job in jobs)
             {
                 try
                 {
@@ -59,9 +58,7 @@ public sealed class InstanceCancellationService(
                 {
                     logger.InstanceJobDeletionFailed(ex, job.JobId, instanceId);
                 }
-            });
-
-            await Task.WhenAll(processingTasks);
+            }
 
             logger.InstanceCanceledJobsProcessed(instanceId, jobs.Count);
 
@@ -106,8 +103,7 @@ public sealed class InstanceCancellationService(
                 return Result.Ok();
             }
 
-            // Process filtered jobs in parallel
-            var processingTasks = jobsToCancel.Select(async job =>
+            foreach (var job in jobsToCancel)
             {
                 try
                 {
@@ -119,9 +115,7 @@ public sealed class InstanceCancellationService(
                 {
                     logger.InstanceJobDeletionFailed(ex, job.JobId, instanceId);
                 }
-            });
-
-            await Task.WhenAll(processingTasks);
+            }
 
             logger.StateTransitionsJobsCanceled(
                 jobsToCancel.Count,

--- a/src/BBT.Workflow.Application/Scripting/ScriptEngine.cs
+++ b/src/BBT.Workflow.Application/Scripting/ScriptEngine.cs
@@ -49,6 +49,7 @@ public sealed class ScriptEngine(
         MetadataReference.CreateFromFile(typeof(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo).Assembly.Location),
         MetadataReference.CreateFromFile(typeof(ScriptBase).Assembly.Location),
         MetadataReference.CreateFromFile(typeof(JsonSerializableAttribute).Assembly.Location),
+        MetadataReference.CreateFromFile(typeof(System.Text.Encodings.Web.JavaScriptEncoder).Assembly.Location),
     ]);
 
     /// <summary>
@@ -66,6 +67,8 @@ public sealed class ScriptEngine(
         "System.Dynamic",
         "System.Text.Json",
         "System.Text.Json.Serialization",
+        "System.Text.Encodings.Web",
+        "System.Text.Unicode",
         "BBT.Workflow.Shared",
         "BBT.Workflow.Scripting",
         "BBT.Workflow.Definitions",

--- a/src/BBT.Workflow.Application/Tasks/Executors/Trigger/DirectTriggerTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Trigger/DirectTriggerTaskExecutor.cs
@@ -69,7 +69,7 @@ public sealed class DirectTriggerTaskExecutor : TriggerTaskExecutorBase<DirectTr
             Logger.TaskInstanceResolutionFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext?.Instance?.Id ?? Guid.Empty,
                 instanceIdResult.Error.Message ?? "Unknown error");
             return Result<TaskInvocationResult>.Fail(instanceIdResult.Error);
         }
@@ -116,7 +116,7 @@ public sealed class DirectTriggerTaskExecutor : TriggerTaskExecutorBase<DirectTr
             Logger.TaskLocalExecutionFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id.ToString(),
+                context.ScriptContext?.Instance?.Id.ToString() ?? string.Empty,
                 instanceIdResult.Error.Message ?? "DirectTrigger instance resolution failed");
 
             return Result<TaskInvocationResult>.Ok(TaskInvocationResult.Failure(
@@ -154,7 +154,7 @@ public sealed class DirectTriggerTaskExecutor : TriggerTaskExecutorBase<DirectTr
             Logger.TaskLocalExecutionFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id.ToString(),
+                context.ScriptContext?.Instance?.Id.ToString() ?? string.Empty,
                 result.Error.Message ?? "DirectTrigger transition failed");
 
             return Result<TaskInvocationResult>.Ok(TaskInvocationResult.Failure(
@@ -261,7 +261,7 @@ public sealed class DirectTriggerTaskExecutor : TriggerTaskExecutorBase<DirectTr
             Logger.TaskEnvelopeCreationFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext?.Instance?.Id ?? Guid.Empty,
                 envelopeResult.Error.Message ?? "Failed to create envelope");
             return Result<TaskInvocationResult>.Fail(envelopeResult.Error);
         }
@@ -279,7 +279,7 @@ public sealed class DirectTriggerTaskExecutor : TriggerTaskExecutorBase<DirectTr
             Logger.TaskRemoteExecutionFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext?.Instance?.Id ?? Guid.Empty,
                 enrichResult.Error.Message ?? "Failed to resolve endpoint");
             return Result<TaskInvocationResult>.Fail(enrichResult.Error);
         }
@@ -297,7 +297,7 @@ public sealed class DirectTriggerTaskExecutor : TriggerTaskExecutorBase<DirectTr
             Logger.TaskRemoteExecutionFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext?.Instance?.Id ?? Guid.Empty,
                 result.Error.Message ?? "Unknown error");
         }
 

--- a/src/BBT.Workflow.Application/Tasks/Executors/Trigger/GetInstanceDataTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Trigger/GetInstanceDataTaskExecutor.cs
@@ -59,7 +59,7 @@ public sealed class GetInstanceDataTaskExecutor : TriggerTaskExecutorBase<GetIns
             Logger.TaskInstanceResolutionFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext?.Instance?.Id ?? Guid.Empty,
                 instanceIdResult.Error.Message ?? "Unknown error");
             return Result<TaskInvocationResult>.Fail(instanceIdResult.Error);
         }
@@ -176,7 +176,7 @@ public sealed class GetInstanceDataTaskExecutor : TriggerTaskExecutorBase<GetIns
             Logger.TaskEnvelopeCreationFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext?.Instance?.Id ?? Guid.Empty,
                 envelopeResult.Error.Message ?? "Failed to create envelope");
             return Result<TaskInvocationResult>.Fail(envelopeResult.Error);
         }
@@ -195,7 +195,7 @@ public sealed class GetInstanceDataTaskExecutor : TriggerTaskExecutorBase<GetIns
             Logger.TaskRemoteExecutionFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext?.Instance?.Id ?? Guid.Empty,
                 enrichResult.Error.Message ?? "Failed to resolve endpoint");
             return Result<TaskInvocationResult>.Fail(enrichResult.Error);
         }
@@ -213,7 +213,7 @@ public sealed class GetInstanceDataTaskExecutor : TriggerTaskExecutorBase<GetIns
             Logger.TaskRemoteExecutionFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext?.Instance?.Id ?? Guid.Empty,
                 result.Error.Message ?? "Unknown error");
         }
 

--- a/src/BBT.Workflow.Application/Tasks/Executors/Trigger/GetInstancesTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Trigger/GetInstancesTaskExecutor.cs
@@ -25,7 +25,6 @@ public sealed class GetInstancesTaskExecutor : TriggerTaskExecutorBase<GetInstan
 {
     private readonly IInstanceQueryGateway _instanceQueryGateway;
     private readonly IDomainDiscoveryResolver _endpointResolver;
-    private readonly IUrlTemplateBuilder _urlTemplateBuilder;
 
     /// <summary>
     /// Initializes a new instance of GetInstancesTaskExecutor.
@@ -36,13 +35,11 @@ public sealed class GetInstancesTaskExecutor : TriggerTaskExecutorBase<GetInstan
         IRemoteInvokerService remoteInvoker,
         IInstanceQueryGateway instanceQueryGateway,
         IDomainDiscoveryResolver endpointResolver,
-        IUrlTemplateBuilder urlTemplateBuilder,
         ILogger<GetInstancesTaskExecutor> logger)
         : base(scriptEngine, runtimeInfoProvider, remoteInvoker, logger)
     {
         _instanceQueryGateway = instanceQueryGateway;
         _endpointResolver = endpointResolver;
-        _urlTemplateBuilder = urlTemplateBuilder;
     }
 
     /// <inheritdoc />
@@ -110,86 +107,28 @@ public sealed class GetInstancesTaskExecutor : TriggerTaskExecutorBase<GetInstan
             }
 
             var listResponse = instanceListResult.Value!;
-            var basePath = _urlTemplateBuilder.BuildFunctionListUrl(
-                task.TriggerDomain,
-                task.TriggerFlow,
-                "data");
+            var itemCount = listResponse.Items.Count;
+            var hasNext = itemCount == task.PageSize;
+            var isGrouped = listResponse.Items.FirstOrDefault() is GroupSummary;
 
-            var groupItems = TryMaterializeGroupSummaries(listResponse);
-            if (groupItems != null)
+            var metadata = new Dictionary<string, object>
             {
-                // groupBy: items are GroupSummary — do not call GetInstanceData per row
-                var currentPage = task.Page;
-                var pageSize = task.PageSize;
-                var totalEstimate = groupItems.Count;
-                var hasNext = (currentPage * pageSize) < totalEstimate;
-
-                var groupedResponseData = new
-                {
-                    links = new
-                    {
-                        self = $"{basePath}?page={currentPage}&pageSize={pageSize}",
-                        first = $"{basePath}?page=1&pageSize={pageSize}",
-                        next = hasNext
-                            ? $"{basePath}?page={currentPage + 1}&pageSize={pageSize}"
-                            : "",
-                        prev = currentPage > 1
-                            ? $"{basePath}?page={currentPage - 1}&pageSize={pageSize}"
-                            : ""
-                    },
-                    items = groupItems
-                };
-
-                return Result<TaskInvocationResult>.Ok(TaskInvocationResult.Success(
-                    data: groupedResponseData,
-                    statusCode: 200,
-                    taskType: TaskType.ToString(),
-                    metadata: new Dictionary<string, object>
-                    {
-                        ["Page"] = currentPage,
-                        ["PageSize"] = pageSize,
-                        ["HasNext"] = hasNext,
-                        ["ItemCount"] = groupItems.Count,
-                        ["Grouped"] = true
-                    }));
-            }
-
-            // Step 2: Get data for each instance (flat list)
-            // Note: ToPagedList uses Items.Count as totalItems estimate since InstanceListWithGroupsResponse doesn't preserve total count
-            var pagedList = listResponse.ToPagedList(task.PageSize, task.Page, listResponse.Items.Count);
-            var instanceDataResults = await ProcessDataFunctionListAsync(
-                task.TriggerDomain,
-                task.TriggerFlow,
-                pagedList,
-                cancellationToken);
-
-            var responseData = new
-            {
-                links = new
-                {
-                    self = $"{basePath}?page={pagedList.CurrentPage}&pageSize={pagedList.PageSize}",
-                    first = $"{basePath}?page=1&pageSize={pagedList.PageSize}",
-                    next = pagedList.HasNext
-                        ? $"{basePath}?page={pagedList.CurrentPage + 1}&pageSize={pagedList.PageSize}"
-                        : "",
-                    prev = pagedList.CurrentPage > 1
-                        ? $"{basePath}?page={pagedList.CurrentPage - 1}&pageSize={pagedList.PageSize}"
-                        : ""
-                },
-                items = instanceDataResults
+                ["Page"] = task.Page,
+                ["PageSize"] = task.PageSize,
+                ["HasNext"] = hasNext,
+                ["ItemCount"] = itemCount,
             };
 
+            if (isGrouped)
+            {
+                metadata["Grouped"] = true;
+            }
+
             return Result<TaskInvocationResult>.Ok(TaskInvocationResult.Success(
-                data: responseData,
+                data: listResponse,
                 statusCode: 200,
                 taskType: TaskType.ToString(),
-                metadata: new Dictionary<string, object>
-                {
-                    ["Page"] = pagedList.CurrentPage,
-                    ["PageSize"] = pagedList.PageSize,
-                    ["HasNext"] = pagedList.HasNext,
-                    ["ItemCount"] = instanceDataResults.Count
-                }));
+                metadata: metadata));
         }
         catch (Exception ex)
         {
@@ -207,74 +146,6 @@ public sealed class GetInstancesTaskExecutor : TriggerTaskExecutorBase<GetInstan
         }
     }
 
-    private async Task<List<GetInstanceDataOutput>> ProcessDataFunctionListAsync(
-        string domain,
-        string workflow,
-        HateoasPagedList<GetInstanceOutput> instanceListResult,
-        CancellationToken cancellationToken)
-    {
-        // Process sequentially to avoid flooding downstream dependencies
-        var results = new List<GetInstanceDataOutput>();
-        
-        foreach (var instance in instanceListResult.Items)
-        {
-            var input = new GetInstanceDataInput
-            {
-                Domain = domain,
-                Workflow = workflow,
-                Instance = instance.Key!
-            };
-            
-            var result = await _instanceQueryGateway.GetInstanceDataAsync(input, cancellationToken);
-            if (result.Result is { IsSuccess: true, Value: not null })
-            {
-                results.Add(result.Result.Value);
-            }
-        }
-        
-        return results;
-    }
-
-    /// <summary>
-    /// When the list API returns groupBy results, <see cref="InstanceListWithGroupsResponse{T}.Items"/> holds
-    /// <see cref="GroupSummary"/> (or JSON elements after deserialization). Returns null if the payload is not
-    /// a homogeneous group list so the flat instance path can run.
-    /// </summary>
-    private static List<GroupSummary>? TryMaterializeGroupSummaries(
-        InstanceListWithGroupsResponse<GetInstanceOutput> listResponse)
-    {
-        if (listResponse.Items.Count == 0)
-        {
-            return null;
-        }
-
-        var groups = new List<GroupSummary>(listResponse.Items.Count);
-        foreach (var item in listResponse.Items)
-        {
-            switch (item)
-            {
-                case GroupSummary groupSummary:
-                    groups.Add(groupSummary);
-                    break;
-                case JsonElement jsonElement:
-                    var deserialized = JsonSerializer.Deserialize<GroupSummary>(
-                        jsonElement,
-                        JsonSerializerConstants.JsonOptions);
-                    if (deserialized == null)
-                    {
-                        return null;
-                    }
-
-                    groups.Add(deserialized);
-                    break;
-                default:
-                    return null;
-            }
-        }
-
-        return groups;
-    }
-
     private async Task<Result<TaskInvocationResult>> ExecuteRemoteAsync(
         GetInstancesTask task,
         TaskExecutorContext context,
@@ -289,7 +160,7 @@ public sealed class GetInstancesTaskExecutor : TriggerTaskExecutorBase<GetInstan
             Logger.TaskEnvelopeCreationFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext?.Instance?.Id ?? Guid.Empty,
                 envelopeResult.Error.Message ?? "Failed to create envelope");
             return Result<TaskInvocationResult>.Fail(envelopeResult.Error);
         }
@@ -307,7 +178,7 @@ public sealed class GetInstancesTaskExecutor : TriggerTaskExecutorBase<GetInstan
             Logger.TaskRemoteExecutionFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext?.Instance?.Id ?? Guid.Empty,
                 enrichResult.Error.Message ?? "Failed to resolve endpoint");
             return Result<TaskInvocationResult>.Fail(enrichResult.Error);
         }
@@ -325,7 +196,7 @@ public sealed class GetInstancesTaskExecutor : TriggerTaskExecutorBase<GetInstan
             Logger.TaskRemoteExecutionFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext?.Instance?.Id ?? Guid.Empty,
                 result.Error.Message ?? "Unknown error");
         }
 

--- a/src/BBT.Workflow.Application/Tasks/Executors/Trigger/StartTriggerTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Trigger/StartTriggerTaskExecutor.cs
@@ -82,7 +82,7 @@ public sealed class StartTriggerTaskExecutor : TriggerTaskExecutorBase<StartTask
                 Logger.TaskLocalExecutionFailed(
                     task.Key,
                     TaskType.ToString(),
-                    context.ScriptContext.Instance.Id.ToString(),
+                    context.ScriptContext?.Instance?.Id.ToString() ?? string.Empty,
                     result.Error.Message ?? "StartTrigger failed");
                 return Result<TaskInvocationResult>.Ok(TaskInvocationResult.Failure(
                     error: result.Error.Message ?? "StartTrigger failed",
@@ -104,7 +104,7 @@ public sealed class StartTriggerTaskExecutor : TriggerTaskExecutorBase<StartTask
             Logger.TaskLocalExecutionFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id.ToString(),
+                context.ScriptContext?.Instance?.Id.ToString() ?? string.Empty,
                 ex.Message);
 
             return Result<TaskInvocationResult>.Fail(
@@ -129,7 +129,7 @@ public sealed class StartTriggerTaskExecutor : TriggerTaskExecutorBase<StartTask
             Logger.TaskEnvelopeCreationFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext?.Instance?.Id ?? Guid.Empty,
                 envelopeResult.Error.Message ?? "Failed to create envelope");
             return Result<TaskInvocationResult>.Fail(envelopeResult.Error);
         }
@@ -147,7 +147,7 @@ public sealed class StartTriggerTaskExecutor : TriggerTaskExecutorBase<StartTask
             Logger.TaskRemoteExecutionFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext?.Instance?.Id ?? Guid.Empty,
                 enrichResult.Error.Message ?? "Failed to resolve endpoint");
             return Result<TaskInvocationResult>.Fail(enrichResult.Error);
         }
@@ -165,7 +165,7 @@ public sealed class StartTriggerTaskExecutor : TriggerTaskExecutorBase<StartTask
             Logger.TaskRemoteExecutionFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext?.Instance?.Id ?? Guid.Empty,
                 result.Error.Message ?? "Unknown error");
         }
 

--- a/src/BBT.Workflow.Application/Tasks/Executors/Trigger/SubProcessTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Trigger/SubProcessTaskExecutor.cs
@@ -135,7 +135,7 @@ public sealed class SubProcessTaskExecutor : TriggerTaskExecutorBase<SubProcessT
                 Logger.TaskLocalExecutionFailed(
                     task.Key,
                     TaskType.ToString(),
-                    context.ScriptContext.Instance.Id.ToString(),
+                    context.ScriptContext?.Instance?.Id.ToString() ?? string.Empty,
                     result.Error.Message ?? "SubProcess start failed");
                 return TaskInvocationResult.Failure(
                     error: result.Error.Message ?? "SubProcess start failed",
@@ -169,7 +169,7 @@ public sealed class SubProcessTaskExecutor : TriggerTaskExecutorBase<SubProcessT
             Logger.TaskLocalExecutionFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id.ToString(),
+                context.ScriptContext?.Instance?.Id.ToString() ?? string.Empty,
                 ex.Message);
 
             return TaskInvocationResult.Failure(
@@ -201,7 +201,7 @@ public sealed class SubProcessTaskExecutor : TriggerTaskExecutorBase<SubProcessT
             Logger.TaskEnvelopeCreationFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext?.Instance?.Id ?? Guid.Empty,
                 envelopeResult.Error.Message ?? "Failed to create envelope");
             return TaskInvocationResult.Failure(
                 error: envelopeResult.Error.Message ?? "Failed to create envelope",
@@ -227,7 +227,7 @@ public sealed class SubProcessTaskExecutor : TriggerTaskExecutorBase<SubProcessT
             Logger.TaskRemoteExecutionFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext?.Instance?.Id ?? Guid.Empty,
                 enrichResult.Error.Message ?? "Failed to resolve endpoint");
             return TaskInvocationResult.Failure(
                 error: enrichResult.Error.Message ?? "Failed to resolve endpoint",
@@ -253,7 +253,7 @@ public sealed class SubProcessTaskExecutor : TriggerTaskExecutorBase<SubProcessT
             Logger.TaskRemoteExecutionFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext?.Instance?.Id ?? Guid.Empty,
                 result.Error.Message ?? "Remote SubProcess execution failed");
             return TaskInvocationResult.Failure(
                 error: result.Error.Message ?? "Remote SubProcess execution failed",
@@ -384,8 +384,8 @@ public sealed class SubProcessTaskExecutor : TriggerTaskExecutorBase<SubProcessT
             {
                 var correlation = InstanceCorrelation.Create(
                     correlationId,
-                    context.ScriptContext.Instance.Id,
-                    context.ScriptContext.Instance.GetCurrentState,
+                    context.ScriptContext?.Instance?.Id ?? Guid.Empty,
+                    context.ScriptContext?.Instance?.GetCurrentState ?? string.Empty,
                     subFlowInstanceId,
                     SubFlowType.SubProcess.Code,
                     task.TriggerDomain,

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/GetInstancesTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/GetInstancesTask.cs
@@ -108,6 +108,11 @@ public sealed class GetInstancesTask : WorkflowTask
     {
         Filter = filter;
     }
+    
+    public void SetFilter(object? filter)
+    {
+        Filter = JsonSerializer.Serialize(filter);
+    }
 
     public void SetUseDapr(bool useDapr)
     {

--- a/src/BBT.Workflow.Domain/Instances/DTOs/GetInstanceOutput.cs
+++ b/src/BBT.Workflow.Domain/Instances/DTOs/GetInstanceOutput.cs
@@ -129,11 +129,56 @@ public sealed class InstanceMetadataDto
 }
 
 /// <summary>
-/// Output for instance history (all data transitions)
+/// Output for instance history (all state transitions)
 /// </summary>
 public sealed class GetInstanceHistoryOutput
 {
-    public List<GetInstanceOutput> Transitions { get; set; } = [];
+    public List<InstanceTransitionDto> Transitions { get; set; } = [];
+}
+
+/// <summary>
+/// DTO representing a single state transition for instance history responses.
+/// </summary>
+public sealed class InstanceTransitionDto
+{
+    /// <summary>Unique transition identifier.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Transition definition key (e.g. "approve", "reject").</summary>
+    public string TransitionId { get; set; } = string.Empty;
+
+    /// <summary>State the instance was in when the transition started.</summary>
+    public string FromState { get; set; } = string.Empty;
+
+    /// <summary>State the instance moved to. Null when the transition is still in progress.</summary>
+    public string? ToState { get; set; }
+
+    /// <summary>UTC timestamp when the transition started.</summary>
+    public DateTime StartedAt { get; set; }
+
+    /// <summary>UTC timestamp when the transition completed. Null when still in progress.</summary>
+    public DateTime? FinishedAt { get; set; }
+
+    /// <summary>Total transition duration in seconds. Null when still in progress.</summary>
+    public double? DurationSeconds { get; set; }
+
+    /// <summary>Trigger type that initiated the transition (Manual, Automatic, Timeout, etc.).</summary>
+    public TriggerType TriggerType { get; set; }
+
+    /// <summary>Body payload submitted with the transition.</summary>
+    public JsonElement? Body { get; set; }
+
+    /// <summary>Header payload submitted with the transition.</summary>
+    public JsonElement? Header { get; set; }
+
+    /// <summary>UTC timestamp when the transition record was created.</summary>
+    public DateTime CreatedAt { get; set; }
+
+    /// <summary>User identifier that created the transition.</summary>
+    public string? CreatedBy { get; set; }
+
+    /// <summary>Behalf-of user identifier captured when the transition was created.</summary>
+    public string? CreatedByBehalfOf { get; set; }
 }
 
 /// <summary>

--- a/src/BBT.Workflow.Domain/Instances/IInstanceTransitionRepository.cs
+++ b/src/BBT.Workflow.Domain/Instances/IInstanceTransitionRepository.cs
@@ -29,4 +29,12 @@ public interface IInstanceTransitionRepository : IRepository<InstanceTransition,
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The last completed manual transition, or null if none found.</returns>
     Task<InstanceTransition?> GetLastCompletedManualTransitionAsync(Guid instanceId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets all transitions for an instance ordered by <see cref="InstanceTransition.StartedAt"/> ascending.
+    /// </summary>
+    /// <param name="instanceId">The instance ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of transitions for the instance.</returns>
+    Task<List<InstanceTransition>> GetByInstanceIdAsync(Guid instanceId, CancellationToken cancellationToken = default);
 }

--- a/src/BBT.Workflow.Execution/Invokers/DirectTriggerRemoteInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/DirectTriggerRemoteInvoker.cs
@@ -399,7 +399,7 @@ public sealed class DirectTriggerRemoteInvoker : ITaskInvoker<DirectTriggerBindi
 
         if (!binding.ValidateSSL)
         {
-            _logger.LogWarning(
+            _logger.LogDebug(
                 "SSL certificate validation is disabled for {TaskType} task {TaskKey}",
                 TaskType, taskKey);
         }

--- a/src/BBT.Workflow.Execution/Invokers/GetInstanceDataRemoteInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/GetInstanceDataRemoteInvoker.cs
@@ -295,7 +295,7 @@ public sealed class GetInstanceDataRemoteInvoker : ITaskInvoker<GetInstanceDataB
 
         if (!binding.ValidateSSL)
         {
-            _logger.LogWarning(
+            _logger.LogDebug(
                 "SSL certificate validation is disabled for {TaskType} task {TaskKey}",
                 TaskType, taskKey);
         }

--- a/src/BBT.Workflow.Execution/Invokers/GetInstancesRemoteInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/GetInstancesRemoteInvoker.cs
@@ -300,7 +300,7 @@ public sealed class GetInstancesRemoteInvoker : ITaskInvoker<GetInstancesBinding
 
         if (!binding.ValidateSSL)
         {
-            _logger.LogWarning(
+            _logger.LogDebug(
                 "SSL certificate validation is disabled for {TaskType} task {TaskKey}",
                 TaskType, taskKey);
         }

--- a/src/BBT.Workflow.Execution/Invokers/HttpTaskInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/HttpTaskInvoker.cs
@@ -182,7 +182,7 @@ public sealed class HttpTaskInvoker(
 
         if (!binding.ValidateSSL)
         {
-            logger.LogWarning("SSL certificate validation is disabled for HTTP task {TaskKey} - URL: {Url}",
+            logger.LogDebug("SSL certificate validation is disabled for HTTP task {TaskKey} - URL: {Url}",
                 taskKey, binding.Url);
         }
 

--- a/src/BBT.Workflow.Execution/Invokers/StartTriggerRemoteInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/StartTriggerRemoteInvoker.cs
@@ -330,7 +330,7 @@ public sealed class StartTriggerRemoteInvoker : ITaskInvoker<StartTriggerBinding
 
         if (!binding.ValidateSSL)
         {
-            _logger.LogWarning(
+            _logger.LogDebug(
                 "SSL certificate validation is disabled for {TaskType} task {TaskKey}",
                 TaskType, taskKey);
         }

--- a/src/BBT.Workflow.Execution/Invokers/SubProcessRemoteInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/SubProcessRemoteInvoker.cs
@@ -338,7 +338,7 @@ public sealed class SubProcessRemoteInvoker : ITaskInvoker<SubProcessBinding>
 
         if (!binding.ValidateSSL)
         {
-            _logger.LogWarning(
+            _logger.LogDebug(
                 "SSL certificate validation is disabled for {TaskType} task {TaskKey}",
                 TaskType, taskKey);
         }

--- a/src/BBT.Workflow.Infrastructure/Gateway/LocalInstanceQueryGateway.cs
+++ b/src/BBT.Workflow.Infrastructure/Gateway/LocalInstanceQueryGateway.cs
@@ -68,7 +68,7 @@ public sealed class LocalInstanceQueryGateway : IInstanceQueryGateway
         GetInstanceHistoryInput input,
         CancellationToken cancellationToken = default)
     {
-        return _serviceScopeFactory.ExecuteWithWorkflowAsync(input.Domain, input.Workflow, input.Version,
+        return _serviceScopeFactory.ExecuteWithWorkflowAsync(input.Domain, input.Workflow, null,
             async (sp, ct) =>
             {
                 var queryService = sp.GetRequiredService<IInstanceQueryAppService>();

--- a/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceTransitionRepository.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceTransitionRepository.cs
@@ -89,4 +89,15 @@ public class EfCoreInstanceTransitionRepository(
             .OrderByDescending(p => p.FinishedAt)
             .FirstOrDefaultAsync(cancellationToken);
     }
+
+    /// <inheritdoc />
+    public async Task<List<InstanceTransition>> GetByInstanceIdAsync(Guid instanceId, CancellationToken cancellationToken = default)
+    {
+        var context = await GetDbContextAsync();
+        return await context.InstanceTransitions
+            .AsNoTracking()
+            .Where(p => p.InstanceId == instanceId)
+            .OrderBy(p => p.StartedAt)
+            .ToListAsync(cancellationToken);
+    }
 }

--- a/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceQueryAppService.cs
@@ -262,23 +262,6 @@ public sealed class RemoteInstanceQueryAppService(
 
             var relativePath = InstanceUrlTemplates.InstanceHistory(input.Domain, input.Workflow, input.Instance, ApiVersionPrefix);
 
-            var queryParams = new List<string>();
-            if (!string.IsNullOrEmpty(input.Version))
-            {
-                queryParams.Add($"version={Uri.EscapeDataString(input.Version)}");
-            }
-
-            if (input.Extensions?.Length > 0)
-            {
-                foreach (var ext in input.Extensions)
-                {
-                    queryParams.Add($"{nameof(input.Extensions).ToLowerInvariant()}={Uri.EscapeDataString(ext)}");
-                }
-            }
-
-            if (queryParams.Count > 0)
-                relativePath += "?" + string.Join("&", queryParams);
-
             var requestUri = new Uri(endpoint.BaseUrl, relativePath.TrimStart('/'));
             using var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
             var forwardHeaders = currentUser.ToForwardHeaders();

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceHistoryTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceHistoryTests.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.DependencyInjection;
+using BBT.Aether.MultiSchema;
+using BBT.Aether.Uow;
+using BBT.Workflow.Authorization;
+using BBT.Workflow.Caching;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Gateway;
+using BBT.Workflow.RepresentationEtag;
+using BBT.Workflow.Runtime;
+using BBT.Workflow.Scripting;
+using BBT.Workflow.Tasks.Coordinator;
+using BBT.Workflow.Extentions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Instances;
+
+/// <summary>
+/// Unit tests for InstanceQueryAppService.GetInstanceHistoryAsync.
+/// Verifies that the response contains the actual state transitions
+/// (InstanceTransition entities) instead of instance data versions.
+/// </summary>
+public class InstanceQueryAppServiceHistoryTests : IDisposable
+{
+    private const string TestDomain = "test-domain";
+    private const string TestWorkflow = "test-flow";
+    private const string TestVersion = "1.0.0";
+
+    private readonly IRuntimeInfoProvider _runtimeInfoProvider;
+    private readonly IInstanceRepository _instanceRepository;
+    private readonly IInstanceTransitionRepository _instanceTransitionRepository;
+    private readonly InstanceQueryAppService _service;
+    private readonly IServiceProvider _ambientServiceProvider;
+    private readonly IServiceProvider? _previousAmbientServiceProvider;
+
+    public InstanceQueryAppServiceHistoryTests()
+    {
+        _runtimeInfoProvider = Substitute.For<IRuntimeInfoProvider>();
+        _instanceRepository = Substitute.For<IInstanceRepository>();
+        _instanceTransitionRepository = Substitute.For<IInstanceTransitionRepository>();
+
+        var mockUoW = Substitute.For<IUnitOfWork>();
+        var mockUoWManager = Substitute.For<IUnitOfWorkManager>();
+        mockUoWManager
+            .BeginAsync(Arg.Any<UnitOfWorkOptions>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(mockUoW));
+
+        var services = new ServiceCollection();
+        services.AddSingleton(mockUoWManager);
+        _ambientServiceProvider = services.BuildServiceProvider();
+
+        _previousAmbientServiceProvider = AmbientServiceProvider.Current;
+        AmbientServiceProvider.Current = _ambientServiceProvider;
+
+        _service = new InstanceQueryAppService(
+            serviceProvider: _ambientServiceProvider,
+            runtimeInfoProvider: _runtimeInfoProvider,
+            componentCacheStore: Substitute.For<IComponentCacheStore>(),
+            instanceRepository: _instanceRepository,
+            instanceTransitionRepository: _instanceTransitionRepository,
+            instanceCorrelationRepository: Substitute.For<IInstanceCorrelationRepository>(),
+            instanceExtensionService: Substitute.For<IInstanceExtensionService>(),
+            scriptContextFactory: Substitute.For<IScriptContextFactory>(),
+            instanceQueryGateway: Substitute.For<IInstanceQueryGateway>(),
+            viewContentResolutionService: Substitute.For<IViewContentResolutionService>(),
+            taskConditionService: Substitute.For<ITaskConditionService>(),
+            urlTemplateBuilder: Substitute.For<IUrlTemplateBuilder>(),
+            currentSchema: Substitute.For<ICurrentSchema>(),
+            transitionAuthorizationManager: Substitute.For<ITransitionAuthorizationManager>(),
+            representationEtagService: Substitute.For<IRepresentationEtagService>(),
+            schemaFieldFilterService: Substitute.For<ISchemaFieldFilterService>(),
+            paginationLinkGenerator: Substitute.For<BBT.Aether.Application.Pagination.IPaginationLinkGenerator>(),
+            logger: Substitute.For<ILogger<InstanceQueryAppService>>());
+    }
+
+    public void Dispose()
+    {
+        AmbientServiceProvider.Current = _previousAmbientServiceProvider;
+        (_ambientServiceProvider as IDisposable)?.Dispose();
+    }
+
+    [Fact]
+    public async Task GetInstanceHistoryAsync_WhenInstanceNotFound_ReturnsFailure()
+    {
+        var input = new GetInstanceHistoryInput
+        {
+            Domain = TestDomain,
+            Workflow = TestWorkflow,
+            Instance = Guid.NewGuid().ToString()
+        };
+
+        _instanceRepository
+            .FindByIdentifierAsReadOnlyAsync(input.Instance, Arg.Any<CancellationToken>())
+            .Returns((Instance?)null);
+
+        var result = await _service.GetInstanceHistoryAsync(input, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeFalse();
+        await _instanceTransitionRepository.DidNotReceive()
+            .GetByInstanceIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetInstanceHistoryAsync_WhenInstanceFound_MapsTransitionsToDto()
+    {
+        var instance = Instance.Create(Guid.NewGuid(), TestWorkflow, TestVersion, "test-key");
+
+        var t1 = InstanceTransition.Create(
+            id: Guid.NewGuid(),
+            instanceId: instance.Id,
+            transitionId: "approve",
+            fromState: "draft",
+            triggerType: TriggerType.Manual,
+            body: new JsonData("{\"amount\":100}"),
+            header: new JsonData("{\"x-request-id\":\"abc\"}"));
+        t1.Completed("approved");
+
+        var t2 = InstanceTransition.Create(
+            id: Guid.NewGuid(),
+            instanceId: instance.Id,
+            transitionId: "complete",
+            fromState: "approved",
+            triggerType: TriggerType.Automatic,
+            body: new JsonData("{}"),
+            header: new JsonData("{}"));
+
+        _instanceRepository
+            .FindByIdentifierAsReadOnlyAsync(instance.Id.ToString(), Arg.Any<CancellationToken>())
+            .Returns(instance);
+
+        _instanceTransitionRepository
+            .GetByInstanceIdAsync(instance.Id, Arg.Any<CancellationToken>())
+            .Returns(new List<InstanceTransition> { t1, t2 });
+
+        var input = new GetInstanceHistoryInput
+        {
+            Domain = TestDomain,
+            Workflow = TestWorkflow,
+            Instance = instance.Id.ToString()
+        };
+
+        var result = await _service.GetInstanceHistoryAsync(input, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        var output = result.Value!;
+        output.Transitions.Count.ShouldBe(2);
+
+        var first = output.Transitions[0];
+        first.Id.ShouldBe(t1.Id);
+        first.TransitionId.ShouldBe("approve");
+        first.FromState.ShouldBe("draft");
+        first.ToState.ShouldBe("approved");
+        first.TriggerType.ShouldBe(TriggerType.Manual);
+        first.FinishedAt.ShouldNotBeNull();
+        first.DurationSeconds.ShouldNotBeNull();
+
+        var second = output.Transitions[1];
+        second.TransitionId.ShouldBe("complete");
+        second.FromState.ShouldBe("approved");
+        second.ToState.ShouldBeNull();
+        second.FinishedAt.ShouldBeNull();
+        second.DurationSeconds.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetInstanceHistoryAsync_WhenNoTransitions_ReturnsEmptyList()
+    {
+        var instance = Instance.Create(Guid.NewGuid(), TestWorkflow, TestVersion, "test-key");
+
+        _instanceRepository
+            .FindByIdentifierAsReadOnlyAsync(instance.Id.ToString(), Arg.Any<CancellationToken>())
+            .Returns(instance);
+
+        _instanceTransitionRepository
+            .GetByInstanceIdAsync(instance.Id, Arg.Any<CancellationToken>())
+            .Returns(new List<InstanceTransition>());
+
+        var input = new GetInstanceHistoryInput
+        {
+            Domain = TestDomain,
+            Workflow = TestWorkflow,
+            Instance = instance.Id.ToString()
+        };
+
+        var result = await _service.GetInstanceHistoryAsync(input, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.Transitions.ShouldBeEmpty();
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceStateTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceStateTests.cs
@@ -76,6 +76,7 @@ public class InstanceQueryAppServiceStateTests : IDisposable
             runtimeInfoProvider: _runtimeInfoProvider,
             componentCacheStore: _componentCacheStore,
             instanceRepository: _instanceRepository,
+            instanceTransitionRepository: Substitute.For<IInstanceTransitionRepository>(),
             instanceCorrelationRepository: Substitute.For<IInstanceCorrelationRepository>(),
             instanceExtensionService: Substitute.For<IInstanceExtensionService>(),
             scriptContextFactory: Substitute.For<IScriptContextFactory>(),
@@ -87,6 +88,7 @@ public class InstanceQueryAppServiceStateTests : IDisposable
             transitionAuthorizationManager: Substitute.For<ITransitionAuthorizationManager>(),
             representationEtagService: _representationEtagService,
             schemaFieldFilterService: Substitute.For<ISchemaFieldFilterService>(),
+            paginationLinkGenerator: Substitute.For<BBT.Aether.Application.Pagination.IPaginationLinkGenerator>(),
             logger: Substitute.For<ILogger<InstanceQueryAppService>>());
     }
 

--- a/test/BBT.Workflow.Application.Tests/Tasks/Executors/GetInstancesTaskExecutorTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Tasks/Executors/GetInstancesTaskExecutorTests.cs
@@ -34,8 +34,19 @@ public sealed class GetInstancesTaskExecutorTests
         return new TaskExecutorContext(task, onExecute, scriptContext, null, TaskTrigger.OnExecute);
     }
 
+    private static GetInstancesTaskExecutor CreateExecutor(
+        IInstanceQueryGateway gateway,
+        IRuntimeInfoProvider runtime)
+        => new(
+            Substitute.For<IScriptEngine>(),
+            runtime,
+            Substitute.For<IRemoteInvokerService>(),
+            gateway,
+            Substitute.For<IDomainDiscoveryResolver>(),
+            NullLogger<GetInstancesTaskExecutor>.Instance);
+
     [Fact]
-    public async Task ExecuteAsync_WhenListReturnsGroups_SkipsGetInstanceData_AndReturnsGroupedMetadata()
+    public async Task ExecuteAsync_WhenListReturnsGroups_ReturnsGroupedMetadata_AndPassesThroughResponse()
     {
         var task = WorkflowTaskFactory.CreateGetInstancesTask(
             domain: "test-domain",
@@ -54,18 +65,7 @@ public sealed class GetInstancesTaskExecutorTests
         var runtime = Substitute.For<IRuntimeInfoProvider>();
         runtime.Domain.Returns("test-domain");
 
-        var urlBuilder = Substitute.For<IUrlTemplateBuilder>();
-        urlBuilder.BuildFunctionListUrl("test-domain", "test-flow", "data")
-            .Returns("/api/test-domain/workflows/test-flow/functions/data");
-
-        var executor = new GetInstancesTaskExecutor(
-            Substitute.For<IScriptEngine>(),
-            runtime,
-            Substitute.For<IRemoteInvokerService>(),
-            gateway,
-            Substitute.For<IDomainDiscoveryResolver>(),
-            urlBuilder,
-            NullLogger<GetInstancesTaskExecutor>.Instance);
+        var executor = CreateExecutor(gateway, runtime);
 
         var result = await executor.ExecuteAsync(CreateContext(task), CancellationToken.None);
 
@@ -85,7 +85,7 @@ public sealed class GetInstancesTaskExecutorTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_WhenListReturnsInstances_CallsGetInstanceDataPerItem()
+    public async Task ExecuteAsync_WhenListReturnsInstances_ReturnsResponseAsIs_WithoutGroupedFlag()
     {
         var task = WorkflowTaskFactory.CreateGetInstancesTask(domain: "test-domain", flow: "test-flow");
 
@@ -96,77 +96,19 @@ public sealed class GetInstancesTaskExecutorTests
         var gateway = Substitute.For<IInstanceQueryGateway>();
         gateway.GetInstanceListAsync(Arg.Any<GetInstanceListInput>(), Arg.Any<CancellationToken>())
             .Returns(Result.Ok(listResponse));
-        gateway.GetInstanceDataAsync(
-                Arg.Is<GetInstanceDataInput>(i => i.Instance == "inst-1"),
-                Arg.Any<CancellationToken>())
-            .Returns(ConditionalResult<GetInstanceDataOutput>.Success(new GetInstanceDataOutput()));
 
         var runtime = Substitute.For<IRuntimeInfoProvider>();
         runtime.Domain.Returns("test-domain");
 
-        var urlBuilder = Substitute.For<IUrlTemplateBuilder>();
-        urlBuilder.BuildFunctionListUrl(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
-            .Returns("/fn/data");
-
-        var executor = new GetInstancesTaskExecutor(
-            Substitute.For<IScriptEngine>(),
-            runtime,
-            Substitute.For<IRemoteInvokerService>(),
-            gateway,
-            Substitute.For<IDomainDiscoveryResolver>(),
-            urlBuilder,
-            NullLogger<GetInstancesTaskExecutor>.Instance);
+        var executor = CreateExecutor(gateway, runtime);
 
         var result = await executor.ExecuteAsync(CreateContext(task), CancellationToken.None);
 
         result.IsSuccess.ShouldBeTrue();
-        await gateway.Received(1)
-            .GetInstanceDataAsync(
-                Arg.Is<GetInstanceDataInput>(i => i.Instance == "inst-1"),
-                Arg.Any<CancellationToken>());
-        result.Value!.Metadata!.ContainsKey("Grouped").ShouldBeFalse();
-    }
-
-    [Fact]
-    public async Task ExecuteAsync_WhenItemsAreJsonElements_DeserializesAsGroupSummaries()
-    {
-        var task = WorkflowTaskFactory.CreateGetInstancesTask(domain: "test-domain", flow: "test-flow");
-
-        var listResponse = new InstanceListWithGroupsResponse<GetInstanceOutput>
-        {
-            Items =
-            [
-                JsonSerializer.SerializeToElement(
-                    new GroupSummary { Name = "a", Count = 5 },
-                    JsonSerializerConstants.JsonOptions)
-            ]
-        };
-
-        var gateway = Substitute.For<IInstanceQueryGateway>();
-        gateway.GetInstanceListAsync(Arg.Any<GetInstanceListInput>(), Arg.Any<CancellationToken>())
-            .Returns(Result.Ok(listResponse));
-
-        var runtime = Substitute.For<IRuntimeInfoProvider>();
-        runtime.Domain.Returns("test-domain");
-
-        var urlBuilder = Substitute.For<IUrlTemplateBuilder>();
-        urlBuilder.BuildFunctionListUrl(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
-            .Returns("/fn/data");
-
-        var executor = new GetInstancesTaskExecutor(
-            Substitute.For<IScriptEngine>(),
-            runtime,
-            Substitute.For<IRemoteInvokerService>(),
-            gateway,
-            Substitute.For<IDomainDiscoveryResolver>(),
-            urlBuilder,
-            NullLogger<GetInstancesTaskExecutor>.Instance);
-
-        var result = await executor.ExecuteAsync(CreateContext(task), CancellationToken.None);
-
-        result.IsSuccess.ShouldBeTrue();
+        // The executor no longer fans out to GetInstanceDataAsync; it returns the list response as-is.
         await gateway.DidNotReceive()
             .GetInstanceDataAsync(Arg.Any<GetInstanceDataInput>(), Arg.Any<CancellationToken>());
-        result.Value!.Metadata!["Grouped"].ShouldBe(true);
+        result.Value!.Metadata!.ContainsKey("Grouped").ShouldBeFalse();
+        result.Value!.Metadata!["ItemCount"].ShouldBe(1);
     }
 }


### PR DESCRIPTION
## Summary
- Replace instance history endpoint to return actual state transitions (`InstanceTransitionDto`) instead of instance data versions, providing accurate audit trail of state changes
- Simplify `GetInstancesTaskExecutor` by removing per-item `GetInstanceData` fan-out calls — the list response is now returned as-is with pagination links generated server-side
- Move HATEOAS pagination link generation from the controller into `InstanceQueryAppService` using `IPaginationLinkGenerator`
- Add null-safety to `ScriptContext.Instance` across all trigger task executors to prevent NREs during local execution
- Downgrade SSL validation disabled logs from Warning to Debug across all remote invokers
- Bump AetherPackageVersion from 1.0.21 to 1.0.22

## Changes
- `InstanceQueryAppService.cs` — rewrote `GetInstanceHistoryAsync` to query `IInstanceTransitionRepository` and map to `InstanceTransitionDto`; moved pagination link generation into `GetInstanceListAsync`
- `GetInstancesTaskExecutor.cs` — removed `ProcessDataFunctionListAsync`, `TryMaterializeGroupSummaries`, and `IUrlTemplateBuilder` dependency; returns list response directly with metadata
- `InstanceController.cs` — removed HATEOAS link generation logic and unused `extensions`/`version` params from history endpoint
- `GetInstanceOutput.cs` — added `InstanceTransitionDto` class; changed `GetInstanceHistoryOutput.Transitions` type
- `IInstanceTransitionRepository.cs` / `EfCoreInstanceTransitionRepository.cs` — added `GetByInstanceIdAsync`
- `DirectTriggerTaskExecutor.cs`, `GetInstanceDataTaskExecutor.cs`, `StartTriggerTaskExecutor.cs`, `SubProcessTaskExecutor.cs` — null-safe `context.ScriptContext?.Instance?.Id`
- `*RemoteInvoker.cs`, `HttpTaskInvoker.cs` — SSL validation disabled log level changed to Debug
- `ScriptEngine.cs` — added `System.Text.Encodings.Web` assembly reference and namespace imports
- `GetInstancesTask.cs` — added `SetFilter(object?)` overload
- `InstanceCancellationService.cs` — replaced `Task.WhenAll` with sequential `foreach` for job cancellation
- New test: `InstanceQueryAppServiceHistoryTests.cs`; updated `InstanceQueryAppServiceStateTests.cs` and `GetInstancesTaskExecutorTests.cs`

## Test Plan
- [ ] Verify instance history endpoint returns state transitions (transitionId, fromState, toState, timestamps, duration) instead of data versions
- [ ] Verify instance list endpoint still returns correct HATEOAS pagination links
- [ ] Verify GetInstances task executor returns list response without per-item GetInstanceData calls
- [ ] Run existing and new unit tests (`InstanceQueryAppServiceHistoryTests`, `GetInstancesTaskExecutorTests`)
- [ ] Confirm no NRE when task executors run without an instance in ScriptContext

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Return instance history as state transition DTOs and simplify instance listing and pagination while improving safety, logging noise, and test coverage.

New Features:
- Expose instance history as a list of state transition DTOs with audit metadata instead of instance data versions.
- Generate HATEOAS pagination links for instance lists within InstanceQueryAppService using the shared pagination link generator.
- Allow GetInstancesTask definitions to accept object filters via a new SetFilter overload and support additional script engine assemblies/namespaces.

Bug Fixes:
- Prevent potential null reference exceptions in trigger task executors by treating ScriptContext.Instance as optional.
- Avoid possible issues with parallel job cancellation by processing instance and state transition job deletions sequentially.

Enhancements:
- Simplify GetInstancesTaskExecutor to return the instance list response directly with lightweight pagination metadata and no per-item data fan-out.
- Refine instance history querying by reading transitions from the InstanceTransitionRepository ordered by start time.
- Lower SSL validation disabled log messages from warning to debug across all remote invokers to reduce log noise.

Documentation:
- Document the new instance history behavior, including the InstanceTransitionDto shape and removal of extensions/version parameters.
- Add tests describing the new instance history behavior and the simplified GetInstances task executor behavior.

Tests:
- Add dedicated tests for GetInstanceHistoryAsync to verify transition-based history responses.
- Update GetInstancesTaskExecutor tests to assert passthrough behavior, grouping metadata, and item counts.
- Adjust existing InstanceQueryAppService state tests to account for new dependencies such as the transition repository and pagination link generator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **API Updates**
  * Instance history endpoint simplified: no longer accepts `extensions` or `version` query parameters.
  * Instance history responses now explicitly return state transitions with transition metadata (ID, states, timestamps, duration).
  * Removed automatic pagination link generation from instance list responses.

* **Improvements**
  * Enhanced error handling robustness across task execution paths.
  * Script engine now supports additional encoding and Unicode libraries.
  * Reduced logging verbosity for SSL certificate validation messages.

* **Documentation**
  * Updated instance history API documentation to reflect response structure changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->