### PR TITLE
feat(init): add replaceDomain parameter and cross-domain exclusion to…

### DIFF
--- a/init/VNext.Init.Host/README.md
+++ b/init/VNext.Init.Host/README.md
@@ -8,7 +8,8 @@ Node.js service for downloading npm packages and publishing them to the vnext AP
 - Processes component files (workflows, tasks, views, etc.)
 - Merges with custom components if available
 - **Automatic version generation** using extended SemVer format
-- **Full domain replacement** at all levels when `appDomain` is provided
+- **Opt-in domain replacement** via `replaceDomain: true` + `appDomain` (standard publish)
+- **Cross-domain exclusion** — components/references marked `crossDomain: true` are skipped during replacement
 - Publishes to vnext API endpoint
 - Provides REST API for package management
 - **Two specialized endpoints** for different package types
@@ -111,6 +112,7 @@ This endpoint is for publishing any npm package with optional domain replacement
   "packageName": "@my-org/my-workflow-package",
   "version": "latest",
   "appDomain": "my-domain",
+  "replaceDomain": true,
   "npmRegistry": "https://registry.npmjs.org/",
   "npmToken": "optional-token",
   "npmUsername": "optional-username",
@@ -122,7 +124,8 @@ This endpoint is for publishing any npm package with optional domain replacement
 | Field | Required | Description |
 |-------|----------|-------------|
 | `packageName` | ✅ **Yes** | The npm package name to download |
-| `appDomain` | No | If provided, replaces all domains. If omitted, no replacement. |
+| `replaceDomain` | No | Set `true` to enable domain replacement. Requires `appDomain`. Default: `false` |
+| `appDomain` | No | Target domain for replacement. Only used when `replaceDomain: true`. |
 | `version` | No | Package version (default: `latest`) |
 | `npmRegistry` | No | NPM registry URL |
 | `npmToken` | No | NPM token for token-based auth (npmjs.org compatible) |
@@ -171,27 +174,91 @@ This endpoint is for publishing any npm package with optional domain replacement
 | Feature | `/api/package/runtime/publish` | `/api/package/publish` |
 |---------|-------------------------------|------------------------|
 | Package | `@burgan-tech/vnext-core-runtime` only | Any npm package |
-| `appDomain` | ✅ **Required** | ⭕ Optional |
-| Domain Replacement | Always (when appDomain provided) | Only if appDomain provided |
+| `appDomain` | ✅ **Required** | ⭕ Only with `replaceDomain: true` |
+| `replaceDomain` | N/A (always active) | Set `true` to enable replacement |
+| Domain Replacement | Always (when appDomain provided) | Only if `replaceDomain: true` + `appDomain` |
+| Cross-domain exclusion | ✅ Yes | ✅ Yes |
 | Special Ordering | Yes (Workflows first, sys-flows first) | No |
 
 ---
 
 ## Domain Replacement
 
-When `appDomain` is provided, **ALL** domain fields are replaced at every level:
+### Standard Package (`/api/package/publish`)
+
+Domain replacement is **opt-in**. It is enabled only when **both** conditions are met:
+- `replaceDomain: true` is set in the request body
+- `appDomain` contains a non-empty target domain
+
+When enabled, **all** domain fields are replaced at every level:
 
 | Field | Replaced? |
 |-------|-----------|
-| Root `domain` | ✅ Yes |
-| `attributes.domain` | ✅ Yes |
-| `data[].domain` | ✅ Yes |
-| `data[].attributes.domain` | ✅ Yes |
-| Any nested `domain` field | ✅ Yes |
+| Root `domain` | ✅ Yes (unless `crossDomain: true` on root) |
+| `attributes.domain` | ✅ Yes (unless enclosing object has `crossDomain: true`) |
+| `data[].domain` | ✅ Yes (unless `crossDomain: true` on the data item) |
+| `data[].attributes.domain` | ✅ Yes (unless enclosing object has `crossDomain: true`) |
+| Any nested `domain` field | ✅ Yes (unless enclosing object has `crossDomain: true`) |
+| Any field inside `config` | ❌ Never (preserved as-is) |
+| Any field inside `process` | ❌ Never (preserved as-is) |
+
+### Runtime Package (`/api/package/runtime/publish`)
+
+Domain replacement is **always active** when `appDomain` is provided (required). The same cross-domain exclusion rules apply.
+
+### Cross-Domain Exclusion
+
+Components or references that intentionally target a different domain can opt out of domain replacement by setting `crossDomain: true` on the relevant object.
+
+**Root-level exclusion** — the entire component is skipped:
+```json
+{
+  "key": "cross-domain-task",
+  "domain": "payments",
+  "crossDomain": true,
+  "flow": "sys-tasks",
+  "version": "1.0.0"
+}
+```
+
+**Reference-level exclusion** — only that reference is skipped; the rest of the component is processed normally:
+```json
+{
+  "key": "my-workflow",
+  "domain": "account",
+  "flow": "sys-flows",
+  "attributes": {
+    "steps": [
+      {
+        "task": {
+          "key": "cross-domain-task",
+          "domain": "payments",
+          "crossDomain": true,
+          "version": "1.0.0",
+          "flow": "sys-tasks"
+        }
+      },
+      {
+        "task": {
+          "key": "local-task",
+          "domain": "account",
+          "version": "1.0.0",
+          "flow": "sys-tasks"
+        }
+      }
+    ]
+  }
+}
+```
+
+After replacement with `appDomain: "my-domain"`:
+- `my-workflow.domain` → `"my-domain"`
+- `local-task.domain` → `"my-domain"`
+- `cross-domain-task.domain` → `"payments"` (unchanged)
 
 ### Example
 
-**Before (appDomain: "my-domain"):**
+**Before (`replaceDomain: true`, `appDomain: "my-domain"`):**
 ```json
 {
   "key": "my-flow",

--- a/init/VNext.Init.Host/package-api-server.js
+++ b/init/VNext.Init.Host/package-api-server.js
@@ -327,9 +327,14 @@ function processComponentFile(jsonData, vnextConfig, shouldReplaceDomain, target
     processed = updateComponentVersions(processed, vnextConfig.version, vnextConfig.domain);
     
     // Step 2: Replace domain at ALL levels if requested
+    // Skip root-level crossDomain components — they intentionally target another domain
     if (shouldReplaceDomain && targetDomain) {
-        log.detail(`Replacing domain → ${targetDomain}`);
-        processed = replaceDomainInJson(processed, targetDomain);
+        if (processed.crossDomain === true) {
+            log.detail(`Skipping domain replacement (crossDomain component)`);
+        } else {
+            log.detail(`Replacing domain → ${targetDomain}`);
+            processed = replaceDomainInJson(processed, targetDomain);
+        }
     }
     
     return processed;
@@ -527,14 +532,17 @@ async function downloadPackage(packageName, version, registry, authOptions = {})
 
 /**
  * Replace ALL domain fields in JSON object at ALL levels
- * 
+ *
  * Replaces domain in:
  * - Root level domain (if object has key, flow, version, domain)
  * - attributes.domain
  * - data[].domain
  * - data[].attributes.domain
  * - Any nested object's domain field
- * 
+ *
+ * Cross-domain exclusion: if an object has `crossDomain: true`, its `domain`
+ * field is preserved as-is (intentionally targets another domain).
+ *
  * @param {Object} obj - Object to process
  * @param {string} targetDomain - Target domain to replace with
  */
@@ -542,29 +550,29 @@ function replaceDomainInJson(obj, targetDomain) {
     if (typeof obj !== 'object' || obj === null) {
         return obj;
     }
-    
+
     if (Array.isArray(obj)) {
         return obj.map(item => replaceDomainInJson(item, targetDomain));
     }
-    
+
     // Create a copy of the object
     const result = { ...obj };
-    
-    // Replace domain field if it exists and is a string
-    if (typeof result.domain === 'string') {
+
+    // Replace domain field only if this object is not marked as cross-domain
+    if (typeof result.domain === 'string' && result.crossDomain !== true) {
         result.domain = targetDomain;
     }
-    
+
     // Recursively process all properties to find nested domain fields
-    // BUT skip "config" and "process" keys - it should always remain unchanged
+    // BUT skip "config" and "process" keys - they should always remain unchanged
     for (const [key, value] of Object.entries(result)) {
-        if (key !== 'domain' && key !== 'config' && key !== "process") { // Skip domain (already processed) and attributes (always preserved)
+        if (key !== 'domain' && key !== 'config' && key !== "process") {
             result[key] = replaceDomainInJson(value, targetDomain);
         }
     }
-    
+
     return result;
-} 
+}
 
 
 /**
@@ -1056,14 +1064,18 @@ async function handleRuntimePublish(req, res) {
 /**
  * Handle Standard Package Publish (async job pattern)
  * Endpoint: POST /api/package/publish
- * 
+ *
  * Returns 202 Accepted immediately with a jobId.
  * Processing runs in the background; poll GET /api/package/publish/status/:jobId for progress.
+ *
+ * Domain replacement is opt-in: set `replaceDomain: true` together with a non-empty
+ * `appDomain` to replace domain fields in all components.  Components (or nested
+ * references) that carry `crossDomain: true` are exempt from replacement.
  */
 async function handlePackagePublish(req, res) {
     try {
         const body = await parseJSON(req);
-        
+
         const {
             packageName,
             version = 'latest',
@@ -1072,6 +1084,8 @@ async function handlePackagePublish(req, res) {
             npmUsername,
             npmPassword,
             npmEmail,
+            appDomain,
+            replaceDomain = false,
             reInitialize = false
         } = body;
 
@@ -1081,11 +1095,16 @@ async function handlePackagePublish(req, res) {
             return;
         }
 
+        // Domain replacement is enabled only when explicitly requested AND a target domain is given
+        const effectiveAppDomain = (replaceDomain === true && appDomain && appDomain.trim() !== '')
+            ? appDomain.trim()
+            : null;
+
         const job = createJob(packageName);
 
         log.section(`API Request: Package Publish [job=${job.id}]`);
         log.info(`Package: ${packageName}@${version}`);
-        log.info(`Domain Replacement: DISABLED`);
+        log.info(`Domain Replacement: ${effectiveAppDomain ? `ENABLED → ${effectiveAppDomain}` : 'DISABLED'}`);
         log.info(`Re-initialize after publish: ${reInitialize === true ? 'ENABLED' : 'DISABLED'}`);
 
         res.writeHead(202, { 'Content-Type': 'application/json' });
@@ -1100,11 +1119,11 @@ async function handlePackagePublish(req, res) {
             version,
             npmRegistry,
             authOptions: { token: npmToken, username: npmUsername, password: npmPassword, email: npmEmail },
-            appDomain: null,
+            appDomain: effectiveAppDomain,
             isRuntimePackage: false,
             reInitialize: reInitialize === true,
         });
-        
+
     } catch (error) {
         log.error(`Error: ${error.message}`);
         if (error.stack) {
@@ -1455,8 +1474,8 @@ function startServer() {
         log.detail(`  - Special ordering (Workflows first, sys-flows first)`);
         log.info(`Package Publish: POST http://localhost:${PORT}/api/package/publish`);
         log.detail(`  - For any npm package`);
-        log.detail(`  - appDomain is OPTIONAL`);
-        log.detail(`  - If appDomain provided, replaces all domains`);
+        log.detail(`  - replaceDomain: true + appDomain to enable domain replacement`);
+        log.detail(`  - Components with crossDomain:true are exempt from replacement`);
         log.info(`Job Status: GET http://localhost:${PORT}/api/package/publish/status/:jobId`);
         log.detail(`  - Poll for job progress after publish`);
         log.info(`Cancel Job: POST http://localhost:${PORT}/api/package/publish/cancel/:jobId`);

--- a/init/VNext.Init.Host/test.http
+++ b/init/VNext.Init.Host/test.http
@@ -147,7 +147,18 @@ Content-Type: application/json
   "version": "{{version}}"
 }
 
-### Package Publish - With domain replacement
+### Package Publish - With domain replacement (replaceDomain: true required)
+POST {{baseUrl}}/api/package/publish
+Content-Type: application/json
+
+{
+  "packageName": "@my-org/my-workflow-package",
+  "version": "{{version}}",
+  "appDomain": "my-custom-domain",
+  "replaceDomain": true
+}
+
+### Package Publish - appDomain provided but replaceDomain omitted (no replacement)
 POST {{baseUrl}}/api/package/publish
 Content-Type: application/json
 
@@ -196,7 +207,8 @@ Content-Type: application/json
   "version": "{{version}}",
   "npmRegistry": "{{npmRegistry}}",
   "npmToken": "your-npm-token-here",
-  "appDomain": "production"
+  "appDomain": "production",
+  "replaceDomain": true
 }
 
 ### Package Publish - Error: Missing packageName
@@ -207,7 +219,7 @@ Content-Type: application/json
   "version": "{{version}}"
 }
 
-### Package Publish - TFS Artifacts authentication
+### Package Publish - TFS Artifacts authentication with domain replacement
 POST {{baseUrl}}/api/package/publish
 Content-Type: application/json
 
@@ -218,7 +230,8 @@ Content-Type: application/json
   "npmUsername": "{{tfsUsername}}",
   "npmPassword": "{{tfsPassword}}",
   "npmEmail": "{{tfsEmail}}",
-  "appDomain": "my-domain"
+  "appDomain": "my-domain",
+  "replaceDomain": true
 }
 
 ### Package Publish - TFS Artifacts (without domain replacement)
@@ -277,8 +290,10 @@ Origin: http://localhost:3001
 # 2. Standard Package (Any npm package)
 #    POST /api/package/publish
 #    - packageName: REQUIRED
-#    - appDomain: OPTIONAL
-#    - Domain replacement: Only if appDomain provided
+#    - replaceDomain: OPTIONAL (boolean, default false)
+#    - appDomain: OPTIONAL (required when replaceDomain:true)
+#    - Domain replacement: Only if replaceDomain:true AND appDomain provided
+#    - Components/references with crossDomain:true are exempt from replacement
 #    - Ordering: Standard (no special ordering)
 #
 # 3. Health Check


### PR DESCRIPTION
… package publish

Standard package publish endpoint now requires explicit opt-in for domain replacement via `replaceDomain: true` + `appDomain` in the request body. Previously domain replacement was never activated for this endpoint.

Cross-domain exclusion: components or nested references that carry `crossDomain: true` are skipped during domain replacement so their intentional cross-domain references are preserved intact.

Changes:
- handlePackagePublish: extract appDomain + replaceDomain; compute effectiveAppDomain (null when not opted-in), pass to job runner
- processComponentFile: skip replaceDomainInJson entirely when root component has crossDomain:true
- replaceDomainInJson: skip domain field when object.crossDomain === true so nested cross-domain references are also preserved
- Runtime publish endpoint is unchanged (domain replacement always active)
- README and test.http updated with new parameter documentation and examples

## Summary by Sourcery

Make domain replacement for standard package publish opt-in and introduce cross-domain exclusion rules while keeping runtime publish behavior unchanged.

New Features:
- Add opt-in `replaceDomain` flag and `appDomain` handling to the standard package publish endpoint to control when domain replacement runs.
- Support cross-domain exclusion so components or nested references marked `crossDomain: true` retain their original domain during replacement.

Enhancements:
- Update component processing to skip domain replacement entirely for root components marked as cross-domain and to log effective domain replacement behavior.
- Refine server startup logs and API usage examples to reflect the new opt-in domain replacement and cross-domain exclusion behavior.

Documentation:
- Expand README domain replacement documentation with opt-in semantics, cross-domain exclusion behavior, and updated endpoint comparison and examples.
- Update HTTP test examples to demonstrate the new `replaceDomain` parameter usage.