### PR TITLE
fix(ci): stamp correct version into common.props before docker build

### DIFF
--- a/.github/workflows/build-and-publish-images.yml
+++ b/.github/workflows/build-and-publish-images.yml
@@ -217,6 +217,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Stamp version into common.props
+        run: |
+          VERSION="${{ needs.prepare.outputs.version }}"
+          sed -i "s|<Version>.*</Version>|<Version>$VERSION</Version>|g" ./common.props
+          echo "Stamped common.props with version $VERSION"
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:


### PR DESCRIPTION
The build-sign-scan job checks out the original triggering commit, not the updated one pushed by the prepare job. This caused dotnet publish to embed the previous (n-1) version into the assembly.

Closes #620

## Summary by Sourcery

CI:
- Add a CI step in the build-and-publish-images workflow to update common.props with the prepared version before running the .NET build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build workflow to automatically stamp release version information during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->