### PR TITLE
640 enhancement add configurable kestrel request header size and count limits

### DIFF
--- a/execution/BBT.Workflow.Execution.HttpApi.Host/Program.cs
+++ b/execution/BBT.Workflow.Execution.HttpApi.Host/Program.cs
@@ -1,5 +1,6 @@
 using BBT.Aether.AspNetCore.Dapr;
 using BBT.Aether.AspNetCore.Threads;
+using BBT.Workflow.Logging;
 using Dapr.Client;
 using Dapr.Extensions.Configuration;
 
@@ -17,10 +18,24 @@ if(builder.Configuration.GetValue<bool>("Vault:Enabled", false)){
     builder.Configuration.AddDaprSecretStore(builder.Configuration["DAPR_SECRET_STORE_NAME"] ?? "vnext-secret", daprClient);
 }
 
-builder.WebHost.ConfigureKestrel(option => option.AddServerHeader = false);
+builder.WebHost.ConfigureKestrel(options =>
+{
+    options.AddServerHeader = false;
+
+    var limitsSection = builder.Configuration.GetSection("Kestrel:Limits");
+    options.Limits.MaxRequestHeadersTotalSize =
+        limitsSection.GetValue<int>(nameof(options.Limits.MaxRequestHeadersTotalSize), 65_536);
+    options.Limits.MaxRequestHeaderCount =
+        limitsSection.GetValue<int>(nameof(options.Limits.MaxRequestHeaderCount), 200);
+});
+
 builder.Services.AddExecutionApiModule();
 
 var app = builder.Build();
 app.UseExecutionApiModule();
+
+app.Logger.KestrelLimitsConfigured(
+    app.Configuration.GetValue<int>("Kestrel:Limits:MaxRequestHeadersTotalSize", 65_536),
+    app.Configuration.GetValue<int>("Kestrel:Limits:MaxRequestHeaderCount", 200));
 
 await app.RunAsync();

--- a/execution/BBT.Workflow.Execution.HttpApi.Host/appsettings.json
+++ b/execution/BBT.Workflow.Execution.HttpApi.Host/appsettings.json
@@ -82,6 +82,12 @@
       }
     }
   },
+  "Kestrel": {
+    "Limits": {
+      "MaxRequestHeadersTotalSize": 65536,
+      "MaxRequestHeaderCount": 200
+    }
+  },
   "AllowedHosts": "*",
   "Vault": {
     "Enabled": false

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Program.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Program.cs
@@ -1,5 +1,6 @@
 using BBT.Aether.AspNetCore.Dapr;
 using BBT.Aether.AspNetCore.Threads;
+using BBT.Workflow.Logging;
 using Dapr.Client;
 using Dapr.Extensions.Configuration;
 
@@ -17,10 +18,24 @@ if(builder.Configuration.GetValue<bool>("Vault:Enabled", false)){
 }
 
 
-builder.WebHost.ConfigureKestrel(option => option.AddServerHeader = false);
+builder.WebHost.ConfigureKestrel(options =>
+{
+    options.AddServerHeader = false;
+
+    var limitsSection = builder.Configuration.GetSection("Kestrel:Limits");
+    options.Limits.MaxRequestHeadersTotalSize =
+        limitsSection.GetValue<int>(nameof(options.Limits.MaxRequestHeadersTotalSize), 65_536);
+    options.Limits.MaxRequestHeaderCount =
+        limitsSection.GetValue<int>(nameof(options.Limits.MaxRequestHeaderCount), 200);
+});
 
 builder.Services.AddOrchestrationApiModule();
 
 var app = builder.Build();
 app.UseOrchestrationApiModule();
+
+app.Logger.KestrelLimitsConfigured(
+    app.Configuration.GetValue<int>("Kestrel:Limits:MaxRequestHeadersTotalSize", 65_536),
+    app.Configuration.GetValue<int>("Kestrel:Limits:MaxRequestHeaderCount", 200));
+
 await app.RunAsync();

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/appsettings.json
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/appsettings.json
@@ -139,6 +139,12 @@
       }
     }
   },
+  "Kestrel": {
+    "Limits": {
+      "MaxRequestHeadersTotalSize": 65536,
+      "MaxRequestHeaderCount": 200
+    }
+  },
   "AllowedHosts": "*",
   "TaskFactory": {
     "UseObjectPooling": false,

--- a/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
@@ -1803,4 +1803,20 @@ public static partial class WorkflowLogs
         string errorCode);
 
     #endregion
+
+    #region Server Configuration
+
+    /// <summary>
+    /// Logs the configured Kestrel request header limits at startup.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 60001,
+        Level = LogLevel.Information,
+        Message = "Kestrel limits configured: MaxRequestHeadersTotalSize={MaxRequestHeadersTotalSize}, MaxRequestHeaderCount={MaxRequestHeaderCount}")]
+    public static partial void KestrelLimitsConfigured(
+        this ILogger logger,
+        int maxRequestHeadersTotalSize,
+        int maxRequestHeaderCount);
+
+    #endregion
 }


### PR DESCRIPTION
## Summary

Adds configurable Kestrel request header size and count limits to both Orchestration and Execution API hosts, resolving `431 Request Header Fields Too Large` errors for clients with large authorization tokens, custom correlation headers, or multi-value headers.

Closes #640

## Changes

### `Program.cs` (both hosts)
- Expanded the `ConfigureKestrel` call to read `MaxRequestHeadersTotalSize` and `MaxRequestHeaderCount` from `Kestrel:Limits` configuration section
- Defaults to **64 KB** (65,536 bytes) / **200 headers** when no configuration is provided
- Preserved existing `AddServerHeader = false` setting
- Added startup log of configured values via `KestrelLimitsConfigured` extension

### `WorkflowLogs.cs`
- Added `KestrelLimitsConfigured` high-performance logging extension method (EventId 60001) in a new `#region Server Configuration` section

### `appsettings.json` (both hosts)
- Added `Kestrel:Limits` section with default values, making configuration discoverable and overridable via environment variables (e.g. `Kestrel__Limits__MaxRequestHeadersTotalSize`)

## Configuration

Operators can override via `appsettings.json`:
```json
"Kestrel": {
  "Limits": {
    "MaxRequestHeadersTotalSize": 65536,
    "MaxRequestHeaderCount": 200
  }
}
```

Or via environment variables / Kubernetes ConfigMaps:
```
Kestrel__Limits__MaxRequestHeadersTotalSize=131072
Kestrel__Limits__MaxRequestHeaderCount=300
```

## Acceptance Criteria

- [x] `MaxRequestHeadersTotalSize` and `MaxRequestHeaderCount` are configurable via `appsettings.json` or environment variables
- [x] Both Orchestration and Execution hosts apply the configured limits
- [x] Default values are increased to 64 KB / 200 headers when no configuration is provided
- [x] Existing `AddServerHeader = false` setting is preserved
- [x] Configuration values are logged at startup (Information level) for observability
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-daaab263-6640-413d-9b6d-d57e405fc8a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-daaab263-6640-413d-9b6d-d57e405fc8a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Make Kestrel request header limits configurable for both orchestration and execution HTTP API hosts and log the applied settings at startup.

New Features:
- Allow configuration of Kestrel MaxRequestHeadersTotalSize and MaxRequestHeaderCount via configuration for orchestration and execution hosts.

Enhancements:
- Increase default Kestrel request header size and count limits to 64 KB and 200 headers for orchestration and execution hosts.
- Log configured Kestrel request header limits at startup for improved observability.
- Add default Kestrel limits configuration to appsettings.json for both orchestration and execution hosts.

## Summary by Sourcery

Make Kestrel HTTP request header limits configurable for both orchestration and execution hosts and log the applied values at startup.

New Features:
- Allow configuration of Kestrel MaxRequestHeadersTotalSize and MaxRequestHeaderCount for orchestration and execution HTTP API hosts via configuration.

Enhancements:
- Increase default Kestrel request header size and count limits to 64 KB and 200 headers for orchestration and execution hosts.
- Log configured Kestrel request header limits at application startup for better observability.
- Add default Kestrel limits configuration entries to appsettings.json for both orchestration and execution hosts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured HTTP request header size and count limits on the API servers to enhance stability and security.
  * Added startup logging to track configured request header limits.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/burgan-tech/vnext/pull/652)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->