### PR TITLE
feat(domain): expose cancel transition in availableTransitions

### DIFF
--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -388,8 +388,8 @@ public sealed class InstanceQueryAppService(
     }
 
     /// <summary>
-    /// Merges subflow transition names with the parent workflow's shared transitions only (manual/event, available in current state).
-    /// When in active subflow, clients see subflow transitions plus parent's shared transitions; state-level parent transitions are not included.
+    /// Merges subflow transition names with the parent workflow's shared transitions and cancel transition (manual/event, available in current state).
+    /// When in active subflow, clients see subflow transitions plus parent's shared transitions and cancel; state-level parent transitions are not included.
     /// </summary>
     private static List<string> MergeWithParentAvailableTransitions(
         List<string> subflowTransitionNames,
@@ -400,8 +400,15 @@ public sealed class InstanceQueryAppService(
         if (!stateResult.IsSuccess)
             return subflowTransitionNames;
 
-        var parentSharedOnly = currentWorkflow.GetAvailableSharedTransitionKeysOnly(stateResult.Value!);
-        return subflowTransitionNames.Union(parentSharedOnly).ToList();
+        var currentState = stateResult.Value!;
+        var parentSharedOnly = currentWorkflow.GetAvailableSharedTransitionKeysOnly(currentState);
+        var merged = subflowTransitionNames.Union(parentSharedOnly);
+
+        var cancelKey = currentWorkflow.GetCancelTransitionKey(currentState);
+        if (cancelKey != null)
+            merged = merged.Union(new[] { cancelKey });
+
+        return merged.ToList();
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Domain/Definitions/Validators/WorkflowValidator.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Validators/WorkflowValidator.cs
@@ -338,10 +338,10 @@ public class WorkflowValidator
             ValidateSingleTransition(workflow.StartTransition, "StartTransition", result, isSharedTransition: false);
         }
 
-        // Validate Cancel transition
+        // Validate Cancel transition — AvailableIn is allowed (same as shared transitions)
         if (workflow.Cancel != null)
         {
-            ValidateSingleTransition(workflow.Cancel, "Cancel", result, isSharedTransition: false);
+            ValidateSingleTransition(workflow.Cancel, "Cancel", result, isSharedTransition: true);
         }
 
         // Validate SharedTransitions - AvailableIn is allowed here

--- a/src/BBT.Workflow.Domain/Definitions/Workflow.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Workflow.cs
@@ -451,7 +451,23 @@ public sealed class Workflow : IDomainEntity, IReference, IReferenceSetter, IHas
         // Get manual shared transitions (AvailableIn empty/null = available in all states, aligned with SharedTransitionAvailabilitySpecification)
         var manualSharedTransitions = GetAvailableSharedTransitionKeysOnly(currentState);
         manualTransitions.AddRange(manualSharedTransitions);
+
+        AppendCancelTransitionKey(manualTransitions, currentState);
+
         return manualTransitions;
+    }
+
+    /// <summary>
+    /// Appends the cancel transition key if configured with Manual or Event trigger type
+    /// and the current state satisfies the AvailableIn constraint.
+    /// AvailableIn empty/null means available in all states (same semantics as shared transitions).
+    /// </summary>
+    private void AppendCancelTransitionKey(List<string> transitions, State currentState)
+    {
+        if (Cancel is { TriggerType: TriggerType.Manual or TriggerType.Event }
+            && (Cancel.AvailableIn == null || !Cancel.AvailableIn.Any() || Cancel.AvailableIn.Contains(currentState.Key))
+            && !transitions.Contains(Cancel.Key))
+            transitions.Add(Cancel.Key);
     }
 
     /// <summary>
@@ -465,6 +481,23 @@ public sealed class Workflow : IDomainEntity, IReference, IReferenceSetter, IHas
                         (t.TriggerType == TriggerType.Manual || t.TriggerType == TriggerType.Event))
             .Select(t => t.Key)
             .ToList();
+    }
+
+    /// <summary>
+    /// Gets the cancel transition key if configured with Manual or Event trigger type
+    /// and the given state satisfies the AvailableIn constraint.
+    /// AvailableIn empty/null means available in all states (same semantics as shared transitions).
+    /// Used when merging parent transitions into SubFlow available transitions.
+    /// </summary>
+    public string? GetCancelTransitionKey(State currentState)
+    {
+        if (Cancel is not { TriggerType: TriggerType.Manual or TriggerType.Event })
+            return null;
+
+        if (Cancel.AvailableIn != null && Cancel.AvailableIn.Any() && !Cancel.AvailableIn.Contains(currentState.Key))
+            return null;
+
+        return Cancel.Key;
     }
 
     public static Workflow Create()


### PR DESCRIPTION
## Summary
- Include the workflow-level `cancel` transition in the State function's `availableTransitions` response, treating it like shared transitions with `AvailableIn` state filtering and role authorization
- Allow `AvailableIn` definition on the cancel transition in the workflow validator so it can be scoped to specific states
- Merge parent cancel transition into SubFlow available transitions alongside shared transitions

## Changes
- `src/BBT.Workflow.Domain/Definitions/Workflow.cs` — add `AppendCancelTransitionKey` (private) and `GetCancelTransitionKey` (public) with `AvailableIn` state filtering
- `src/BBT.Workflow.Domain/Definitions/Validators/WorkflowValidator.cs` — allow `AvailableIn` on cancel transition (`isSharedTransition: true`)
- `src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs` — include parent cancel key in `MergeWithParentAvailableTransitions` for SubFlow scenarios

## Test Plan
- [ ] Deploy a workflow with a `cancel` transition configured (Manual trigger, with roles and view/schema)
- [ ] Call the State function and verify cancel appears in `transitions` array with correct `HasView` and `HasSchema` flags
- [ ] Verify cancel is filtered out when the user role does not match the cancel transition's roles
- [ ] Add `availableIn` to the cancel transition and verify it only appears in the listed states
- [ ] Test SubFlow scenario: verify parent cancel appears in available transitions while in an active SubFlow
- [ ] Verify `update-data` and `exit` do NOT appear in `availableTransitions`
- [ ] Verify view/schema functions return cancel definitions when queried with `transitionKey=cancel`

Closes #622

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Expose workflow-level cancel transitions as available transitions, including in subflows, with state scoping and validation aligned to shared transitions.

New Features:
- Include workflow cancel transitions in available user transitions when configured as manual or event and allowed in the current state.
- Expose parent workflow cancel transitions alongside shared transitions when merging available transitions for active subflows.

Enhancements:
- Allow the cancel transition to define AvailableIn constraints by validating it with shared-transition semantics.