### PR TITLE
v0.0.52

### DIFF
--- a/.github/workflows/build-and-publish-images.yml
+++ b/.github/workflows/build-and-publish-images.yml
@@ -155,6 +155,10 @@ jobs:
         if: steps.version.outputs.is_prerelease != 'true'
         run: |
           VERSION="${{ steps.version.outputs.version }}"
+
+          # Pull latest remote state to avoid non-fast-forward on re-runs
+          git pull --rebase origin ${{ github.ref_name }}
+
           sed -i "s|<Version>.*</Version>|<Version>$VERSION</Version>|g" ./common.props
           echo "Updated common.props with version $VERSION"
 
@@ -167,7 +171,7 @@ jobs:
             git push origin ${{ github.ref_name }}
             echo "Committed and pushed common.props update"
           else
-            echo "No changes in common.props"
+            echo "No changes in common.props (already at version $VERSION)"
           fi
 
   build-sign-scan:

--- a/execution/BBT.Workflow.Execution.HttpApi.Host/Dockerfile
+++ b/execution/BBT.Workflow.Execution.HttpApi.Host/Dockerfile
@@ -1,5 +1,5 @@
 # Base image using Alpine
-FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine3.23 AS base
 WORKDIR /app
 
 # Create non-root user for security
@@ -8,7 +8,7 @@ RUN adduser -D workflowuser && chown -R workflowuser:workflowuser /app
 USER workflowuser
 
 # Build image
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-alpine3.23 AS build
 
 # Install NETStandard.Library.Ref targeting pack for PostSharp compatibility
 RUN wget -q https://www.nuget.org/api/v2/package/NETStandard.Library.Ref/2.1.0 -O /tmp/netstandard.nupkg && \

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Dockerfile
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Dockerfile
@@ -1,5 +1,5 @@
 # Base image using Alpine
-FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine3.23 AS base
 WORKDIR /app
 
 # Create non-root user for security
@@ -8,7 +8,7 @@ RUN adduser -D workflowuser && chown -R workflowuser:workflowuser /app
 USER workflowuser
 
 # Build image
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-alpine3.23 AS build
 
 # Install NETStandard.Library.Ref targeting pack for PostSharp compatibility
 RUN wget -q https://www.nuget.org/api/v2/package/NETStandard.Library.Ref/2.1.0 -O /tmp/netstandard.nupkg && \

--- a/workers/BBT.Workflow.DbMigrator/Dockerfile
+++ b/workers/BBT.Workflow.DbMigrator/Dockerfile
@@ -8,7 +8,7 @@ RUN adduser -D workflowuser && chown -R workflowuser:workflowuser /app
 USER workflowuser
 
 # Build image
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-alpine3.23 AS build
 
 # Install NETStandard.Library.Ref targeting pack for PostSharp compatibility
 RUN wget -q https://www.nuget.org/api/v2/package/NETStandard.Library.Ref/2.1.0 -O /tmp/netstandard.nupkg && \

--- a/workers/BBT.Workflow.Workers.Inbox/Dockerfile
+++ b/workers/BBT.Workflow.Workers.Inbox/Dockerfile
@@ -1,5 +1,5 @@
 # Base image using Alpine
-FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine3.23 AS base
 WORKDIR /app
 
 # Create non-root user for security
@@ -8,7 +8,7 @@ RUN adduser -D workflowuser && chown -R workflowuser:workflowuser /app
 USER workflowuser
 
 # Build image
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-alpine3.23 AS build
 
 # Install NETStandard.Library.Ref targeting pack for PostSharp compatibility
 RUN wget -q https://www.nuget.org/api/v2/package/NETStandard.Library.Ref/2.1.0 -O /tmp/netstandard.nupkg && \

--- a/workers/BBT.Workflow.Workers.Outbox/Dockerfile
+++ b/workers/BBT.Workflow.Workers.Outbox/Dockerfile
@@ -1,5 +1,5 @@
 # Base image using Alpine
-FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine3.23 AS base
 WORKDIR /app
 
 # Create non-root user for security
@@ -8,7 +8,7 @@ RUN adduser -D workflowuser && chown -R workflowuser:workflowuser /app
 USER workflowuser
 
 # Build image
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-alpine3.23 AS build
 
 # Install NETStandard.Library.Ref targeting pack for PostSharp compatibility
 RUN wget -q https://www.nuget.org/api/v2/package/NETStandard.Library.Ref/2.1.0 -O /tmp/netstandard.nupkg && \


### PR DESCRIPTION
## Summary by Sourcery

Update CI image publishing workflow and align Dockerfiles to a specific Alpine variant for .NET 10 images.

Build:
- Ensure the image publishing workflow rebases against the remote branch before updating common.props to avoid non-fast-forward errors on reruns.
- Clarify workflow logging when common.props is already at the target version during version bump steps.

Deployment:
- Update all .NET 10 Dockerfiles to use the alpine3.23 variant for both runtime and SDK base images.