### PR TITLE
feat(shared-transitions): make AvailableIn optional for shared transitions

### DIFF
--- a/src/BBT.Workflow.Domain/Definitions/Transitions/Transition.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Transitions/Transition.cs
@@ -83,6 +83,13 @@ public sealed class Transition : IHasKey
     [JsonInclude] public ScriptCode? Timer { get; private set; }
     [JsonInclude] public ScriptCode? Rule { get; private set; }
     [JsonInclude] public Reference? Schema { get; private set; }
+
+    /// <summary>
+    /// Optional list of state keys restricting where this shared transition can be executed.
+    /// When empty or null, the transition is available from all states.
+    /// When populated, the transition is only available in the listed states.
+    /// Only valid for shared transitions and cancel; ignored for state-level transitions.
+    /// </summary>
     [JsonInclude] public List<string> AvailableIn { get; private set; }
     [JsonInclude] public ScriptCode? Mapping { get; private set; }
     [JsonInclude] public ResourceLockDefinition? ResourceLock { get; private set; }

--- a/src/BBT.Workflow.Domain/Definitions/Workflow.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Workflow.cs
@@ -186,8 +186,11 @@ public sealed class Workflow : IDomainEntity, IReference, IReferenceSetter, IHas
     public IReadOnlyCollection<IReference> Features => features.AsReadOnly();
 
     /// <summary>
-    /// It is used for common transition definitions such as Cancel in the flow.
-    /// It is to prevent redefinition in each state that passes.
+    /// Common transition definitions available across multiple states (e.g. Cancel, AddNote).
+    /// Prevents redefinition in each state.
+    /// Each shared transition may optionally specify an <see cref="Transition.AvailableIn"/> list
+    /// to restrict which states it can be executed from. When <c>AvailableIn</c> is empty or null,
+    /// the transition is available from all states.
     /// </summary>
     [JsonIgnore]
     public IReadOnlyCollection<Transition> SharedTransitions => sharedTransitions.AsReadOnly();

--- a/test/BBT.Workflow.Domain.Tests/Definitions/Specifications/SharedTransitionAvailabilitySpecificationTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Definitions/Specifications/SharedTransitionAvailabilitySpecificationTests.cs
@@ -1,0 +1,253 @@
+using System;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Definitions.Specifications;
+using BBT.Workflow.Execution;
+using BBT.Workflow.Instances;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Definitions.Specifications;
+
+/// <summary>
+/// Unit tests for SharedTransitionAvailabilitySpecification.
+/// Validates AvailableIn semantics: empty/null means available in all states,
+/// populated list restricts availability to listed states.
+/// </summary>
+public class SharedTransitionAvailabilitySpecificationTests
+{
+    private readonly SharedTransitionAvailabilitySpecification _specification;
+
+    public SharedTransitionAvailabilitySpecificationTests()
+    {
+        _specification = new SharedTransitionAvailabilitySpecification();
+    }
+
+    [Fact]
+    public void Priority_ShouldBe60()
+    {
+        _specification.Priority.ShouldBe(60);
+    }
+
+    #region IsApplicable
+
+    [Fact]
+    public void IsApplicable_ShouldReturnTrue_WhenTransitionIsSharedTransition()
+    {
+        var context = CreateContextWithSharedTransition("cancel", "cancelled", "review");
+
+        var result = _specification.IsApplicable(context);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsApplicable_ShouldReturnFalse_WhenTransitionIsNotSharedTransition()
+    {
+        var context = CreateContextWithStateTransition("submit", "review", "approved");
+
+        var result = _specification.IsApplicable(context);
+
+        result.ShouldBeFalse();
+    }
+
+    #endregion
+
+    #region IsSatisfiedBy — Empty AvailableIn
+
+    [Fact]
+    public void IsSatisfiedBy_ShouldReturnOk_WhenAvailableInIsEmpty()
+    {
+        var context = CreateContextWithSharedTransition("cancel", "cancelled", "review");
+
+        var result = _specification.IsSatisfiedBy(context);
+
+        result.IsSuccess.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsSatisfiedBy_ShouldReturnOk_WhenAvailableInIsEmpty_FromAnyState()
+    {
+        var context = CreateContextWithSharedTransition("cancel", "cancelled", "some-random-state");
+
+        var result = _specification.IsSatisfiedBy(context);
+
+        result.IsSuccess.ShouldBeTrue();
+    }
+
+    #endregion
+
+    #region IsSatisfiedBy — Populated AvailableIn
+
+    [Fact]
+    public void IsSatisfiedBy_ShouldReturnOk_WhenCurrentStateIsInAvailableIn()
+    {
+        var context = CreateContextWithSharedTransition(
+            "cancel", "cancelled", "review",
+            availableIn: ["review", "pending"]);
+
+        var result = _specification.IsSatisfiedBy(context);
+
+        result.IsSuccess.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsSatisfiedBy_ShouldReturnFail_WhenCurrentStateIsNotInAvailableIn()
+    {
+        var context = CreateContextWithSharedTransition(
+            "cancel", "cancelled", "initial",
+            availableIn: ["review", "pending"]);
+
+        var result = _specification.IsSatisfiedBy(context);
+
+        result.IsSuccess.ShouldBeFalse();
+        result.Error.Code.ShouldBe(WorkflowErrorCodes.SharedTransitionNotAvailableInState);
+    }
+
+    #endregion
+
+    #region IsSatisfiedBy — Error Boundary
+
+    [Fact]
+    public void IsSatisfiedBy_ShouldReturnOk_WhenIsErrorBoundaryTransition_EvenIfNotInAvailableIn()
+    {
+        var context = CreateContextWithSharedTransition(
+            "cancel", "cancelled", "initial",
+            availableIn: ["review"],
+            isErrorBoundary: true);
+
+        var result = _specification.IsSatisfiedBy(context);
+
+        result.IsSuccess.ShouldBeTrue();
+    }
+
+    #endregion
+
+    #region IsSatisfiedBy — Transition Not Found
+
+    [Fact]
+    public void IsSatisfiedBy_ShouldReturnFail_WhenTransitionIsNull()
+    {
+        var context = CreateContextWithNullTransition();
+
+        var result = _specification.IsSatisfiedBy(context);
+
+        result.IsSuccess.ShouldBeFalse();
+        result.Error.Code.ShouldBe("TransitionNotFound");
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static TransitionExecutionContext CreateContextWithSharedTransition(
+        string transitionKey,
+        string target,
+        string currentStateKey,
+        string[]? availableIn = null,
+        bool isErrorBoundary = false)
+    {
+        var workflow = Workflow.Create();
+        workflow.SetReference(new Reference("test-flow", "test-domain", "sys-flows", "1.0.0"));
+        workflow.SetType("F");
+
+        var currentState = State.Create(currentStateKey, StateType.Intermediate, StateSubType.None, "Patch");
+        workflow.AddState(currentState);
+
+        var targetState = State.Create(target, StateType.Finish, StateSubType.Cancelled, "Patch");
+        workflow.AddState(targetState);
+
+        var sharedTransition = Transition.Create(transitionKey, null, target, TriggerType.Manual, "Patch");
+
+        if (availableIn != null)
+        {
+            foreach (var state in availableIn)
+            {
+                sharedTransition.AddAvailableIn(state);
+            }
+        }
+
+        workflow.AddSharedTransition(sharedTransition);
+
+        var instanceId = Guid.NewGuid();
+        var instance = Instance.Create(instanceId, "sys_flows", "1.0.0", "test-key");
+
+        return new TransitionExecutionContext
+        {
+            InstanceId = instanceId,
+            Domain = "test-domain",
+            WorkflowKey = "test-flow",
+            TransitionKey = transitionKey,
+            Trigger = TriggerType.Manual,
+            Workflow = workflow,
+            Current = currentState,
+            Transition = sharedTransition,
+            Instance = instance,
+            IsErrorBoundaryTransition = isErrorBoundary
+        };
+    }
+
+    private static TransitionExecutionContext CreateContextWithStateTransition(
+        string transitionKey,
+        string fromState,
+        string toState)
+    {
+        var workflow = Workflow.Create();
+        workflow.SetReference(new Reference("test-flow", "test-domain", "sys-flows", "1.0.0"));
+        workflow.SetType("F");
+
+        var currentState = State.Create(fromState, StateType.Intermediate, StateSubType.None, "Patch");
+        var stateTransition = Transition.Create(transitionKey, fromState, toState, TriggerType.Manual, "Patch");
+        currentState.AddTransition(stateTransition);
+        workflow.AddState(currentState);
+
+        var targetState = State.Create(toState, StateType.Finish, StateSubType.Success, "Patch");
+        workflow.AddState(targetState);
+
+        var instanceId = Guid.NewGuid();
+        var instance = Instance.Create(instanceId, "sys_flows", "1.0.0", "test-key");
+
+        return new TransitionExecutionContext
+        {
+            InstanceId = instanceId,
+            Domain = "test-domain",
+            WorkflowKey = "test-flow",
+            TransitionKey = transitionKey,
+            Trigger = TriggerType.Manual,
+            Workflow = workflow,
+            Current = currentState,
+            Transition = stateTransition,
+            Instance = instance
+        };
+    }
+
+    private static TransitionExecutionContext CreateContextWithNullTransition()
+    {
+        var workflow = Workflow.Create();
+        workflow.SetReference(new Reference("test-flow", "test-domain", "sys-flows", "1.0.0"));
+        workflow.SetType("F");
+
+        var sharedTransition = Transition.Create("cancel", null, "cancelled", TriggerType.Manual, "Patch");
+        workflow.AddSharedTransition(sharedTransition);
+
+        var currentState = State.Create("review", StateType.Intermediate, StateSubType.None, "Patch");
+        workflow.AddState(currentState);
+
+        var instanceId = Guid.NewGuid();
+        var instance = Instance.Create(instanceId, "sys_flows", "1.0.0", "test-key");
+
+        return new TransitionExecutionContext
+        {
+            InstanceId = instanceId,
+            Domain = "test-domain",
+            WorkflowKey = "test-flow",
+            TransitionKey = "cancel",
+            Trigger = TriggerType.Manual,
+            Workflow = workflow,
+            Current = currentState,
+            Transition = null,
+            Instance = instance
+        };
+    }
+
+    #endregion
+}

--- a/test/BBT.Workflow.Domain.Tests/Definitions/Specifications/SubFlowBypassSpecificationTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Definitions/Specifications/SubFlowBypassSpecificationTests.cs
@@ -66,20 +66,68 @@ public class SubFlowBypassSpecificationTests
         result.IsSuccess.ShouldBeTrue();
     }
 
+    [Fact]
+    public void IsApplicable_WhenActiveSubFlowAndSharedTransitionWithEmptyAvailableIn_ShouldReturnFalse()
+    {
+        // Shared transition with empty AvailableIn is available in all states,
+        // so bypass should NOT apply (transition executes on parent).
+        var context = CreateContextWithSharedTransition(
+            hasActiveSubFlow: true,
+            transitionKey: "cancel",
+            availableIn: null);
+
+        var result = _specification.IsApplicable(context);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsApplicable_WhenActiveSubFlowAndSharedTransitionWithMatchingAvailableIn_ShouldReturnFalse()
+    {
+        var context = CreateContextWithSharedTransition(
+            hasActiveSubFlow: true,
+            transitionKey: "cancel",
+            availableIn: ["test-state"]);
+
+        var result = _specification.IsApplicable(context);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsApplicable_WhenActiveSubFlowAndSharedTransitionWithNonMatchingAvailableIn_ShouldReturnTrue()
+    {
+        // Shared transition is NOT available in current state, so bypass applies (forward to child).
+        var context = CreateContextWithSharedTransition(
+            hasActiveSubFlow: true,
+            transitionKey: "cancel",
+            availableIn: ["other-state"]);
+
+        var result = _specification.IsApplicable(context);
+
+        result.ShouldBeTrue();
+    }
+
     private static TransitionExecutionContext CreateContext(bool hasActiveSubFlow)
     {
+        var workflow = Workflow.Create();
+        workflow.SetReference(new Reference("test-workflow", "test-domain", "sys-flows", "1.0.0"));
+        workflow.SetType("F");
+
+        var currentState = State.Create("test-state", StateType.Intermediate, StateSubType.None, "Patch");
+        workflow.AddState(currentState);
+
         var instanceId = Guid.NewGuid();
         var instance = Instance.Create(instanceId, "sys_flows", "1.0.0","test-key");
 
         if (hasActiveSubFlow)
         {
-            // Add an active SubFlow correlation
             var correlation = InstanceCorrelation.Create(
                 Guid.NewGuid(),
                 instanceId,
                 "test-state",
                 Guid.NewGuid(),
-                "S", // SubFlow type code
+                "S",
                 "test-domain",
                 "test-subflow",
                 "1.0.0");
@@ -87,16 +135,72 @@ public class SubFlowBypassSpecificationTests
             instance.AddCorrelation(correlation);
         }
 
-        var context = new TransitionExecutionContext
+        return new TransitionExecutionContext
         {
             InstanceId = instanceId,
             Domain = "test-domain",
             WorkflowKey = "test-workflow",
             TransitionKey = "test-transition",
             Trigger = TriggerType.Manual,
+            Workflow = workflow,
+            Current = currentState,
             Instance = instance
         };
+    }
 
-        return context;
+    private static TransitionExecutionContext CreateContextWithSharedTransition(
+        bool hasActiveSubFlow,
+        string transitionKey,
+        string[]? availableIn)
+    {
+        var workflow = Workflow.Create();
+        workflow.SetReference(new Reference("test-workflow", "test-domain", "sys-flows", "1.0.0"));
+        workflow.SetType("F");
+
+        var currentState = State.Create("test-state", StateType.Intermediate, StateSubType.None, "Patch");
+        workflow.AddState(currentState);
+
+        var targetState = State.Create("cancelled", StateType.Finish, StateSubType.Cancelled, "Patch");
+        workflow.AddState(targetState);
+
+        var sharedTransition = Transition.Create(transitionKey, null, "cancelled", TriggerType.Manual, "Patch");
+        if (availableIn != null)
+        {
+            foreach (var state in availableIn)
+            {
+                sharedTransition.AddAvailableIn(state);
+            }
+        }
+        workflow.AddSharedTransition(sharedTransition);
+
+        var instanceId = Guid.NewGuid();
+        var instance = Instance.Create(instanceId, "sys_flows", "1.0.0", "test-key");
+
+        if (hasActiveSubFlow)
+        {
+            var correlation = InstanceCorrelation.Create(
+                Guid.NewGuid(),
+                instanceId,
+                "test-state",
+                Guid.NewGuid(),
+                "S",
+                "test-domain",
+                "test-subflow",
+                "1.0.0");
+            instance.AddCorrelation(correlation);
+        }
+
+        return new TransitionExecutionContext
+        {
+            InstanceId = instanceId,
+            Domain = "test-domain",
+            WorkflowKey = "test-workflow",
+            TransitionKey = transitionKey,
+            Trigger = TriggerType.Manual,
+            Workflow = workflow,
+            Current = currentState,
+            Transition = sharedTransition,
+            Instance = instance
+        };
     }
 }

--- a/test/BBT.Workflow.Domain.Tests/Definitions/Validators/WorkflowValidatorTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Definitions/Validators/WorkflowValidatorTests.cs
@@ -336,6 +336,164 @@ public class WorkflowValidatorTests : DomainTestBase<DomainEntryPoint>
 
     #endregion
 
+    #region SharedTransition AvailableIn Validation Tests
+
+    [Fact]
+    public void Validate_ShouldPass_WhenSharedTransitionHasNoAvailableIn()
+    {
+        var workflow = DeserializeWorkflow("""
+        {
+            "type": "F",
+            "labels": [{"label": "Test", "language": "en"}],
+            "states": [
+                {
+                    "key": "initial",
+                    "stateType": "initial",
+                    "labels": [{"label": "Initial", "language": "en"}],
+                    "transitions": []
+                },
+                {
+                    "key": "review",
+                    "stateType": "intermediate",
+                    "labels": [{"label": "Review", "language": "en"}],
+                    "transitions": []
+                },
+                {
+                    "key": "cancelled",
+                    "stateType": "finish",
+                    "labels": [{"label": "Cancelled", "language": "en"}],
+                    "transitions": []
+                }
+            ],
+            "sharedTransitions": [
+                {
+                    "key": "cancel",
+                    "target": "cancelled",
+                    "triggerType": "manual",
+                    "labels": [{"label": "Cancel", "language": "en"}]
+                }
+            ],
+            "startTransition": {
+                "key": "start",
+                "target": "initial",
+                "triggerType": "manual",
+                "labels": [{"label": "Start", "language": "en"}]
+            }
+        }
+        """);
+
+        var result = _validator.Validate(workflow);
+
+        var availableInErrors = result.ValidationErrors
+            .Where(e => e.ErrorMessage!.Contains("availableIn", StringComparison.OrdinalIgnoreCase) ||
+                        e.ErrorMessage!.Contains("AvailableIn", StringComparison.Ordinal))
+            .ToList();
+        availableInErrors.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Validate_ShouldPass_WhenSharedTransitionHasValidAvailableIn()
+    {
+        var workflow = DeserializeWorkflow("""
+        {
+            "type": "F",
+            "labels": [{"label": "Test", "language": "en"}],
+            "states": [
+                {
+                    "key": "initial",
+                    "stateType": "initial",
+                    "labels": [{"label": "Initial", "language": "en"}],
+                    "transitions": []
+                },
+                {
+                    "key": "review",
+                    "stateType": "intermediate",
+                    "labels": [{"label": "Review", "language": "en"}],
+                    "transitions": []
+                },
+                {
+                    "key": "cancelled",
+                    "stateType": "finish",
+                    "labels": [{"label": "Cancelled", "language": "en"}],
+                    "transitions": []
+                }
+            ],
+            "sharedTransitions": [
+                {
+                    "key": "cancel",
+                    "target": "cancelled",
+                    "triggerType": "manual",
+                    "availableIn": ["initial", "review"],
+                    "labels": [{"label": "Cancel", "language": "en"}]
+                }
+            ],
+            "startTransition": {
+                "key": "start",
+                "target": "initial",
+                "triggerType": "manual",
+                "labels": [{"label": "Start", "language": "en"}]
+            }
+        }
+        """);
+
+        var result = _validator.Validate(workflow);
+
+        var availableInErrors = result.ValidationErrors
+            .Where(e => e.ErrorMessage!.Contains("availableIn", StringComparison.OrdinalIgnoreCase) ||
+                        e.ErrorMessage!.Contains("AvailableIn", StringComparison.Ordinal))
+            .ToList();
+        availableInErrors.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Validate_ShouldFail_WhenSharedTransitionAvailableInReferencesInvalidState()
+    {
+        var workflow = DeserializeWorkflow("""
+        {
+            "type": "F",
+            "labels": [{"label": "Test", "language": "en"}],
+            "states": [
+                {
+                    "key": "initial",
+                    "stateType": "initial",
+                    "labels": [{"label": "Initial", "language": "en"}],
+                    "transitions": []
+                },
+                {
+                    "key": "cancelled",
+                    "stateType": "finish",
+                    "labels": [{"label": "Cancelled", "language": "en"}],
+                    "transitions": []
+                }
+            ],
+            "sharedTransitions": [
+                {
+                    "key": "cancel",
+                    "target": "cancelled",
+                    "triggerType": "manual",
+                    "availableIn": ["non-existent-state"],
+                    "labels": [{"label": "Cancel", "language": "en"}]
+                }
+            ],
+            "startTransition": {
+                "key": "start",
+                "target": "initial",
+                "triggerType": "manual",
+                "labels": [{"label": "Start", "language": "en"}]
+            }
+        }
+        """);
+
+        var result = _validator.Validate(workflow);
+
+        result.IsValid.ShouldBeFalse();
+        result.ValidationErrors.ShouldContain(e =>
+            e.ErrorMessage!.Contains("availableIn", StringComparison.OrdinalIgnoreCase) &&
+            e.ErrorMessage.Contains("non-existent-state", StringComparison.Ordinal));
+    }
+
+    #endregion
+
     #region Helper Methods
 
     private WorkflowDefinition CreateWorkflowWithDefaultAutoTransition()

--- a/test/BBT.Workflow.Domain.Tests/Definitions/WorkflowTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Definitions/WorkflowTests.cs
@@ -505,6 +505,98 @@ public class WorkflowTests : DomainTestBase<DomainEntryPoint>
     }
 
     [Fact]
+    public void GetAvailableUserTransitionKeys_ShouldIncludeSharedTransition_WhenAvailableInIsEmpty()
+    {
+        // Arrange
+        var workflow = Workflow.Create();
+        var state = State.Create("review", StateType.Intermediate, StateSubType.None, "Patch");
+        workflow.AddState(state);
+
+        var anotherState = State.Create("pending", StateType.Intermediate, StateSubType.None, "Patch");
+        workflow.AddState(anotherState);
+
+        var sharedTransition = Transition.Create("cancel", null, "cancelled", TriggerType.Manual, "Patch");
+        workflow.AddSharedTransition(sharedTransition);
+
+        // Act — should be available from any state when AvailableIn is empty
+        var resultReview = workflow.GetAvailableUserTransitionKeys(state);
+        var resultPending = workflow.GetAvailableUserTransitionKeys(anotherState);
+
+        // Assert
+        Assert.Contains("cancel", resultReview);
+        Assert.Contains("cancel", resultPending);
+    }
+
+    [Fact]
+    public void GetAvailableUserTransitionKeys_ShouldExcludeSharedTransition_WhenAvailableInDoesNotContainCurrentState()
+    {
+        // Arrange
+        var workflow = Workflow.Create();
+        var reviewState = State.Create("review", StateType.Intermediate, StateSubType.None, "Patch");
+        workflow.AddState(reviewState);
+
+        var pendingState = State.Create("pending", StateType.Intermediate, StateSubType.None, "Patch");
+        workflow.AddState(pendingState);
+
+        var sharedTransition = Transition.Create("cancel", null, "cancelled", TriggerType.Manual, "Patch");
+        sharedTransition.AddAvailableIn("review");
+        workflow.AddSharedTransition(sharedTransition);
+
+        // Act
+        var resultReview = workflow.GetAvailableUserTransitionKeys(reviewState);
+        var resultPending = workflow.GetAvailableUserTransitionKeys(pendingState);
+
+        // Assert
+        Assert.Contains("cancel", resultReview);
+        Assert.DoesNotContain("cancel", resultPending);
+    }
+
+    [Fact]
+    public void GetAvailableSharedTransitionKeysOnly_ShouldReturnAll_WhenAvailableInIsEmpty()
+    {
+        // Arrange
+        var workflow = Workflow.Create();
+        var stateA = State.Create("state-a", StateType.Intermediate, StateSubType.None, "Patch");
+        var stateB = State.Create("state-b", StateType.Intermediate, StateSubType.None, "Patch");
+        workflow.AddState(stateA);
+        workflow.AddState(stateB);
+
+        var sharedTransition = Transition.Create("notes", null, "$self", TriggerType.Manual, "Patch");
+        workflow.AddSharedTransition(sharedTransition);
+
+        // Act
+        var resultA = workflow.GetAvailableSharedTransitionKeysOnly(stateA);
+        var resultB = workflow.GetAvailableSharedTransitionKeysOnly(stateB);
+
+        // Assert
+        Assert.Contains("notes", resultA);
+        Assert.Contains("notes", resultB);
+    }
+
+    [Fact]
+    public void GetAvailableSharedTransitionKeysOnly_ShouldFilterByAvailableIn_WhenPopulated()
+    {
+        // Arrange
+        var workflow = Workflow.Create();
+        var stateA = State.Create("state-a", StateType.Intermediate, StateSubType.None, "Patch");
+        var stateB = State.Create("state-b", StateType.Intermediate, StateSubType.None, "Patch");
+        workflow.AddState(stateA);
+        workflow.AddState(stateB);
+
+        var sharedTransition = Transition.Create("notes", null, "$self", TriggerType.Manual, "Patch");
+        sharedTransition.AddAvailableIn("state-a");
+        workflow.AddSharedTransition(sharedTransition);
+
+        // Act
+        var resultA = workflow.GetAvailableSharedTransitionKeysOnly(stateA);
+        var resultB = workflow.GetAvailableSharedTransitionKeysOnly(stateB);
+
+        // Assert
+        Assert.Contains("notes", resultA);
+        Assert.DoesNotContain("notes", resultB);
+    }
+
+    [Fact]
     public void FindTransitionInContext_ShouldSearchAllTransitions()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- Make `availableIn` optional for shared transitions. When empty or null, the transition is available from **all states**; when populated, only from listed states.
- No runtime or validator code changes were needed — the codebase already handled empty `AvailableIn` correctly. This PR formalizes the contract with comprehensive tests and updated XML documentation.
- Fix a pre-existing NPE in `SubFlowBypassSpecificationTests` where the test context was missing a `Workflow` object.

## Changes
- `src/BBT.Workflow.Domain/Definitions/Transitions/Transition.cs` — XML doc on `AvailableIn` property
- `src/BBT.Workflow.Domain/Definitions/Workflow.cs` — XML doc on `SharedTransitions` property
- `test/.../SharedTransitionAvailabilitySpecificationTests.cs` — **new**: 9 tests covering empty, populated, error-boundary, and null-transition scenarios
- `test/.../SubFlowBypassSpecificationTests.cs` — 3 new tests for empty/matching/non-matching AvailableIn + fix pre-existing NPE
- `test/.../WorkflowValidatorTests.cs` — 3 new tests: no AvailableIn passes, valid AvailableIn passes, invalid state reference fails
- `test/.../WorkflowTests.cs` — 4 new tests for `GetAvailableUserTransitionKeys` and `GetAvailableSharedTransitionKeysOnly` with empty/populated AvailableIn

## Test Plan
- [ ] All 23 new/modified tests pass (`dotnet test --filter "SharedTransitionAvailability|SubFlowBypass|WorkflowValidatorTests.Validate_ShouldPass_WhenSharedTransaction|WorkflowTests.GetAvailableSharedTransition"`)
- [ ] Full domain test suite shows no regressions (pre-existing failures unchanged)

Closes #566

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Clarify and document semantics of shared transition availability and strengthen tests around AvailableIn handling and sub-flow bypass behavior.

Bug Fixes:
- Fix SubFlowBypass specification context setup to include workflow and transition data, preventing null reference errors when evaluating applicability.

Enhancements:
- Document AvailableIn as an optional list restricting shared transitions to specific states, including behavior when empty or null on transitions and workflows.
- Add comprehensive specification tests for SharedTransitionAvailabilitySpecification covering AvailableIn semantics, error-boundary behavior, and missing transition handling.
- Expand workflow tests to cover shared transition availability resolution for user transitions and shared-only transitions based on AvailableIn filtering.

Tests:
- Add validator tests ensuring shared transitions without AvailableIn or with valid state references pass validation, and that invalid AvailableIn state references fail as expected.
- Add SubFlowBypass specification tests verifying bypass applicability based on shared transition AvailableIn configuration and active sub-flows.