### PR TITLE
fix(ci): resolve pipeline re-run failure and pin alpine image tags

### DIFF
--- a/.github/workflows/build-and-publish-images.yml
+++ b/.github/workflows/build-and-publish-images.yml
@@ -155,6 +155,10 @@ jobs:
         if: steps.version.outputs.is_prerelease != 'true'
         run: |
           VERSION="${{ steps.version.outputs.version }}"
+
+          # Pull latest remote state to avoid non-fast-forward on re-runs
+          git pull --rebase origin ${{ github.ref_name }}
+
           sed -i "s|<Version>.*</Version>|<Version>$VERSION</Version>|g" ./common.props
           echo "Updated common.props with version $VERSION"
 
@@ -167,7 +171,7 @@ jobs:
             git push origin ${{ github.ref_name }}
             echo "Committed and pushed common.props update"
           else
-            echo "No changes in common.props"
+            echo "No changes in common.props (already at version $VERSION)"
           fi
 
   build-sign-scan:

--- a/execution/BBT.Workflow.Execution.HttpApi.Host/Dockerfile
+++ b/execution/BBT.Workflow.Execution.HttpApi.Host/Dockerfile
@@ -1,5 +1,5 @@
 # Base image using Alpine
-FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine3.23 AS base
 WORKDIR /app
 
 # Create non-root user for security
@@ -8,7 +8,7 @@ RUN adduser -D workflowuser && chown -R workflowuser:workflowuser /app
 USER workflowuser
 
 # Build image
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-alpine3.23 AS build
 
 # Install NETStandard.Library.Ref targeting pack for PostSharp compatibility
 RUN wget -q https://www.nuget.org/api/v2/package/NETStandard.Library.Ref/2.1.0 -O /tmp/netstandard.nupkg && \

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Dockerfile
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Dockerfile
@@ -1,5 +1,5 @@
 # Base image using Alpine
-FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine3.23 AS base
 WORKDIR /app
 
 # Create non-root user for security
@@ -8,7 +8,7 @@ RUN adduser -D workflowuser && chown -R workflowuser:workflowuser /app
 USER workflowuser
 
 # Build image
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-alpine3.23 AS build
 
 # Install NETStandard.Library.Ref targeting pack for PostSharp compatibility
 RUN wget -q https://www.nuget.org/api/v2/package/NETStandard.Library.Ref/2.1.0 -O /tmp/netstandard.nupkg && \

--- a/workers/BBT.Workflow.DbMigrator/Dockerfile
+++ b/workers/BBT.Workflow.DbMigrator/Dockerfile
@@ -8,7 +8,7 @@ RUN adduser -D workflowuser && chown -R workflowuser:workflowuser /app
 USER workflowuser
 
 # Build image
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-alpine3.23 AS build
 
 # Install NETStandard.Library.Ref targeting pack for PostSharp compatibility
 RUN wget -q https://www.nuget.org/api/v2/package/NETStandard.Library.Ref/2.1.0 -O /tmp/netstandard.nupkg && \

--- a/workers/BBT.Workflow.Workers.Inbox/Dockerfile
+++ b/workers/BBT.Workflow.Workers.Inbox/Dockerfile
@@ -1,5 +1,5 @@
 # Base image using Alpine
-FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine3.23 AS base
 WORKDIR /app
 
 # Create non-root user for security
@@ -8,7 +8,7 @@ RUN adduser -D workflowuser && chown -R workflowuser:workflowuser /app
 USER workflowuser
 
 # Build image
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-alpine3.23 AS build
 
 # Install NETStandard.Library.Ref targeting pack for PostSharp compatibility
 RUN wget -q https://www.nuget.org/api/v2/package/NETStandard.Library.Ref/2.1.0 -O /tmp/netstandard.nupkg && \

--- a/workers/BBT.Workflow.Workers.Outbox/Dockerfile
+++ b/workers/BBT.Workflow.Workers.Outbox/Dockerfile
@@ -1,5 +1,5 @@
 # Base image using Alpine
-FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine3.23 AS base
 WORKDIR /app
 
 # Create non-root user for security
@@ -8,7 +8,7 @@ RUN adduser -D workflowuser && chown -R workflowuser:workflowuser /app
 USER workflowuser
 
 # Build image
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-alpine3.23 AS build
 
 # Install NETStandard.Library.Ref targeting pack for PostSharp compatibility
 RUN wget -q https://www.nuget.org/api/v2/package/NETStandard.Library.Ref/2.1.0 -O /tmp/netstandard.nupkg && \


### PR DESCRIPTION
## Summary
- Add `git pull --rebase` before version commit push to make the prepare job idempotent on re-runs
- Pin all Dockerfile base images from floating `10.0-alpine` to `10.0-alpine3.23` to prevent transient MCR 403 manifest resolution errors

## Changes
- `.github/workflows/build-and-publish-images.yml` — pull latest remote state before commit/push
- `execution/BBT.Workflow.Execution.HttpApi.Host/Dockerfile` — pin to alpine3.23
- `orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Dockerfile` — pin to alpine3.23
- `workers/BBT.Workflow.DbMigrator/Dockerfile` — pin SDK to alpine3.23
- `workers/BBT.Workflow.Workers.Inbox/Dockerfile` — pin to alpine3.23
- `workers/BBT.Workflow.Workers.Outbox/Dockerfile` — pin to alpine3.23

## Test Plan
- [ ] Push to a release branch and let the pipeline run to completion
- [ ] Verify re-running the pipeline after a partial failure does not produce non-fast-forward errors
- [ ] Confirm Docker images build successfully with pinned `10.0-alpine3.23` tags

Closes #627

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Make the image build pipeline more robust and deterministic by fixing CI re-run behavior and pinning Docker base images to a specific Alpine version.

Build:
- Pin all .NET ASP.NET and SDK Docker base images to the 10.0-alpine3.23 tags across execution, orchestration, and worker services to avoid issues with floating tags.

CI:
- Update build-and-publish workflow to pull the latest remote branch state before committing the version bump, improving idempotency on pipeline re-runs.
- Clarify workflow logging when no version change is needed in common.props.