### PR TITLE
v.0.0.54

### DIFF
--- a/.github/workflows/build-and-publish-images.yml
+++ b/.github/workflows/build-and-publish-images.yml
@@ -232,7 +232,7 @@ jobs:
         with:
           dotnet-version: |
             9.0.x
-            10.0.x
+            10.0.2xx
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -705,7 +705,10 @@ jobs:
         with:
           dotnet-version: |
             9.0.x
-            10.0.x
+            10.0.2xx
+
+      - name: Setup NETStandard.Library.Ref for PostSharp
+        run: ./scripts/setup-netstandard-ref.sh
 
       - name: Restore solution
         run: dotnet restore ./BBT.Workflow.slnx --verbosity normal
@@ -801,5 +804,10 @@ jobs:
             echo "tag=latest" >> $GITHUB_OUTPUT
           fi
 
-      - name: Publish to npm with provenance
-        run: npm publish --provenance --access public --tag ${{ steps.dist_tag.outputs.tag }}
+      - name: Publish to npm (OIDC)
+        uses: JS-DevTools/npm-publish@v4
+        with:
+          access: public
+          tag: ${{ steps.dist_tag.outputs.tag }}
+          provenance: true
+          package: vnext-meta

--- a/execution/BBT.Workflow.Execution.HttpApi.Host/Dockerfile
+++ b/execution/BBT.Workflow.Execution.HttpApi.Host/Dockerfile
@@ -7,8 +7,8 @@ RUN adduser -D workflowuser && chown -R workflowuser:workflowuser /app
 
 USER workflowuser
 
-# Build image
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-alpine3.23 AS build
+# Build image (pinned to 10.0.2xx band — SDK 10.0.300 produces assets format v4 incompatible with PostSharp)
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0.203-alpine3.23 AS build
 
 # Install NETStandard.Library.Ref targeting pack for PostSharp compatibility
 RUN wget -q https://www.nuget.org/api/v2/package/NETStandard.Library.Ref/2.1.0 -O /tmp/netstandard.nupkg && \

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "10.0.101",
-      "rollForward": "latestFeature"
+      "version": "10.0.200",
+      "rollForward": "latestPatch"
     }
   }

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Dockerfile
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Dockerfile
@@ -7,8 +7,8 @@ RUN adduser -D workflowuser && chown -R workflowuser:workflowuser /app
 
 USER workflowuser
 
-# Build image
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-alpine3.23 AS build
+# Build image (pinned to 10.0.2xx band — SDK 10.0.300 produces assets format v4 incompatible with PostSharp)
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0.203-alpine3.23 AS build
 
 # Install NETStandard.Library.Ref targeting pack for PostSharp compatibility
 RUN wget -q https://www.nuget.org/api/v2/package/NETStandard.Library.Ref/2.1.0 -O /tmp/netstandard.nupkg && \

--- a/workers/BBT.Workflow.DbMigrator/Dockerfile
+++ b/workers/BBT.Workflow.DbMigrator/Dockerfile
@@ -7,8 +7,8 @@ RUN adduser -D workflowuser && chown -R workflowuser:workflowuser /app
 
 USER workflowuser
 
-# Build image
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-alpine3.23 AS build
+# Build image (pinned to 10.0.2xx band — SDK 10.0.300 produces assets format v4 incompatible with PostSharp)
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0.203-alpine3.23 AS build
 
 # Install NETStandard.Library.Ref targeting pack for PostSharp compatibility
 RUN wget -q https://www.nuget.org/api/v2/package/NETStandard.Library.Ref/2.1.0 -O /tmp/netstandard.nupkg && \

--- a/workers/BBT.Workflow.Workers.Inbox/Dockerfile
+++ b/workers/BBT.Workflow.Workers.Inbox/Dockerfile
@@ -7,8 +7,8 @@ RUN adduser -D workflowuser && chown -R workflowuser:workflowuser /app
 
 USER workflowuser
 
-# Build image
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-alpine3.23 AS build
+# Build image (pinned to 10.0.2xx band — SDK 10.0.300 produces assets format v4 incompatible with PostSharp)
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0.203-alpine3.23 AS build
 
 # Install NETStandard.Library.Ref targeting pack for PostSharp compatibility
 RUN wget -q https://www.nuget.org/api/v2/package/NETStandard.Library.Ref/2.1.0 -O /tmp/netstandard.nupkg && \

--- a/workers/BBT.Workflow.Workers.Outbox/Dockerfile
+++ b/workers/BBT.Workflow.Workers.Outbox/Dockerfile
@@ -7,8 +7,8 @@ RUN adduser -D workflowuser && chown -R workflowuser:workflowuser /app
 
 USER workflowuser
 
-# Build image
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-alpine3.23 AS build
+# Build image (pinned to 10.0.2xx band — SDK 10.0.300 produces assets format v4 incompatible with PostSharp)
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0.203-alpine3.23 AS build
 
 # Install NETStandard.Library.Ref targeting pack for PostSharp compatibility
 RUN wget -q https://www.nuget.org/api/v2/package/NETStandard.Library.Ref/2.1.0 -O /tmp/netstandard.nupkg && \


### PR DESCRIPTION
## Summary by Sourcery

Pin .NET SDK usage across build workflows and Docker images to the 10.0.2xx band and adjust publishing to use npm OIDC with provenance.

Build:
- Update GitHub Actions workflows to use .NET SDK 10.0.2xx instead of the generic 10.0.x range and adjust npm publishing to use JS-DevTools/npm-publish with OIDC provenance for the vnext-meta package.

CI:
- Add a setup step for NETStandard.Library.Ref in CI builds to maintain PostSharp compatibility.

Deployment:
- Pin Docker build images for all services to mcr.microsoft.com/dotnet/sdk:10.0.203-alpine3.23 to avoid incompatibilities introduced by newer SDK assets formats.
- Update global.json to target .NET SDK 10.0.200 with roll-forward limited to latest patch for consistent local and container builds.