### PR TITLE
feat(timeout): add dynamic mapping support for flow timeout scheduling

### DIFF
--- a/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
@@ -21,7 +21,9 @@ using BBT.Workflow.Execution.Validation;
 using BBT.Workflow.Extentions;
 using BBT.Workflow.Headers;
 using BBT.Workflow.Runtime;
+using BBT.Workflow.Definitions.Timer;
 using BBT.Workflow.Scripting;
+using BBT.Workflow.Tasks.Evaluation;
 using Dapr.Jobs.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
@@ -50,6 +52,7 @@ public sealed class InstanceCommandAppService(
     ISchemaFieldFilterService schemaFieldFilterService,
     IInstanceExtensionService instanceExtensionService,
     IScriptContextFactory scriptContextFactory,
+    ITimerEvaluator timerEvaluator,
     ILogger<InstanceCommandAppService> logger)
     : ApplicationService(serviceProvider), IInstanceCommandAppService
 {
@@ -300,6 +303,8 @@ public sealed class InstanceCommandAppService(
     /// <summary>
     /// Schedules a workflow timeout job if the workflow has a timeout configuration.
     /// When extraProperties contains a timeout override (set by SubflowStarter), it takes precedence over the workflow's own timeout.
+    /// When a mapping script is configured, it is evaluated to determine the timeout schedule dynamically.
+    /// If mapping fails, the static Timer.Duration is used as fallback.
     /// </summary>
     private async Task ScheduleWorkflowTimeoutIfConfiguredAsync(
         Definitions.Workflow workflow,
@@ -338,19 +343,23 @@ public sealed class InstanceCommandAppService(
                 TraceState = activity?.TraceStateString
             };
 
-            // Parse ISO 8601 duration string to TimeSpan
-            var timeoutDuration = System.Xml.XmlConvert.ToTimeSpan(effectiveTimeout.Timer.Duration);
+            var resolvedSchedule = await ResolveTimeoutScheduleAsync(
+                effectiveTimeout, workflow, instance, cancellationToken);
 
-            // Calculate timeout schedule - workflow timeout should be evaluated from creation time
-            var timeoutDateTime = DateTime.UtcNow.Add(timeoutDuration);
-            var schedule = DaprJobSchedule.FromDateTime(timeoutDateTime).ExpressionValue;
+            var schedule = resolvedSchedule.ToDaprJobSchedule().ExpressionValue;
+
+            var timeoutAt = resolvedSchedule.ScheduleType == TimerScheduleType.DateTime
+                ? resolvedSchedule.ScheduledDateTime!.Value
+                : resolvedSchedule.Duration.HasValue
+                    ? DateTime.UtcNow.Add(resolvedSchedule.Duration.Value)
+                    : DateTime.UtcNow;
 
             var metadata = new Dictionary<string, object>
             {
                 ["domain"] = workflow.Domain,
                 ["flowName"] = workflow.Key,
                 ["instanceId"] = instance.Id.ToString(),
-                ["timeoutAt"] = timeoutDateTime.ToString("O")
+                ["timeoutAt"] = timeoutAt.ToString("O")
             };
 
             // Enqueue the timeout job
@@ -375,13 +384,53 @@ public sealed class InstanceCommandAppService(
                 true,
                 cancellationToken);
 
-            logger.WorkflowTimeoutScheduled(instance.Id, effectiveTimeout.Timer.Duration, timeoutDateTime);
+            logger.WorkflowTimeoutScheduled(instance.Id, effectiveTimeout.Timer.Duration, timeoutAt);
         }
         catch (Exception ex)
         {
             logger.WorkflowTimeoutSchedulingFailed(ex, instance.Id);
             // Don't throw - timeout scheduling failure should not prevent workflow start
         }
+    }
+
+    /// <summary>
+    /// Resolves the timeout schedule, trying mapping first (if configured) with static duration as fallback.
+    /// </summary>
+    private async Task<TimerSchedule> ResolveTimeoutScheduleAsync(
+        WorkflowTimeout effectiveTimeout,
+        Definitions.Workflow workflow,
+        Instance instance,
+        CancellationToken cancellationToken)
+    {
+        if (effectiveTimeout.Mapping != null)
+        {
+            var scriptContext = await scriptContextFactory.NewBuilder(instanceRepository)
+                .WithWorkflow(workflow)
+                .WithInstance(instance)
+                .WithRuntime(runtimeInfoProvider)
+                .WithTransition(effectiveTimeout.Key)
+                .WithBody(instance.LatestData?.Data ?? new JsonData("{}"))
+                .BuildAsync(cancellationToken);
+
+            var mappingResult = await timerEvaluator.EvaluateAsync(
+                effectiveTimeout.Mapping, scriptContext, cancellationToken);
+
+            if (mappingResult.IsSuccess)
+            {
+                logger.TimeoutMappingResolved(instance.Id, mappingResult.Value!.ScheduleType.ToString());
+                return mappingResult.Value!;
+            }
+
+            logger.TimeoutMappingFallback(
+                instance.Id,
+                effectiveTimeout.Timer.Duration,
+                mappingResult.Error.Message ?? mappingResult.Error.Code);
+        }
+
+        // Static fallback: parse ISO 8601 duration
+        var timeoutDuration = System.Xml.XmlConvert.ToTimeSpan(effectiveTimeout.Timer.Duration);
+        var timeoutDateTime = DateTime.UtcNow.Add(timeoutDuration);
+        return TimerSchedule.FromDateTime(timeoutDateTime);
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Domain/Definitions/Validators/WorkflowValidator.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Validators/WorkflowValidator.cs
@@ -80,6 +80,13 @@ public class WorkflowValidator
                     $"The 'target' value in the timeout does not match any state '{workflow.Timeout.Target}'.",
                     [$"{nameof(Workflow)}.{nameof(WorkflowTimeout)}.{nameof(WorkflowTimeout.Target)}"]));
             }
+
+            if (workflow.Timeout.Mapping != null && workflow.Timeout.Timer == null)
+            {
+                result.AddError(new ValidationResult(
+                    "When timeout mapping is defined, static timer configuration is also required as fallback.",
+                    [$"{nameof(Workflow)}.{nameof(WorkflowTimeout)}.{nameof(WorkflowTimeout.Timer)}"]));
+            }
         }
     }
 

--- a/src/BBT.Workflow.Domain/Definitions/WorkflowTimeout.cs
+++ b/src/BBT.Workflow.Domain/Definitions/WorkflowTimeout.cs
@@ -19,13 +19,15 @@ public sealed class WorkflowTimeout : IHasKey
         string key,
         string target,
         VersionStrategy versionStrategy,
-        TimerConfig timer
+        TimerConfig timer,
+        ScriptCode? mapping = null
     )
     {
         Key = Check.NotNullOrWhiteSpace(key, nameof(Key), WorkflowConstants.MaxKeyLength);
         Target = Check.NotNullOrWhiteSpace(target, nameof(Target), StateConstants.MaxKeyLength);
         VersionStrategy = versionStrategy;
         Timer = timer;
+        Mapping = mapping;
     }
 
     /// <summary>
@@ -46,19 +48,28 @@ public sealed class WorkflowTimeout : IHasKey
 
     public TimerConfig Timer { get; private set; }
 
+    /// <summary>
+    /// Optional mapping script for dynamic timeout duration calculation.
+    /// When provided, the script is executed at runtime to determine the timeout schedule.
+    /// If the mapping fails (compile or runtime error), the static Timer.Duration is used as fallback.
+    /// </summary>
+    public ScriptCode? Mapping { get; private set; }
+
     public static WorkflowTimeout Create(
         string key,
         string target,
         string versionStrategy,
         string reset,
-        string duration
+        string duration,
+        ScriptCode? mapping = null
     )
     {
         return new WorkflowTimeout(
             key,
             target,
             VersionStrategy.FromCode(versionStrategy),
-            new TimerConfig(reset, duration)
+            new TimerConfig(reset, duration),
+            mapping
         );
     }
 }

--- a/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
@@ -969,6 +969,31 @@ public static partial class WorkflowLogs
         Guid instanceId);
 
     /// <summary>
+    /// Logs when timeout mapping script fails and static timer duration is used as fallback.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 40100,
+        Level = LogLevel.Warning,
+        Message = "Timeout mapping failed for instance {InstanceId}, falling back to static duration {Duration}. Error: {ErrorMessage}")]
+    public static partial void TimeoutMappingFallback(
+        this ILogger logger,
+        Guid instanceId,
+        string duration,
+        string errorMessage);
+
+    /// <summary>
+    /// Logs when timeout mapping script executes successfully.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 40101,
+        Level = LogLevel.Information,
+        Message = "Timeout mapping resolved for instance {InstanceId}, schedule type: {ScheduleType}")]
+    public static partial void TimeoutMappingResolved(
+        this ILogger logger,
+        Guid instanceId,
+        string scheduleType);
+
+    /// <summary>
     /// Logs when workflow definition is not found.
     /// </summary>
     [LoggerMessage(

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceVersionTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceVersionTests.cs
@@ -100,6 +100,7 @@ public class InstanceQueryAppServiceVersionTests : IDisposable
             runtimeInfoProvider: _runtimeInfoProvider,
             componentCacheStore: _componentCacheStore,
             instanceRepository: _instanceRepository,
+            instanceTransitionRepository: Substitute.For<IInstanceTransitionRepository>(),
             instanceCorrelationRepository: Substitute.For<IInstanceCorrelationRepository>(),
             instanceExtensionService: _instanceExtensionService,
             scriptContextFactory: _scriptContextFactory,
@@ -111,6 +112,7 @@ public class InstanceQueryAppServiceVersionTests : IDisposable
             transitionAuthorizationManager: Substitute.For<ITransitionAuthorizationManager>(),
             representationEtagService: _representationEtagService,
             schemaFieldFilterService: _schemaFieldFilterService,
+            paginationLinkGenerator: Substitute.For<BBT.Aether.Application.Pagination.IPaginationLinkGenerator>(),
             logger: Substitute.For<ILogger<InstanceQueryAppService>>());
     }
 

--- a/test/BBT.Workflow.Domain.Tests/Definitions/Validators/WorkflowValidatorTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Definitions/Validators/WorkflowValidatorTests.cs
@@ -194,6 +194,148 @@ public class WorkflowValidatorTests : DomainTestBase<DomainEntryPoint>
 
     #endregion
 
+    #region Timeout Mapping Validation Tests
+
+    [Fact]
+    public void Validate_ShouldPass_WhenTimeoutHasMappingAndStaticTimer()
+    {
+        var workflow = DeserializeWorkflow("""
+        {
+            "type": "F",
+            "labels": [{"label": "Test", "language": "en"}],
+            "timeout": {
+                "key": "$timeout",
+                "target": "timed-out",
+                "versionStrategy": "None",
+                "timer": {"reset": "false", "duration": "PT1H"},
+                "mapping": {"location": "inline", "code": "dHJ1ZQ=="}
+            },
+            "states": [
+                {
+                    "key": "initial",
+                    "stateType": "initial",
+                    "labels": [{"label": "Initial", "language": "en"}],
+                    "transitions": []
+                },
+                {
+                    "key": "timed-out",
+                    "stateType": "finish",
+                    "labels": [{"label": "Timed Out", "language": "en"}],
+                    "transitions": []
+                }
+            ],
+            "sharedTransitions": [],
+            "startTransition": {
+                "key": "start",
+                "target": "initial",
+                "triggerType": "manual",
+                "labels": [{"label": "Start", "language": "en"}]
+            }
+        }
+        """);
+
+        var result = _validator.Validate(workflow);
+
+        var timeoutErrors = result.ValidationErrors
+            .Where(e => e.ErrorMessage!.Contains("timeout mapping", StringComparison.OrdinalIgnoreCase) ||
+                        e.ErrorMessage!.Contains("static timer", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        timeoutErrors.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Validate_ShouldPass_WhenTimeoutHasStaticTimerOnly()
+    {
+        var workflow = DeserializeWorkflow("""
+        {
+            "type": "F",
+            "labels": [{"label": "Test", "language": "en"}],
+            "timeout": {
+                "key": "$timeout",
+                "target": "timed-out",
+                "versionStrategy": "None",
+                "timer": {"reset": "false", "duration": "PT30M"}
+            },
+            "states": [
+                {
+                    "key": "initial",
+                    "stateType": "initial",
+                    "labels": [{"label": "Initial", "language": "en"}],
+                    "transitions": []
+                },
+                {
+                    "key": "timed-out",
+                    "stateType": "finish",
+                    "labels": [{"label": "Timed Out", "language": "en"}],
+                    "transitions": []
+                }
+            ],
+            "sharedTransitions": [],
+            "startTransition": {
+                "key": "start",
+                "target": "initial",
+                "triggerType": "manual",
+                "labels": [{"label": "Start", "language": "en"}]
+            }
+        }
+        """);
+
+        var result = _validator.Validate(workflow);
+
+        var timeoutErrors = result.ValidationErrors
+            .Where(e => e.ErrorMessage!.Contains("timeout", StringComparison.OrdinalIgnoreCase) &&
+                        e.ErrorMessage!.Contains("timer", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        timeoutErrors.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Validate_ShouldFail_WhenTimeoutHasMappingButNoTimer()
+    {
+        var workflow = DeserializeWorkflow("""
+        {
+            "type": "F",
+            "labels": [{"label": "Test", "language": "en"}],
+            "timeout": {
+                "key": "$timeout",
+                "target": "timed-out",
+                "versionStrategy": "None",
+                "mapping": {"location": "inline", "code": "dHJ1ZQ=="}
+            },
+            "states": [
+                {
+                    "key": "initial",
+                    "stateType": "initial",
+                    "labels": [{"label": "Initial", "language": "en"}],
+                    "transitions": []
+                },
+                {
+                    "key": "timed-out",
+                    "stateType": "finish",
+                    "labels": [{"label": "Timed Out", "language": "en"}],
+                    "transitions": []
+                }
+            ],
+            "sharedTransitions": [],
+            "startTransition": {
+                "key": "start",
+                "target": "initial",
+                "triggerType": "manual",
+                "labels": [{"label": "Start", "language": "en"}]
+            }
+        }
+        """);
+
+        var result = _validator.Validate(workflow);
+
+        result.IsValid.ShouldBeFalse();
+        result.ValidationErrors.ShouldContain(e =>
+            e.ErrorMessage!.Contains("static timer configuration is also required as fallback",
+                StringComparison.OrdinalIgnoreCase));
+    }
+
+    #endregion
+
     #region Helper Methods
 
     private WorkflowDefinition CreateWorkflowWithDefaultAutoTransition()


### PR DESCRIPTION
## Summary
- Add `ScriptCode? Mapping` property to `WorkflowTimeout` for dynamic timeout duration via `ITimerMapping` scripts
- When mapping is defined and succeeds, use the script result; on failure, fall back to the static `Timer.Duration`
- Enforce via validator that static timer config is always required when mapping is present (fallback guarantee)

## Changes
- `src/BBT.Workflow.Domain/Definitions/WorkflowTimeout.cs` — add `Mapping` property, update constructor and factory method
- `src/BBT.Workflow.Domain/Definitions/Validators/WorkflowValidator.cs` — validate Timer is required when Mapping is set
- `src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs` — inject `ITimerEvaluator`, add `ResolveTimeoutScheduleAsync` with mapping-first + static fallback
- `src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs` — add `TimeoutMappingFallback` and `TimeoutMappingResolved` log messages
- `test/BBT.Workflow.Domain.Tests/Definitions/Validators/WorkflowValidatorTests.cs` — 3 new timeout mapping validation tests
- `test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceVersionTests.cs` — fix missing constructor params

## Test Plan
- [ ] Publish a flow with timeout + mapping + static timer — verify validation passes
- [ ] Publish a flow with timeout + mapping but no static timer — verify validation rejects
- [ ] Start an instance with timeout mapping — verify dynamic schedule is used when mapping succeeds
- [ ] Simulate mapping failure — verify static duration fallback and warning log
- [ ] Run `dotnet test` on WorkflowValidatorTests and InstanceQueryAppServiceVersionTests — all green

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Add support for dynamically scheduled workflow timeouts via optional mapping scripts with static timer fallback and logging.

New Features:
- Allow workflow timeouts to specify an optional mapping script for dynamic timeout schedule calculation.
- Introduce timeout schedule resolution in instance command handling that evaluates mapping scripts first and falls back to static timer duration.

Bug Fixes:
- Fix instance query application tests by providing all required constructor dependencies.

Enhancements:
- Validate that a static timer configuration is present whenever a timeout mapping script is defined.
- Extend workflow logging with events for successful timeout mapping resolution and fallback to static duration on mapping failure.

Tests:
- Add validator tests covering timeout configurations with mapping plus static timer, static-only timer, and mapping without timer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Workflows now support dynamic timeout scheduling through configurable script mapping, with automatic fallback to static timer duration when mapping execution fails.

* **Improvements**
  * Enhanced validation ensures timeout mapping is properly paired with static timer fallback configuration.
  * Added detailed logging for timeout mapping resolution success and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->