### PR TITLE
fix(domain): add backward-compatible "view" JSON binding to Transition

### DIFF
--- a/src/BBT.Workflow.Domain/Definitions/Transitions/Transition.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Transitions/Transition.cs
@@ -99,9 +99,21 @@ public sealed class Transition : IHasKey
     private List<RoleGrant> roles = new();
 
     [JsonInclude]
+    [JsonPropertyName("view")]
+    [JsonConverter(typeof(ViewDefinitionJsonConverter))]
+    private ViewDefinition? view { get; set; }
+
+    [JsonInclude]
     [JsonPropertyName("views")]
     [JsonConverter(typeof(ViewDefinitionJsonConverter))]
-    public ViewDefinition? View { get; private set; }
+    private ViewDefinition? views { get; set; }
+
+    /// <summary>
+    /// View definition for the transition. Supports both old "view" and new "views" JSON formats.
+    /// New format takes precedence when both are present.
+    /// </summary>
+    [JsonIgnore]
+    public ViewDefinition? View => views ?? view;
 
     /// <summary>
     /// Transition roles for authorization. DENY always overrides ALLOW.
@@ -114,12 +126,6 @@ public sealed class Transition : IHasKey
     /// </summary>
     [JsonIgnore]
     public IReadOnlyCollection<LanguageLabel> Labels => labels.AsReadOnly();
-
-    // /// <summary>
-    // /// Transition View
-    // /// </summary>
-    // [JsonIgnore]
-    // public ViewDefinition? View { get; private set; }
 
     /// <summary>
     /// On Execution Tasks
@@ -166,7 +172,7 @@ public sealed class Transition : IHasKey
 
     public void SetView(ViewDefinition viewDefinition)
     {
-        View = viewDefinition;
+        views = viewDefinition;
     }
 
     public void AddOnExecutionTask(OnExecuteTask task)

--- a/test/BBT.Workflow.Domain.Tests/Definitions/TransitionTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Definitions/TransitionTests.cs
@@ -479,5 +479,132 @@ public class TransitionTests : DomainTestBase<DomainEntryPoint>
         Assert.NotNull(transition);
         Assert.Null(transition.TriggerKind);
     }
+
+    [Fact]
+    public void View_ShouldDeserialize_FromOldViewFormat()
+    {
+        var json = """
+        {
+            "key": "shared-cancel",
+            "from": null,
+            "target": "cancelled",
+            "triggerType": "manual",
+            "versionStrategy": "Patch",
+            "labels": [],
+            "onExecutionTasks": [],
+            "view": {
+                "view": {
+                    "key": "cancel-confirmation-view",
+                    "domain": "core",
+                    "version": "1.0.0",
+                    "flow": "sys-views"
+                },
+                "loadData": true
+            }
+        }
+        """;
+
+        var transition = System.Text.Json.JsonSerializer.Deserialize<Transition>(json, JsonSerializerConstants.JsonOptions);
+
+        Assert.NotNull(transition);
+        Assert.NotNull(transition.View);
+        Assert.Single(transition.View.Views);
+        Assert.Equal("cancel-confirmation-view", transition.View.Views[0].View.Key);
+    }
+
+    [Fact]
+    public void View_ShouldDeserialize_FromNewViewsArrayFormat()
+    {
+        var json = """
+        {
+            "key": "submit-transition",
+            "from": null,
+            "target": "review-state",
+            "triggerType": "manual",
+            "versionStrategy": "Patch",
+            "labels": [],
+            "onExecutionTasks": [],
+            "views": [
+                {
+                    "view": {
+                        "key": "submit-desktop-view",
+                        "domain": "forms",
+                        "version": "1.0.0",
+                        "flow": "sys-views"
+                    },
+                    "loadData": true
+                }
+            ]
+        }
+        """;
+
+        var transition = System.Text.Json.JsonSerializer.Deserialize<Transition>(json, JsonSerializerConstants.JsonOptions);
+
+        Assert.NotNull(transition);
+        Assert.NotNull(transition.View);
+        Assert.Single(transition.View.Views);
+        Assert.Equal("submit-desktop-view", transition.View.Views[0].View.Key);
+    }
+
+    [Fact]
+    public void View_ShouldPreferNewFormat_WhenBothPresent()
+    {
+        var json = """
+        {
+            "key": "dual-format-transition",
+            "from": null,
+            "target": "next-state",
+            "triggerType": "manual",
+            "versionStrategy": "Patch",
+            "labels": [],
+            "onExecutionTasks": [],
+            "view": {
+                "view": {
+                    "key": "old-view",
+                    "domain": "core",
+                    "version": "1.0.0",
+                    "flow": "sys-views"
+                }
+            },
+            "views": [
+                {
+                    "view": {
+                        "key": "new-view",
+                        "domain": "forms",
+                        "version": "2.0.0",
+                        "flow": "sys-views"
+                    }
+                }
+            ]
+        }
+        """;
+
+        var transition = System.Text.Json.JsonSerializer.Deserialize<Transition>(json, JsonSerializerConstants.JsonOptions);
+
+        Assert.NotNull(transition);
+        Assert.NotNull(transition.View);
+        Assert.Equal("new-view", transition.View.Views[0].View.Key);
+    }
+
+    [Fact]
+    public void View_ShouldBeNull_WhenNeitherFormatPresent()
+    {
+        var json = """
+        {
+            "key": "no-view-transition",
+            "from": null,
+            "target": "next-state",
+            "triggerType": "manual",
+            "versionStrategy": "Patch",
+            "labels": [],
+            "onExecutionTasks": []
+        }
+        """;
+
+        var transition = System.Text.Json.JsonSerializer.Deserialize<Transition>(json, JsonSerializerConstants.JsonOptions);
+
+        Assert.NotNull(transition);
+        Assert.Null(transition.View);
+    }
 }
 


### PR DESCRIPTION
## Summary
- Fix shared transitions reporting `hasView: false` in state function responses when view is defined using the old `"view"` (singular) JSON format
- Add backward-compatible dual-property deserialization to `Transition` class, matching the pattern already used in the `State` class

## Changes
- `src/BBT.Workflow.Domain/Definitions/Transitions/Transition.cs` — add private `view` property for old format, rename existing to private `views`, expose computed `View` that prefers new format
- `test/BBT.Workflow.Domain.Tests/Definitions/TransitionTests.cs` — add 4 tests covering old format, new format, precedence, and null cases

## Test Plan
- [x] Existing TransitionTests pass (52 passed, 1 pre-existing skip)
- [x] InstanceQueryAppServiceStateTests pass (5/5)
- [x] FlowCastHandlerTests pass (18/18)
- [x] Full solution builds with no errors
- [ ] Deploy and verify shared transitions with `"view"` format return `hasView: true` in state function response

## Notes
- The pre-existing test `Kind_ShouldDeserialize_FromJson` was already failing before this change (unrelated JSON property name mismatch for `TriggerKind`)
- Closes #572

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Ensure transitions deserialize view definitions from both legacy and current JSON formats while preserving a single View API surface.

Bug Fixes:
- Fix transitions deserialized from the legacy "view" JSON field incorrectly reporting no view definition.

Enhancements:
- Unify transition view handling behind a computed View property that prefers the new "views" format but falls back to the legacy "view" field.

Tests:
- Add unit tests covering deserialization from the legacy "view" field, the new "views" array, dual-format precedence, and absence of any view data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Transition view configuration now supports both legacy and new JSON formats seamlessly.

* **Tests**
  * Enhanced test coverage for JSON deserialization of transition view configurations across multiple format scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->