### PR TITLE
feat(functions): add HTTP verbs and rawResponse for BFF support

### DIFF
--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using BBT.Aether.AspNetCore.Controllers;
 using BBT.Aether.Users;
 using BBT.Workflow.Functions;
@@ -83,5 +84,68 @@ public sealed class FunctionController(
         return FromResult(await functionAppService.GetFunctionByInstanceAsync(
             function, workflow, domain, instance,
             requestContext.Headers, requestContext.QueryParameters, cancellationToken));
+    }
+
+    [HttpPost("{domain}/functions/{function}")]
+    [HttpPatch("{domain}/functions/{function}")]
+    [HttpDelete("{domain}/functions/{function}")]
+    public async Task<IActionResult> InvokeDomainFunctionAsync(
+        [FromRoute] string domain,
+        [FromRoute] string function,
+        [FromBody] JsonElement? body = null,
+        [FromQuery] string? version = null,
+        CancellationToken cancellationToken = default)
+    {
+        var requestContext = HttpContext.GetRequestBindingContext();
+
+        var request = new DomainFunctionRequest(
+            domain,
+            function,
+            version,
+            requestContext.Headers,
+            requestContext.QueryParameters,
+            HttpContext,
+            body);
+
+        var handler = domainHandlerFactory.Get(function.ToLowerInvariant());
+        return await handler.HandleAsync(request, cancellationToken);
+    }
+
+    [HttpPost("{domain}/workflows/{workflow}/instances/{instance}/functions/{function}")]
+    [HttpPatch("{domain}/workflows/{workflow}/instances/{instance}/functions/{function}")]
+    [HttpDelete("{domain}/workflows/{workflow}/instances/{instance}/functions/{function}")]
+    public async Task<IActionResult> InvokeInstanceFunctionAsync(
+        [FromRoute] string domain,
+        [FromRoute] string function,
+        [FromRoute] string workflow,
+        [FromRoute] string instance,
+        [FromQuery] FunctionQueryParameters parameters,
+        [FromBody] JsonElement? body = null,
+        CancellationToken cancellationToken = default)
+    {
+        var requestContext = HttpContext.GetRequestBindingContext();
+        var functionType = function.ToLowerInvariant();
+
+        var handler = handlerFactory.Get(functionType);
+        if (handler != null)
+        {
+            var request = new InstanceFunctionRequest(
+                domain,
+                workflow,
+                instance,
+                parameters,
+                null,
+                requestContext.Headers,
+                requestContext.QueryParameters,
+                currentUser,
+                HttpContext,
+                body);
+
+            return await handler.HandleAsync(request, cancellationToken);
+        }
+
+        return FromResult(await functionAppService.GetFunctionByInstanceAsync(
+            function, workflow, domain, instance,
+            requestContext.Headers, requestContext.QueryParameters, body, cancellationToken));
     }
 }

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs
@@ -83,7 +83,7 @@ public sealed class FunctionController(
 
         return FromResult(await functionAppService.GetFunctionByInstanceAsync(
             function, workflow, domain, instance,
-            requestContext.Headers, requestContext.QueryParameters, cancellationToken));
+            requestContext.Headers, requestContext.QueryParameters, null, cancellationToken));
     }
 
     [HttpPost("{domain}/functions/{function}")]

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/DefaultDomainFunctionHandler.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/DefaultDomainFunctionHandler.cs
@@ -22,6 +22,7 @@ public sealed class DefaultDomainFunctionHandler(
             request.Version,
             request.Headers,
             request.QueryParameters,
+            request.Body,
             cancellationToken);
 
         return result.ToActionResult(request.HttpContext);

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/DomainFunctionRequest.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/DomainFunctionRequest.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 
 namespace BBT.Workflow.Controllers.Instances;
@@ -12,4 +13,5 @@ public sealed record DomainFunctionRequest(
     string? Version,
     Dictionary<string, string?> Headers,
     Dictionary<string, string?> QueryParameters,
-    HttpContext HttpContext);
+    HttpContext HttpContext,
+    JsonElement? Body = null);

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/InstanceFunctionRequest.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/InstanceFunctionRequest.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using BBT.Aether.Users;
 using BBT.Workflow.Instances.DTOs;
 using Microsoft.AspNetCore.Http;
@@ -17,4 +18,5 @@ public sealed record InstanceFunctionRequest(
     Dictionary<string, string?> Headers,
     Dictionary<string, string?> QueryParameters,
     ICurrentUser CurrentUser,
-    HttpContext HttpContext);
+    HttpContext HttpContext,
+    JsonElement? Body = null);

--- a/src/BBT.Workflow.Application/Functions/FunctionAppService.cs
+++ b/src/BBT.Workflow.Application/Functions/FunctionAppService.cs
@@ -128,7 +128,7 @@ public sealed class FunctionAppService(
 
         object scriptBody = body.HasValue
             ? (object)body.Value
-            : (object)(instance?.LatestData?.Data ?? new JsonData("{}"));
+            : new JsonData("{}");
 
         var scriptContext = await scriptContextFactory.NewBuilder(instanceRepository)
             .WithWorkflow(workflow)
@@ -155,6 +155,7 @@ public sealed class FunctionAppService(
     /// <summary>
     /// Builds the final response: uses the <c>output</c> script when defined, otherwise falls back to
     /// legacy single-task extraction from <see cref="ScriptContext.OutputResponse"/>.
+    /// When <see cref="Function.RawResponse"/> is <c>true</c>, data is returned unwrapped.
     /// </summary>
     private async Task<Result<Dictionary<string, dynamic?>>> BuildResponseAsync(
         Function function,
@@ -166,11 +167,63 @@ public sealed class FunctionAppService(
             var handler = await scriptEngine.CompileToInstanceAsync<IOutputHandler>(
                 function.Output.DecodedCode, cancellationToken: cancellationToken);
             var scriptResponse = await handler.OutputHandler(scriptContext);
+
+            if (function.RawResponse)
+                return Result<Dictionary<string, dynamic?>>.Ok(ToRawDictionary(scriptResponse.Data));
+
             return Result<Dictionary<string, dynamic?>>.Ok(
                 new Dictionary<string, dynamic?> { [function.Key.ToVariableName()] = scriptResponse.Data });
         }
 
+        if (function.RawResponse)
+            return Result<Dictionary<string, dynamic?>>.Ok(ExtractRawFunctionResponse(function, scriptContext));
+
         return Result<Dictionary<string, dynamic?>>.Ok(ExtractFunctionResponse(function, scriptContext));
+    }
+
+    /// <summary>
+    /// Converts an arbitrary object to a flat <c>Dictionary&lt;string, dynamic?&gt;</c> for raw responses.
+    /// </summary>
+    private static Dictionary<string, dynamic?> ToRawDictionary(object? data)
+    {
+        if (data is Dictionary<string, dynamic?> dict)
+            return dict;
+
+        var json = JsonSerializer.Serialize(data);
+        return JsonSerializer.Deserialize<Dictionary<string, dynamic?>>(json) ?? [];
+    }
+
+    /// <summary>
+    /// Raw variant of legacy single-task extraction: returns the task value directly
+    /// without wrapping it in the function-key dictionary.
+    /// </summary>
+    private static Dictionary<string, dynamic?> ExtractRawFunctionResponse(
+        Function function,
+        ScriptContext scriptContext)
+    {
+        var variableKeyTask = function.Task!.Task.Key.ToVariableName();
+
+        if (!scriptContext.OutputResponse.TryGetValue(variableKeyTask, out var value))
+            return [];
+
+        try
+        {
+            if (value is JsonElement jsonElement)
+            {
+                var target = jsonElement.TryGetProperty("data", out var dataProp)
+                    ? dataProp
+                    : jsonElement;
+
+                if (target.ValueKind == JsonValueKind.Object)
+                    return JsonSerializer.Deserialize<Dictionary<string, dynamic?>>(target.GetRawText()) ?? [];
+            }
+
+            if (value is Dictionary<string, dynamic?> d)
+                return d;
+        }
+        catch { /* ignore */ }
+
+        return [];
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Application/Functions/FunctionAppService.cs
+++ b/src/BBT.Workflow.Application/Functions/FunctionAppService.cs
@@ -33,6 +33,7 @@ public sealed class FunctionAppService(
         string? version = null,
         Dictionary<string, string?>? headers = null,
         Dictionary<string, string?>? queryParameters = null,
+        JsonElement? body = null,
         CancellationToken cancellationToken = default)
     {
         runtimeInfoProvider.Check(domain);
@@ -41,7 +42,7 @@ public sealed class FunctionAppService(
             return await componentCacheStore
                 .GetFunctionAsync(domain, key, version, cancellationToken)
                 .BindAsync(function =>
-                    ExecuteFunctionAsync(function, null, null, headers, queryParameters, cancellationToken));
+                    ExecuteFunctionAsync(function, null, null, headers, queryParameters, body, cancellationToken));
         }
     }
 
@@ -53,6 +54,7 @@ public sealed class FunctionAppService(
         string instanceKey,
         Dictionary<string, string?>? headers = null,
         Dictionary<string, string?>? queryParameters = null,
+        JsonElement? body = null,
         CancellationToken cancellationToken = default)
     {
         runtimeInfoProvider.Check(domain);
@@ -65,7 +67,7 @@ public sealed class FunctionAppService(
             return await componentCacheStore
                 .GetFlowAsync(domain, flow, instance.FlowVersion, cancellationToken)
                 .BindAsync(workflow =>
-                    ResolveFunctionAndExecuteAsync(domain, key, instance, workflow, headers, queryParameters, cancellationToken));
+                    ResolveFunctionAndExecuteAsync(domain, key, instance, workflow, headers, queryParameters, body, cancellationToken));
         }
     }
 
@@ -93,13 +95,14 @@ public sealed class FunctionAppService(
         Definitions.Workflow workflow,
         Dictionary<string, string?>? headers,
         Dictionary<string, string?>? queryParameters,
+        JsonElement? body,
         CancellationToken cancellationToken)
     {
         var functionReference = workflow.FindFunction(key);
         return componentCacheStore
             .GetFunctionAsync(domain, key, functionReference?.Version, cancellationToken)
             .BindAsync(function =>
-                ExecuteFunctionAsync(function, instance, workflow, headers, queryParameters, cancellationToken));
+                ExecuteFunctionAsync(function, instance, workflow, headers, queryParameters, body, cancellationToken));
     }
 
     /// <summary>
@@ -111,6 +114,7 @@ public sealed class FunctionAppService(
         Definitions.Workflow? workflow,
         Dictionary<string, string?>? headers,
         Dictionary<string, string?>? queryParameters,
+        JsonElement? body,
         CancellationToken cancellationToken)
     {
         if (instance != null &&
@@ -122,11 +126,15 @@ public sealed class FunctionAppService(
                 WorkflowErrors.FunctionNotInWorkflow(function.Key, workflow.Key));
         }
 
+        object scriptBody = body.HasValue
+            ? (object)body.Value
+            : (object)(instance?.LatestData?.Data ?? new JsonData("{}"));
+
         var scriptContext = await scriptContextFactory.NewBuilder(instanceRepository)
             .WithWorkflow(workflow)
             .WithInstance(instance)
             .WithRuntime(runtimeInfoProvider)
-            .WithBody(instance?.LatestData?.Data ?? new JsonData("{}"))
+            .WithBody(scriptBody)
             .WithHeaders(headers)
             .WithQueryParameters(queryParameters)
             .BuildAsync(cancellationToken);

--- a/src/BBT.Workflow.Application/Functions/IFunctionAppService.cs
+++ b/src/BBT.Workflow.Application/Functions/IFunctionAppService.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using BBT.Aether.Application;
 using BBT.Aether.Results;
 using BBT.Workflow.Instances;
@@ -24,6 +25,7 @@ public interface IFunctionAppService : IApplicationService
         string? version = null,
         Dictionary<string, string?>? headers = null,
         Dictionary<string, string?>? queryParameters = null,
+        JsonElement? body = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -43,6 +45,7 @@ public interface IFunctionAppService : IApplicationService
         string instance,
         Dictionary<string, string?>? headers = null,
         Dictionary<string, string?>? queryParameters = null,
+        JsonElement? body = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/BBT.Workflow.Domain/Definitions/Functions/Function.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Functions/Function.cs
@@ -21,7 +21,8 @@ public sealed class Function : IDomainEntity, IFunctionReference, IReferenceSett
         OnExecuteTask? task,
         List<OnExecuteTask>? onExecutionTasks = null,
         ScriptCode? output = null,
-        List<RoleGrant>? roles = null
+        List<RoleGrant>? roles = null,
+        bool rawResponse = false
     ) : this()
     {
         Scope = scope;
@@ -29,6 +30,7 @@ public sealed class Function : IDomainEntity, IFunctionReference, IReferenceSett
         this.onExecutionTasks = onExecutionTasks ?? [];
         Output = output;
         this.roles = roles ?? [];
+        RawResponse = rawResponse;
     }
 
     /// <summary>
@@ -71,6 +73,14 @@ public sealed class Function : IDomainEntity, IFunctionReference, IReferenceSett
     /// </summary>
     [JsonInclude] [JsonPropertyName("output")]
     public ScriptCode? Output { get; private set; }
+
+    /// <summary>
+    /// When <c>true</c>, the response data is returned as-is without wrapping it in
+    /// <c>{ "functionKey": data }</c>. Use this for BFF functions that already return
+    /// the desired response shape. Defaults to <c>false</c> (current behaviour preserved).
+    /// </summary>
+    [JsonPropertyName("rawResponse")]
+    public bool RawResponse { get; private set; }
 
     [JsonInclude] [JsonPropertyName("roles")]
     private List<RoleGrant> roles = new();

--- a/test/BBT.Workflow.Application.Tests/Functions/FunctionOutputHandlerTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Functions/FunctionOutputHandlerTests.cs
@@ -139,4 +139,48 @@ public class FunctionOutputHandlerTests
         function.ShouldNotBeNull();
         function!.Output.ShouldNotBeNull();
     }
+
+    // ─── RawResponse ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void RawResponse_DefaultsFalse()
+    {
+        var function = new Function(TaskScope.Domain, CreateTask(1, TaskRef));
+        function.RawResponse.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Function_DeserializesFromJson_WithoutRawResponse_DefaultsFalse()
+    {
+        var json = """
+            {
+                "scope": "D",
+                "task": { "order": 1, "task": { "key": "t", "domain": "d", "flow": "f", "version": "1" }, "mapping": { "code": "" } }
+            }
+            """;
+
+        var function = JsonSerializer.Deserialize<Function>(json,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        function.ShouldNotBeNull();
+        function!.RawResponse.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Function_DeserializesRawResponseTrueFromJson()
+    {
+        var json = """
+            {
+                "scope": "D",
+                "rawResponse": true,
+                "task": { "order": 1, "task": { "key": "t", "domain": "d", "flow": "f", "version": "1" }, "mapping": { "code": "" } }
+            }
+            """;
+
+        var function = JsonSerializer.Deserialize<Function>(json,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        function.ShouldNotBeNull();
+        function!.RawResponse.ShouldBeTrue();
+    }
 }


### PR DESCRIPTION
## Summary
- Extend workflow Functions beyond GET-only invocation with POST, PATCH, and DELETE at domain and instance scope, accepting a free-form JSON body for create/update/delete flows without a separate BFF hop.
- Add optional `rawResponse` on function definitions so BFF-style functions return payload as-is instead of wrapping under `{ functionKey: data }`, preserving backward compatibility when unset.
- Thread request body through orchestration handlers and `FunctionAppService`; use empty `JsonData` when no body is sent on non-GET paths after the rawResponse change.

## Changes
- `orchestration/.../Controllers/Functions/FunctionController.cs` — POST/PATCH/DELETE endpoints; GET passes `null` body
- `src/BBT.Workflow.Application/Functions/FunctionAppService.cs` — body handling, `rawResponse` output paths
- `src/BBT.Workflow.Application/Functions/IFunctionAppService.cs`
- `src/BBT.Workflow.Application/Functions/Handlers/*` — `DomainFunctionRequest`, `InstanceFunctionRequest`, `DefaultDomainFunctionHandler`
- `src/BBT.Workflow.Domain/Definitions/Functions/Function.cs` — `rawResponse` property
- `test/BBT.Workflow.Application.Tests/Functions/FunctionOutputHandlerTests.cs` — `rawResponse` deserialization tests

## Test Plan
- [ ] Invoke a domain function via POST/PATCH/DELETE with a JSON body and verify the script receives it as `ScriptContext.Body`
- [ ] Invoke the same function via GET and confirm existing behavior is unchanged
- [ ] Define a function with `"rawResponse": true` and verify the response is not wrapped in the function key
- [ ] Define a function without `rawResponse` (or `false`) and verify the legacy `{ functionKey: data }` shape still applies
- [ ] Run `dotnet test test/BBT.Workflow.Application.Tests --filter "FullyQualifiedName~FunctionOutputHandlerTests"`

## Notes
- Closes #646 (HTTP method support commit).
- `rawResponse` defaults to `false`; no migration required for existing definitions.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Extend function invocation to accept HTTP bodies and support unwrapped raw responses for BFF-style functions, while preserving existing behavior by default.

New Features:
- Allow domain and instance functions to be invoked via POST, PATCH, and DELETE HTTP verbs with an optional JSON body passed through to the script context.
- Introduce a configurable rawResponse flag on function definitions to return function output without wrapping it under the function key.

Enhancements:
- Propagate optional request bodies through orchestration handlers and FunctionAppService into ScriptContext, defaulting to an empty JSON object when absent.
- Adjust function output handling to return either wrapped or raw data depending on the rawResponse flag, including support for output scripts.

Tests:
- Add unit tests verifying default and explicit JSON deserialization behavior for the new rawResponse property on Function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new HTTP endpoints (POST, PATCH, DELETE) for invoking workflow functions across domain and instance scopes
  * Functions now accept optional JSON request bodies during invocation
  * Introduced RawResponse flag enabling functions to return responses directly without wrapping

* **Tests**
  * Added test coverage validating RawResponse functionality and JSON deserialization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/burgan-tech/vnext/pull/679?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->