### PR TITLE
feat(pipeline): add request-scoped distributed lock with SubFlow busy…

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
     <PropertyGroup>
 
         <!-- All Prism packages -->
-        <AetherPackageVersion>1.0.23</AetherPackageVersion>
+        <AetherPackageVersion>1.0.24</AetherPackageVersion>
         <!-- Elastic Apm packages -->
         <ElasticApmPackageVersion>1.31.0</ElasticApmPackageVersion>
         <!-- Microsoft packages -->
@@ -12,7 +12,7 @@
         <!-- HealthChecks packages - currently only support .NET 9.0 -->
         <HealthChecksPackageVersion>9.0.0</HealthChecksPackageVersion>
         <!-- Dapr packages -->
-        <DaprPackageVersion>1.16.1</DaprPackageVersion>
+        <DaprPackageVersion>1.17.9</DaprPackageVersion>
         <!-- Ulid -->
         <UlidPackageVersion>1.4.1</UlidPackageVersion>
         <!-- JsonSchema.NET -->
@@ -22,7 +22,7 @@
         <PollyPackageVersion>8.6.5</PollyPackageVersion>
 
         <!-- OpenTelemetry packages -->
-        <OpenTelemetryPackageVersion>1.14.0</OpenTelemetryPackageVersion>
+        <OpenTelemetryPackageVersion>1.15.3</OpenTelemetryPackageVersion>
       
         <!-- Microsot Test SDK packages -->
         <TestSdkPackageVersion>18.0.1</TestSdkPackageVersion>

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
@@ -3,6 +3,7 @@ using BBT.Aether;
 using BBT.Aether.AspNetCore.Controllers;
 using BBT.Aether.AspNetCore.Results;
 using BBT.Workflow.Domain.Shared;
+using BBT.Workflow.Gateway;
 using BBT.Workflow.Instances;
 using BBT.Workflow.SubFlow;
 using Microsoft.AspNetCore.Mvc;
@@ -21,7 +22,8 @@ public sealed class InstanceController(
     IHttpContextAccessor httpContextAccessor,
     ISubflowCompletionService subflowCompletionService,
     ISubflowStateService subflowStateService,
-    ISubflowFaultService subflowFaultService) : AetherControllerBase
+    ISubflowFaultService subflowFaultService,
+    IInstanceCommandGateway instanceCommandGateway) : AetherControllerBase
 {
     /// <summary>
     /// Starts a new workflow instance.
@@ -153,6 +155,38 @@ public sealed class InstanceController(
     {
         await subflowFaultService.FaultAsync(request, cancellationToken);
         return Ok();
+    }
+
+    /// <summary>
+    /// Marks an instance Busy and recursively propagates to nested SubFlows.
+    /// Internal endpoint for cross-domain SubFlow busy propagation.
+    /// </summary>
+    /// <param name="domain">Target workflow domain.</param>
+    /// <param name="workflow">Target workflow definition key.</param>
+    /// <param name="instance">Instance identifier (GUID).</param>
+    /// <param name="version">Optional workflow version for schema resolution.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <response code="200">Operation completed successfully or instance was absent (no-op).</response>
+    [ApiExplorerSettings(IgnoreApi = true)]
+    [HttpPut("{domain}/workflows/{workflow}/instances/{instance}/busy")]
+    public async Task<IActionResult> MarkBusyAsync(
+        [FromRoute] string domain,
+        [FromRoute] string workflow,
+        [FromRoute] Guid instance,
+        [FromQuery] string? version = null,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await instanceCommandGateway.MarkBusyAsync(
+            new MarkBusyInput
+            {
+                Domain = domain,
+                Workflow = workflow,
+                InstanceId = instance,
+                Version = version
+            },
+            cancellationToken);
+
+        return FromResult(result);
     }
 
     /// <summary>

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Microsoft/Extensions/DependencyInjection/OrchestrationApiServiceCollectionExtensions.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Microsoft/Extensions/DependencyInjection/OrchestrationApiServiceCollectionExtensions.cs
@@ -36,6 +36,7 @@ public static class OrchestrationApiServiceCollectionExtensions
             .AddTelemetry(configuration)
             .AddDistributedCache(configuration) // Can be called before or after InfrastructureModule
             .AddDistributedLock(configuration)
+            .AddTransitionLockScope()
             .AddBackgroundJob()
             .AddRedis()
             .AddExceptionHandling()

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/ReservedTransitionResolver.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/ReservedTransitionResolver.cs
@@ -1,0 +1,25 @@
+using BBT.Workflow.Execution.Pipeline;
+
+namespace BBT.Workflow.Execution;
+
+/// <summary>
+/// Identifies reserved transitions for instance locking behavior.
+/// Cancel, exit, updateData, and timeout transitions bypass locking; subflow resume
+/// is reserved but acquires an independent lock scope.
+/// </summary>
+public sealed class ReservedTransitionResolver : IReservedTransitionResolver
+{
+    /// <inheritdoc />
+    public bool IsReserved(TransitionExecutionContext context)
+    {
+        return context.IsCancelTransition()
+            || context.IsExitTransition()
+            || context.IsUpdateDataTransition()
+            || context.Directives.IsTimeoutTransition
+            || context.Directives.IsSubFlowResume;
+    }
+
+    /// <inheritdoc />
+    public bool RequiresOwnLock(TransitionExecutionContext context)
+        => context.Directives.IsSubFlowResume;
+}

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/TransitionPipeline.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/TransitionPipeline.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using BBT.Aether.Aspects;
-using BBT.Aether.DistributedLock;
 using BBT.Aether.Results;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Execution;
@@ -14,25 +13,22 @@ namespace BBT.Workflow.Execution.Pipeline;
 
 /// <summary>
 /// Orchestrates the execution of transition lifecycle steps in a deterministic order.
-/// Manages distributed locks and sync dispatch chain for automatic transitions.
-/// Each step in the pipeline performs a specific operation during the transition.
-/// Uses Result pattern for exception-free error handling.
-/// Error boundary handling is delegated to TaskCoordinator at task level.
+/// Acquires a single request-scoped lock that covers the entire auto-chain —
+/// no gap between chained transitions.
+/// Reserved transitions bypass the outer lock unless they require an own scope (subflow resume).
 /// </summary>
 public class TransitionPipeline
 {
     private readonly IReadOnlyList<ITransitionStep> _steps;
-    private readonly IDistributedLockService _distributedLockService;
+    private readonly ITransitionLockScopeFactory _lockScopeFactory;
+    private readonly IReservedTransitionResolver _reservedTransitionResolver;
+    private readonly IInstanceBusyMarker _busyMarker;
     private readonly ITransitionContextFactory _contextFactory;
     private readonly IPostCommitExecutor _postCommitExecutor;
     private readonly IInstanceRepository _instanceRepository;
     private readonly ITransitionValidationService _validationService;
     private readonly IPipelineProfileResolver _profileResolver;
     private readonly ILogger<TransitionPipeline> _logger;
-    /// <summary>
-    /// Default lock lease duration in seconds.
-    /// </summary>
-    private const int DefaultLockLeaseSeconds = 60;
 
     /// <summary>
     /// Maximum allowed chain depth for automatic transitions.
@@ -43,17 +39,11 @@ public class TransitionPipeline
     /// <summary>
     /// Initializes a new instance of the TransitionPipeline.
     /// </summary>
-    /// <param name="steps">The collection of pipeline steps to execute.</param>
-    /// <param name="distributedLockService">Service for distributed locking.</param>
-    /// <param name="contextFactory">Factory for creating transition contexts.</param>
-    /// <param name="postCommitExecutor">Executor for post-commit jobs.</param>
-    /// <param name="instanceRepository">Repository for instance operations.</param>
-    /// <param name="validationService">Service for transition validation.</param>
-    /// <param name="profileResolver">Resolver that selects the pipeline execution profile for the current workflow context.</param>
-    /// <param name="logger">Logger instance.</param>
     public TransitionPipeline(
         IEnumerable<ITransitionStep> steps,
-        IDistributedLockService distributedLockService,
+        ITransitionLockScopeFactory lockScopeFactory,
+        IReservedTransitionResolver reservedTransitionResolver,
+        IInstanceBusyMarker busyMarker,
         ITransitionContextFactory contextFactory,
         IPostCommitExecutor postCommitExecutor,
         IInstanceRepository instanceRepository,
@@ -62,7 +52,9 @@ public class TransitionPipeline
         ILogger<TransitionPipeline> logger)
     {
         _steps = steps.OrderBy(s => s.Order).ToList();
-        _distributedLockService = distributedLockService;
+        _lockScopeFactory = lockScopeFactory;
+        _reservedTransitionResolver = reservedTransitionResolver;
+        _busyMarker = busyMarker;
         _contextFactory = contextFactory;
         _postCommitExecutor = postCommitExecutor;
         _instanceRepository = instanceRepository;
@@ -72,135 +64,164 @@ public class TransitionPipeline
     }
 
     /// <summary>
-    /// Executes the transition pipeline with distributed locking and sync dispatch chain.
-    /// Manages lock acquisition/release per transition and chains automatic transitions.
+    /// Executes the transition pipeline with a single request-scoped lock.
+    /// The lock is acquired once before the first transition and held for the
+    /// entire auto-chain, except reserved paths that bypass or use an independent scope.
     /// </summary>
-    /// <param name="workflowContext">The workflow execution context containing request details.</param>
-    /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
-    /// <returns>A Result containing the final TransitionExecutionContext or an error.</returns>
     public async Task<Result<TransitionExecutionContext>> RunAsync(
         WorkflowExecutionContext workflowContext,
         CancellationToken cancellationToken)
     {
-        var currentWorkflowContext = workflowContext;
-        bool pipelineFaulted = false;
+        // 1) Build the first context to decide reserved vs normal path
+        var contextResult = await CreateAndValidateContextAsync(workflowContext, cancellationToken);
+        if (!contextResult.IsSuccess)
+            return Result<TransitionExecutionContext>.Fail(contextResult.Error);
 
-        // Sync dispatch loop: chains automatic transitions under the same trace
+        var context = contextResult.Value!;
+
+        if (context.SkipImmediateExecution)
+            return Result<TransitionExecutionContext>.Ok(context);
+
+        // 2) Reserved transitions — bypass lock or use an independent scope (subflow resume)
+        if (_reservedTransitionResolver.IsReserved(context))
+        {
+            if (_reservedTransitionResolver.RequiresOwnLock(context))
+            {
+                await using var ownLock = await _lockScopeFactory.AcquireAsync(context.LockKey, cancellationToken);
+                if (!ownLock.IsAcquired)
+                {
+                    _logger.InstanceLockFailed(context.InstanceId.ToString());
+                    return Result<TransitionExecutionContext>.Fail(
+                        WorkflowErrors.InstanceLockConflict(context.InstanceId));
+                }
+
+                await _busyMarker.MarkBusyAsync(context.InstanceId, cancellationToken);
+                return await RunChainAsync(context, workflowContext, ownLock, cancellationToken);
+            }
+
+            _logger.LogDebug(
+                "Reserved transition {TransitionKey} for instance {InstanceId} — lock bypassed",
+                context.TransitionKey, context.InstanceId);
+            return await RunChainAsync(context, workflowContext, lockScope: null, cancellationToken);
+        }
+
+        // 3) Normal transitions — acquire single lock for the entire chain
+        await using var lockScope = await _lockScopeFactory.AcquireAsync(context.LockKey, cancellationToken);
+
+        if (!lockScope.IsAcquired)
+        {
+            _logger.InstanceLockFailed(context.InstanceId.ToString());
+            return Result<TransitionExecutionContext>.Fail(
+                WorkflowErrors.InstanceLockConflict(context.InstanceId));
+        }
+
+        // 4) Mark instance Busy immediately after lock acquisition
+        await _busyMarker.MarkBusyAsync(context.InstanceId, cancellationToken);
+
+        // 5) Run the entire chain under this lock scope
+        return await RunChainAsync(context, workflowContext, lockScope, cancellationToken);
+    }
+
+    /// <summary>
+    /// Runs the full transition chain (first + auto-chained) under a single lock scope.
+    /// The lock is extended between chain iterations to prevent TTL expiry.
+    /// </summary>
+    private async Task<Result<TransitionExecutionContext>> RunChainAsync(
+        TransitionExecutionContext initialContext,
+        WorkflowExecutionContext initialWorkflowContext,
+        ITransitionLockScope? lockScope,
+        CancellationToken cancellationToken)
+    {
+        var context = initialContext;
+        var currentWorkflowContext = initialWorkflowContext;
+
         while (true)
         {
-            // Guard: Prevent infinite chain loops (defense in depth)
-            var currentDepth = currentWorkflowContext.Execution?.ChainDepth ?? 0;
-            if (currentDepth > MaxChainDepth)
+            // Guard: Prevent infinite chain loops
+            if (context.ChainDepth > MaxChainDepth)
             {
-                _logger.TransitionChainDepthExceeded(
-                    currentDepth,
-                    MaxChainDepth,
-                    currentWorkflowContext.TransitionKey);
+                _logger.TransitionChainDepthExceeded(context.ChainDepth, MaxChainDepth, context.TransitionKey);
                 return Result<TransitionExecutionContext>.Fail(
                     WorkflowErrors.TransitionChainDepthExceeded(
-                        currentDepth,
-                        MaxChainDepth,
-                        currentWorkflowContext.TransitionKey));
+                        context.ChainDepth, MaxChainDepth, context.TransitionKey));
             }
 
-            // 1) Create TransitionExecutionContext
-            var contextResult = await _contextFactory.CreateAsync(currentWorkflowContext, cancellationToken);
-            if (!contextResult.IsSuccess)
-                return Result<TransitionExecutionContext>.Fail(contextResult.Error);
-
-            var context = contextResult.Value!;
-
-            // 1.5) VALIDATION GUARD - Validate trigger type and execution rules
-            // This ensures all transitions (including auto-chained) are validated
-            var triggerValidationResult = await _validationService.ValidateAsync(context, cancellationToken);
-            if (!triggerValidationResult.IsSuccess)
-                return Result<TransitionExecutionContext>.Fail(triggerValidationResult.Error);
-
-            // Guard: Skip immediate execution requested (e.g., scheduled transitions)
-            if (context.SkipImmediateExecution)
-                return Result<TransitionExecutionContext>.Ok(context);
-
-            var profile = _profileResolver.Resolve(currentWorkflowContext);
-            context.Profile = profile;
-
-            // Post-commit jobs collected during pipeline execution
-            IReadOnlyList<IPostCommitJob> postCommitJobs = [];
-
-            // 2) Execute with distributed lock
-            var lockAcquired = await _distributedLockService.ExecuteWithLockAsync(
-                context.LockKey,
-                async () =>
-                {
-                    // 3) Execute pipeline steps
-                    var pipelineResult = await RunSingleTransitionAsync(context, cancellationToken);
-                    if (!pipelineResult.IsSuccess)
-                    {
-                        // Mark instance as faulted instead of propagating error
-                        // This allows returning OK response with Status = "F" to client
-                        await MarkInstanceFaultedAsync(context, pipelineResult.Error, cancellationToken);
-                        pipelineFaulted = true;
-                        return;
-                    }
-
-                    // 4) Consume post-commit jobs before lock release
-                    postCommitJobs = context.Directives.ConsumePostCommitJobs();
-                },
-                DefaultLockLeaseSeconds,
-                cancellationToken);
-
-            if (!lockAcquired)
+            // Execute pipeline steps for this transition
+            var pipelineResult = await RunSingleTransitionAsync(context, cancellationToken);
+            if (!pipelineResult.IsSuccess)
             {
-                _logger.InstanceLockFailed(context.InstanceId.ToString());
-                return Result<TransitionExecutionContext>.Fail(
-                    WorkflowErrors.InstanceLockConflict(context.InstanceId));
+                await MarkInstanceFaultedAsync(context, pipelineResult.Error, cancellationToken);
+                return Result<TransitionExecutionContext>.Ok(context);
             }
 
-            // Pipeline faulted: return success with faulted instance (client sees Status = "F")
-            if (pipelineFaulted)
-                return Result<TransitionExecutionContext>.Ok(context);
-
-            // 5) Execute post-commit jobs (outside lock - avoids deadlocks for remote calls)
+            // Execute post-commit jobs (inside lock scope)
+            var postCommitJobs = context.Directives.ConsumePostCommitJobs();
             if (postCommitJobs.Count > 0)
             {
                 var postCommitResult = await _postCommitExecutor.ExecuteAsync(postCommitJobs, context, cancellationToken);
                 if (!postCommitResult.IsSuccess)
                 {
-                    // System error with fault request: reacquire lock and mark instance as faulted
                     if (postCommitResult.FaultRequest is not null)
                     {
-                        await MarkInstanceFaultedWithLockAsync(
-                            context,
-                            postCommitResult.FaultRequest,
-                            cancellationToken);
-                        
-                        // Return OK with faulted instance - client sees Status = "F"
+                        await MarkInstanceFaultedFromPostCommitAsync(context, postCommitResult.FaultRequest, cancellationToken);
                         return Result<TransitionExecutionContext>.Ok(context);
                     }
 
-                    // Client error (no fault request): return error to client without faulting instance
-                    // context.ClientResponse already contains the error details set by the handler
-                    var error = postCommitResult.Error ?? WorkflowErrors.ConfigInvalid(context.InstanceId, "Post-commit execution failed without error details");
+                    var error = postCommitResult.Error
+                        ?? WorkflowErrors.ConfigInvalid(context.InstanceId, "Post-commit execution failed without error details");
                     return Result<TransitionExecutionContext>.Fail(error);
                 }
             }
 
-            // 6) Apply deferred resolved status after all work is done
-            await ApplyResolvedStatusAsync(context, cancellationToken);
-
-            // 7) Check for next transition in sync dispatch chain
+            // Check for next transition in the auto-chain
             var nextTransition = context.Directives.ConsumeNextTransition();
             if (nextTransition is null)
+            {
+                // Chain complete — apply deferred status (inside lock, no re-acquire needed)
+                await ApplyResolvedStatusAsync(context, cancellationToken);
                 return Result<TransitionExecutionContext>.Ok(context);
+            }
 
-            // 8) Create new WorkflowExecutionContext for next transition
+            // Extend lock TTL before starting the next chained transition
+            if (lockScope is not null)
+            {
+                await lockScope.ExtendAsync(cancellationToken);
+            }
+
+            // Build next context for the chained transition
             currentWorkflowContext = CreateNextWorkflowContext(context, nextTransition);
-            pipelineFaulted = false; // Reset for next iteration
+            var nextContextResult = await CreateAndValidateContextAsync(currentWorkflowContext, cancellationToken);
+            if (!nextContextResult.IsSuccess)
+                return Result<TransitionExecutionContext>.Fail(nextContextResult.Error);
+
+            context = nextContextResult.Value!;
         }
     }
 
     /// <summary>
+    /// Creates and validates a transition context from a workflow context.
+    /// Shared by the initial entry and auto-chain iterations.
+    /// </summary>
+    private async Task<Result<TransitionExecutionContext>> CreateAndValidateContextAsync(
+        WorkflowExecutionContext workflowContext,
+        CancellationToken cancellationToken)
+    {
+        var contextResult = await _contextFactory.CreateAsync(workflowContext, cancellationToken);
+        if (!contextResult.IsSuccess)
+            return Result<TransitionExecutionContext>.Fail(contextResult.Error);
+
+        var context = contextResult.Value!;
+
+        var validationResult = await _validationService.ValidateAsync(context, cancellationToken);
+        if (!validationResult.IsSuccess)
+            return Result<TransitionExecutionContext>.Fail(validationResult.Error);
+
+        context.Profile = _profileResolver.Resolve(workflowContext);
+        return Result<TransitionExecutionContext>.Ok(context);
+    }
+
+    /// <summary>
     /// Executes a single transition's pipeline steps.
-    /// Includes global error boundary wrapper for unhandled exceptions.
     /// </summary>
     [Trace]
     private async Task<Result> RunSingleTransitionAsync(
@@ -218,21 +239,17 @@ public class TransitionPipeline
             {
                 while (state.HasMoreSteps())
                 {
-                    // Guard: Skip immediate execution requested
                     if (context.SkipImmediateExecution)
                         return Result.Ok();
 
-                    // Execute current step with error boundary handling
                     var stepResult = await ExecuteStepWithBoundaryAsync(
                         state.CurrentStep, context, cancellationToken);
 
                     if (!stepResult.IsSuccess)
                         return Result.Fail(stepResult.Error);
 
-                    // Determine flow control based on step outcome
                     var flowControl = DetermineFlowControl(stepResult.Value!, state.CurrentStep, context, state);
 
-                    // Apply flow control decision
                     if (flowControl.ShouldStop)
                         break;
 
@@ -249,7 +266,6 @@ public class TransitionPipeline
             }
             catch (Exception ex)
             {
-                // Unhandled exception - propagate as error
                 _logger.LogError(ex, "Unhandled exception in pipeline execution for workflow {WorkflowKey}",
                     context.Workflow.Key);
                 return Result.Fail(Error.Failure("PipelineException", ex.Message));
@@ -259,7 +275,6 @@ public class TransitionPipeline
 
     /// <summary>
     /// Builds a log scope dictionary for the current transition.
-    /// All log lines emitted within <see cref="RunSingleTransitionAsync"/> will carry these fields automatically.
     /// </summary>
     private static Dictionary<string, object> BuildLogScope(TransitionExecutionContext context)
     {
@@ -286,8 +301,7 @@ public class TransitionPipeline
     }
 
     /// <summary>
-    /// Executes a pipeline step.
-    /// Error boundary handling is now delegated to TaskCoordinator for task steps.
+    /// Executes a pipeline step with exception boundary.
     /// </summary>
     private async Task<Result<StepOutcome>> ExecuteStepWithBoundaryAsync(
         ITransitionStep step,
@@ -379,7 +393,6 @@ public class TransitionPipeline
 
     /// <summary>
     /// Builds an execution plan by filtering and ordering steps based on context directives.
-    /// Handles resume points, epilogue modes, and terminal states.
     /// </summary>
     private IReadOnlyList<ITransitionStep> BuildExecutionPlan(
         TransitionExecutionContext context,
@@ -389,19 +402,16 @@ public class TransitionPipeline
             .Where(s => !profile.ExcludedStepOrders.Contains(s.Order))
             .ToList();
 
-        // 1) ResumeFrom start
         var startOrder = context.Directives.ConsumeResumeFrom();
         if (startOrder.HasValue)
             ordered = ordered.Where(s => s.Order >= startOrder.Value).ToList();
 
-        // 2) Subflow terminal short circuit (until Finalize)
         if (context.Directives.TerminalReached)
         {
             var maxOrder = LifecycleOrder.Finalize;
             ordered = ordered.Where(s => s.Order <= maxOrder).ToList();
         }
 
-        // 3) Epilogue policy
         if (context.Directives.Epilogue == EpilogueMode.Skip)
         {
             ordered = ordered
@@ -414,19 +424,7 @@ public class TransitionPipeline
     }
 
     /// <summary>
-    /// Executes a single pipeline step.
-    /// Delegates to step implementation.
-    /// </summary>
-    private static Task<Result<StepOutcome>> ExecuteStepAsync(
-        ITransitionStep step,
-        TransitionExecutionContext context,
-        CancellationToken cancellationToken)
-        => step.ExecuteAsync(context, cancellationToken);
-
-    /// <summary>
     /// Determines flow control based on step outcome.
-    /// Applies directive mutations and returns appropriate flow control decision.
-    /// Sync method - no async operations needed.
     /// </summary>
     private static FlowControl DetermineFlowControl(
         StepOutcome outcome,
@@ -434,35 +432,26 @@ public class TransitionPipeline
         TransitionExecutionContext context,
         PipelineState state)
     {
-        // Apply directive mutations from outcome
         outcome.MutateDirectives?.Invoke(context.Directives);
 
-        // 1) Stop pipeline?
         if (outcome.StopPipeline)
             return FlowControl.Stop();
 
-        // 2) Skip to specific order? (e.g., restart from CreateTransition after inline auto)
         if (outcome.SkipToOrder is { } skipTo)
         {
             context.Directives.RequestResumeFrom(skipTo);
             return FlowControl.Replan();
         }
 
-        // 3) Directives changed requiring replan?
         if (NeedsReplan(state.Plan, context.Directives))
         {
             context.Directives.RequestResumeFrom(step.Order + 1);
             return FlowControl.Replan();
         }
 
-        // Continue to next step
         return FlowControl.Continue();
     }
 
-    /// <summary>
-    /// Determines if the execution plan needs to be rebuilt.
-    /// Checks for terminal state, epilogue mode changes, and resume requests.
-    /// </summary>
     private static bool NeedsReplan(IReadOnlyList<ITransitionStep> currentPlan, PipelineDirectives d)
     {
         if (d.TerminalReached)
@@ -479,13 +468,9 @@ public class TransitionPipeline
     }
 
     /// <summary>
-    /// Marks the workflow instance as faulted within an existing lock scope.
-    /// Called when pipeline execution fails after all error boundary actions are exhausted.
-    /// Client will receive OK response with Status = "F" instead of an exception.
+    /// Marks the workflow instance as faulted. Already within lock scope —
+    /// no re-acquisition needed.
     /// </summary>
-    /// <param name="context">The transition execution context.</param>
-    /// <param name="error">The error that caused the fault.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
     private async Task MarkInstanceFaultedAsync(
         TransitionExecutionContext context,
         Error error,
@@ -493,11 +478,8 @@ public class TransitionPipeline
     {
         _logger.LogWarning(
             "Marking instance {InstanceId} as faulted due to unhandled pipeline error: {ErrorCode} - {ErrorMessage}",
-            context.InstanceId,
-            error.Code,
-            error.Message);
+            context.InstanceId, error.Code, error.Message);
 
-        // Record incident if not already recorded by a boundary handler
         if (!context.Instance.HasActiveIncident)
         {
             var incident = InstanceIncidentFactory.Create(
@@ -512,7 +494,6 @@ public class TransitionPipeline
             context.Instance.AddIncident(incident);
         }
 
-        // Already within lock scope - update instance directly
         context.Instance.Fault(context.Domain);
         context.ExtractAndDeferInstanceEvents();
         await _instanceRepository.UpdateAsync(context.Instance, true, cancellationToken);
@@ -523,77 +504,31 @@ public class TransitionPipeline
     }
 
     /// <summary>
-    /// Marks the workflow instance as faulted within a lock scope.
-    /// Reacquires the distributed lock to ensure consistent state update.
-    /// Used for post-commit failures that occur outside the main lock.
+    /// Marks the workflow instance as faulted due to a post-commit failure.
+    /// Already within lock scope — no re-acquisition needed.
+    /// Uses the context's instance directly since we never released the lock.
     /// </summary>
-    /// <param name="context">The transition execution context.</param>
-    /// <param name="faultRequest">The fault request containing error details.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    private async Task MarkInstanceFaultedWithLockAsync(
+    private async Task MarkInstanceFaultedFromPostCommitAsync(
         TransitionExecutionContext context,
         PostCommitFaultRequest faultRequest,
         CancellationToken cancellationToken)
     {
         _logger.LogWarning(
             "Marking instance {InstanceId} as faulted due to post-commit failure: {ErrorCode} - {ErrorMessage}",
-            context.InstanceId,
-            faultRequest.ErrorCode,
-            faultRequest.ErrorMessage);
+            context.InstanceId, faultRequest.ErrorCode, faultRequest.ErrorMessage);
 
-        var lockAcquired = await _distributedLockService.ExecuteWithLockAsync(
-            context.LockKey,
-            async () =>
-            {
-                var instanceResult = await _instanceRepository.GetResultAsync(
-                    context.InstanceId.ToString(),
-                    includeDetails: false,
-                    cancellationToken);
+        context.Instance.Fault(context.Domain);
+        context.ExtractAndDeferInstanceEvents();
+        await _instanceRepository.UpdateAsync(context.Instance, true, cancellationToken);
 
-                if (instanceResult is { IsSuccess: true, Value: not null })
-                {
-                    instanceResult.Value.Fault(context.Domain);
-                    var faultEvents = instanceResult.Value.GetDomainEvents();
-                    if (faultEvents.Count > 0)
-                    {
-                        context.Directives.DeferEvents(faultEvents);
-                        instanceResult.Value.ClearDomainEvents();
-                    }
-
-                    await _instanceRepository.UpdateAsync(instanceResult.Value, true, cancellationToken);
-
-                    _logger.LogInformation(
-                        "Instance {InstanceId} marked as faulted successfully",
-                        context.InstanceId);
-                }
-                else
-                {
-                    _logger.LogError(
-                        "Failed to load instance {InstanceId} for fault marking: {Error}",
-                        context.InstanceId,
-                        instanceResult.Error.Message);
-                }
-            },
-            DefaultLockLeaseSeconds,
-            cancellationToken);
-
-        if (!lockAcquired)
-        {
-            _logger.LogError(
-                "Failed to acquire lock for marking instance {InstanceId} as faulted",
-                context.InstanceId);
-        }
+        _logger.LogInformation(
+            "Instance {InstanceId} marked as faulted successfully",
+            context.InstanceId);
     }
 
     /// <summary>
-    /// Applies the deferred resolved status to the instance after all pipeline work
-    /// (including post-commit jobs) has completed.
-    /// Re-acquires the distributed lock to ensure consistent state update.
-    /// Guards against applying Active when:
-    /// - Auto chain is continuing (NextTransition is set)
-    /// - Instance has reached a terminal status (Completed/Faulted)
-    /// - Target state SubType is Busy (ChangeState already set Busy)
-    /// - Instance has an active SubFlow correlation (SubFlow is still running)
+    /// Applies the deferred resolved status to the instance.
+    /// Already within lock scope — no re-acquisition needed.
     /// </summary>
     private async Task ApplyResolvedStatusAsync(
         TransitionExecutionContext context,
@@ -603,54 +538,24 @@ public class TransitionPipeline
         if (resolvedStatus is null)
             return;
 
-        // Auto chain is continuing — instance should stay Busy
-        if (context.Directives.NextTransition is not null)
-            return;
-
-        // Terminal status reached (Completed/Faulted/Passive) — don't override
         if (context.Instance.IsCompleted)
             return;
 
-        // Target state SubType is Busy — ChangeState already set Busy
         if (context.Target?.SubType == StateSubType.Busy)
             return;
 
-        // Active SubFlow correlation exists — instance must stay Busy while SubFlow is running.
-        // Defense-in-depth guard: HandleSubFlowStep adds the correlation at order 70, before
-        // ResolveAvailableStep (112) or ClearBusyOnResumeStep (79) run. A resume pipeline that
-        // immediately enters a new SubFlow would otherwise flip the parent to Active while the
-        // SubFlow is still initialising, producing a premature A for long-polling clients.
         if (context.Instance.ActiveCorrelations.Any(c =>
                 c.SubFlowType.Equals(SubFlowType.SubFlow) && !c.IsCompleted))
             return;
 
-        // All guards passed — re-acquire lock and apply the resolved status
-        var lockAcquired = await _distributedLockService.ExecuteWithLockAsync(
-            context.LockKey,
-            async () =>
-            {
-                context.Instance.Active();
-                await _instanceRepository.UpdateAsync(context.Instance, true, cancellationToken);
+        context.Instance.Active();
+        await _instanceRepository.UpdateAsync(context.Instance, true, cancellationToken);
 
-                _logger.LogDebug(
-                    "Instance {InstanceId} resolved to Active after post-commit completion",
-                    context.InstanceId);
-            },
-            DefaultLockLeaseSeconds,
-            cancellationToken);
-
-        if (!lockAcquired)
-        {
-            _logger.LogWarning(
-                "Failed to acquire lock for applying resolved status on instance {InstanceId}",
-                context.InstanceId);
-        }
+        _logger.LogDebug(
+            "Instance {InstanceId} resolved to Active after chain completion",
+            context.InstanceId);
     }
 
-    /// <summary>
-    /// Represents the current execution state of the pipeline.
-    /// Immutable record struct for functional state management.
-    /// </summary>
     private readonly record struct PipelineState(IReadOnlyList<ITransitionStep> Plan, int Index)
     {
         public ITransitionStep CurrentStep => Plan[Index];
@@ -658,10 +563,6 @@ public class TransitionPipeline
         public PipelineState MoveNext() => this with { Index = Index + 1 };
     }
 
-    /// <summary>
-    /// Represents flow control decision after step execution.
-    /// Factory methods provide clear intent.
-    /// </summary>
     private readonly record struct FlowControl(bool ShouldStop, bool ShouldReplan)
     {
         public static FlowControl Stop() => new(ShouldStop: true, ShouldReplan: false);

--- a/src/BBT.Workflow.Application/Execution/Transitions/Strategy/AsyncTransitionStrategy.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Strategy/AsyncTransitionStrategy.cs
@@ -7,6 +7,7 @@ using BBT.Aether.Uow;
 using BBT.Workflow.BackgroundJobs.Handlers;
 using BBT.Workflow.BackgroundJobs.Payloads;
 using BBT.Workflow.Execution.Validation;
+using BBT.Workflow.Gateway;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Logging;
 using Dapr.Jobs.Models;
@@ -31,6 +32,7 @@ public sealed class AsyncTransitionStrategy(
     IDistributedLockService distributedLockService,
     ITransitionValidationService validationService,
     IUnitOfWorkManager uowManager,
+    IInstanceCommandGateway instanceCommandGateway,
     ILogger<AsyncTransitionStrategy> logger) : ITransitionStrategy
 {
     /// <summary>
@@ -139,26 +141,42 @@ public sealed class AsyncTransitionStrategy(
 
     /// <summary>
     /// Marks the instance as Busy and persists it within the ambient UoW.
-    /// Skips silently when the instance is already Busy (chained auto transitions),
-    /// already Completed, or being resumed from a SubFlow.
+    /// Skips self-marking silently when the instance is already Busy (chained auto transitions),
+    /// already Completed, or being resumed from a SubFlow. SubFlow busy propagation runs regardless.
     /// </summary>
     private async Task SetInstanceBusyAsync(
         TransitionExecutionContext ctx,
         CancellationToken cancellationToken)
     {
-        if (ctx.Instance.IsBusy || ctx.Instance.IsCompleted || ctx.Directives.IsSubFlowResume)
+        if (!ctx.Instance.IsBusy && !ctx.Instance.IsCompleted && !ctx.Directives.IsSubFlowResume)
+        {
+            await using var innerUow = await uowManager.BeginAsync(
+                new UnitOfWorkOptions
+                {
+                    Scope = UnitOfWorkScopeOption.RequiresNew
+                }, cancellationToken);
+
+            ctx.Instance.Busy();
+            await instanceRepository.UpdateAsync(ctx.Instance, false, cancellationToken);
+            await innerUow.CommitAsync(cancellationToken);
+            logger.InstanceSetBusyForAsyncTransition(ctx.InstanceId, ctx.TransitionKey);
+        }
+
+        var subflow = ctx.Instance.Subflow;
+        if (subflow is null)
             return;
 
-        await using var innerUow = await uowManager.BeginAsync(
-            new UnitOfWorkOptions
-            {
-                Scope = UnitOfWorkScopeOption.RequiresNew
-            }, cancellationToken);
+        var markBusyResult = await instanceCommandGateway.MarkBusyAsync(new MarkBusyInput
+        {
+            Domain = subflow.SubFlowDomain,
+            Workflow = subflow.SubFlowName,
+            InstanceId = subflow.SubFlowInstanceId,
+            Version = subflow.SubFlowVersion
+        }, cancellationToken);
 
-        ctx.Instance.Busy();
-        await instanceRepository.UpdateAsync(ctx.Instance, false, cancellationToken);
-        await innerUow.CommitAsync(cancellationToken);
-        logger.InstanceSetBusyForAsyncTransition(ctx.InstanceId, ctx.TransitionKey);
+        if (!markBusyResult.IsSuccess)
+            logger.SubFlowBusyPropagationFailedForAsyncTransition(ctx.InstanceId, subflow.SubFlowInstanceId,
+                markBusyResult.Error.Message);
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Application/Gateway/IInstanceCommandGateway.cs
+++ b/src/BBT.Workflow.Application/Gateway/IInstanceCommandGateway.cs
@@ -81,5 +81,18 @@ public interface IInstanceCommandGateway
     Task<Result> FaultAsync(
         SubFlowFaultedInput input,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Marks a workflow instance as Busy and recursively propagates to active SubFlow correlations.
+    /// Routes to local or remote execution based on target domain.
+    /// Each level marks itself Busy, then checks for an active SubFlow correlation and
+    /// calls <see cref="MarkBusyAsync"/> for the nested instance (cross-domain routing).
+    /// </summary>
+    /// <param name="input">Target domain, workflow, and instance id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result indicating success or failure of remote or local persistence.</returns>
+    Task<Result> MarkBusyAsync(
+        MarkBusyInput input,
+        CancellationToken cancellationToken = default);
 }
 

--- a/src/BBT.Workflow.Application/Gateway/MarkBusyInput.cs
+++ b/src/BBT.Workflow.Application/Gateway/MarkBusyInput.cs
@@ -1,0 +1,27 @@
+namespace BBT.Workflow.Gateway;
+
+/// <summary>
+/// Input for marking an instance Busy and recursively propagating to active SubFlow correlations.
+/// </summary>
+public record MarkBusyInput
+{
+    /// <summary>
+    /// Target workflow domain.
+    /// </summary>
+    public required string Domain { get; init; }
+
+    /// <summary>
+    /// Target workflow definition key/name.
+    /// </summary>
+    public required string Workflow { get; init; }
+
+    /// <summary>
+    /// Identifier of the instance to mark Busy.
+    /// </summary>
+    public required Guid InstanceId { get; init; }
+
+    /// <summary>
+    /// Workflow version from the SubFlow correlation. Used for schema resolution.
+    /// </summary>
+    public string? Version { get; init; }
+}

--- a/src/BBT.Workflow.Application/Instances/Remote/IRemoteInstanceCommandAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/Remote/IRemoteInstanceCommandAppService.cs
@@ -1,4 +1,5 @@
 using BBT.Aether.Results;
+using BBT.Workflow.Gateway;
 using BBT.Workflow.SubFlow;
 
 namespace BBT.Workflow.Instances.Remote;
@@ -36,5 +37,13 @@ public interface IRemoteInstanceCommandAppService
     /// </summary>
     Task<Result> FaultAsync(
         SubFlowFaultedInput input,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Marks an instance Busy and propagates recursively to nested SubFlows.
+    /// PUT {baseUrl}/api/v{version}/{domain}/workflows/{workflow}/instances/{instanceId}/busy
+    /// </summary>
+    Task<Result> MarkBusyAsync(
+        MarkBusyInput input,
         CancellationToken cancellationToken = default);
 }

--- a/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/PipelineServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/PipelineServiceCollectionExtensions.cs
@@ -47,6 +47,7 @@ public static class PipelineServiceCollectionExtensions
         services.AddScoped<ITransitionValidationService, TransitionValidationService>();
 
         services.AddSingleton<IPipelineProfileResolver, PipelineProfileResolver>();
+        services.AddSingleton<IReservedTransitionResolver, ReservedTransitionResolver>();
 
         // State Machine Validation - Specification Pattern
         services.AddScoped<ITransitionSpecification, ResumeModeSpecification>();
@@ -91,7 +92,7 @@ public static class PipelineServiceCollectionExtensions
         // Error Boundary Services (used by TaskCoordinator for task-level error handling)
         services.AddScoped<IErrorNormalizer, ErrorNormalizer>();
         
-        // Post-Commit Execution (jobs run after lock release)
+        // Post-Commit Execution (jobs run inside lock scope)
         services.AddScoped<IPostCommitExecutor, PostCommitExecutor>();
         services.AddScoped<IPostCommitHandler<StartSubflowJob>, StartSubflowJobHandler>();
         services.AddScoped<IPostCommitHandler<ForwardToSubflowJob>, ForwardToSubflowJobHandler>();

--- a/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
@@ -68,6 +68,7 @@ public static class WorkflowApplicationModuleServiceCollectionExtensions
         services.AddScoped<ISubflowStateService, SubflowStateService>();
         services.AddScoped<ISubflowStarter, SubflowStarter>();
         services.AddScoped<ISubflowForwardingService, SubflowForwardingService>();
+        services.AddScoped<IInstanceBusyPropagationService, InstanceBusyPropagationService>();
         services.AddScoped<IChildSubflowCancellationService, ChildSubflowCancellationService>();
         
         // Instance Services

--- a/src/BBT.Workflow.Application/SubFlow/Contracts/IInstanceBusyPropagationService.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Contracts/IInstanceBusyPropagationService.cs
@@ -1,0 +1,19 @@
+using BBT.Workflow.Gateway;
+
+namespace BBT.Workflow.SubFlow;
+
+/// <summary>
+/// Marks an instance as Busy and recursively propagates to active SubFlow correlations
+/// via gateway routing. Handles cross-domain SubFlow chains by delegating recursive
+/// calls through <see cref="IInstanceCommandGateway"/>.
+/// </summary>
+public interface IInstanceBusyPropagationService
+{
+    /// <summary>
+    /// Marks the target instance as Busy and recursively propagates to its active SubFlow.
+    /// Idempotent: skips marking if the instance is already Busy or Completed.
+    /// </summary>
+    /// <param name="input">Target domain, workflow, instance id, and optional version.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task MarkBusyAsync(MarkBusyInput input, CancellationToken cancellationToken = default);
+}

--- a/src/BBT.Workflow.Application/SubFlow/Services/InstanceBusyPropagationService.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/InstanceBusyPropagationService.cs
@@ -1,0 +1,51 @@
+using BBT.Aether.Uow;
+using BBT.Workflow.Gateway;
+using BBT.Workflow.Instances;
+using Microsoft.Extensions.Logging;
+
+namespace BBT.Workflow.SubFlow;
+
+/// <inheritdoc cref="IInstanceBusyPropagationService" />
+public sealed class InstanceBusyPropagationService(
+    IUnitOfWorkManager uowManager,
+    IInstanceRepository instanceRepository,
+    IInstanceCommandGateway instanceCommandGateway,
+    ILogger<InstanceBusyPropagationService> logger)
+    : IInstanceBusyPropagationService
+{
+    /// <inheritdoc />
+    public async Task MarkBusyAsync(
+        MarkBusyInput input,
+        CancellationToken cancellationToken = default)
+    {
+        await using var uow = await uowManager.BeginAsync(
+            new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew },
+            cancellationToken);
+
+        var instance = await instanceRepository.FindWithActiveSubFlowAsync(
+            input.InstanceId, cancellationToken);
+
+        if (instance is null)
+            return;
+
+        if (instance is { IsBusy: false, IsCompleted: false })
+        {
+            instance.Busy();
+            await instanceRepository.UpdateAsync(instance, false, cancellationToken);
+        }
+
+        await uow.CommitAsync(cancellationToken);
+
+        var subflow = instance.Subflow;
+        if (subflow is not null)
+        {
+            await instanceCommandGateway.MarkBusyAsync(new MarkBusyInput
+            {
+                Domain = subflow.SubFlowDomain,
+                Workflow = subflow.SubFlowName,
+                InstanceId = subflow.SubFlowInstanceId,
+                Version = subflow.SubFlowVersion
+            }, cancellationToken);
+        }
+    }
+}

--- a/src/BBT.Workflow.Domain/Definitions/InstanceUrlTemplates.cs
+++ b/src/BBT.Workflow.Domain/Definitions/InstanceUrlTemplates.cs
@@ -119,6 +119,12 @@ public static class InstanceUrlTemplates
     public const string SubFlowFaultTemplate = "/{0}/workflows/{1}/instances/{2}/sub/fault";
 
     /// <summary>
+    /// URL template for SubFlow Busy propagation endpoints.
+    /// Format: /{domain}/workflows/{workflow}/instances/{instance}/busy
+    /// </summary>
+    public const string MarkBusyTemplate = "/{0}/workflows/{1}/instances/{2}/busy";
+
+    /// <summary>
     /// URL template for retry instance endpoints.
     /// Format: /{domain}/workflows/{workflow}/instances/{instance}/retry
     /// </summary>
@@ -336,6 +342,17 @@ public static class InstanceUrlTemplates
     /// <returns>Generated URL</returns>
     public static string SubFlowFault(string domain, string workflow, string instance, string? apiVersionPrefix = null)
         => BuildUrl(SubFlowFaultTemplate, apiVersionPrefix, domain, workflow, instance);
+
+    /// <summary>
+    /// Generates URL for SubFlow Busy propagation endpoint.
+    /// </summary>
+    /// <param name="domain">The domain name</param>
+    /// <param name="workflow">The workflow name</param>
+    /// <param name="instance">The instance id</param>
+    /// <param name="apiVersionPrefix">Optional API version prefix (e.g., "api/v1")</param>
+    /// <returns>Generated URL</returns>
+    public static string MarkBusy(string domain, string workflow, string instance, string? apiVersionPrefix = null)
+        => BuildUrl(MarkBusyTemplate, apiVersionPrefix, domain, workflow, instance);
 
     /// <summary>
     /// Generates URL for retry instance endpoint.

--- a/src/BBT.Workflow.Domain/Execution/Transitions/Context/TransitionExecutionContextExtensions.cs
+++ b/src/BBT.Workflow.Domain/Execution/Transitions/Context/TransitionExecutionContextExtensions.cs
@@ -7,35 +7,41 @@ public static class TransitionExecutionContextExtensions
 {
     /// <summary>
     /// Determines whether the current transition is a cancel transition.
-    /// A transition is considered a cancel transition if it matches the workflow's configured cancel transition key.
+    /// Matches both the workflow's configured cancel key and the well-known reserved key.
     /// </summary>
-    /// <param name="ctx">The transition execution context</param>
-    /// <returns>True if this is a cancel transition, false otherwise</returns>
     public static bool IsCancelTransition(this TransitionExecutionContext ctx)
     {
-        return ctx.Workflow.Cancel?.Key.Equals(ctx.Transition?.Key, StringComparison.OrdinalIgnoreCase) == true;
+        var key = ctx.Transition?.Key;
+        if (key is null) return false;
+
+        return key.Equals(Definitions.WellKnownTransitionKeys.Cancel, StringComparison.OrdinalIgnoreCase)
+            || ctx.Workflow.Cancel?.Key.Equals(key, StringComparison.OrdinalIgnoreCase) == true;
     }
 
     /// <summary>
     /// Determines whether the current transition is an updateData transition.
-    /// A transition is considered an updateData transition if it matches the workflow's configured updateData transition key.
+    /// Matches both the workflow's configured updateData key and the well-known reserved key.
     /// </summary>
-    /// <param name="ctx">The transition execution context</param>
-    /// <returns>True if this is an updateData transition, false otherwise</returns>
     public static bool IsUpdateDataTransition(this TransitionExecutionContext ctx)
     {
-        return ctx.Workflow.UpdateData?.Key.Equals(ctx.Transition?.Key, StringComparison.OrdinalIgnoreCase) == true;
+        var key = ctx.Transition?.Key;
+        if (key is null) return false;
+
+        return key.Equals(Definitions.WellKnownTransitionKeys.UpdateData, StringComparison.OrdinalIgnoreCase)
+            || ctx.Workflow.UpdateData?.Key.Equals(key, StringComparison.OrdinalIgnoreCase) == true;
     }
 
     /// <summary>
     /// Determines whether the current transition is an exit transition.
-    /// A transition is considered an exit transition if it matches the workflow's configured exit transition key.
+    /// Matches both the workflow's configured exit key and the well-known reserved key.
     /// </summary>
-    /// <param name="ctx">The transition execution context</param>
-    /// <returns>True if this is an exit transition, false otherwise</returns>
     public static bool IsExitTransition(this TransitionExecutionContext ctx)
     {
-        return ctx.Workflow.Exit?.Key.Equals(ctx.Transition?.Key, StringComparison.OrdinalIgnoreCase) == true;
+        var key = ctx.Transition?.Key;
+        if (key is null) return false;
+
+        return key.Equals(Definitions.WellKnownTransitionKeys.Exit, StringComparison.OrdinalIgnoreCase)
+            || ctx.Workflow.Exit?.Key.Equals(key, StringComparison.OrdinalIgnoreCase) == true;
     }
 }
 

--- a/src/BBT.Workflow.Domain/Execution/Transitions/Pipeline/IInstanceBusyMarker.cs
+++ b/src/BBT.Workflow.Domain/Execution/Transitions/Pipeline/IInstanceBusyMarker.cs
@@ -1,0 +1,17 @@
+namespace BBT.Workflow.Execution.Pipeline;
+
+/// <summary>
+/// Marks an instance as Busy immediately after lock acquisition,
+/// before the pipeline steps begin. This ensures any concurrent reader
+/// sees the instance as in-progress from the moment the lock is held.
+/// </summary>
+public interface IInstanceBusyMarker
+{
+    /// <summary>
+    /// Sets the instance status to Busy and persists in an isolated unit of work.
+    /// No-op if the instance is already Busy, Completed, or in a SubFlow resume path.
+    /// </summary>
+    /// <param name="instanceId">The workflow instance identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task MarkBusyAsync(Guid instanceId, CancellationToken cancellationToken = default);
+}

--- a/src/BBT.Workflow.Domain/Execution/Transitions/Pipeline/IReservedTransitionResolver.cs
+++ b/src/BBT.Workflow.Domain/Execution/Transitions/Pipeline/IReservedTransitionResolver.cs
@@ -1,0 +1,22 @@
+namespace BBT.Workflow.Execution.Pipeline;
+
+/// <summary>
+/// Determines whether a transition is "reserved" relative to instance locking.
+/// Most reserved transitions (cancel, exit, updateData, timeout) bypass the lock entirely.
+/// Subflow resume is reserved but uses its own lock scope via <see cref="RequiresOwnLock"/>.
+/// </summary>
+public interface IReservedTransitionResolver
+{
+    /// <summary>
+    /// Returns <c>true</c> if the transition is reserved (cancel, exit, updateData, timeout transition, or subflow resume).
+    /// </summary>
+    /// <param name="context">The transition execution context.</param>
+    bool IsReserved(TransitionExecutionContext context);
+
+    /// <summary>
+    /// Returns <c>true</c> when the reserved transition must acquire its own instance lock scope
+    /// instead of bypassing locking (subflow resume only).
+    /// </summary>
+    /// <param name="context">The transition execution context.</param>
+    bool RequiresOwnLock(TransitionExecutionContext context);
+}

--- a/src/BBT.Workflow.Domain/Execution/Transitions/Pipeline/ITransitionLockScope.cs
+++ b/src/BBT.Workflow.Domain/Execution/Transitions/Pipeline/ITransitionLockScope.cs
@@ -1,0 +1,42 @@
+namespace BBT.Workflow.Execution.Pipeline;
+
+/// <summary>
+/// Represents a request-scoped lock that lives for the entire transition chain.
+/// Auto-chained transitions share the same lock scope — no gap between iterations.
+/// Automatically releases the lock on dispose.
+/// </summary>
+public interface ITransitionLockScope : IAsyncDisposable
+{
+    /// <summary>
+    /// Gets a value indicating whether the lock was successfully acquired.
+    /// </summary>
+    bool IsAcquired { get; }
+
+    /// <summary>
+    /// Gets the lock key that this scope protects.
+    /// </summary>
+    string LockKey { get; }
+
+    /// <summary>
+    /// Extends the lock TTL. Call between auto-chained transitions
+    /// to prevent expiry during long-running chains.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns><c>true</c> if the TTL was extended; <c>false</c> if the lock was lost.</returns>
+    Task<bool> ExtendAsync(CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Factory for acquiring request-scoped transition lock scopes.
+/// </summary>
+public interface ITransitionLockScopeFactory
+{
+    /// <summary>
+    /// Acquires a lock scope for the given lock key.
+    /// The returned scope should be disposed when the entire transition chain completes.
+    /// </summary>
+    /// <param name="lockKey">Instance-level lock key (e.g. <c>vnext:{domain}:{flow}:{instanceId}</c>).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A lock scope. Check <see cref="ITransitionLockScope.IsAcquired"/> before proceeding.</returns>
+    Task<ITransitionLockScope> AcquireAsync(string lockKey, CancellationToken cancellationToken = default);
+}

--- a/src/BBT.Workflow.Domain/Execution/Transitions/Pipeline/PipelineExecutionProfile.cs
+++ b/src/BBT.Workflow.Domain/Execution/Transitions/Pipeline/PipelineExecutionProfile.cs
@@ -32,6 +32,7 @@ public sealed class PipelineExecutionProfile
         LifecycleOrder.Preflight,
         LifecycleOrder.CheckParentUpdateDataTransition,
         LifecycleOrder.ForwardToActiveSubflow,
+        LifecycleOrder.SetBusy,
         LifecycleOrder.ResourceLock,
         LifecycleOrder.ApplyTimeoutState);
 

--- a/src/BBT.Workflow.Domain/Instances/IInstanceRepository.cs
+++ b/src/BBT.Workflow.Domain/Instances/IInstanceRepository.cs
@@ -89,6 +89,16 @@ public interface IInstanceRepository : IRepository<Instance, Guid>
     Task<bool> AnyActiveByKeyAsync(string key, Guid excludeInstanceId, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Loads a change-tracked instance with only active SubFlow-type correlations.
+    /// DataList and SubProcess correlations are NOT loaded.
+    /// Designed for lightweight operations that need SubFlow chain traversal
+    /// (e.g. recursive busy propagation).
+    /// </summary>
+    Task<Instance?> FindWithActiveSubFlowAsync(
+        Guid instanceId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Returns active instances with Human state subtype.
     /// Includes DataList for JSON data extraction.
     /// </summary>

--- a/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
@@ -49,6 +49,20 @@ public static partial class WorkflowLogs
         string transitionKey);
 
     /// <summary>
+    /// Logs when recursive SubFlow busy propagation fails during async transition enqueue.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 10096,
+        Level = LogLevel.Warning,
+        Message =
+            "SubFlow busy propagation failed for parent instance {ParentInstanceId} targeting subflow {SubFlowInstanceId}: {Reason}")]
+    public static partial void SubFlowBusyPropagationFailedForAsyncTransition(
+        this ILogger logger,
+        Guid parentInstanceId,
+        Guid subFlowInstanceId,
+        string reason);
+
+    /// <summary>
     /// Logs when an active job already exists for the same instance and transition key,
     /// causing the request to be rejected with 409 Conflict.
     /// </summary>

--- a/src/BBT.Workflow.HttpApi.Shared/Microsoft/Extensions/DependencyInjection/WorkflowApiBaseServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.HttpApi.Shared/Microsoft/Extensions/DependencyInjection/WorkflowApiBaseServiceCollectionExtensions.cs
@@ -198,6 +198,18 @@ public static class WorkflowApiBaseServiceCollectionExtensions
         return services;
     }
 
+    /// <summary>
+    /// Registers request-scoped transition lock scope and busy marker services.
+    /// </summary>
+    public static IServiceCollection AddTransitionLockScope(this IServiceCollection services)
+    {
+        services.AddScoped<BBT.Workflow.Execution.Pipeline.ITransitionLockScopeFactory,
+            BBT.Workflow.Infrastructure.Execution.Locks.TransitionLockScopeFactory>();
+        services.AddScoped<BBT.Workflow.Execution.Pipeline.IInstanceBusyMarker,
+            BBT.Workflow.Infrastructure.Execution.Locks.InstanceBusyMarker>();
+        return services;
+    }
+
     public static IServiceCollection AddResourceLock(this IServiceCollection services, string lockStoreName)
     {
         services.AddScoped<BBT.Workflow.Execution.IResourceLockService>(sp =>

--- a/src/BBT.Workflow.Infrastructure/Execution/Locks/InstanceBusyMarker.cs
+++ b/src/BBT.Workflow.Infrastructure/Execution/Locks/InstanceBusyMarker.cs
@@ -1,0 +1,52 @@
+using BBT.Aether.Uow;
+using BBT.Workflow.Execution.Pipeline;
+using BBT.Workflow.Instances;
+using Microsoft.Extensions.Logging;
+
+namespace BBT.Workflow.Infrastructure.Execution.Locks;
+
+/// <summary>
+/// Marks an instance as Busy immediately after lock acquisition,
+/// using an isolated unit of work so the status is visible to concurrent readers
+/// even before the pipeline's main UoW commits.
+/// </summary>
+public sealed class InstanceBusyMarker(
+    IInstanceRepository instanceRepository,
+    IUnitOfWorkManager unitOfWorkManager,
+    ILogger<InstanceBusyMarker> logger) : IInstanceBusyMarker
+{
+    /// <inheritdoc />
+    public async Task MarkBusyAsync(Guid instanceId, CancellationToken cancellationToken = default)
+    {
+        var instanceResult = await instanceRepository.GetResultAsync(
+            instanceId.ToString(), includeDetails: false, cancellationToken);
+
+        if (!instanceResult.IsSuccess || instanceResult.Value is null)
+        {
+            logger.LogWarning("Instance {InstanceId} not found for early Busy marker", instanceId);
+            return;
+        }
+
+        var instance = instanceResult.Value;
+
+        if (instance.IsBusy || instance.IsCompleted)
+        {
+            logger.LogDebug(
+                "Instance {InstanceId} is already {Status}, skipping early Busy marker",
+                instanceId, instance.Status.Description);
+            return;
+        }
+
+        await using var innerUow = await unitOfWorkManager.BeginAsync(
+            new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew },
+            cancellationToken);
+
+        instance.Busy();
+        await instanceRepository.UpdateAsync(instance, false, cancellationToken);
+        await innerUow.CommitAsync(cancellationToken);
+
+        logger.LogDebug(
+            "Instance {InstanceId} marked Busy via early marker (pre-pipeline)",
+            instanceId);
+    }
+}

--- a/src/BBT.Workflow.Infrastructure/Execution/Locks/TransitionLockScopeFactory.cs
+++ b/src/BBT.Workflow.Infrastructure/Execution/Locks/TransitionLockScopeFactory.cs
@@ -1,0 +1,111 @@
+using BBT.Aether.DistributedLock;
+using BBT.Workflow.Execution.Pipeline;
+using BBT.Workflow.Logging;
+using Microsoft.Extensions.Logging;
+
+namespace BBT.Workflow.Infrastructure.Execution.Locks;
+
+/// <summary>
+/// Creates request-scoped lock scopes backed by the Aether distributed lock service.
+/// Each scope wraps an <see cref="IDistributedLockHandle"/> and delegates
+/// extend / release operations to the underlying handle.
+/// </summary>
+public sealed class TransitionLockScopeFactory(
+    IDistributedLockService distributedLockService,
+    ILogger<TransitionLockScopeFactory> logger) : ITransitionLockScopeFactory
+{
+    /// <summary>
+    /// Default lock lease duration in seconds.
+    /// Doubled compared to the old per-transition lease (60s) because the lock
+    /// now covers the entire auto-chain. ExtendAsync resets the TTL between iterations.
+    /// </summary>
+    private const int DefaultLeaseSeconds = 120;
+
+    /// <inheritdoc />
+    public async Task<ITransitionLockScope> AcquireAsync(
+        string lockKey,
+        CancellationToken cancellationToken = default)
+    {
+        var handle = await distributedLockService.TryAcquireLockAsync(
+            lockKey,
+            DefaultLeaseSeconds,
+            cancellationToken);
+
+        if (handle is null)
+        {
+            logger.InstanceLockFailed(lockKey);
+            return TransitionLockScope.NotAcquired(lockKey);
+        }
+
+        logger.LogDebug("Transition lock acquired for {LockKey} (lease={LeaseSeconds}s)",
+            lockKey, DefaultLeaseSeconds);
+
+        return new TransitionLockScope(lockKey, handle, DefaultLeaseSeconds, logger);
+    }
+}
+
+/// <summary>
+/// Wraps an <see cref="IDistributedLockHandle"/> with domain-specific semantics.
+/// Implements <see cref="ITransitionLockScope"/> for pipeline consumption.
+/// </summary>
+internal sealed class TransitionLockScope : ITransitionLockScope
+{
+    private readonly IDistributedLockHandle? _handle;
+    private readonly int _leaseSeconds;
+    private readonly ILogger _logger;
+
+    internal TransitionLockScope(
+        string lockKey,
+        IDistributedLockHandle handle,
+        int leaseSeconds,
+        ILogger logger)
+    {
+        LockKey = lockKey;
+        IsAcquired = true;
+        _handle = handle;
+        _leaseSeconds = leaseSeconds;
+        _logger = logger;
+    }
+
+    private TransitionLockScope(string lockKey)
+    {
+        LockKey = lockKey;
+        IsAcquired = false;
+        _handle = null;
+        _leaseSeconds = 0;
+        _logger = null!;
+    }
+
+    /// <inheritdoc />
+    public bool IsAcquired { get; }
+
+    /// <inheritdoc />
+    public string LockKey { get; }
+
+    /// <inheritdoc />
+    public async Task<bool> ExtendAsync(CancellationToken cancellationToken = default)
+    {
+        if (_handle is null) return false;
+
+        var extended = await _handle.ExtendAsync(_leaseSeconds, cancellationToken);
+
+        if (!extended)
+        {
+            _logger.LogDebug("Failed to extend transition lock for {LockKey}", LockKey);
+        }
+
+        return extended;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (_handle is not null)
+        {
+            await _handle.DisposeAsync();
+            _logger.LogDebug("Transition lock released for {LockKey}", LockKey);
+        }
+    }
+
+    internal static TransitionLockScope NotAcquired(string lockKey) => new(lockKey);
+}

--- a/src/BBT.Workflow.Infrastructure/Gateway/LocalInstanceCommandGateway.cs
+++ b/src/BBT.Workflow.Infrastructure/Gateway/LocalInstanceCommandGateway.cs
@@ -148,4 +148,18 @@ public sealed class LocalInstanceCommandGateway : IInstanceCommandGateway
             return Result.Ok();
         }, cancellationToken);
     }
+
+    /// <inheritdoc />
+    public Task<Result> MarkBusyAsync(
+        MarkBusyInput input,
+        CancellationToken cancellationToken = default)
+    {
+        return _serviceScopeFactory.ExecuteWithWorkflowAsync(input.Domain, input.Workflow, input.Version ?? string.Empty,
+            async (sp, ct) =>
+            {
+                var busyService = sp.GetRequiredService<IInstanceBusyPropagationService>();
+                await busyService.MarkBusyAsync(input, ct);
+                return Result.Ok();
+            }, cancellationToken);
+    }
 }

--- a/src/BBT.Workflow.Infrastructure/Gateway/RemoteInstanceCommandGateway.cs
+++ b/src/BBT.Workflow.Infrastructure/Gateway/RemoteInstanceCommandGateway.cs
@@ -72,5 +72,13 @@ public sealed class RemoteInstanceCommandGateway : IInstanceCommandGateway
     {
         return _remoteService.FaultAsync(input, cancellationToken);
     }
+
+    /// <inheritdoc />
+    public Task<Result> MarkBusyAsync(
+        MarkBusyInput input,
+        CancellationToken cancellationToken = default)
+    {
+        return _remoteService.MarkBusyAsync(input, cancellationToken);
+    }
 }
 

--- a/src/BBT.Workflow.Infrastructure/Gateway/RoutedInstanceCommandGateway.cs
+++ b/src/BBT.Workflow.Infrastructure/Gateway/RoutedInstanceCommandGateway.cs
@@ -93,5 +93,15 @@ public sealed class RoutedInstanceCommandGateway : IInstanceCommandGateway
             ? _local.FaultAsync(input, cancellationToken)
             : _remote.FaultAsync(input, cancellationToken);
     }
+
+    /// <inheritdoc />
+    public Task<Result> MarkBusyAsync(
+        MarkBusyInput input,
+        CancellationToken cancellationToken = default)
+    {
+        return _runtimeInfoProvider.IsDomainMatch(input.Domain)
+            ? _local.MarkBusyAsync(input, cancellationToken)
+            : _remote.MarkBusyAsync(input, cancellationToken);
+    }
 }
 

--- a/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceRepository.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceRepository.cs
@@ -68,6 +68,18 @@ public sealed class EfCoreInstanceRepository(
             .Include(i => i.ChildCorrelations.Where(c => !c.IsCompleted));
     }
 
+    /// <inheritdoc />
+    public async Task<Instance?> FindWithActiveSubFlowAsync(
+        Guid instanceId,
+        CancellationToken cancellationToken = default)
+    {
+        var dbSet = await GetDbSetAsync();
+        return await dbSet
+            .Include(i => i.ChildCorrelations
+                .Where(c => !c.IsCompleted && c.SubFlowType == SubFlowType.SubFlow))
+            .FirstOrDefaultAsync(i => i.Id == instanceId, cancellationToken);
+    }
+
     /// <summary>
     /// Inserts a new instance and automatically records metrics
     /// </summary>

--- a/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceCommandAppService.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceCommandAppService.cs
@@ -6,6 +6,7 @@ using BBT.Workflow.Definitions;
 using BBT.Workflow.Discovery;
 using BBT.Aether.Users;
 using BBT.Workflow.CurrentUser;
+using BBT.Workflow.Gateway;
 using BBT.Workflow.Remote;
 using BBT.Workflow.Remote.Configuration;
 using BBT.Workflow.SubFlow;
@@ -377,6 +378,49 @@ public sealed class RemoteInstanceCommandAppService(
             {
                 Content = content
             };
+
+            var forwardHeaders = currentUser.ToForwardHeaders();
+            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, null, RemoteHttpResponseHelper.IsRestrictedHeader);
+
+            var response = await httpClient.SendAsync(requestMessage, cancellationToken);
+
+            return await HandleResponseAsync(response, cancellationToken);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or OperationCanceledException)
+        {
+            return Result.Fail(Error.Transient("remote_network_error", ex.Message));
+        }
+    }
+
+    /// <summary>
+    /// Marks instance Busy recursively by calling the remote API.
+    /// PUT {baseUrl}/api/v{version}/{domain}/workflows/{workflow}/instances/{instanceId}/busy
+    /// </summary>
+    public async Task<Result> MarkBusyAsync(
+        MarkBusyInput input,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var endpointResult = await endpointResolver.GetEndpointAsync(input.Domain, EndpointKind.Url, cancellationToken);
+
+            if (!endpointResult.IsSuccess)
+                return Result.Fail(endpointResult.Error);
+
+            var endpoint = endpointResult.Value!;
+
+            var relativePath = InstanceUrlTemplates.MarkBusy(
+                input.Domain,
+                input.Workflow,
+                input.InstanceId.ToString(),
+                ApiVersionPrefix);
+
+            if (!string.IsNullOrEmpty(input.Version))
+                relativePath += $"?version={Uri.EscapeDataString(input.Version)}";
+
+            var requestUri = new Uri(endpoint.BaseUrl, relativePath.TrimStart('/'));
+
+            var requestMessage = new HttpRequestMessage(HttpMethod.Put, requestUri);
 
             var forwardHeaders = currentUser.ToForwardHeaders();
             CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, null, RemoteHttpResponseHelper.IsRestrictedHeader);

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/ReservedTransitionResolverTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/ReservedTransitionResolverTests.cs
@@ -1,0 +1,156 @@
+using System;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Execution;
+using BBT.Workflow.Shared;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Application.Tests.Execution.Transitions.Pipeline;
+
+/// <summary>
+/// Tests for <see cref="ReservedTransitionResolver"/>.
+/// Validates reserved transition detection for cancel, exit, updateData,
+/// timeout, and subflow resume, and <see cref="IReservedTransitionResolver.RequiresOwnLock"/>.
+/// </summary>
+public class ReservedTransitionResolverTests
+{
+    private readonly ReservedTransitionResolver _resolver = new();
+
+    [Fact]
+    public void IsReserved_WithCancelTransition_ShouldReturnTrue()
+    {
+        var ctx = CreateContext(cancelKey: "cancel", transitionKey: "cancel");
+        _resolver.IsReserved(ctx).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsReserved_WithExitTransition_ShouldReturnTrue()
+    {
+        var ctx = CreateContext(exitKey: "exit", transitionKey: "exit");
+        _resolver.IsReserved(ctx).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsReserved_WithUpdateDataTransition_ShouldReturnTrue()
+    {
+        var ctx = CreateContext(updateDataKey: "updateData", transitionKey: "updateData");
+        _resolver.IsReserved(ctx).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsReserved_WithNormalTransition_ShouldReturnFalse()
+    {
+        var ctx = CreateContext(transitionKey: "approve");
+        _resolver.IsReserved(ctx).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsReserved_WithTimeoutTransition_ShouldReturnTrue()
+    {
+        var ctx = CreateContext(transitionKey: "$timeout");
+        ctx.Directives.MarkAsTimeoutTransition();
+        _resolver.IsReserved(ctx).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsReserved_WithSubFlowResume_ShouldReturnTrue()
+    {
+        var ctx = CreateContext(transitionKey: "resume");
+        ctx.Directives.MarkAsSubFlowResume();
+        _resolver.IsReserved(ctx).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void RequiresOwnLock_WithSubFlowResume_ShouldReturnTrue()
+    {
+        var ctx = CreateContext(transitionKey: "resume");
+        ctx.Directives.MarkAsSubFlowResume();
+        _resolver.RequiresOwnLock(ctx).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void RequiresOwnLock_WithTimeoutTransition_ShouldReturnFalse()
+    {
+        var ctx = CreateContext(transitionKey: "$timeout");
+        ctx.Directives.MarkAsTimeoutTransition();
+        _resolver.RequiresOwnLock(ctx).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void RequiresOwnLock_WithCancelTransition_ShouldReturnFalse()
+    {
+        var ctx = CreateContext(cancelKey: "cancel", transitionKey: "cancel");
+        _resolver.RequiresOwnLock(ctx).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void RequiresOwnLock_WithNormalTransition_ShouldReturnFalse()
+    {
+        var ctx = CreateContext(transitionKey: "approve");
+        _resolver.RequiresOwnLock(ctx).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsReserved_WithMismatchedKey_ShouldReturnFalse()
+    {
+        var ctx = CreateContext(cancelKey: "cancel", transitionKey: "not-cancel");
+        _resolver.IsReserved(ctx).ShouldBeFalse();
+    }
+
+    private static TransitionExecutionContext CreateContext(
+        string transitionKey = "test",
+        string? cancelKey = null,
+        string? exitKey = null,
+        string? updateDataKey = null)
+    {
+        var json = $$"""
+        {
+            "type": "F",
+            "timeout": null,
+            "labels": [],
+            "functions": [],
+            "features": [],
+            {{(cancelKey is not null ? $"\"cancel\": {{\"key\": \"{cancelKey}\", \"from\": null, \"target\": \"cancelled\", \"triggerType\": \"Manual\", \"versionStrategy\": \"Patch\", \"labels\": [], \"onExecutionTasks\": [], \"view\": null}}," : "")}}
+            {{(exitKey is not null ? $"\"exit\": {{\"key\": \"{exitKey}\", \"from\": null, \"target\": \"exited\", \"triggerType\": \"Manual\", \"versionStrategy\": \"Patch\", \"labels\": [], \"onExecutionTasks\": [], \"view\": null}}," : "")}}
+            {{(updateDataKey is not null ? $"\"updateData\": {{\"key\": \"{updateDataKey}\", \"from\": null, \"target\": \"state1\", \"triggerType\": \"Manual\", \"versionStrategy\": \"Patch\", \"labels\": [], \"onExecutionTasks\": [], \"view\": null}}," : "")}}
+            "states": [
+                {"key": "state1", "type": "P", "transitions": []},
+                {"key": "cancelled", "type": "Q", "transitions": []},
+                {"key": "exited", "type": "Q", "transitions": []}
+            ],
+            "sharedTransitions": [],
+            "extensions": [],
+            "startTransition": {"key": "start", "from": null, "target": "state1", "triggerType": "Manual", "versionStrategy": "Patch", "labels": [], "onExecutionTasks": [], "view": null}
+        }
+        """;
+
+        var options = new System.Text.Json.JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+        };
+        var workflow = System.Text.Json.JsonSerializer.Deserialize<Definitions.Workflow>(json, options)!;
+        workflow.SetReference(new Reference("test-flow", "test-domain", "sys-flows", "1.0.0"));
+
+        var transition = Transition.Create(transitionKey, null, "state1", TriggerType.Manual, "Patch");
+
+        return new TransitionExecutionContext
+        {
+            InstanceId = Guid.NewGuid(),
+            Domain = "test-domain",
+            WorkflowKey = "test-flow",
+            TransitionKey = transitionKey,
+            Trigger = TriggerType.Manual,
+            Actor = ExecutionActor.User,
+            CorrelationId = Guid.NewGuid().ToString("N"),
+            ExecutionChainId = Guid.NewGuid().ToString("N"),
+            RequestedAt = DateTimeOffset.UtcNow,
+            Workflow = workflow,
+            Current = workflow.GetState("state1").Value!,
+            Transition = transition,
+            Instance = Instances.Instance.Create(Guid.NewGuid(), "test-flow", "1.0.0"),
+            TraceId = Guid.NewGuid().ToString("N"),
+            SpanId = Guid.NewGuid().ToString("N")[..16]
+        };
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/TransitionPipelineTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/TransitionPipelineTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using BBT.Aether.DistributedLock;
 using BBT.Aether.Results;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Execution;
@@ -11,7 +10,6 @@ using BBT.Workflow.Execution.Pipeline;
 using BBT.Workflow.Execution.PostCommit;
 using BBT.Workflow.Execution.Validation;
 using BBT.Workflow.Instances;
-using BBT.Workflow.Logging;
 using BBT.Workflow.Shared;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
@@ -21,13 +19,16 @@ using Xunit;
 namespace BBT.Workflow.Application.Tests.Execution.Transitions.Pipeline;
 
 /// <summary>
-/// Unit tests for TransitionPipeline
-/// Tests pipeline orchestration, step execution, lock management and flow control
+/// Unit tests for TransitionPipeline.
+/// Validates request-scoped lock, reserved transition bypass, auto-chain under single lock,
+/// busy marking, and fault handling.
 /// </summary>
 public class TransitionPipelineTests
 {
     private readonly ILogger<TransitionPipeline> _mockLogger;
-    private readonly IDistributedLockService _mockLockService;
+    private readonly ITransitionLockScopeFactory _mockLockScopeFactory;
+    private readonly IReservedTransitionResolver _mockReservedResolver;
+    private readonly IInstanceBusyMarker _mockBusyMarker;
     private readonly ITransitionContextFactory _mockContextFactory;
     private readonly IPostCommitExecutor _mockPostCommitExecutor;
     private readonly IInstanceRepository _mockInstanceRepository;
@@ -38,14 +39,15 @@ public class TransitionPipelineTests
     public TransitionPipelineTests()
     {
         _mockLogger = Substitute.For<ILogger<TransitionPipeline>>();
-        _mockLockService = Substitute.For<IDistributedLockService>();
+        _mockLockScopeFactory = Substitute.For<ITransitionLockScopeFactory>();
+        _mockReservedResolver = Substitute.For<IReservedTransitionResolver>();
+        _mockBusyMarker = Substitute.For<IInstanceBusyMarker>();
         _mockContextFactory = Substitute.For<ITransitionContextFactory>();
         _mockPostCommitExecutor = Substitute.For<IPostCommitExecutor>();
         _mockInstanceRepository = Substitute.For<IInstanceRepository>();
         _mockValidationService = Substitute.For<ITransitionValidationService>();
         _mockSteps = new List<ITransitionStep>();
-        
-        // Create a default set of steps in order
+
         _mockSteps.Add(CreateMockStep(LifecycleOrder.CreateTransition));
         _mockSteps.Add(CreateMockStep(LifecycleOrder.OnExecute));
         _mockSteps.Add(CreateMockStep(LifecycleOrder.OnExit));
@@ -55,27 +57,30 @@ public class TransitionPipelineTests
         _mockSteps.Add(CreateMockStep(LifecycleOrder.Auto));
         _mockSteps.Add(CreateMockStep(LifecycleOrder.Finalize));
 
-        // Default lock service behavior - always succeed
-        _mockLockService.ExecuteWithLockAsync(
-            Arg.Any<string>(),
-            Arg.Any<Func<Task>>(),
-            Arg.Any<int>(),
-            Arg.Any<CancellationToken>())
-            .Returns(callInfo =>
-            {
-                var action = callInfo.ArgAt<Func<Task>>(1);
-                action().GetAwaiter().GetResult();
-                return true;
-            });
+        // Default: lock acquired successfully
+        var mockLockScope = CreateAcquiredLockScope();
+        _mockLockScopeFactory
+            .AcquireAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(mockLockScope);
 
-        // Default post-commit executor behavior - always succeed
+        // Default: not a reserved transition
+        _mockReservedResolver
+            .IsReserved(Arg.Any<TransitionExecutionContext>())
+            .Returns(false);
+
+        // Default: busy marker succeeds silently
+        _mockBusyMarker
+            .MarkBusyAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        // Default: post-commit succeeds
         _mockPostCommitExecutor.ExecuteAsync(
             Arg.Any<IReadOnlyList<IPostCommitJob>>(),
             Arg.Any<TransitionExecutionContext>(),
             Arg.Any<CancellationToken>())
             .Returns(PostCommitResult.Ok());
 
-        // Default validation service behavior - always succeed
+        // Default: validation succeeds
         _mockValidationService.ValidateAsync(
             Arg.Any<TransitionExecutionContext>(),
             Arg.Any<CancellationToken>())
@@ -87,7 +92,9 @@ public class TransitionPipelineTests
 
         _pipeline = new TransitionPipeline(
             _mockSteps,
-            _mockLockService,
+            _mockLockScopeFactory,
+            _mockReservedResolver,
+            _mockBusyMarker,
             _mockContextFactory,
             _mockPostCommitExecutor,
             _mockInstanceRepository,
@@ -96,10 +103,10 @@ public class TransitionPipelineTests
             _mockLogger);
     }
 
-    #region RunAsync Tests
+    #region Lock Scope Tests
 
     [Fact]
-    public async Task RunAsync_WithValidContext_ShouldExecuteAllStepsInOrder()
+    public async Task RunAsync_WithValidContext_ShouldAcquireLockOnceAndExecuteAllSteps()
     {
         // Arrange
         var context = CreateTransitionExecutionContext();
@@ -107,7 +114,7 @@ public class TransitionPipelineTests
         var executionOrder = new List<int>();
 
         SetupContextFactory(context);
-        
+
         foreach (var step in _mockSteps)
         {
             var order = step.Order;
@@ -126,6 +133,10 @@ public class TransitionPipelineTests
         result.IsSuccess.ShouldBeTrue();
         executionOrder.Count.ShouldBe(_mockSteps.Count);
         executionOrder.ShouldBe(_mockSteps.Select(m => m.Order).OrderBy(o => o).ToList());
+
+        // Lock acquired exactly once for the entire chain
+        await _mockLockScopeFactory.Received(1)
+            .AcquireAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -136,13 +147,11 @@ public class TransitionPipelineTests
         var workflowContext = CreateWorkflowExecutionContext(context);
 
         SetupContextFactory(context);
-        
-        _mockLockService.ExecuteWithLockAsync(
-            Arg.Any<string>(),
-            Arg.Any<Func<Task>>(),
-            Arg.Any<int>(),
-            Arg.Any<CancellationToken>())
-            .Returns(false);
+
+        var failedScope = CreateNotAcquiredLockScope();
+        _mockLockScopeFactory
+            .AcquireAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(failedScope);
 
         // Act
         var result = await _pipeline.RunAsync(workflowContext, CancellationToken.None);
@@ -153,127 +162,62 @@ public class TransitionPipelineTests
     }
 
     [Fact]
-    public async Task RunAsync_WhenStepFails_ShouldStopAndMarkInstanceFaultedWithSuccessResult()
+    public async Task RunAsync_ShouldMarkBusyImmediatelyAfterLockAcquisition()
     {
         // Arrange
         var context = CreateTransitionExecutionContext();
         var workflowContext = CreateWorkflowExecutionContext(context);
-        var error = Error.Failure("step.failed", "Step execution failed");
-        var executionCount = 0;
 
         SetupContextFactory(context);
-
-        // Setup first two steps to succeed
-        for (int i = 0; i < 2; i++)
-        {
-            _mockSteps[i].ExecuteAsync(Arg.Any<TransitionExecutionContext>(), Arg.Any<CancellationToken>())
-                .Returns(callInfo =>
-                {
-                    executionCount++;
-                    return Task.FromResult(Result<StepOutcome>.Ok(StepOutcome.Continue()));
-                });
-        }
-
-        // Setup third step to fail
-        _mockSteps[2].ExecuteAsync(Arg.Any<TransitionExecutionContext>(), Arg.Any<CancellationToken>())
-            .Returns(callInfo =>
-            {
-                executionCount++;
-                return Task.FromResult(Result<StepOutcome>.Fail(error));
-            });
-
-        // Setup remaining steps
-        for (int i = 3; i < _mockSteps.Count; i++)
-        {
-            _mockSteps[i].ExecuteAsync(Arg.Any<TransitionExecutionContext>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(Result<StepOutcome>.Ok(StepOutcome.Continue())));
-        }
+        SetupStepsToSucceed();
 
         // Act
-        var result = await _pipeline.RunAsync(workflowContext, CancellationToken.None);
+        await _pipeline.RunAsync(workflowContext, CancellationToken.None);
 
-        // Assert — pipeline marks instance faulted and returns OK so clients see Status = F (see TransitionPipeline.RunAsync)
-        result.IsSuccess.ShouldBeTrue();
-        executionCount.ShouldBe(3); // Only first 3 steps executed
-        await _mockInstanceRepository.Received(1)
-            .UpdateAsync(Arg.Is<Instance>(x => x.Status.Equals(InstanceStatus.Faulted)), true, Arg.Any<CancellationToken>());
+        // Assert
+        await _mockBusyMarker.Received(1)
+            .MarkBusyAsync(context.InstanceId, Arg.Any<CancellationToken>());
     }
 
+    #endregion
+
+    #region Reserved Transition Tests
+
     [Fact]
-    public async Task RunAsync_WhenStepReturnsStop_ShouldStopPipeline()
+    public async Task RunAsync_WhenReservedTransition_ShouldBypassLockAndBusy()
     {
         // Arrange
-        var context = CreateTransitionExecutionContext();
+        var context = CreateTransitionExecutionContext("cancel");
         var workflowContext = CreateWorkflowExecutionContext(context);
-        var executionCount = 0;
 
         SetupContextFactory(context);
+        SetupStepsToSucceed();
 
-        // Setup first two steps to succeed
-        for (int i = 0; i < 2; i++)
-        {
-            _mockSteps[i].ExecuteAsync(Arg.Any<TransitionExecutionContext>(), Arg.Any<CancellationToken>())
-                .Returns(callInfo =>
-                {
-                    executionCount++;
-                    return Task.FromResult(Result<StepOutcome>.Ok(StepOutcome.Continue()));
-                });
-        }
-
-        // Setup third step to stop pipeline
-        _mockSteps[2].ExecuteAsync(Arg.Any<TransitionExecutionContext>(), Arg.Any<CancellationToken>())
-            .Returns(callInfo =>
-            {
-                executionCount++;
-                return Task.FromResult(Result<StepOutcome>.Ok(StepOutcome.Stop()));
-            });
-
-        // Setup remaining steps
-        for (int i = 3; i < _mockSteps.Count; i++)
-        {
-            _mockSteps[i].ExecuteAsync(Arg.Any<TransitionExecutionContext>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(Result<StepOutcome>.Ok(StepOutcome.Continue())));
-        }
+        _mockReservedResolver
+            .IsReserved(Arg.Any<TransitionExecutionContext>())
+            .Returns(true);
 
         // Act
         var result = await _pipeline.RunAsync(workflowContext, CancellationToken.None);
 
         // Assert
         result.IsSuccess.ShouldBeTrue();
-        executionCount.ShouldBe(3); // Only first 3 steps executed
+
+        // Lock should NOT be acquired
+        await _mockLockScopeFactory.DidNotReceive()
+            .AcquireAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+
+        // Busy should NOT be marked
+        await _mockBusyMarker.DidNotReceive()
+            .MarkBusyAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
     }
 
-    [Fact]
-    public async Task RunAsync_WhenSkipImmediateExecution_ShouldNotExecuteSteps()
-    {
-        // Arrange
-        var context = CreateTransitionExecutionContext();
-        context.SkipImmediateExecution = true;
-        var workflowContext = CreateWorkflowExecutionContext(context);
-        var executionCount = 0;
+    #endregion
 
-        SetupContextFactory(context);
-
-        foreach (var step in _mockSteps)
-        {
-            step.ExecuteAsync(Arg.Any<TransitionExecutionContext>(), Arg.Any<CancellationToken>())
-                .Returns(callInfo =>
-                {
-                    executionCount++;
-                    return Task.FromResult(Result<StepOutcome>.Ok(StepOutcome.Continue()));
-                });
-        }
-
-        // Act
-        var result = await _pipeline.RunAsync(workflowContext, CancellationToken.None);
-
-        // Assert
-        result.IsSuccess.ShouldBeTrue();
-        executionCount.ShouldBe(0);
-    }
+    #region Auto-Chain Tests
 
     [Fact]
-    public async Task RunAsync_WithNextTransitionRequest_ShouldChainTransitions()
+    public async Task RunAsync_WithAutoChain_ShouldRunEntireChainUnderSingleLock()
     {
         // Arrange
         var context1 = CreateTransitionExecutionContext();
@@ -286,12 +230,11 @@ public class TransitionPipelineTests
             {
                 contextCallCount++;
                 return Task.FromResult(
-                    contextCallCount == 1 
+                    contextCallCount == 1
                         ? Result<TransitionExecutionContext>.Ok(context1)
                         : Result<TransitionExecutionContext>.Ok(context2));
             });
 
-        // Setup steps to return continue except auto step which requests next transition
         foreach (var step in _mockSteps)
         {
             if (step.Order == LifecycleOrder.Auto)
@@ -304,8 +247,10 @@ public class TransitionPipelineTests
                         if (callCount == 1)
                         {
                             var ctx = callInfo.ArgAt<TransitionExecutionContext>(0);
-                            ctx.Directives.RequestNextTransition(new NextTransitionRequest("auto-transition", "auto"));
-                            return Task.FromResult(Result<StepOutcome>.Ok(StepOutcome.SkipTo(LifecycleOrder.Finalize)));
+                            ctx.Directives.RequestNextTransition(
+                                new NextTransitionRequest("auto-transition", "auto"));
+                            return Task.FromResult(
+                                Result<StepOutcome>.Ok(StepOutcome.SkipTo(LifecycleOrder.Finalize)));
                         }
                         return Task.FromResult(Result<StepOutcome>.Ok(StepOutcome.Continue()));
                     });
@@ -322,7 +267,182 @@ public class TransitionPipelineTests
 
         // Assert
         result.IsSuccess.ShouldBeTrue();
-        contextCallCount.ShouldBe(2); // Two contexts created for two transitions
+        contextCallCount.ShouldBe(2);
+
+        // Lock acquired only ONCE for the entire chain (not per-transition)
+        await _mockLockScopeFactory.Received(1)
+            .AcquireAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunAsync_WithAutoChain_ShouldExtendLockBetweenIterations()
+    {
+        // Arrange
+        var context1 = CreateTransitionExecutionContext();
+        var context2 = CreateTransitionExecutionContext("auto-transition");
+        var workflowContext = CreateWorkflowExecutionContext(context1);
+        var contextCallCount = 0;
+
+        var mockLockScope = CreateAcquiredLockScope();
+
+        _mockLockScopeFactory
+            .AcquireAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(mockLockScope);
+
+        _mockContextFactory.CreateAsync(Arg.Any<WorkflowExecutionContext>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                contextCallCount++;
+                return Task.FromResult(
+                    contextCallCount == 1
+                        ? Result<TransitionExecutionContext>.Ok(context1)
+                        : Result<TransitionExecutionContext>.Ok(context2));
+            });
+
+        foreach (var step in _mockSteps)
+        {
+            if (step.Order == LifecycleOrder.Auto)
+            {
+                var callCount = 0;
+                step.ExecuteAsync(Arg.Any<TransitionExecutionContext>(), Arg.Any<CancellationToken>())
+                    .Returns(callInfo =>
+                    {
+                        callCount++;
+                        if (callCount == 1)
+                        {
+                            var ctx = callInfo.ArgAt<TransitionExecutionContext>(0);
+                            ctx.Directives.RequestNextTransition(
+                                new NextTransitionRequest("auto-transition", "auto"));
+                            return Task.FromResult(
+                                Result<StepOutcome>.Ok(StepOutcome.SkipTo(LifecycleOrder.Finalize)));
+                        }
+                        return Task.FromResult(Result<StepOutcome>.Ok(StepOutcome.Continue()));
+                    });
+            }
+            else
+            {
+                step.ExecuteAsync(Arg.Any<TransitionExecutionContext>(), Arg.Any<CancellationToken>())
+                    .Returns(Task.FromResult(Result<StepOutcome>.Ok(StepOutcome.Continue())));
+            }
+        }
+
+        // Act
+        await _pipeline.RunAsync(workflowContext, CancellationToken.None);
+
+        // Assert: lock extended between chain iterations
+        await mockLockScope.Received(1)
+            .ExtendAsync(Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+
+    #region Fault Handling Tests
+
+    [Fact]
+    public async Task RunAsync_WhenStepFails_ShouldMarkInstanceFaultedWithSuccessResult()
+    {
+        // Arrange
+        var context = CreateTransitionExecutionContext();
+        var workflowContext = CreateWorkflowExecutionContext(context);
+        var error = Error.Failure("step.failed", "Step execution failed");
+        var executionCount = 0;
+
+        SetupContextFactory(context);
+
+        for (int i = 0; i < 2; i++)
+        {
+            _mockSteps[i].ExecuteAsync(Arg.Any<TransitionExecutionContext>(), Arg.Any<CancellationToken>())
+                .Returns(callInfo =>
+                {
+                    executionCount++;
+                    return Task.FromResult(Result<StepOutcome>.Ok(StepOutcome.Continue()));
+                });
+        }
+
+        _mockSteps[2].ExecuteAsync(Arg.Any<TransitionExecutionContext>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                executionCount++;
+                return Task.FromResult(Result<StepOutcome>.Fail(error));
+            });
+
+        for (int i = 3; i < _mockSteps.Count; i++)
+        {
+            _mockSteps[i].ExecuteAsync(Arg.Any<TransitionExecutionContext>(), Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult(Result<StepOutcome>.Ok(StepOutcome.Continue())));
+        }
+
+        // Act
+        var result = await _pipeline.RunAsync(workflowContext, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        executionCount.ShouldBe(3);
+        await _mockInstanceRepository.Received(1)
+            .UpdateAsync(
+                Arg.Is<Instance>(x => x.Status.Equals(InstanceStatus.Faulted)),
+                true,
+                Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenStepReturnsStop_ShouldStopPipeline()
+    {
+        // Arrange
+        var context = CreateTransitionExecutionContext();
+        var workflowContext = CreateWorkflowExecutionContext(context);
+        var executionCount = 0;
+
+        SetupContextFactory(context);
+
+        for (int i = 0; i < 2; i++)
+        {
+            _mockSteps[i].ExecuteAsync(Arg.Any<TransitionExecutionContext>(), Arg.Any<CancellationToken>())
+                .Returns(callInfo =>
+                {
+                    executionCount++;
+                    return Task.FromResult(Result<StepOutcome>.Ok(StepOutcome.Continue()));
+                });
+        }
+
+        _mockSteps[2].ExecuteAsync(Arg.Any<TransitionExecutionContext>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                executionCount++;
+                return Task.FromResult(Result<StepOutcome>.Ok(StepOutcome.Stop()));
+            });
+
+        for (int i = 3; i < _mockSteps.Count; i++)
+        {
+            _mockSteps[i].ExecuteAsync(Arg.Any<TransitionExecutionContext>(), Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult(Result<StepOutcome>.Ok(StepOutcome.Continue())));
+        }
+
+        // Act
+        var result = await _pipeline.RunAsync(workflowContext, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        executionCount.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenSkipImmediateExecution_ShouldNotAcquireLockOrExecuteSteps()
+    {
+        // Arrange
+        var context = CreateTransitionExecutionContext();
+        context.SkipImmediateExecution = true;
+        var workflowContext = CreateWorkflowExecutionContext(context);
+
+        SetupContextFactory(context);
+
+        // Act
+        var result = await _pipeline.RunAsync(workflowContext, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        await _mockLockScopeFactory.DidNotReceive()
+            .AcquireAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     #endregion
@@ -336,10 +456,36 @@ public class TransitionPipelineTests
         return mockStep;
     }
 
+    private static ITransitionLockScope CreateAcquiredLockScope()
+    {
+        var scope = Substitute.For<ITransitionLockScope>();
+        scope.IsAcquired.Returns(true);
+        scope.LockKey.Returns("test-lock-key");
+        scope.ExtendAsync(Arg.Any<CancellationToken>()).Returns(true);
+        return scope;
+    }
+
+    private static ITransitionLockScope CreateNotAcquiredLockScope()
+    {
+        var scope = Substitute.For<ITransitionLockScope>();
+        scope.IsAcquired.Returns(false);
+        scope.LockKey.Returns("test-lock-key");
+        return scope;
+    }
+
     private void SetupContextFactory(TransitionExecutionContext context)
     {
         _mockContextFactory.CreateAsync(Arg.Any<WorkflowExecutionContext>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(Result<TransitionExecutionContext>.Ok(context)));
+    }
+
+    private void SetupStepsToSucceed()
+    {
+        foreach (var step in _mockSteps)
+        {
+            step.ExecuteAsync(Arg.Any<TransitionExecutionContext>(), Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult(Result<StepOutcome>.Ok(StepOutcome.Continue())));
+        }
     }
 
     private WorkflowExecutionContext CreateWorkflowExecutionContext(TransitionExecutionContext context)
@@ -413,8 +559,8 @@ public class TransitionPipelineTests
         }
         """;
 
-        var options = new System.Text.Json.JsonSerializerOptions 
-        { 
+        var options = new System.Text.Json.JsonSerializerOptions
+        {
             PropertyNameCaseInsensitive = true,
             Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
         };

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Strategy/AsyncTransitionStrategyTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Strategy/AsyncTransitionStrategyTests.cs
@@ -12,6 +12,7 @@ using BBT.Workflow.Definitions;
 using BBT.Workflow.Execution;
 using BBT.Workflow.Execution.Strategies;
 using BBT.Workflow.Execution.Validation;
+using BBT.Workflow.Gateway;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Shared;
 using Microsoft.Extensions.Logging;
@@ -34,6 +35,7 @@ public class AsyncTransitionStrategyTests
     private readonly Mock<IDistributedLockService> _mockDistributedLockRepository;
     private readonly Mock<ITransitionValidationService> _mockValidationService;
     private readonly Mock<IUnitOfWorkManager> _uowManager;
+    private readonly Mock<IInstanceCommandGateway> _mockInstanceCommandGateway;
     private readonly Mock<ILogger<AsyncTransitionStrategy>> _mockLogger;
     private readonly AsyncTransitionStrategy _strategy;
 
@@ -46,7 +48,19 @@ public class AsyncTransitionStrategyTests
         _mockDistributedLockRepository = new Mock<IDistributedLockService>();
         _mockValidationService = new Mock<ITransitionValidationService>();
         _uowManager = new Mock<IUnitOfWorkManager>();
+        _mockInstanceCommandGateway = new Mock<IInstanceCommandGateway>();
         _mockLogger = new Mock<ILogger<AsyncTransitionStrategy>>();
+
+        _mockInstanceCommandGateway
+            .Setup(x => x.MarkBusyAsync(It.IsAny<MarkBusyInput>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Ok());
+
+        var innerUow = new Mock<IUnitOfWork>();
+        innerUow.Setup(x => x.DisposeAsync()).Returns(ValueTask.CompletedTask);
+        innerUow.Setup(x => x.CommitAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        _uowManager
+            .Setup(x => x.BeginAsync(It.IsAny<UnitOfWorkOptions?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(innerUow.Object);
 
         // Default: validation passes — individual tests override this when they need to
         // exercise the schema/policy rejection path.
@@ -62,6 +76,7 @@ public class AsyncTransitionStrategyTests
             _mockDistributedLockRepository.Object,
             _mockValidationService.Object,
             _uowManager.Object,
+            _mockInstanceCommandGateway.Object,
             _mockLogger.Object);
     }
 
@@ -164,12 +179,15 @@ public class AsyncTransitionStrategyTests
     [Fact]
     public async Task ExecuteAsync_ShouldGenerateUniqueJobId()
     {
-        // Arrange
-        var workflowContext = CreateWorkflowExecutionContext();
-        var transitionContext = CreateTransitionExecutionContext();
-        var jobIds = new List<string>();
+        var workflowContextOne = CreateWorkflowExecutionContext();
+        var transitionContextOne = CreateTransitionExecutionContext();
+        SetupSuccessfulExecution(workflowContextOne, transitionContextOne);
 
-        SetupSuccessfulExecution(workflowContext, transitionContext);
+        var workflowContextTwo = CreateWorkflowExecutionContext();
+        var transitionContextTwo = CreateTransitionExecutionContext();
+        SetupSuccessfulExecution(workflowContextTwo, transitionContextTwo);
+
+        var jobIds = new List<string>();
 
         _mockBackgroundJobService
             .Setup(x => x.EnqueueAsync(
@@ -183,11 +201,9 @@ public class AsyncTransitionStrategyTests
                 (_, jobId, _, _, _, _) => jobIds.Add(jobId))
             .ReturnsAsync(It.IsAny<Guid>());
 
-        // Act
-        await _strategy.ExecuteAsync(workflowContext, CancellationToken.None);
-        await _strategy.ExecuteAsync(workflowContext, CancellationToken.None);
+        await _strategy.ExecuteAsync(workflowContextOne, CancellationToken.None);
+        await _strategy.ExecuteAsync(workflowContextTwo, CancellationToken.None);
 
-        // Assert
         jobIds.Count.ShouldBe(2);
         jobIds[0].ShouldNotBe(jobIds[1]);
     }
@@ -280,26 +296,26 @@ public class AsyncTransitionStrategyTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_ShouldLogExecutionStartAndComplete()
+    public async Task ExecuteAsync_WhenEnqueueSucceeds_LogsWereElidedBySourceGenerators()
     {
-        // Arrange
+        // Structured logging extensions on ILogger<AsyncTransitionStrategy> bypass the mock's Log() pipeline.
         var workflowContext = CreateWorkflowExecutionContext();
         var transitionContext = CreateTransitionExecutionContext();
 
         SetupSuccessfulExecution(workflowContext, transitionContext);
 
-        // Act
-        await _strategy.ExecuteAsync(workflowContext, CancellationToken.None);
+        var result = await _strategy.ExecuteAsync(workflowContext, CancellationToken.None);
 
-        // Assert
-        _mockLogger.Verify(
-            x => x.Log(
-                It.IsAny<LogLevel>(),
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("enqueued") || v.ToString()!.Contains("Successfully")),
-                null,
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.AtLeast(1));
+        result.IsSuccess.ShouldBeTrue();
+        _mockBackgroundJobService.Verify(
+            x => x.EnqueueAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<TransitionJobPayload>(),
+                It.IsAny<string>(),
+                It.IsAny<Dictionary<string, object>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]
@@ -359,10 +375,106 @@ public class AsyncTransitionStrategyTests
 
     #endregion
 
+    #region SubFlow Busy propagation
+
+    [Fact]
+    public async Task ExecuteAsync_WithActiveSubFlowCorrelation_CallsGatewayMarkBusyAndSkipsSelfPersistence()
+    {
+        var workflowContext = CreateWorkflowExecutionContext();
+        var transitionContext = CreateTransitionExecutionContext();
+        var subInstanceId = Guid.NewGuid();
+
+        transitionContext.Instance.AddCorrelation(InstanceCorrelation.Create(
+            Guid.NewGuid(),
+            transitionContext.Instance.Id,
+            "parent-state",
+            subInstanceId,
+            "S",
+            "child-domain",
+            "child-flow",
+            "1.0.0"));
+
+        SetupSuccessfulExecution(workflowContext, transitionContext);
+
+        var result = await _strategy.ExecuteAsync(workflowContext, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+
+        _mockInstanceRepository.Verify(
+            x => x.UpdateAsync(It.IsAny<Instance>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        _mockInstanceCommandGateway.Verify(
+            x => x.MarkBusyAsync(
+                It.Is<MarkBusyInput>(
+                    i => i.Domain == "child-domain"
+                         && i.Workflow == "child-flow"
+                         && i.InstanceId == subInstanceId
+                         && i.Version == "1.0.0"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithNoActiveSubFlow_DoesNotCallGatewayMarkBusy()
+    {
+        var workflowContext = CreateWorkflowExecutionContext();
+        var transitionContext = CreateTransitionExecutionContext();
+
+        SetupSuccessfulExecution(workflowContext, transitionContext);
+
+        var result = await _strategy.ExecuteAsync(workflowContext, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+
+        _mockInstanceCommandGateway.Verify(
+            x => x.MarkBusyAsync(It.IsAny<MarkBusyInput>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenGatewayMarkBusyFails_TransitionEnqueueStillSucceeds()
+    {
+        var workflowContext = CreateWorkflowExecutionContext();
+        var transitionContext = CreateTransitionExecutionContext();
+        transitionContext.Instance.AddCorrelation(InstanceCorrelation.Create(
+            Guid.NewGuid(),
+            transitionContext.Instance.Id,
+            "parent-state",
+            Guid.NewGuid(),
+            "S",
+            "d",
+            "f",
+            null));
+
+        _mockInstanceCommandGateway
+            .Setup(x => x.MarkBusyAsync(It.IsAny<MarkBusyInput>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Fail(Error.Dependency("mark-busy.failed", "Remote busy failed")));
+
+        SetupSuccessfulExecution(workflowContext, transitionContext);
+
+        var result = await _strategy.ExecuteAsync(workflowContext, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        _mockBackgroundJobService.Verify(
+            x => x.EnqueueAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<TransitionJobPayload>(),
+                It.IsAny<string>(),
+                It.IsAny<Dictionary<string, object>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    #endregion
+
     #region Helper Methods
 
     private void SetupSuccessfulExecution(WorkflowExecutionContext workflowContext, TransitionExecutionContext transitionContext)
     {
+        workflowContext.InstanceId = transitionContext.InstanceId.ToString();
+
         _mockContextFactory
             .Setup(x => x.CreateAsync(workflowContext, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<TransitionExecutionContext>.Ok(transitionContext));

--- a/test/BBT.Workflow.Infrastructure.Tests/Gateway/RoutedInstanceCommandGatewayMarkBusyTests.cs
+++ b/test/BBT.Workflow.Infrastructure.Tests/Gateway/RoutedInstanceCommandGatewayMarkBusyTests.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.MultiSchema;
+using BBT.Aether.Results;
+using BBT.Aether.Uow;
+using BBT.Workflow.Caching;
+using BBT.Workflow.DefinitionContext;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Gateway;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Instances.Remote;
+using BBT.Workflow.Runtime;
+using BBT.Workflow.SubFlow;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Infrastructure.Tests.Gateway;
+
+/// <summary>
+/// Routing tests for <see cref="RoutedInstanceCommandGateway.MarkBusyAsync"/>.
+/// </summary>
+public sealed class RoutedInstanceCommandGatewayMarkBusyTests
+{
+    [Fact]
+    public async Task MarkBusyAsync_WhenDomainMismatch_DelegatesToRemoteService()
+    {
+        var input = new MarkBusyInput { Domain = "remote-domain", Workflow = "wf", InstanceId = Guid.NewGuid() };
+        var remoteService = Substitute.For<IRemoteInstanceCommandAppService>();
+        remoteService.MarkBusyAsync(Arg.Any<MarkBusyInput>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok());
+
+        var runtimeInfo = Substitute.For<IRuntimeInfoProvider>();
+        runtimeInfo.IsDomainMatch(Arg.Any<string>()).Returns(false);
+
+        var unusedScopeFactory = Substitute.For<IServiceScopeFactory>();
+
+        var sut = new RoutedInstanceCommandGateway(
+            new LocalInstanceCommandGateway(unusedScopeFactory),
+            new RemoteInstanceCommandGateway(remoteService),
+            runtimeInfo);
+
+        await sut.MarkBusyAsync(input, CancellationToken.None);
+
+        runtimeInfo.Received(1).IsDomainMatch(input.Domain);
+        await remoteService.Received(1).MarkBusyAsync(
+            Arg.Is<MarkBusyInput>(
+                x => x.Domain == input.Domain
+                     && x.Workflow == input.Workflow
+                     && x.InstanceId == input.InstanceId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task MarkBusyAsync_WhenDomainMatches_DelegatesLocally_AndNeverCallsRemote()
+    {
+        const string domain = "local-domain";
+        const string workflowKey = "local-wf";
+
+        var input = new MarkBusyInput
+        {
+            Domain = domain,
+            Workflow = workflowKey,
+            InstanceId = Guid.NewGuid(),
+        };
+
+        var remoteService = Substitute.For<IRemoteInstanceCommandAppService>();
+        var runtimeInfo = Substitute.For<IRuntimeInfoProvider>();
+        runtimeInfo.IsDomainMatch(Arg.Any<string>()).Returns(true);
+
+        var schema = Substitute.For<ICurrentSchema>();
+        schema.Name.Returns((string?)null);
+        schema.When(x => x.Set(Arg.Any<string>())).Do(_ => { });
+
+        var workflow = DeserializeMinimalWorkflow(workflowKey, domain);
+        var cacheStore = Substitute.For<IComponentCacheStore>();
+        cacheStore.GetFlowAsync(domain, workflowKey, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok(workflow));
+
+        var workflowContext = Substitute.For<IWorkflowContext>();
+
+        var busyService = Substitute.For<IInstanceBusyPropagationService>();
+        busyService.MarkBusyAsync(Arg.Any<MarkBusyInput>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(_ => schema);
+        services.AddSingleton(_ => cacheStore);
+        services.AddSingleton(_ => workflowContext);
+        services.AddSingleton(_ => busyService);
+
+        services.AddSingleton<LocalInstanceCommandGateway>();
+        services.AddSingleton(_ => new RemoteInstanceCommandGateway(remoteService));
+        services.AddSingleton(provider => new RoutedInstanceCommandGateway(
+            provider.GetRequiredService<LocalInstanceCommandGateway>(),
+            provider.GetRequiredService<RemoteInstanceCommandGateway>(),
+            runtimeInfo));
+
+        await using var root = services.BuildServiceProvider();
+        var sut = root.GetRequiredService<RoutedInstanceCommandGateway>();
+
+        var result = await sut.MarkBusyAsync(input, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        runtimeInfo.Received(1).IsDomainMatch(input.Domain);
+        await busyService.Received(1).MarkBusyAsync(
+            Arg.Is<MarkBusyInput>(x => x.InstanceId == input.InstanceId),
+            Arg.Any<CancellationToken>());
+        await remoteService.Received(0).MarkBusyAsync(Arg.Any<MarkBusyInput>(), Arg.Any<CancellationToken>());
+    }
+
+    private static BBT.Workflow.Definitions.Workflow DeserializeMinimalWorkflow(string key, string domain)
+    {
+        const string json = """
+        {
+            "type": "F",
+            "timeout": null,
+            "labels": [],
+            "functions": [],
+            "features": [],
+            "states": [
+                {
+                    "key": "state1",
+                    "type": "P",
+                    "transitions": []
+                }
+            ],
+            "sharedTransitions": [],
+            "extensions": [],
+            "startTransition": {"key": "start", "from": null, "target": "state1", "triggerType": "Manual", "versionStrategy": "Patch", "labels": [], "onExecutionTasks": [], "view": null}
+        }
+        """;
+
+        var options = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new JsonStringEnumConverter() },
+        };
+
+        var workflow = JsonSerializer.Deserialize<BBT.Workflow.Definitions.Workflow>(json, options)!;
+        workflow.SetReference(new Reference(key, domain, "sys-flows", "1.0.0"));
+        return workflow;
+    }
+}

--- a/vnext-meta/package.json
+++ b/vnext-meta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@burgan-tech/vnext-meta",
-  "version": "0.0.26",
+  "version": "0.0.53",
   "description": "vNext Runtime metadata package — version manifest, feature catalog, deprecation registry, and component metadata for offline consumption by Forge Studio, CLI, and domain packages.",
   "main": "index.js",
   "files": [

--- a/workers/BBT.Workflow.Workers.Inbox/Microsoft/Extensions/DependencyInjection/InboxWorkerServiceCollectionExtensions.cs
+++ b/workers/BBT.Workflow.Workers.Inbox/Microsoft/Extensions/DependencyInjection/InboxWorkerServiceCollectionExtensions.cs
@@ -39,6 +39,7 @@ public static class InboxWorkerServiceCollectionExtensions
             .AddTelemetry(configuration)
             .AddDistributedCache(configuration)
             .AddDistributedLock(configuration)
+            .AddTransitionLockScope()
             .AddBackgroundJob()
             .AddRedis()
             .AddExceptionHandling()

--- a/workers/BBT.Workflow.Workers.Outbox/Microsoft/Extensions/DependencyInjection/OutboxWorkerServiceCollectionExtensions.cs
+++ b/workers/BBT.Workflow.Workers.Outbox/Microsoft/Extensions/DependencyInjection/OutboxWorkerServiceCollectionExtensions.cs
@@ -38,6 +38,7 @@ public static class OutboxWorkerServiceCollectionExtensions
             .AddTelemetry(configuration)
             .AddDistributedCache(configuration)
             .AddDistributedLock(configuration)
+            .AddTransitionLockScope()
             .AddAetherBackgroundJob<WorkflowDbContext>()
             .AddDaprJobScheduler()
             .AddRedis()


### PR DESCRIPTION
… propagation

Refactor the transition pipeline to use a single request-scoped distributed lock that spans the entire auto-chain, replacing the per-transition lock model. Key changes:

- ITransitionLockScope/Factory for lock lifecycle management
- IReservedTransitionResolver: cancel, exit, updateData, $timeout bypass the lock; SubFlow resume acquires an independent lock
- Recursive MarkBusy propagation via IInstanceBusyPropagationService and IInstanceCommandGateway for cross-domain SubFlow chains
- IInstanceBusyMarker for immediate busy marking after lock acquisition
- FindWithActiveSubFlowAsync for lightweight correlation loading
- MarkBusyInput now carries Version for schema resolution
- InstanceController exposes internal /busy endpoint for remote calls
- Bump Aether 1.0.24, Dapr 1.17.9, OpenTelemetry 1.15.3

Closes #672

## Summary by Sourcery

Introduce request-scoped distributed locking for transition pipelines and add recursive busy propagation for cross-domain SubFlow chains.

New Features:
- Add request-scoped transition lock scopes that cover entire auto-chains and reserved transition resolution for lock bypass or separate scopes.
- Introduce recursive busy propagation via instance command gateway and remote/local APIs, including a new internal /busy endpoint for instances.
- Add MarkBusyInput contract, instance busy propagation service, and lightweight instance loading with active SubFlow correlations only.

Enhancements:
- Refactor TransitionPipeline to use a single lock scope with immediate busy marking, in-lock post-commit execution, and simplified fault handling.
- Extend AsyncTransitionStrategy to propagate Busy status to child SubFlows without blocking transition enqueue when propagation fails.
- Update transition context helpers to recognize well-known cancel, exit, and updateData keys alongside configurable workflow keys and register new pipeline profile steps for busy handling.

Build:
- Bump vnext-meta package version to 0.0.53 and register transition lock scope services in orchestration and worker modules.

Tests:
- Expand TransitionPipeline unit tests for request-scoped locking, reserved transition behavior, auto-chain locking, busy marking, and fault handling.
- Add tests for ReservedTransitionResolver reserved/own-lock detection.
- Add routing tests for MarkBusyAsync in RoutedInstanceCommandGateway and async strategy SubFlow busy propagation behavior.