### PR TITLE
643 enhancement add renderer property to view entity for UI sdk dispatch

### DIFF
--- a/src/BBT.Workflow.Application/Definitions/Validators/ViewComponentValidator.cs
+++ b/src/BBT.Workflow.Application/Definitions/Validators/ViewComponentValidator.cs
@@ -38,6 +38,13 @@ public sealed class ViewComponentValidator : IComponentValidator
                 result.AddError("View display is required.", $"{nameof(View)}.{nameof(View.Display)}");
             }
 
+            if (!string.IsNullOrEmpty(view.Renderer) && view.Type != ViewType.Json)
+            {
+                result.AddError(
+                    "Renderer can only be set when view type is Json.",
+                    $"{nameof(View)}.{nameof(View.Renderer)}");
+            }
+
             return result;
         }
         catch (JsonException ex)

--- a/src/BBT.Workflow.Application/Instances/DTOs/GetViewOutput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/GetViewOutput.cs
@@ -29,5 +29,11 @@ public sealed class GetViewOutput
     /// Localization label
     /// </summary>
     public string Label { get; set; }
+
+    /// <summary>
+    /// Identifies which UI SDK / render engine should interpret the view content.
+    /// Only relevant when <see cref="Type"/> is Json. Null when not specified.
+    /// </summary>
+    public string? Renderer { get; set; }
 }
 

--- a/src/BBT.Workflow.Application/Instances/DTOs/ViewInstanceAttributesDto.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/ViewInstanceAttributesDto.cs
@@ -32,4 +32,10 @@ public sealed class ViewInstanceAttributesDto
     /// </summary>
     [JsonPropertyName("label")]
     public string? Label { get; set; }
+
+    /// <summary>
+    /// Identifies which UI SDK / render engine should interpret the view content.
+    /// </summary>
+    [JsonPropertyName("renderer")]
+    public string? Renderer { get; set; }
 }

--- a/src/BBT.Workflow.Application/Instances/ViewContentResolutionService.cs
+++ b/src/BBT.Workflow.Application/Instances/ViewContentResolutionService.cs
@@ -106,7 +106,8 @@ public sealed class ViewContentResolutionService(
             Content = content,
             Type = view.Type.ToString(),
             Display = view.Display,
-            Label = string.Empty
+            Label = string.Empty,
+            Renderer = view.Renderer
         };
     }
 
@@ -128,7 +129,8 @@ public sealed class ViewContentResolutionService(
             Content = contentTyped,
             Type = viewType.ToString(),
             Display = attrs?.Display ?? string.Empty,
-            Label = attrs?.Label ?? string.Empty
+            Label = attrs?.Label ?? string.Empty,
+            Renderer = attrs?.Renderer
         };
     }
 

--- a/src/BBT.Workflow.Domain/Definitions/Views/View.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Views/View.cs
@@ -22,12 +22,14 @@ public sealed class View : IDomainEntity, IViewReference, IReferenceSetter
         ViewType type,
         object content,
         string display,
-        LanguageLabel[]? labels) : this()
+        LanguageLabel[]? labels,
+        string? renderer) : this()
     {
         Type = type;
         Content = content;
         Display = display;
         Labels = labels ?? [];
+        Renderer = renderer;
     }
 
     /// <summary>
@@ -71,10 +73,18 @@ public sealed class View : IDomainEntity, IViewReference, IReferenceSetter
     public string Display { get; private set; } = string.Empty;
     
     /// <summary>
-    /// Display
+    /// Localization labels
     /// </summary>
     public LanguageLabel[]? Labels { get; private set; } = [];
-    
+
+    /// <summary>
+    /// Identifies which UI SDK / render engine should interpret the view content.
+    /// Only relevant when <see cref="Type"/> is <see cref="ViewType.Json"/>.
+    /// Well-known values are defined in <see cref="ViewRenderer"/>.
+    /// </summary>
+    [JsonPropertyName("renderer")]
+    public string? Renderer { get; private set; }
+
     public static string ComponentTypeKey => RuntimeSysSchemaInfo.Views;
     public string ComponentKey => ComponentTypeKey;
 

--- a/src/BBT.Workflow.Domain/Definitions/Views/ViewEnums.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Views/ViewEnums.cs
@@ -35,3 +35,51 @@ public enum ViewType
     /// </summary>
     URN = 6
 }
+
+/// <summary>
+/// Well-known renderer identifiers for UI SDK dispatch.
+/// Used as values for <see cref="View.Renderer"/> to indicate which render engine
+/// should interpret the view content on the client side.
+/// </summary>
+public static class ViewRenderer
+{
+    /// <summary>
+    /// Pseudo UI renderer (schema-driven form generation)
+    /// </summary>
+    public const string PseudoUi = "pseudo-ui";
+
+    /// <summary>
+    /// Flutter renderer
+    /// </summary>
+    public const string Flutter = "flutter";
+
+    /// <summary>
+    /// Angular renderer
+    /// </summary>
+    public const string Angular = "angular";
+
+    /// <summary>
+    /// Vue.js renderer
+    /// </summary>
+    public const string Vue = "vue";
+
+    /// <summary>
+    /// React renderer
+    /// </summary>
+    public const string React = "react";
+
+    /// <summary>
+    /// React Native renderer
+    /// </summary>
+    public const string ReactNative = "react-native";
+
+    /// <summary>
+    /// Native iOS renderer
+    /// </summary>
+    public const string NativeIos = "native-ios";
+
+    /// <summary>
+    /// Native Android renderer
+    /// </summary>
+    public const string NativeAndroid = "native-android";
+}

--- a/test/BBT.Workflow.Application.Tests/Definitions/CastHandlers/ViewWorkflowCastHandlerTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Definitions/CastHandlers/ViewWorkflowCastHandlerTests.cs
@@ -85,4 +85,71 @@ public class ViewWorkflowCastHandlerTests
                 It.IsAny<CancellationToken>()), 
             Times.Once);
     }
+
+    [Fact]
+    public async Task HandleAsync_ShouldDeserializeAndCacheView_WithRenderer()
+    {
+        // Arrange
+        var reference = new Reference("renderer-view", "test-domain", "sys-views", "2.0.0");
+
+        var viewJson = """
+        {
+            "type": 1,
+            "content": "{}",
+            "display": "test-display",
+            "renderer": "flutter"
+        }
+        """;
+
+        var attributes = JsonDocument.Parse(viewJson).RootElement;
+
+        _mockViewsCacheSet
+            .Setup(x => x.SetAsync(It.IsAny<View>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Ok());
+
+        // Act
+        await _handler.HandleAsync(reference, attributes, CancellationToken.None);
+
+        // Assert
+        _mockViewsCacheSet.Verify(
+            x => x.SetAsync(It.Is<View>(v =>
+                v.Key == "renderer-view" &&
+                v.Domain == "test-domain" &&
+                v.Version == "2.0.0" &&
+                v.Renderer == "flutter"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ShouldDeserializeAndCacheView_WithoutRenderer()
+    {
+        // Arrange
+        var reference = new Reference("no-renderer-view", "test-domain", "sys-views", "1.0.0");
+
+        var viewJson = """
+        {
+            "type": 1,
+            "content": "{}",
+            "display": "test-display"
+        }
+        """;
+
+        var attributes = JsonDocument.Parse(viewJson).RootElement;
+
+        _mockViewsCacheSet
+            .Setup(x => x.SetAsync(It.IsAny<View>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Ok());
+
+        // Act
+        await _handler.HandleAsync(reference, attributes, CancellationToken.None);
+
+        // Assert
+        _mockViewsCacheSet.Verify(
+            x => x.SetAsync(It.Is<View>(v =>
+                v.Key == "no-renderer-view" &&
+                v.Renderer == null),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
 }

--- a/test/BBT.Workflow.Application.Tests/Definitions/Validators/ViewComponentValidatorTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Definitions/Validators/ViewComponentValidatorTests.cs
@@ -93,4 +93,108 @@ public class ViewComponentValidatorTests
         // Assert
         result.IsValid.ShouldBeFalse();
     }
+
+    [Fact]
+    public void Validate_ShouldReturnSuccess_ForJsonViewWithRenderer()
+    {
+        // Arrange
+        var viewJson = """
+        {
+            "type": "json",
+            "content": "{\"test\": \"content\"}",
+            "display": "test-display",
+            "renderer": "flutter"
+        }
+        """;
+        var attributes = JsonDocument.Parse(viewJson).RootElement;
+
+        // Act
+        var result = _validator.Validate(attributes);
+
+        // Assert
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_ShouldReturnSuccess_ForJsonViewWithoutRenderer()
+    {
+        // Arrange
+        var viewJson = """
+        {
+            "type": "json",
+            "content": "{\"test\": \"content\"}",
+            "display": "test-display"
+        }
+        """;
+        var attributes = JsonDocument.Parse(viewJson).RootElement;
+
+        // Act
+        var result = _validator.Validate(attributes);
+
+        // Assert
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_ShouldReturnError_ForNonJsonViewWithRenderer()
+    {
+        // Arrange
+        var viewJson = """
+        {
+            "type": "html",
+            "content": "<p>hello</p>",
+            "display": "test-display",
+            "renderer": "angular"
+        }
+        """;
+        var attributes = JsonDocument.Parse(viewJson).RootElement;
+
+        // Act
+        var result = _validator.Validate(attributes);
+
+        // Assert
+        result.IsValid.ShouldBeFalse();
+        result.ValidationErrors.ShouldContain(e => e.MemberNames.Contains("View.Renderer"));
+    }
+
+    [Fact]
+    public void Validate_ShouldReturnSuccess_ForNonJsonViewWithoutRenderer()
+    {
+        // Arrange
+        var viewJson = """
+        {
+            "type": "html",
+            "content": "<p>hello</p>",
+            "display": "test-display"
+        }
+        """;
+        var attributes = JsonDocument.Parse(viewJson).RootElement;
+
+        // Act
+        var result = _validator.Validate(attributes);
+
+        // Assert
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_ShouldReturnSuccess_ForJsonViewWithNullRenderer()
+    {
+        // Arrange
+        var viewJson = """
+        {
+            "type": "json",
+            "content": "{\"test\": \"content\"}",
+            "display": "test-display",
+            "renderer": null
+        }
+        """;
+        var attributes = JsonDocument.Parse(viewJson).RootElement;
+
+        // Act
+        var result = _validator.Validate(attributes);
+
+        // Assert
+        result.IsValid.ShouldBeTrue();
+    }
 }

--- a/test/BBT.Workflow.Application.Tests/Instances/ViewGetContentAsTypedTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/ViewGetContentAsTypedTests.cs
@@ -108,4 +108,48 @@ public class ViewGetContentAsTypedTests
         el.GetArrayLength().ShouldBe(3);
         el[0].GetInt32().ShouldBe(1);
     }
+
+    [Fact]
+    public void Deserialize_WithRenderer_RetainsRendererValue()
+    {
+        var json = """
+            {"type": 1, "content": "{}", "display": "test", "renderer": "flutter"}
+            """;
+        var view = JsonSerializer.Deserialize<View>(json, JsonSerializerConstants.JsonOptions);
+        view.ShouldNotBeNull();
+        view.Renderer.ShouldBe("flutter");
+    }
+
+    [Fact]
+    public void Deserialize_WithoutRenderer_HasNullRenderer()
+    {
+        var json = """
+            {"type": 1, "content": "{}", "display": "test"}
+            """;
+        var view = JsonSerializer.Deserialize<View>(json, JsonSerializerConstants.JsonOptions);
+        view.ShouldNotBeNull();
+        view.Renderer.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Deserialize_WithNullRenderer_HasNullRenderer()
+    {
+        var json = """
+            {"type": 1, "content": "{}", "display": "test", "renderer": null}
+            """;
+        var view = JsonSerializer.Deserialize<View>(json, JsonSerializerConstants.JsonOptions);
+        view.ShouldNotBeNull();
+        view.Renderer.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Deserialize_WithWellKnownRenderer_RetainsValue()
+    {
+        var json = $$"""
+            {"type": 1, "content": "{}", "display": "test", "renderer": "{{ViewRenderer.ReactNative}}"}
+            """;
+        var view = JsonSerializer.Deserialize<View>(json, JsonSerializerConstants.JsonOptions);
+        view.ShouldNotBeNull();
+        view.Renderer.ShouldBe(ViewRenderer.ReactNative);
+    }
 }


### PR DESCRIPTION
## Summary by Sourcery

Add support for an optional renderer identifier on views for UI SDK dispatch, including validation and exposure through DTOs and serialization.

New Features:
- Introduce a Renderer property on View and related DTOs to indicate which UI SDK or render engine should interpret view content.
- Define well-known renderer identifiers via the ViewRenderer helper class for consistent client-side dispatch.

Enhancements:
- Enforce that renderer can only be specified for JSON view types via component validation.
- Ensure view renderer values are deserialized, preserved, and cached correctly when handling views and resolving view content.

Tests:
- Add unit tests covering validation rules, deserialization behavior, and caching logic for views with and without renderer values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added renderer engine specification for JSON-based views to indicate which UI SDK interprets the content.
  * Introduced predefined renderer constants for Flutter, React, Angular, Vue, React Native, and native iOS/Android platforms.

* **Tests**
  * Added comprehensive test coverage for renderer field functionality, validation rules, and deserialization behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/burgan-tech/vnext/pull/656)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->