### PR TITLE
fix(pipeline): store mapped payload in InstanceTransition body instead of raw data

### DIFF
--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/CreateTransitionRecordStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/CreateTransitionRecordStep.cs
@@ -43,7 +43,7 @@ public sealed class CreateTransitionRecordStep(
 
         // Railway chain: Map data -> Add to instance -> Validate key uniqueness -> Persist
         return await MapTransitionDataAsync(context, transition, cancellationToken)
-            .Tap(mappedData => AddMappedDataToInstance(context, mappedData, transition))
+            .Tap(mappedData => AddMappedDataToInstance(context, mappedData, transition, instanceTransition))
             .BindAsync(_ => ValidateAndSetInstanceKeyAsync(context, cancellationToken))
             .TapAsync(_ => instanceRepository.UpdateAsync(context.Instance, true, cancellationToken))
             .TapAsync(_ =>
@@ -109,12 +109,13 @@ public sealed class CreateTransitionRecordStep(
     }
 
     /// <summary>
-    /// Adds mapped data to instance if available.
+    /// Adds mapped data to instance and updates the transition body when a mapping script was applied.
     /// </summary>
     private void AddMappedDataToInstance(
         TransitionExecutionContext context,
         object? mappedData,
-        Definitions.Transition? transition)
+        Definitions.Transition? transition,
+        InstanceTransition instanceTransition)
     {
         if (mappedData != null)
         {
@@ -122,6 +123,11 @@ public sealed class CreateTransitionRecordStep(
                 guidGenerator.Create(),
                 new JsonData(mappedData),
                 transition?.VersionStrategy);
+
+            if (transition?.Mapping is not null)
+            {
+                instanceTransition.SetBody(new JsonData(mappedData));
+            }
         }
 
         if (context.Tags != null)

--- a/src/BBT.Workflow.Domain/Instances/InstanceTransition.cs
+++ b/src/BBT.Workflow.Domain/Instances/InstanceTransition.cs
@@ -70,6 +70,14 @@ public sealed class InstanceTransition : Entity<Guid>, ICreationAuditedObject
     /// </summary>
     public JsonData Header { get; private set; }
     
+    /// <summary>
+    /// Updates the transition body with post-processed data (e.g. after mapping script execution).
+    /// </summary>
+    public void SetBody(JsonData body)
+    {
+        Body = body;
+    }
+
     public void Completed(string toState)
     {
         ToState = toState;

--- a/test/BBT.Workflow.Domain.Tests/Instances/InstanceTransitionTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Instances/InstanceTransitionTests.cs
@@ -318,5 +318,52 @@ public class InstanceTransitionTests : DomainTestBase<DomainEntryPoint>
         // Assert
         Assert.NotEqual(transition1.StartedAt, transition2.StartedAt);
     }
+
+    [Fact]
+    public void SetBody_ShouldUpdateBody()
+    {
+        // Arrange
+        var instanceTransition = InstanceTransition.Create(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            "transition",
+            "state",
+            TriggerType.Manual,
+            JsonData.CreateFrom("{\"raw\":true}"),
+            JsonData.CreateFrom("{}")
+        );
+        var mappedBody = JsonData.CreateFrom("{\"mapped\":true}");
+
+        // Act
+        instanceTransition.SetBody(mappedBody);
+
+        // Assert
+        Assert.Equal(mappedBody.Json, instanceTransition.Body.Json);
+    }
+
+    [Fact]
+    public void SetBody_ShouldReplaceOriginalBody()
+    {
+        // Arrange
+        var originalBody = JsonData.CreateFrom("{\"sensitive\":\"secret\",\"extra\":\"field\"}");
+        var instanceTransition = InstanceTransition.Create(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            "transition",
+            "state",
+            TriggerType.Manual,
+            originalBody,
+            JsonData.CreateFrom("{}")
+        );
+        var mappedBody = JsonData.CreateFrom("{\"safe\":\"value\"}");
+
+        // Act
+        instanceTransition.SetBody(mappedBody);
+
+        // Assert
+        Assert.DoesNotContain("sensitive", instanceTransition.Body.Json);
+        Assert.DoesNotContain("secret", instanceTransition.Body.Json);
+        Assert.Contains("safe", instanceTransition.Body.Json);
+    }
 }
 


### PR DESCRIPTION
## Summary
- When a transition mapping script is defined, `InstanceTransition.Body` now stores the mapped payload instead of the raw request data
- This keeps the transition audit record consistent with instance data and prevents sensitive/unwanted fields from leaking into the record
- When no mapping is defined, behavior is unchanged (raw payload stored as-is)

## Changes
- `src/BBT.Workflow.Domain/Instances/InstanceTransition.cs` — added `SetBody(JsonData)` domain method
- `src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/CreateTransitionRecordStep.cs` — updated `AddMappedDataToInstance` to propagate mapped data to transition body
- `test/BBT.Workflow.Domain.Tests/Instances/InstanceTransitionTests.cs` — added unit tests for `SetBody`

## Test Plan
- [ ] Run `dotnet test --filter "InstanceTransitionTests"` — all 14 tests pass
- [ ] Trigger a transition **with** a mapping script and verify `InstanceTransition.Body` contains the mapped payload
- [ ] Trigger a transition **without** a mapping script and verify `InstanceTransition.Body` contains the raw payload (unchanged behavior)

Closes #641

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Update transition records to store mapped payloads instead of raw request data when a mapping script is applied.

Bug Fixes:
- Ensure InstanceTransition.Body reflects the mapped payload to keep audit data consistent with stored instance data and avoid leaking unwanted fields.

Enhancements:
- Add a SetBody domain method on InstanceTransition to allow updating the transition body with post-processed data.
- Propagate mapped transition data to both the instance and the transition body when a mapping script is present.

Tests:
- Add unit tests covering InstanceTransition.SetBody behavior, including replacement of the original body and removal of sensitive fields from the stored payload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transition workflows now support updating transition record bodies during mapping script execution, enabling post-processing data transformations and customizations of transition records.

* **Tests**
  * Added comprehensive validation tests ensuring transition record bodies are correctly updated when mapping scripts are applied, with verification of field replacement and data transformation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/burgan-tech/vnext/pull/661)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->