### PR TITLE
642 enhancement add annotations metadata to transition definitions for client side filtering

### DIFF
--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -837,19 +837,21 @@ public sealed class InstanceQueryAppService(
                 {
                     var subFlowItem = subFlowItemsByName.GetValueOrDefault(key);
                     bool hasView, loadData, hasSchema;
+                    Dictionary<string, string>? annotations;
                     if (subFlowItem != null)
                     {
                         hasView = subFlowItem.View?.HasView ?? false;
                         loadData = subFlowItem.View?.LoadData ?? false;
                         hasSchema = subFlowItem.Schema?.HasSchema ?? false;
+                        annotations = subFlowItem.Annotations;
                     }
                     else
                     {
-                        // Parent-owned transition (e.g., shared transition not from SubFlow): resolve from parent workflow
                         var transition = currentWorkflow.ResolveTransition(key, currentStateValue);
                         hasView = transition?.View is { Views.Count: > 0 };
                         loadData = false;
                         hasSchema = transition?.Schema != null;
+                        annotations = transition?.Annotations;
                     }
                     return new TransitionItem
                     {
@@ -868,7 +870,8 @@ public sealed class InstanceQueryAppService(
                             Href = urlTemplateBuilder.BuildSchemaUrl(input.Domain, input.Workflow,
                                 instance.Id.ToString(), key),
                             HasSchema = hasSchema
-                        }
+                        },
+                        Annotations = annotations
                     };
                 })
                 .ToList();
@@ -896,7 +899,8 @@ public sealed class InstanceQueryAppService(
                         Href = urlTemplateBuilder.BuildSchemaUrl(input.Domain, input.Workflow, instance.Id.ToString(),
                             transitionKey),
                         HasSchema = hasSchema
-                    }
+                    },
+                    Annotations = transition?.Annotations
                 };
             }).ToList();
         }

--- a/src/BBT.Workflow.Domain/Definitions/Transitions/Transition.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Transitions/Transition.cs
@@ -87,6 +87,14 @@ public sealed class Transition : IHasKey
     [JsonInclude] public ScriptCode? Mapping { get; private set; }
     [JsonInclude] public ResourceLockDefinition? ResourceLock { get; private set; }
 
+    /// <summary>
+    /// Optional key-value metadata for client-side filtering and UI context.
+    /// The platform treats annotations as pure passthrough and does not interpret or act on values.
+    /// Use namespaced keys to avoid collisions (e.g., <c>ui/visible-in</c>, <c>ui/priority</c>).
+    /// </summary>
+    [JsonInclude]
+    public Dictionary<string, string>? Annotations { get; private set; }
+
     [JsonInclude]
     [JsonPropertyName("labels")]
     private List<LanguageLabel> labels = new();

--- a/src/BBT.Workflow.Domain/Definitions/Transitions/Transition.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Transitions/Transition.cs
@@ -93,6 +93,7 @@ public sealed class Transition : IHasKey
     /// Use namespaced keys to avoid collisions (e.g., <c>ui/visible-in</c>, <c>ui/priority</c>).
     /// </summary>
     [JsonInclude]
+    [JsonPropertyName("annotations")]
     public Dictionary<string, string>? Annotations { get; private set; }
 
     [JsonInclude]

--- a/src/BBT.Workflow.Domain/Shared/HrefBase.cs
+++ b/src/BBT.Workflow.Domain/Shared/HrefBase.cs
@@ -33,6 +33,12 @@ public sealed class TransitionItem : HrefBase
     /// Schema href for this transition. When HasSchema is true, the schema endpoint returns meaningful content for this transition key.
     /// </summary>
     public SchemaHref? Schema { get; set; }
+
+    /// <summary>
+    /// Optional key-value metadata for client-side filtering and UI context.
+    /// Use namespaced keys to avoid collisions (e.g., <c>ui/visible-in</c>, <c>ui/priority</c>).
+    /// </summary>
+    public Dictionary<string, string>? Annotations { get; set; }
 }
 
 /// <summary>

--- a/test/BBT.Workflow.Domain.Tests/Definitions/TransitionTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Definitions/TransitionTests.cs
@@ -587,6 +587,71 @@ public class TransitionTests : DomainTestBase<DomainEntryPoint>
     }
 
     [Fact]
+    public void Annotations_ShouldBeNull_ByDefault()
+    {
+        // Act
+        var transition = Transition.Create("key", "from", "to", TriggerType.Manual, "Patch");
+
+        // Assert
+        Assert.Null(transition.Annotations);
+    }
+
+    [Fact]
+    public void Annotations_ShouldDeserialize_FromJson()
+    {
+        // Arrange
+        var json = """
+        {
+            "key": "submit",
+            "from": "draft",
+            "target": "review",
+            "triggerType": "manual",
+            "versionStrategy": "Patch",
+            "labels": [],
+            "onExecutionTasks": [],
+            "annotations": {
+                "ui/visible-in": "detail-page",
+                "ui/priority": "high"
+            }
+        }
+        """;
+
+        // Act
+        var transition = System.Text.Json.JsonSerializer.Deserialize<Transition>(json, JsonSerializerConstants.JsonOptions);
+
+        // Assert
+        Assert.NotNull(transition);
+        Assert.NotNull(transition.Annotations);
+        Assert.Equal(2, transition.Annotations.Count);
+        Assert.Equal("detail-page", transition.Annotations["ui/visible-in"]);
+        Assert.Equal("high", transition.Annotations["ui/priority"]);
+    }
+
+    [Fact]
+    public void Annotations_ShouldBeNull_WhenNotInJson()
+    {
+        // Arrange
+        var json = """
+        {
+            "key": "submit",
+            "from": "draft",
+            "target": "review",
+            "triggerType": "manual",
+            "versionStrategy": "Patch",
+            "labels": [],
+            "onExecutionTasks": []
+        }
+        """;
+
+        // Act
+        var transition = System.Text.Json.JsonSerializer.Deserialize<Transition>(json, JsonSerializerConstants.JsonOptions);
+
+        // Assert
+        Assert.NotNull(transition);
+        Assert.Null(transition.Annotations);
+    }
+
+    [Fact]
     public void View_ShouldBeNull_WhenNeitherFormatPresent()
     {
         var json = """


### PR DESCRIPTION
## Summary

Closes #642

Adds an optional `annotations` field (`Dictionary<string, string>?`) to transition definitions, enabling product teams to attach arbitrary key-value metadata for client-side filtering. The platform treats annotations as pure passthrough -- no pipeline step reads or acts on annotation values.

## Changes

### Domain Layer
- **`Transition.cs`**: Added `Annotations` property with `[JsonInclude]` for JSON deserialization from workflow definitions.

### Shared DTO
- **`HrefBase.cs`** (`TransitionItem`): Added `Annotations` property to the state function response DTO.

### Application Layer
- **`InstanceQueryAppService.cs`**: Maps annotations from resolved transition definitions to `TransitionItem` in three code paths:
  - Main-flow transitions (resolved from workflow definition)
  - SubFlow-originated transitions (propagated from SubFlow state response)
  - Parent-owned transitions in SubFlow context (resolved from parent workflow)

### Tests
- **`TransitionTests.cs`**: Added 3 tests:
  - `Annotations_ShouldBeNull_ByDefault`
  - `Annotations_ShouldDeserialize_FromJson`
  - `Annotations_ShouldBeNull_WhenNotInJson`

## Design Decisions

- **`Dictionary<string, string>`** chosen over `Dictionary<string, object>` for type safety and serialization simplicity.
- **Null suppression** handled globally by `DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull` -- annotations are omitted from JSON response when not defined.
- **No EF migration needed** -- transition definitions live in JSON/distributed cache, not in PostgreSQL.
- **Naming convention for keys**: use namespaced keys like `ui/visible-in`, `ui/priority` to avoid collisions (documented in XML comments).

## Acceptance Criteria

- [x] `Transition` definition model deserializes `annotations` from workflow JSON
- [x] `TransitionItem` in state function response includes `annotations` when present
- [x] `annotations` is omitted from JSON response when not defined (null suppression)
- [x] No pipeline step reads or acts on annotation values
- [x] Existing tests pass without modification
- [x] Build succeeds
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d4de148-ccd6-4af7-8a9e-ce957aa8d120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d4de148-ccd6-4af7-8a9e-ce957aa8d120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Add optional annotations metadata to workflow transitions and surface it in instance state responses for client-side use.

New Features:
- Introduce an optional annotations dictionary on transition definitions for attaching key-value metadata.
- Expose transition annotations on TransitionItem responses returned by the instance state API.

Tests:
- Add unit tests verifying default null annotations, JSON deserialization when annotations are present, and omission when absent.

## Summary by Sourcery

Add optional annotations metadata to workflow transition definitions and surface it on transition responses for client-side use.

New Features:
- Introduce an optional annotations dictionary on transition definitions for attaching key-value metadata.
- Expose transition annotations on TransitionItem responses returned by the instance state API.

Tests:
- Add unit tests verifying default null annotations, JSON deserialization when annotations are present, and null when absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Transitions now support annotations—optional metadata that enables client-side filtering and UI customization (e.g., visibility controls, priority settings).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/burgan-tech/vnext/pull/654)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->