### PR TITLE
add filter to  "CreatedBy",

### DIFF
--- a/docs/features/instance-filtering.md
+++ b/docs/features/instance-filtering.md
@@ -72,6 +72,14 @@ Alternatively, pass `groupBy` and `aggregations` as query parameters:
 ?filter={"status":{"eq":"Active"}}&groupBy={"field":"attributes.status"}&aggregations={"count":true}
 ```
 
+`groupBy.field` / `groupBy.fields` may use JSON paths (`attributes.*`) or any **instance column** that is filterable on the `Instances` table (same whitelist as top-level GraphQL filters). Example grouping by creator:
+
+```
+?groupBy={"field":"createdBy"}&aggregations={"count":true}
+```
+
+You can combine instance-column filters with JSON or instance `groupBy` keys in one request.
+
 **Format precedence:** If any `filter` value is GraphQL JSON, the request is handled as GraphQL format.
 
 ### URL Encoding
@@ -99,6 +107,10 @@ Filters can target these Instance columns:
 | `modifiedAt` | Modification timestamp |
 | `completedAt` | Completion timestamp |
 | `isTransient` | Boolean flag |
+| `createdBy` | Creator user identifier |
+| `createdByBehalfOf` | Behalf-of user at creation |
+| `modifiedBy` | Last modifier user identifier |
+| `modifiedByBehalfOf` | Behalf-of user at last modification |
 
 ### JSON Attributes
 
@@ -140,6 +152,10 @@ Instance list results can be sorted via the `sort` or `orderBy` query parameter 
 | `status` | Instance status |
 | `key` | Instance key |
 | `currentState` / `state` | Current state (state is alias) |
+| `createdBy` | Creator user identifier |
+| `createdByBehalfOf` | Behalf-of user at creation |
+| `modifiedBy` | Last modifier user identifier |
+| `modifiedByBehalfOf` | Behalf-of user at last modification |
 | `attributes.fieldName` | JSON attribute (path into `InstancesData.Data`); nested paths supported (e.g. `attributes.nested.path`) |
 
 Instance columns are applied in the database; `attributes.*` ordering uses the latest instance data JSON and is subject to the same schema/security as filtering.

--- a/src/BBT.Workflow.Domain/QueryExtensions/GraphQL/GraphQLAggregationService.cs
+++ b/src/BBT.Workflow.Domain/QueryExtensions/GraphQL/GraphQLAggregationService.cs
@@ -1,5 +1,6 @@
 using System.Data;
 using System.Text;
+using BBT.Workflow.Definitions;
 using Microsoft.EntityFrameworkCore;
 using Npgsql;
 using NpgsqlTypes;
@@ -107,13 +108,19 @@ public static class GraphQLAggregationService
         var parameters = new List<NpgsqlParameter>();
         var parameterIndex = 0;
 
-        var (selectClause, groupByClause) = BuildGroupBySelectClause(
+        var (selectClause, groupByClause, needsInstanceJoin) = BuildGroupBySelectClause(
             groupByFields, groupBy.Aggregations ?? new AggregationRequest { Count = true }, jsonColumnName);
 
         var (jsonWhereClause, instanceWhereClause) = GraphQLJsonFilterService.BuildSeparatedWhereClausesForSql(
             filterNode, jsonColumnName, parameters, ref parameterIndex, schemaContext: schemaContext);
 
-        var sql = BuildAggregationSql(selectClause, jsonWhereClause, instanceWhereClause, groupByClause, schema);
+        var sql = BuildAggregationSql(
+            selectClause,
+            jsonWhereClause,
+            instanceWhereClause,
+            groupByClause,
+            schema,
+            forceInstanceJoin: needsInstanceJoin);
 
         using var connection = dbContext.Database.GetDbConnection();
         if (connection.State != ConnectionState.Open)
@@ -212,19 +219,32 @@ public static class GraphQLAggregationService
         return (string.Join(", ", selectParts), null);
     }
 
-    private static (string selectClause, string groupByClause) BuildGroupBySelectClause(
+    internal static (string selectClause, string groupByClause, bool needsInstanceJoin) BuildGroupBySelectClause(
         List<string> groupByFields,
         AggregationRequest aggregations,
         string jsonColumnName)
     {
         var selectParts = new List<string>();
         var groupByParts = new List<string>();
+        var needsInstanceJoin = false;
 
         // Add group by fields to select
         foreach (var field in groupByFields)
         {
-            var alias = SanitizeAlias(field);
-            var accessor = BuildJsonTextAccessor(field, jsonColumnName);
+            var trimmed = field.Trim();
+            var alias = SanitizeAlias(trimmed);
+            string accessor;
+            if (InstanceFieldDiscriminator.IsInstanceColumn(trimmed))
+            {
+                var columnName = InstanceFieldDiscriminator.GetInstanceColumnName(trimmed);
+                accessor = $"s.\"{columnName}\"";
+                needsInstanceJoin = true;
+            }
+            else
+            {
+                accessor = BuildJsonTextAccessor(trimmed, jsonColumnName);
+            }
+
             selectParts.Add($"{accessor} AS \"{alias}\"");
             groupByParts.Add(accessor);
         }
@@ -271,21 +291,26 @@ public static class GraphQLAggregationService
             selectParts.Add($"MAX({accessor}) AS max_result");
         }
 
-        return (string.Join(", ", selectParts), string.Join(", ", groupByParts));
+        return (string.Join(", ", selectParts), string.Join(", ", groupByParts), needsInstanceJoin);
     }
 
+    /// <summary>
+    /// Builds aggregation/groupBy SQL against <c>InstancesData</c> (alias <c>d</c> when joined) and optional <c>Instances</c> join (<c>s</c>).
+    /// </summary>
+    /// <param name="forceInstanceJoin">When true, always joins <c>Instances</c> as <c>s</c> (required when grouping or selecting instance columns).</param>
     internal static string BuildAggregationSql(
         string selectClause,
         string jsonWhereClause,
         string? instanceWhereClause,
         string? groupByClause,
-        string schema)
+        string schema,
+        bool forceInstanceJoin = false)
     {
         var sb = new StringBuilder();
 
         sb.AppendLine($@"SELECT {selectClause}");
 
-        var hasInstanceJoin = !string.IsNullOrEmpty(instanceWhereClause);
+        var hasInstanceJoin = forceInstanceJoin || !string.IsNullOrEmpty(instanceWhereClause);
         if (hasInstanceJoin)
         {
             sb.AppendLine($@"FROM ""{schema}"".""InstancesData"" d");

--- a/src/BBT.Workflow.Domain/QueryExtensions/InstanceFieldDiscriminator.cs
+++ b/src/BBT.Workflow.Domain/QueryExtensions/InstanceFieldDiscriminator.cs
@@ -24,7 +24,11 @@ public static class InstanceFieldDiscriminator
         "CompletedAt",
         "IsTransient",
         "EffectiveStateType",
-        "EffectiveStateSubType"
+        "EffectiveStateSubType",
+        "CreatedBy",
+        "CreatedByBehalfOf",
+        "ModifiedBy",
+        "ModifiedByBehalfOf"
     };
 
     /// <summary>

--- a/test/BBT.Workflow.Domain.Tests/QueryExtensions/GraphQL/GraphQLAggregationGroupByTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/QueryExtensions/GraphQL/GraphQLAggregationGroupByTests.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using BBT.Workflow.Definitions.GraphQL;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Domain.Tests.QueryExtensions.GraphQL;
+
+public sealed class GraphQLAggregationGroupByTests
+{
+    [Fact]
+    public void BuildGroupBySelectClause_InstanceColumn_UsesTableAccessorAndNeedsJoin()
+    {
+        var fields = new List<string> { "createdBy" };
+        var aggregations = new AggregationRequest { Count = true };
+
+        var (selectClause, groupByClause, needsInstanceJoin) =
+            GraphQLAggregationService.BuildGroupBySelectClause(fields, aggregations, "Data");
+
+        needsInstanceJoin.ShouldBeTrue();
+        selectClause.ShouldContain("s.\"CreatedBy\"");
+        groupByClause.ShouldContain("s.\"CreatedBy\"");
+        selectClause.ShouldContain("COUNT(*)");
+    }
+
+    [Fact]
+    public void BuildGroupBySelectClause_JsonField_KeepsJsonAccessorAndNoJoinRequired()
+    {
+        var fields = new List<string> { "attributes.status" };
+        var aggregations = new AggregationRequest { Count = true };
+
+        var (selectClause, groupByClause, needsInstanceJoin) =
+            GraphQLAggregationService.BuildGroupBySelectClause(fields, aggregations, "Data");
+
+        needsInstanceJoin.ShouldBeFalse();
+        selectClause.ShouldContain("\"Data\" ->> 'status'");
+        groupByClause.ShouldContain("\"Data\" ->> 'status'");
+    }
+
+    [Fact]
+    public void BuildGroupBySelectClause_MixedInstanceAndJson_NeedsJoin()
+    {
+        var fields = new List<string> { "modifiedBy", "attributes.region" };
+        var aggregations = new AggregationRequest { Count = true };
+
+        var (_, _, needsInstanceJoin) =
+            GraphQLAggregationService.BuildGroupBySelectClause(fields, aggregations, "Data");
+
+        needsInstanceJoin.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void BuildAggregationSql_GroupByOnlyInstanceColumn_ForceJoin_AddsInnerJoin()
+    {
+        var sql = GraphQLAggregationService.BuildAggregationSql(
+            "s.\"CreatedBy\" AS \"createdBy\", COUNT(*) AS count_result",
+            jsonWhereClause: string.Empty,
+            instanceWhereClause: null,
+            groupByClause: "s.\"CreatedBy\"",
+            schema: "wf",
+            forceInstanceJoin: true);
+
+        sql.ShouldContain("INNER JOIN \"wf\".\"Instances\" s");
+        sql.ShouldContain("FROM \"wf\".\"InstancesData\" d");
+        sql.ShouldContain("WHERE d.\"IsLatest\" = true");
+        sql.ShouldContain("GROUP BY s.\"CreatedBy\"");
+    }
+}

--- a/test/BBT.Workflow.Domain.Tests/QueryExtensions/InstanceColumnFilterTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/QueryExtensions/InstanceColumnFilterTests.cs
@@ -28,6 +28,11 @@ public class InstanceColumnFilterTests
     [InlineData("ModifiedAt", true)]
     [InlineData("CompletedAt", true)]
     [InlineData("IsTransient", true)]
+    [InlineData("CreatedBy", true)]
+    [InlineData("createdby", true)]
+    [InlineData("CreatedByBehalfOf", true)]
+    [InlineData("ModifiedBy", true)]
+    [InlineData("ModifiedByBehalfOf", true)]
     [InlineData("attributes", false)]
     [InlineData("triggerId", false)]
     [InlineData("customField", false)]
@@ -46,10 +51,15 @@ public class InstanceColumnFilterTests
     [InlineData("key", "Key")]
     [InlineData("Status", "Status")]
     [InlineData("status", "Status")]
-    [InlineData("State", "CurrentState")] // Alias mapping
-    [InlineData("state", "CurrentState")]
+    [InlineData("State", "EffectiveState")] // Alias mapping
+    [InlineData("state", "EffectiveState")]
     [InlineData("CreatedAt", "CreatedAt")]
     [InlineData("createdat", "CreatedAt")]
+    [InlineData("CreatedBy", "CreatedBy")]
+    [InlineData("createdby", "CreatedBy")]
+    [InlineData("CreatedByBehalfOf", "CreatedByBehalfOf")]
+    [InlineData("ModifiedBy", "ModifiedBy")]
+    [InlineData("ModifiedByBehalfOf", "ModifiedByBehalfOf")]
     public void GetInstanceColumnName_ShouldReturnProperCaseName(string input, string expected)
     {
         // Act


### PR DESCRIPTION
"CreatedByBehalfOf",
"ModifiedBy",
"ModifiedByBehalfOf"

## Summary by Sourcery

Support aggregations grouped by instance-level columns in GraphQL queries and document the new capabilities.

New Features:
- Allow GraphQL aggregation groupBy fields to reference instance columns in addition to JSON attributes, automatically joining the Instances table when required.

Enhancements:
- Extend instance field discrimination to include CreatedBy/CreatedByBehalfOf and ModifiedBy/ModifiedByBehalfOf and surface them consistently across filtering, sorting, and grouping APIs.

Documentation:
- Document support for using instance columns (including CreatedBy/BehalfOf and ModifiedBy/BehalfOf) in filters, sort/orderBy, and groupBy for instance aggregation endpoints.

Tests:
- Add unit tests covering instance-column detection and mapping for new fields and the GraphQL aggregation groupBy behavior with instance-only, JSON-only, and mixed fields.