### PR TITLE
feat(execution): add layered timeout model with Busy recovery

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
     <PropertyGroup>
 
         <!-- All Prism packages -->
-        <AetherPackageVersion>1.0.24</AetherPackageVersion>
+        <AetherPackageVersion>1.0.25</AetherPackageVersion>
         <!-- Elastic Apm packages -->
         <ElasticApmPackageVersion>1.31.0</ElasticApmPackageVersion>
         <!-- Microsoft packages -->

--- a/execution/BBT.Workflow.Execution.HttpApi.Host/appsettings.json
+++ b/execution/BBT.Workflow.Execution.HttpApi.Host/appsettings.json
@@ -91,12 +91,5 @@
   "AllowedHosts": "*",
   "Vault": {
     "Enabled": false
-  },
-  "Dapr": {
-    "Notification": {
-      "ComponentName": "vnext-notification-binding",
-      "DefaultOperation": "create",
-      "TimeoutSeconds": 30
-    }
   }
 }

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/appsettings.json
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/appsettings.json
@@ -169,7 +169,15 @@
     ]
   },
   "ExecutionApi": {
-    "AppId": "vnext-execution-app"
+    "AppId": "vnext-execution-app",
+    "InvocationTimeoutSeconds": 60
+  },
+  "WorkflowExecution": {
+    "TransitionJobTimeoutSeconds": 300,
+    "FailurePolicy": {
+      "MaxRetries": 5,
+      "IntervalSeconds": 30
+    }
   },
   "Vault": {
     "Enabled": false
@@ -217,6 +225,13 @@
   "Workflow": {
     "InstanceFiltering": {
       "EnforceMasterSchemaFiltering": true
+    }
+  },
+  "Dapr": {
+    "Notification": {
+      "BindingPrefix": "vnext-notification",
+      "DefaultOperation": "create",
+      "TimeoutSeconds": 30
     }
   }
 }

--- a/src/BBT.Workflow.Application/BackgroundJobs/Handlers/TransitionJobHandler.cs
+++ b/src/BBT.Workflow.Application/BackgroundJobs/Handlers/TransitionJobHandler.cs
@@ -1,12 +1,16 @@
 using System.Diagnostics;
 using BBT.Aether.BackgroundJob;
 using BBT.Aether.MultiSchema;
+using BBT.Workflow.BackgroundJobs.Options;
 using BBT.Workflow.BackgroundJobs.Payloads;
+using BBT.Workflow.BackgroundJobs.Recovery;
 using BBT.Workflow.Execution;
 using BBT.Workflow.Execution.Services;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Logging;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace BBT.Workflow.BackgroundJobs.Handlers;
 
@@ -18,6 +22,9 @@ public sealed class TransitionJobHandler(
     IInstanceJobRepository jobRepository,
     IWorkflowExecutionService workflowExecutionService,
     ICurrentSchema currentSchema,
+    IJobTimeoutRecoveryService recoveryService,
+    IOptions<WorkflowExecutionOptions> executionOptions,
+    IHostApplicationLifetime hostLifetime,
     ILogger<TransitionJobHandler> logger) : IBackgroundJobHandler<TransitionJobPayload>
 {
     public const string HandlerName = "flow.transition";
@@ -38,6 +45,17 @@ public sealed class TransitionJobHandler(
                        [TelemetryConstants.TagNames.TransitionKey] = args.TransitionKey,
                        [TelemetryConstants.TagNames.JobName] = args.JobName
                    }))
+            {
+                var timeoutSeconds = executionOptions.Value.TransitionJobTimeoutSeconds;
+
+                // Separate execution budget CTS from the incoming Dapr/host cancellation token.
+                // This lets us distinguish: own timeout vs Dapr HTTP timeout vs host shutdown.
+                using var executionCts = new CancellationTokenSource(TimeSpan.FromSeconds(timeoutSeconds));
+                using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+                    cancellationToken, executionCts.Token);
+
+                bool needsRecovery = false;
+
                 try
                 {
                     BackgroundJobActivityHelper.EnrichActivity(activity, args);
@@ -67,14 +85,40 @@ public sealed class TransitionJobHandler(
                     context.CallerMode = args.CallerSync ? ExecMode.Sync : ExecMode.Async;
 
                     // Use the background-specific method that handles pre-reserved instances
-                    var result = await workflowExecutionService.ExecuteTransitionAsync(context, cancellationToken);
+                    var result = await workflowExecutionService.ExecuteTransitionAsync(context, linkedCts.Token);
 
-                    activity?.SetStatus(ActivityStatusCode.Ok);
-                    logger.JobCompleted(args.JobName, args.TransitionKey, args.InstanceId);
+                    if (!result.IsSuccess)
+                    {
+                        activity?.SetStatus(ActivityStatusCode.Error, result.Error.Message);
+                        logger.JobFailed(args.JobName, args.InstanceId, result.Error.Message ?? "Unknown error");
+                    }
+                    else
+                    {
+                        activity?.SetStatus(ActivityStatusCode.Ok);
+                        logger.JobCompleted(args.JobName, args.TransitionKey, args.InstanceId);
+                    }
                 }
-                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                catch (OperationCanceledException) when (executionCts.IsCancellationRequested)
                 {
-                    activity?.SetStatus(ActivityStatusCode.Error, "Job cancelled");
+                    // Own 300s execution budget exceeded
+                    needsRecovery = true;
+                    activity?.SetStatus(ActivityStatusCode.Error, "Job execution timeout");
+                    activity?.SetTag("timeout.layer", "job");
+                    logger.JobTimedOut(args.JobName, timeoutSeconds, args.TransitionKey, args.InstanceId);
+                }
+                catch (OperationCanceledException) when (
+                    !hostLifetime.ApplicationStopping.IsCancellationRequested)
+                {
+                    // Dapr HTTP response timeout or external cancellation (not host shutdown)
+                    needsRecovery = true;
+                    activity?.SetStatus(ActivityStatusCode.Error, "Job cancelled by Dapr/external");
+                    activity?.SetTag("timeout.layer", "dapr-cancel");
+                    logger.JobCancelledByExternal(args.JobName, args.TransitionKey, args.InstanceId);
+                }
+                catch (OperationCanceledException)
+                {
+                    // Host shutdown (SIGTERM) — recovery not feasible, host is going down
+                    activity?.SetStatus(ActivityStatusCode.Error, "Job cancelled (host shutdown)");
                     logger.JobCancelled(args.JobName, args.TransitionKey, args.InstanceId);
                 }
                 catch (Exception e)
@@ -85,8 +129,15 @@ public sealed class TransitionJobHandler(
                 }
                 finally
                 {
+                    if (needsRecovery)
+                    {
+                        // CancellationToken.None: recovery must complete even if host is shutting down
+                        await recoveryService.FaultInstanceAsync(args, CancellationToken.None);
+                    }
+
                     await jobRepository.MarkAsProcessedAsync(args.InstanceId, args.JobName, CancellationToken.None);
                 }
+            }
         }
     }
 }

--- a/src/BBT.Workflow.Application/BackgroundJobs/Options/WorkflowExecutionOptions.cs
+++ b/src/BBT.Workflow.Application/BackgroundJobs/Options/WorkflowExecutionOptions.cs
@@ -1,0 +1,16 @@
+namespace BBT.Workflow.BackgroundJobs.Options;
+
+public sealed class WorkflowExecutionOptions
+{
+    public const string SectionName = "WorkflowExecution";
+
+    public int TransitionJobTimeoutSeconds { get; set; } = 300;
+
+    public TransitionJobFailurePolicyOptions FailurePolicy { get; set; } = new();
+}
+
+public sealed class TransitionJobFailurePolicyOptions
+{
+    public int MaxRetries { get; set; } = 5;
+    public int IntervalSeconds { get; set; } = 30;
+}

--- a/src/BBT.Workflow.Application/BackgroundJobs/Recovery/IJobTimeoutRecoveryService.cs
+++ b/src/BBT.Workflow.Application/BackgroundJobs/Recovery/IJobTimeoutRecoveryService.cs
@@ -1,0 +1,12 @@
+using BBT.Workflow.BackgroundJobs.Payloads;
+
+namespace BBT.Workflow.BackgroundJobs.Recovery;
+
+public interface IJobTimeoutRecoveryService
+{
+    /// <summary>
+    /// Recovers an instance stuck in Busy status after a job execution timeout or cancellation.
+    /// Faults the instance, records an incident, and closes any open transition record.
+    /// </summary>
+    Task FaultInstanceAsync(TransitionJobPayload args, CancellationToken cancellationToken);
+}

--- a/src/BBT.Workflow.Application/BackgroundJobs/Recovery/JobTimeoutRecoveryService.cs
+++ b/src/BBT.Workflow.Application/BackgroundJobs/Recovery/JobTimeoutRecoveryService.cs
@@ -1,0 +1,79 @@
+using BBT.Aether.Uow;
+using BBT.Workflow.BackgroundJobs.Options;
+using BBT.Workflow.BackgroundJobs.Payloads;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Logging;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace BBT.Workflow.BackgroundJobs.Recovery;
+
+/// <inheritdoc cref="IJobTimeoutRecoveryService" />
+public sealed class JobTimeoutRecoveryService(
+    IUnitOfWorkManager uowManager,
+    IInstanceRepository instanceRepository,
+    IInstanceTransitionRepository transitionRepository,
+    IOptions<WorkflowExecutionOptions> options,
+    ILogger<JobTimeoutRecoveryService> logger) : IJobTimeoutRecoveryService
+{
+    public async Task FaultInstanceAsync(TransitionJobPayload args, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var uow = await uowManager.BeginAsync(
+                new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew },
+                cancellationToken);
+
+            var instance = await instanceRepository.FindAsync(args.InstanceId, true, cancellationToken);
+
+            if (instance == null)
+            {
+                logger.InstanceNotFound(args.InstanceId, args.Workflow);
+                return;
+            }
+
+            if (!instance.Status.Equals(InstanceStatus.Busy))
+            {
+                logger.LogDebug(
+                    "Recovery skipped: instance {InstanceId} is not in Busy status (current: {Status})",
+                    args.InstanceId, instance.Status);
+                return;
+            }
+
+            var incident = InstanceIncidentFactory.Create(
+                state: instance.GetCurrentState,
+                transition: args.TransitionKey,
+                taskKey: null,
+                message: $"Job execution timed out or was cancelled after {options.Value.TransitionJobTimeoutSeconds}s",
+                errorCode: "JOB_EXECUTION_TIMEOUT",
+                errorLayer: "Job",
+                boundaryAction: "Abort",
+                boundaryLevel: "Job");
+
+            instance.AddIncident(incident);
+            instance.Fault(args.Domain);
+
+            var openTransition = await transitionRepository.GetLatestIncompleteAsync(
+                args.InstanceId, cancellationToken);
+            if (openTransition != null)
+            {
+                openTransition.Failed();
+                await transitionRepository.UpdateCompletedAsync(openTransition, cancellationToken);
+            }
+
+            await instanceRepository.UpdateAsync(instance, true, cancellationToken);
+            await uow.CommitAsync(cancellationToken);
+
+            logger.LogError(
+                "Instance {InstanceId} faulted after job execution timeout. " +
+                "Transition: {TransitionKey}, State: {State}",
+                args.InstanceId, args.TransitionKey, instance.GetCurrentState);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex,
+                "Recovery failed for instance {InstanceId}. Instance may remain in Busy status",
+                args.InstanceId);
+        }
+    }
+}

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ScheduleTransitionsStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ScheduleTransitionsStep.cs
@@ -172,7 +172,7 @@ public sealed class ScheduleTransitionsStep(
             info.Payload,
             info.ScheduleExpression,
             metadata: info.Metadata,
-            cancellationToken);
+            cancellationToken: cancellationToken);
 
         await jobRepository.InsertAsync(
             InstanceJob.Create(

--- a/src/BBT.Workflow.Application/Execution/Transitions/Strategy/AsyncTransitionStrategy.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Strategy/AsyncTransitionStrategy.cs
@@ -289,7 +289,7 @@ public sealed class AsyncTransitionStrategy(
             Stage = context.Data?.Stage
         };
 
-        var schedule = DaprJobSchedule.FromDateTime(DateTime.UtcNow.AddSeconds(2)).ExpressionValue;
+        var schedule = DaprJobSchedule.FromDateTime(DateTime.UtcNow.AddMilliseconds(5)).ExpressionValue;
 
         var metadata = new Dictionary<string, object>
         {

--- a/src/BBT.Workflow.Application/Execution/Transitions/Strategy/AsyncTransitionStrategy.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Strategy/AsyncTransitionStrategy.cs
@@ -5,6 +5,7 @@ using BBT.Aether.DistributedLock;
 using BBT.Aether.Results;
 using BBT.Aether.Uow;
 using BBT.Workflow.BackgroundJobs.Handlers;
+using BBT.Workflow.BackgroundJobs.Options;
 using BBT.Workflow.BackgroundJobs.Payloads;
 using BBT.Workflow.Execution.Validation;
 using BBT.Workflow.Gateway;
@@ -12,6 +13,7 @@ using BBT.Workflow.Instances;
 using BBT.Workflow.Logging;
 using Dapr.Jobs.Models;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace BBT.Workflow.Execution.Strategies;
 
@@ -33,6 +35,7 @@ public sealed class AsyncTransitionStrategy(
     ITransitionValidationService validationService,
     IUnitOfWorkManager uowManager,
     IInstanceCommandGateway instanceCommandGateway,
+    IOptions<WorkflowExecutionOptions> executionOptions,
     ILogger<AsyncTransitionStrategy> logger) : ITransitionStrategy
 {
     /// <summary>
@@ -213,6 +216,11 @@ public sealed class AsyncTransitionStrategy(
         Dictionary<string, object> metadata,
         CancellationToken cancellationToken)
     {
+        var fp = executionOptions.Value.FailurePolicy;
+        var failurePolicy = JobScheduleFailurePolicy.Constant(
+            TimeSpan.FromSeconds(fp.IntervalSeconds),
+            (uint)fp.MaxRetries);
+
         return ResultExtensions.TryAsync(
             async ct => await backgroundJobService.EnqueueAsync(
                 TransitionJobHandler.HandlerName,
@@ -220,6 +228,7 @@ public sealed class AsyncTransitionStrategy(
                 jobPayload,
                 schedule,
                 metadata,
+                failurePolicy,
                 ct),
             cancellationToken,
             ex => Error.Dependency(

--- a/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
@@ -370,7 +370,7 @@ public sealed class InstanceCommandAppService(
                 payload,
                 schedule,
                 metadata,
-                cancellationToken);
+                cancellationToken: cancellationToken);
 
             // Track the job in the database
             await instanceJobRepository.InsertAsync(

--- a/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/TaskServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/TaskServiceCollectionExtensions.cs
@@ -1,3 +1,5 @@
+using BBT.Workflow.BackgroundJobs.Options;
+using BBT.Workflow.BackgroundJobs.Recovery;
 using BBT.Workflow.Execution.ErrorHandling;
 using BBT.Workflow.Scripting;
 using BBT.Workflow.Scripting.Evaluators;
@@ -45,6 +47,19 @@ public static class TaskServiceCollectionExtensions
         services.AddTaskFactories();
         services.AddTaskPersistence();
         services.AddScriptingServices();
+
+        // Background job recovery and execution options
+        services.AddBackgroundJobServices();
+
+        return services;
+    }
+
+    private static IServiceCollection AddBackgroundJobServices(this IServiceCollection services)
+    {
+        services.AddOptions<WorkflowExecutionOptions>()
+            .BindConfiguration(WorkflowExecutionOptions.SectionName);
+
+        services.AddScoped<IJobTimeoutRecoveryService, JobTimeoutRecoveryService>();
 
         return services;
     }

--- a/src/BBT.Workflow.Application/Tasks/Executors/Remote/RemoteInvokerService.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Remote/RemoteInvokerService.cs
@@ -18,11 +18,9 @@ public sealed class RemoteInvokerService : IRemoteInvokerService
 {
     private readonly DaprClient _daprClient;
     private readonly string _executionServiceAppId;
+    private readonly int _invocationTimeoutSeconds;
     private readonly ILogger<RemoteInvokerService> _logger;
 
-    /// <summary>
-    /// Initializes a new instance of RemoteInvokerService.
-    /// </summary>
     public RemoteInvokerService(
         DaprClient daprClient,
         IConfiguration configuration,
@@ -30,6 +28,8 @@ public sealed class RemoteInvokerService : IRemoteInvokerService
     {
         _daprClient = daprClient;
         _executionServiceAppId = configuration["ExecutionApi:AppId"] ?? "vnext-execution";
+        _invocationTimeoutSeconds = int.TryParse(
+            configuration["ExecutionApi:InvocationTimeoutSeconds"], out var t) ? t : 60;
         _logger = logger;
     }
 
@@ -52,7 +52,12 @@ public sealed class RemoteInvokerService : IRemoteInvokerService
             TraceContext = traceContext
         };
 
-        var result = await ResultExtensions.TryAsync(async ct =>
+        // Per-invocation timeout: parent pipeline cancellation takes priority.
+        // If only our own timer fires → invocation timeout (timeout.layer=remote).
+        using var invocationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        invocationCts.CancelAfter(TimeSpan.FromSeconds(_invocationTimeoutSeconds));
+
+        try
         {
             var httpRequest = _daprClient.CreateInvokeMethodRequest(
                 _executionServiceAppId,
@@ -65,57 +70,59 @@ public sealed class RemoteInvokerService : IRemoteInvokerService
                 traceContext.WorkflowVersion ?? "latest",
                 traceContext.InstanceId));
 
-            return await _daprClient.InvokeMethodAsync<TaskInvokeResponse>(httpRequest, ct);
-        }, cancellationToken);
+            var response = await _daprClient.InvokeMethodAsync<TaskInvokeResponse>(
+                httpRequest, invocationCts.Token);
 
-        stopwatch.Stop();
+            stopwatch.Stop();
 
-        if (!result.IsSuccess)
+            var remoteResult = new TaskInvocationResult
+            {
+                IsSuccess = response.Result!.IsSuccess,
+                StatusCode = response.Result.StatusCode,
+                Body = response.Result.Body,
+                Data = response.Result.Data,
+                ErrorMessage = response.Result.ErrorMessage,
+                Headers = response.Result.Headers,
+                TaskType = response.Result.TaskType,
+                Metadata = response.Result.Metadata,
+                ExecutionDurationMs = stopwatch.ElapsedMilliseconds
+            };
+
+            return Result<TaskInvocationResult>.Ok(remoteResult);
+        }
+        catch (OperationCanceledException) when (
+            invocationCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
         {
-            _logger.LogError("Failed to invoke remote task {TaskKey}: {Error}",
-                taskKey, result.Error.Message);
+            // Own per-invocation timeout — not caused by parent pipeline cancellation
+            stopwatch.Stop();
+            _logger.LogError(
+                "Dapr invocation timeout after {Seconds}s. TaskType: {TaskType}, TaskKey: {TaskKey} [timeout.layer=remote]",
+                _invocationTimeoutSeconds, taskType, taskKey);
 
             return Result<TaskInvocationResult>.Ok(TaskInvocationResult.Failure(
-                error: result.Error.Message ?? "Remote invocation failed",
+                error: $"Dapr invocation timeout after {_invocationTimeoutSeconds}s",
+                statusCode: 408,
+                executionDurationMs: stopwatch.ElapsedMilliseconds,
+                taskType: taskType));
+        }
+        catch (OperationCanceledException)
+        {
+            // Parent pipeline cancelled — propagate so the pipeline handles it correctly
+            stopwatch.Stop();
+            throw;
+        }
+        catch (Exception ex)
+        {
+            stopwatch.Stop();
+            _logger.LogError("Failed to invoke remote task {TaskKey}: {Error}",
+                taskKey, ex.Message);
+
+            return Result<TaskInvocationResult>.Ok(TaskInvocationResult.Failure(
+                error: ex.Message,
                 statusCode: 500,
                 executionDurationMs: stopwatch.ElapsedMilliseconds,
                 taskType: taskType));
         }
-        
-        if (!result.IsSuccess)
-        {
-            _logger.LogWarning("Remote task {TaskKey} execution failed: {Error}",
-                taskKey, result.Error.Message ?? "Unknown error");
-
-            return Result<TaskInvocationResult>.Ok(TaskInvocationResult.Failure(
-                error: result.Error.Message ?? "Remote execution failed",
-                statusCode: 500,
-                executionDurationMs: stopwatch.ElapsedMilliseconds,
-                taskType: taskType,
-                metadata: new Dictionary<string, object>
-                {
-                    ["RemoteSuccess"] = false,
-                    ["TaskKey"] = taskKey
-                }));
-        }
-
-        var response = result.Value!;
-        
-        // Update execution duration to include network time
-        var remoteResult = new TaskInvocationResult
-        {
-            IsSuccess = response.Result!.IsSuccess,
-            StatusCode = response.Result.StatusCode,
-            Body = response.Result.Body,
-            Data = response.Result.Data,
-            ErrorMessage = response.Result.ErrorMessage,
-            Headers = response.Result.Headers,
-            TaskType = response.Result.TaskType,
-            Metadata = response.Result.Metadata,
-            ExecutionDurationMs = stopwatch.ElapsedMilliseconds
-        };
-
-        return Result<TaskInvocationResult>.Ok(remoteResult);
     }
 
     /// <inheritdoc />
@@ -138,4 +145,3 @@ public sealed class RemoteInvokerService : IRemoteInvokerService
             instanceDataJson: instance?.LatestData?.Data?.Json);
     }
 }
-

--- a/src/BBT.Workflow.Domain/Instances/InstanceTransition.cs
+++ b/src/BBT.Workflow.Domain/Instances/InstanceTransition.cs
@@ -85,6 +85,17 @@ public sealed class InstanceTransition : Entity<Guid>, ICreationAuditedObject
         Duration = FinishedAt - StartedAt;
     }
 
+    /// <summary>
+    /// Closes the transition record as failed without a target state.
+    /// Used when the pipeline was aborted (timeout, unhandled fault) before reaching ChangeStateStep.
+    /// </summary>
+    public void Failed()
+    {
+        FinishedAt = DateTime.UtcNow;
+        Duration = FinishedAt - StartedAt;
+        // ToState remains null — signals incomplete/aborted transition
+    }
+
     public static InstanceTransition Create(
         Guid id,
         Guid instanceId,

--- a/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
@@ -1490,6 +1490,33 @@ public static partial class WorkflowLogs
         string transitionKey,
         Guid instanceId);
 
+    /// <summary>
+    /// Logs when a job's execution budget is exceeded (timeout.layer=job).
+    /// </summary>
+    [LoggerMessage(
+        EventId = 40117,
+        Level = LogLevel.Error,
+        Message = "Job {JobName} timed out after {TimeoutSeconds}s: {TransitionKey} for instance {InstanceId} [timeout.layer=job]")]
+    public static partial void JobTimedOut(
+        this ILogger logger,
+        string jobName,
+        int timeoutSeconds,
+        string transitionKey,
+        Guid instanceId);
+
+    /// <summary>
+    /// Logs when a job handler is cancelled by Dapr or an external signal (not host shutdown).
+    /// </summary>
+    [LoggerMessage(
+        EventId = 40118,
+        Level = LogLevel.Error,
+        Message = "Job {JobName} cancelled by Dapr/external signal: {TransitionKey} for instance {InstanceId} [timeout.layer=dapr-cancel]")]
+    public static partial void JobCancelledByExternal(
+        this ILogger logger,
+        string jobName,
+        string transitionKey,
+        Guid instanceId);
+
     #endregion
 
     #region Runtime

--- a/src/BBT.Workflow.HttpApi.Shared/Microsoft/Extensions/DependencyInjection/WorkflowApiBaseServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.HttpApi.Shared/Microsoft/Extensions/DependencyInjection/WorkflowApiBaseServiceCollectionExtensions.cs
@@ -162,8 +162,9 @@ public static class WorkflowApiBaseServiceCollectionExtensions
             options.AddHandler<TransitionJobHandler>(TransitionJobHandler.HandlerName);
             options.AddHandler<TransitionTimerJobHandler>(TransitionTimerJobHandler.HandlerName);
         });
-        
+
         services.AddDaprJobScheduler();
+
         return services;
     }
     

--- a/test/BBT.Workflow.Application.Tests/BackgroundJobs/Handlers/TransitionJobHandlerTests.cs
+++ b/test/BBT.Workflow.Application.Tests/BackgroundJobs/Handlers/TransitionJobHandlerTests.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.MultiSchema;
+using BBT.Aether.Results;
+using BBT.Workflow.BackgroundJobs.Handlers;
+using BBT.Workflow.BackgroundJobs.Options;
+using BBT.Workflow.BackgroundJobs.Payloads;
+using BBT.Workflow.BackgroundJobs.Recovery;
+using BBT.Workflow.Execution;
+using BBT.Workflow.Execution.Services;
+using BBT.Workflow.Instances;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace BBT.Workflow.Application.Tests.BackgroundJobs.Handlers;
+
+public class TransitionJobHandlerTests
+{
+    private readonly Mock<IInstanceJobRepository> _jobRepo = new();
+    private readonly Mock<IWorkflowExecutionService> _executionService = new();
+    private readonly Mock<ICurrentSchema> _currentSchema = new();
+    private readonly Mock<IJobTimeoutRecoveryService> _recoveryService = new();
+    private readonly Mock<IHostApplicationLifetime> _hostLifetime = new();
+    private readonly Mock<ILogger<TransitionJobHandler>> _logger = new();
+    private readonly CancellationTokenSource _appStoppingCts = new();
+
+    public TransitionJobHandlerTests()
+    {
+        _hostLifetime.Setup(h => h.ApplicationStopping).Returns(_appStoppingCts.Token);
+        _hostLifetime.Setup(h => h.ApplicationStarted).Returns(CancellationToken.None);
+        _hostLifetime.Setup(h => h.ApplicationStopped).Returns(CancellationToken.None);
+
+        _jobRepo
+            .Setup(r => r.MarkAsProcessedAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _recoveryService
+            .Setup(r => r.FaultInstanceAsync(
+                It.IsAny<TransitionJobPayload>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+    }
+
+    private TransitionJobHandler CreateHandler(int timeoutSeconds = 300)
+    {
+        var options = Options.Create(new WorkflowExecutionOptions
+        {
+            TransitionJobTimeoutSeconds = timeoutSeconds
+        });
+        return new TransitionJobHandler(
+            _jobRepo.Object, _executionService.Object, _currentSchema.Object,
+            _recoveryService.Object, options, _hostLifetime.Object, _logger.Object);
+    }
+
+    private static TransitionJobPayload CreatePayload(Guid? instanceId = null) => new()
+    {
+        JobName = "trans-abc-go",
+        InstanceId = instanceId ?? Guid.NewGuid(),
+        TransitionKey = "go",
+        Domain = "test",
+        Workflow = "test-flow",
+        Version = "1.0.0"
+    };
+
+    /// <summary>
+    /// Own 300s budget expires (executionCts fires) → recovery must run.
+    /// Simulated by setting timeout to 0 seconds so the CTS fires immediately.
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_WhenOwnBudgetExpires_CallsRecovery()
+    {
+        var payload = CreatePayload();
+        var handler = CreateHandler(timeoutSeconds: 0);
+
+        _executionService
+            .Setup(s => s.ExecuteTransitionAsync(
+                It.IsAny<WorkflowExecutionContext>(), It.IsAny<CancellationToken>()))
+            .Returns<WorkflowExecutionContext, CancellationToken>(async (_, ct) =>
+            {
+                await Task.Delay(Timeout.Infinite, ct);
+                return Result<TransitionOutput>.Ok(new TransitionOutput());
+            });
+
+        await handler.HandleAsync(payload, CancellationToken.None);
+
+        _recoveryService.Verify(
+            r => r.FaultInstanceAsync(payload, CancellationToken.None),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Dapr HTTP timeout or external cancellation while the host is still up → recovery must run.
+    /// Simulated by passing a pre-cancelled outer token with a long job budget (won't expire).
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_WhenDaprCancels_AndHostNotStopping_CallsRecovery()
+    {
+        var payload = CreatePayload();
+        var handler = CreateHandler(timeoutSeconds: 300);
+        using var outerCts = new CancellationTokenSource();
+        outerCts.Cancel();
+
+        _executionService
+            .Setup(s => s.ExecuteTransitionAsync(
+                It.IsAny<WorkflowExecutionContext>(), It.IsAny<CancellationToken>()))
+            .Returns<WorkflowExecutionContext, CancellationToken>(async (_, ct) =>
+            {
+                await Task.Delay(Timeout.Infinite, ct);
+                return Result<TransitionOutput>.Ok(new TransitionOutput());
+            });
+
+        await handler.HandleAsync(payload, outerCts.Token);
+
+        _recoveryService.Verify(
+            r => r.FaultInstanceAsync(payload, CancellationToken.None),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Host shutdown (SIGTERM) → do NOT call recovery; the host is going down.
+    /// Simulated by cancelling both the outer token and ApplicationStopping.
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_WhenHostIsShuttingDown_DoesNotCallRecovery()
+    {
+        var payload = CreatePayload();
+        var handler = CreateHandler(timeoutSeconds: 300);
+        using var outerCts = new CancellationTokenSource();
+        outerCts.Cancel();
+        await _appStoppingCts.CancelAsync(); // Simulate SIGTERM
+
+        _executionService
+            .Setup(s => s.ExecuteTransitionAsync(
+                It.IsAny<WorkflowExecutionContext>(), It.IsAny<CancellationToken>()))
+            .Returns<WorkflowExecutionContext, CancellationToken>(async (_, ct) =>
+            {
+                await Task.Delay(Timeout.Infinite, ct);
+                return Result<TransitionOutput>.Ok(new TransitionOutput());
+            });
+
+        await handler.HandleAsync(payload, outerCts.Token);
+
+        _recoveryService.Verify(
+            r => r.FaultInstanceAsync(It.IsAny<TransitionJobPayload>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// Successful pipeline execution → no recovery needed.
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_WhenExecutionSucceeds_DoesNotCallRecovery()
+    {
+        var payload = CreatePayload();
+        var handler = CreateHandler();
+
+        _executionService
+            .Setup(s => s.ExecuteTransitionAsync(
+                It.IsAny<WorkflowExecutionContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<TransitionOutput>.Ok(new TransitionOutput
+            {
+                Status = InstanceStatus.Active
+            }));
+
+        await handler.HandleAsync(payload, CancellationToken.None);
+
+        _recoveryService.Verify(
+            r => r.FaultInstanceAsync(It.IsAny<TransitionJobPayload>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// Pipeline returns a failure Result (e.g. validation error) → no recovery; handled inline.
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_WhenPipelineReturnsFailure_DoesNotCallRecovery()
+    {
+        var payload = CreatePayload();
+        var handler = CreateHandler();
+
+        _executionService
+            .Setup(s => s.ExecuteTransitionAsync(
+                It.IsAny<WorkflowExecutionContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<TransitionOutput>.Fail(
+                Error.Validation("Transition:NotFound", "Transition not found")));
+
+        await handler.HandleAsync(payload, CancellationToken.None);
+
+        _recoveryService.Verify(
+            r => r.FaultInstanceAsync(It.IsAny<TransitionJobPayload>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// MarkAsProcessedAsync must always run — including after a timeout recovery.
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_AfterTimeout_AlwaysCallsMarkAsProcessed()
+    {
+        var instanceId = Guid.NewGuid();
+        var payload = CreatePayload(instanceId);
+        var handler = CreateHandler(timeoutSeconds: 0);
+
+        _executionService
+            .Setup(s => s.ExecuteTransitionAsync(
+                It.IsAny<WorkflowExecutionContext>(), It.IsAny<CancellationToken>()))
+            .Returns<WorkflowExecutionContext, CancellationToken>(async (_, ct) =>
+            {
+                await Task.Delay(Timeout.Infinite, ct);
+                return Result<TransitionOutput>.Ok(new TransitionOutput());
+            });
+
+        await handler.HandleAsync(payload, CancellationToken.None);
+
+        _jobRepo.Verify(
+            r => r.MarkAsProcessedAsync(instanceId, payload.JobName, CancellationToken.None),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// MarkAsProcessedAsync must always run — even after an unhandled exception.
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_WhenUnhandledExceptionOccurs_AlwaysCallsMarkAsProcessed()
+    {
+        var instanceId = Guid.NewGuid();
+        var payload = CreatePayload(instanceId);
+        var handler = CreateHandler();
+
+        _executionService
+            .Setup(s => s.ExecuteTransitionAsync(
+                It.IsAny<WorkflowExecutionContext>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("unexpected infrastructure error"));
+
+        await handler.HandleAsync(payload, CancellationToken.None);
+
+        _jobRepo.Verify(
+            r => r.MarkAsProcessedAsync(instanceId, payload.JobName, CancellationToken.None),
+            Times.Once);
+        _recoveryService.Verify(
+            r => r.FaultInstanceAsync(It.IsAny<TransitionJobPayload>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/BackgroundJobs/Recovery/JobTimeoutRecoveryServiceTests.cs
+++ b/test/BBT.Workflow.Application.Tests/BackgroundJobs/Recovery/JobTimeoutRecoveryServiceTests.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.Uow;
+using BBT.Workflow.BackgroundJobs.Options;
+using BBT.Workflow.BackgroundJobs.Payloads;
+using BBT.Workflow.BackgroundJobs.Recovery;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Instances;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Application.Tests.BackgroundJobs.Recovery;
+
+public class JobTimeoutRecoveryServiceTests
+{
+    private readonly Mock<IUnitOfWorkManager> _uowManager = new();
+    private readonly Mock<IUnitOfWork> _uow = new();
+    private readonly Mock<IInstanceRepository> _instanceRepo = new();
+    private readonly Mock<IInstanceTransitionRepository> _transitionRepo = new();
+    private readonly Mock<ILogger<JobTimeoutRecoveryService>> _logger = new();
+
+    public JobTimeoutRecoveryServiceTests()
+    {
+        _uow.Setup(u => u.CommitAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        _uow.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        _uow.Setup(u => u.DisposeAsync()).Returns(ValueTask.CompletedTask);
+
+        _uowManager
+            .Setup(m => m.BeginAsync(It.IsAny<UnitOfWorkOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_uow.Object);
+    }
+
+    private JobTimeoutRecoveryService CreateService(int timeoutSeconds = 300) =>
+        new(_uowManager.Object, _instanceRepo.Object, _transitionRepo.Object,
+            Options.Create(new WorkflowExecutionOptions { TransitionJobTimeoutSeconds = timeoutSeconds }),
+            _logger.Object);
+
+    private static TransitionJobPayload CreatePayload(Guid? instanceId = null) => new()
+    {
+        JobName = "trans-abc-go",
+        InstanceId = instanceId ?? Guid.NewGuid(),
+        TransitionKey = "go",
+        Domain = "test",
+        Workflow = "test-flow",
+        Version = "1.0.0"
+    };
+
+    /// <summary>
+    /// Instance not found → early return, no fault or persistence.
+    /// </summary>
+    [Fact]
+    public async Task FaultInstanceAsync_WhenInstanceNotFound_DoesNothing()
+    {
+        var payload = CreatePayload();
+
+        _instanceRepo
+            .Setup(r => r.FindAsync(payload.InstanceId, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Instance?)null);
+
+        await CreateService().FaultInstanceAsync(payload, CancellationToken.None);
+
+        _instanceRepo.Verify(
+            r => r.UpdateAsync(It.IsAny<Instance>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _uow.Verify(u => u.CommitAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    /// <summary>
+    /// Instance found but not Busy (e.g. already Completed by a race) → skip, no fault.
+    /// </summary>
+    [Fact]
+    public async Task FaultInstanceAsync_WhenInstanceNotBusy_DoesNothing()
+    {
+        var instanceId = Guid.NewGuid();
+        var payload = CreatePayload(instanceId);
+        var instance = Instance.Create(instanceId, "test_flow", "1.0.0", "key");
+        // Instance.Create starts as Active — not Busy
+
+        _instanceRepo
+            .Setup(r => r.FindAsync(instanceId, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(instance);
+
+        await CreateService().FaultInstanceAsync(payload, CancellationToken.None);
+
+        _instanceRepo.Verify(
+            r => r.UpdateAsync(It.IsAny<Instance>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _uow.Verify(u => u.CommitAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    /// <summary>
+    /// Instance is Busy and has an open TransitionRecord → fault + incident + close transition + commit.
+    /// </summary>
+    [Fact]
+    public async Task FaultInstanceAsync_WhenBusyWithOpenTransition_FaultsAndClosesTransition()
+    {
+        var instanceId = Guid.NewGuid();
+        var payload = CreatePayload(instanceId);
+        var instance = Instance.Create(instanceId, "test_flow", "1.0.0", "key");
+        instance.Busy();
+
+        var openTransition = InstanceTransition.Create(
+            Guid.NewGuid(), instanceId, "go", "state-a",
+            TriggerType.Manual,
+            JsonData.CreateFrom("{}"),
+            JsonData.CreateFrom("{}"));
+
+        _instanceRepo
+            .Setup(r => r.FindAsync(instanceId, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(instance);
+        _instanceRepo
+            .Setup(r => r.UpdateAsync(instance, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(instance);
+        _transitionRepo
+            .Setup(r => r.GetLatestIncompleteAsync(instanceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(openTransition);
+        _transitionRepo
+            .Setup(r => r.UpdateCompletedAsync(openTransition, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        await CreateService().FaultInstanceAsync(payload, CancellationToken.None);
+
+        // Instance faulted with an incident
+        instance.Status.ShouldBe(InstanceStatus.Faulted);
+        instance.HasActiveIncident.ShouldBeTrue();
+
+        // Open TransitionRecord was closed
+        openTransition.FinishedAt.ShouldNotBeNull();
+        _transitionRepo.Verify(
+            r => r.UpdateCompletedAsync(openTransition, CancellationToken.None),
+            Times.Once);
+
+        // Persistence committed
+        _instanceRepo.Verify(
+            r => r.UpdateAsync(instance, true, CancellationToken.None),
+            Times.Once);
+        _uow.Verify(u => u.CommitAsync(CancellationToken.None), Times.Once);
+    }
+
+    /// <summary>
+    /// Instance is Busy but no open TransitionRecord → fault + incident, no transition update.
+    /// </summary>
+    [Fact]
+    public async Task FaultInstanceAsync_WhenBusyWithNoOpenTransition_FaultsWithoutClosingTransition()
+    {
+        var instanceId = Guid.NewGuid();
+        var payload = CreatePayload(instanceId);
+        var instance = Instance.Create(instanceId, "test_flow", "1.0.0", "key");
+        instance.Busy();
+
+        _instanceRepo
+            .Setup(r => r.FindAsync(instanceId, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(instance);
+        _instanceRepo
+            .Setup(r => r.UpdateAsync(instance, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(instance);
+        _transitionRepo
+            .Setup(r => r.GetLatestIncompleteAsync(instanceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((InstanceTransition?)null);
+
+        await CreateService().FaultInstanceAsync(payload, CancellationToken.None);
+
+        instance.Status.ShouldBe(InstanceStatus.Faulted);
+        _transitionRepo.Verify(
+            r => r.UpdateCompletedAsync(It.IsAny<InstanceTransition>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _uow.Verify(u => u.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Strategy/AsyncTransitionStrategyTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Strategy/AsyncTransitionStrategyTests.cs
@@ -6,8 +6,9 @@ using BBT.Aether.BackgroundJob;
 using BBT.Aether.DistributedLock;
 using BBT.Aether.Results;
 using BBT.Aether.Uow;
-using BBT.Workflow.BackgroundJobs.Payloads;
 using BBT.Workflow.BackgroundJobs.Handlers;
+using BBT.Workflow.BackgroundJobs.Options;
+using BBT.Workflow.BackgroundJobs.Payloads;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Execution;
 using BBT.Workflow.Execution.Strategies;
@@ -16,6 +17,7 @@ using BBT.Workflow.Gateway;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Shared;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using Shouldly;
 using Xunit;
@@ -51,6 +53,8 @@ public class AsyncTransitionStrategyTests
         _mockInstanceCommandGateway = new Mock<IInstanceCommandGateway>();
         _mockLogger = new Mock<ILogger<AsyncTransitionStrategy>>();
 
+        var executionOptions = Options.Create(new WorkflowExecutionOptions());
+
         _mockInstanceCommandGateway
             .Setup(x => x.MarkBusyAsync(It.IsAny<MarkBusyInput>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Ok());
@@ -77,6 +81,7 @@ public class AsyncTransitionStrategyTests
             _mockValidationService.Object,
             _uowManager.Object,
             _mockInstanceCommandGateway.Object,
+            executionOptions,
             _mockLogger.Object);
     }
 
@@ -105,6 +110,7 @@ public class AsyncTransitionStrategyTests
                 It.IsAny<TransitionJobPayload>(),
                 It.IsAny<string>(),
                 It.IsAny<Dictionary<string, object>>(),
+                It.IsAny<JobScheduleFailurePolicy?>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -126,9 +132,10 @@ public class AsyncTransitionStrategyTests
                 It.IsAny<TransitionJobPayload>(),
                 It.IsAny<string>(),
                 It.IsAny<Dictionary<string, object>>(),
+                It.IsAny<JobScheduleFailurePolicy?>(),
                 It.IsAny<CancellationToken>()))
-            .Callback<string, string, TransitionJobPayload, string, Dictionary<string, object>, CancellationToken>(
-                (_, _, payload, _, _, _) => capturedPayload = payload)
+            .Callback<string, string, TransitionJobPayload, string, Dictionary<string, object>, JobScheduleFailurePolicy?, CancellationToken>(
+                (_, _, payload, _, _, _, _) => capturedPayload = payload)
             .ReturnsAsync(It.IsAny<Guid>());
 
         // Act
@@ -161,9 +168,10 @@ public class AsyncTransitionStrategyTests
                 It.IsAny<TransitionJobPayload>(),
                 It.IsAny<string>(),
                 It.IsAny<Dictionary<string, object>>(),
+                It.IsAny<JobScheduleFailurePolicy?>(),
                 It.IsAny<CancellationToken>()))
-            .Callback<string, string, TransitionJobPayload, string, Dictionary<string, object>, CancellationToken>(
-                (_, _, _, _, metadata, _) => capturedMetadata = metadata)
+            .Callback<string, string, TransitionJobPayload, string, Dictionary<string, object>, JobScheduleFailurePolicy?, CancellationToken>(
+                (_, _, _, _, metadata, _, _) => capturedMetadata = metadata)
             .ReturnsAsync(It.IsAny<Guid>());
 
         // Act
@@ -196,9 +204,10 @@ public class AsyncTransitionStrategyTests
                 It.IsAny<TransitionJobPayload>(),
                 It.IsAny<string>(),
                 It.IsAny<Dictionary<string, object>>(),
+                It.IsAny<JobScheduleFailurePolicy?>(),
                 It.IsAny<CancellationToken>()))
-            .Callback<string, string, TransitionJobPayload, string, Dictionary<string, object>, CancellationToken>(
-                (_, jobId, _, _, _, _) => jobIds.Add(jobId))
+            .Callback<string, string, TransitionJobPayload, string, Dictionary<string, object>, JobScheduleFailurePolicy?, CancellationToken>(
+                (_, jobId, _, _, _, _, _) => jobIds.Add(jobId))
             .ReturnsAsync(It.IsAny<Guid>());
 
         await _strategy.ExecuteAsync(workflowContextOne, CancellationToken.None);
@@ -233,6 +242,7 @@ public class AsyncTransitionStrategyTests
                 It.IsAny<TransitionJobPayload>(),
                 It.IsAny<string>(),
                 It.IsAny<Dictionary<string, object>>(),
+                It.IsAny<JobScheduleFailurePolicy?>(),
                 It.IsAny<CancellationToken>()),
             Times.Never);
     }
@@ -255,6 +265,7 @@ public class AsyncTransitionStrategyTests
                 It.IsAny<TransitionJobPayload>(),
                 It.IsAny<string>(),
                 It.IsAny<Dictionary<string, object>>(),
+                It.IsAny<JobScheduleFailurePolicy?>(),
                 It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("Job service unavailable"));
 
@@ -283,9 +294,10 @@ public class AsyncTransitionStrategyTests
                 It.IsAny<TransitionJobPayload>(),
                 It.IsAny<string>(),
                 It.IsAny<Dictionary<string, object>>(),
+                It.IsAny<JobScheduleFailurePolicy?>(),
                 It.IsAny<CancellationToken>()))
-            .Callback<string, string, TransitionJobPayload, string, Dictionary<string, object>, CancellationToken>(
-                (_, _, _, schedule, _, _) => capturedSchedule = schedule)
+            .Callback<string, string, TransitionJobPayload, string, Dictionary<string, object>, JobScheduleFailurePolicy?, CancellationToken>(
+                (_, _, _, schedule, _, _, _) => capturedSchedule = schedule)
             .ReturnsAsync(It.IsAny<Guid>());
 
         // Act
@@ -314,6 +326,7 @@ public class AsyncTransitionStrategyTests
                 It.IsAny<TransitionJobPayload>(),
                 It.IsAny<string>(),
                 It.IsAny<Dictionary<string, object>>(),
+                It.IsAny<JobScheduleFailurePolicy?>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -359,9 +372,10 @@ public class AsyncTransitionStrategyTests
                 It.IsAny<TransitionJobPayload>(),
                 It.IsAny<string>(),
                 It.IsAny<Dictionary<string, object>>(),
+                It.IsAny<JobScheduleFailurePolicy?>(),
                 It.IsAny<CancellationToken>()))
-            .Callback<string, string, TransitionJobPayload, string, Dictionary<string, object>, CancellationToken>(
-                (_, _, payload, _, _, _) => capturedPayload = payload)
+            .Callback<string, string, TransitionJobPayload, string, Dictionary<string, object>, JobScheduleFailurePolicy?, CancellationToken>(
+                (_, _, payload, _, _, _, _) => capturedPayload = payload)
             .ReturnsAsync(It.IsAny<Guid>());
 
         // Act
@@ -463,6 +477,7 @@ public class AsyncTransitionStrategyTests
                 It.IsAny<TransitionJobPayload>(),
                 It.IsAny<string>(),
                 It.IsAny<Dictionary<string, object>>(),
+                It.IsAny<JobScheduleFailurePolicy?>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -486,6 +501,7 @@ public class AsyncTransitionStrategyTests
                 It.IsAny<TransitionJobPayload>(),
                 It.IsAny<string>(),
                 It.IsAny<Dictionary<string, object>>(),
+                It.IsAny<JobScheduleFailurePolicy?>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(It.IsAny<Guid>());
 
@@ -544,6 +560,7 @@ public class AsyncTransitionStrategyTests
                 It.IsAny<TransitionJobPayload>(),
                 It.IsAny<string>(),
                 It.IsAny<Dictionary<string, object>>(),
+                It.IsAny<JobScheduleFailurePolicy?>(),
                 It.IsAny<CancellationToken>()),
             Times.Never);
 

--- a/test/BBT.Workflow.Application.Tests/Tasks/Executors/RemoteInvokerServiceTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Tasks/Executors/RemoteInvokerServiceTests.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Workflow.Tasks.Executors;
+using TaskEnvelope = BBT.Workflow.Tasks.TaskEnvelope;
+using TaskTraceContext = BBT.Workflow.Tasks.TaskTraceContext;
+using TaskInvokeResponse = BBT.Workflow.Execution.TaskInvokeResponse;
+using TaskInvocationResult = BBT.Workflow.Execution.TaskInvocationResult;
+using Dapr.Client;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Application.Tests.Tasks.Executors;
+
+/// <summary>
+/// Tests the per-invocation Dapr timeout and parent-cancellation propagation in
+/// <see cref="RemoteInvokerService"/>.
+/// </summary>
+public class RemoteInvokerServiceTests
+{
+    private readonly Mock<DaprClient> _daprClient = new();
+    private readonly Mock<ILogger<RemoteInvokerService>> _logger = new();
+
+    private RemoteInvokerService CreateService(int invocationTimeoutSeconds = 60)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ExecutionApi:AppId"] = "test-execution",
+                ["ExecutionApi:InvocationTimeoutSeconds"] = invocationTimeoutSeconds.ToString()
+            })
+            .Build();
+
+        return new RemoteInvokerService(_daprClient.Object, config, _logger.Object);
+    }
+
+    private static TaskEnvelope CreateEnvelope() => new()
+    {
+        TaskType = "HttpTask",
+        TaskKey = "call-api",
+        Binding = JsonDocument.Parse("{}").RootElement
+    };
+
+    private static TaskTraceContext CreateTraceContext() => TaskTraceContext.Create(
+        instanceId: Guid.NewGuid(),
+        domain: "test",
+        workflowKey: "test-flow",
+        workflowVersion: "1.0.0",
+        headers: null,
+        instanceDataJson: null);
+
+    private void SetupDaprCreateRequest()
+    {
+        // CreateInvokeMethodRequest(HttpMethod, string, string) is the abstract base.
+        // The concrete generic overload delegates to it, then attaches the serialized body.
+        _daprClient
+            .Setup(d => d.CreateInvokeMethodRequest(
+                HttpMethod.Post,
+                It.IsAny<string>(),
+                It.IsAny<string>()))
+            .Returns(new HttpRequestMessage());
+    }
+
+    /// <summary>
+    /// When only the per-invocation CTS fires (parent pipeline is fine),
+    /// InvokeAsync should return a failure Result with HTTP 408 — not throw.
+    /// </summary>
+    [Fact]
+    public async Task InvokeAsync_WhenInvocationTimeoutExpires_ReturnsFailureResult()
+    {
+        SetupDaprCreateRequest();
+
+        _daprClient
+            .Setup(d => d.InvokeMethodAsync<TaskInvokeResponse>(
+                It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+            .Returns<HttpRequestMessage, CancellationToken>(async (_, ct) =>
+            {
+                await Task.Delay(Timeout.Infinite, ct);
+                return new TaskInvokeResponse();
+            });
+
+        var service = CreateService(invocationTimeoutSeconds: 0);
+
+        var result = await service.InvokeAsync(
+            "HttpTask", "call-api",
+            CreateEnvelope(), CreateTraceContext(),
+            CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.IsSuccess.ShouldBeFalse();
+        result.Value.StatusCode.ShouldBe(408);
+        result.Value.ErrorMessage.ShouldNotBeNull();
+        result.Value.ErrorMessage!.ShouldContain("timeout");
+    }
+
+    /// <summary>
+    /// When the parent pipeline token is cancelled (not the invocation CTS),
+    /// InvokeAsync must propagate OperationCanceledException to the pipeline.
+    /// </summary>
+    [Fact]
+    public async Task InvokeAsync_WhenParentTokenCancelled_ThrowsOperationCanceledException()
+    {
+        SetupDaprCreateRequest();
+
+        _daprClient
+            .Setup(d => d.InvokeMethodAsync<TaskInvokeResponse>(
+                It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+            .Returns<HttpRequestMessage, CancellationToken>(async (_, ct) =>
+            {
+                await Task.Delay(Timeout.Infinite, ct);
+                return new TaskInvokeResponse();
+            });
+
+        var service = CreateService(invocationTimeoutSeconds: 300);
+        using var parentCts = new CancellationTokenSource();
+        parentCts.Cancel();
+
+        await Should.ThrowAsync<OperationCanceledException>(
+            () => service.InvokeAsync(
+                "HttpTask", "call-api",
+                CreateEnvelope(), CreateTraceContext(),
+                parentCts.Token));
+    }
+
+    /// <summary>
+    /// When Dapr throws an unexpected exception, InvokeAsync returns a failure Result with 500.
+    /// </summary>
+    [Fact]
+    public async Task InvokeAsync_WhenDaprThrowsUnexpectedException_ReturnsFailureResult()
+    {
+        SetupDaprCreateRequest();
+
+        _daprClient
+            .Setup(d => d.InvokeMethodAsync<TaskInvokeResponse>(
+                It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("connection refused"));
+
+        var service = CreateService();
+
+        var result = await service.InvokeAsync(
+            "HttpTask", "call-api",
+            CreateEnvelope(), CreateTraceContext(),
+            CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.IsSuccess.ShouldBeFalse();
+        result.Value.StatusCode.ShouldBe(500);
+    }
+
+    /// <summary>
+    /// On a successful Dapr response, InvokeAsync returns a mapped success result.
+    /// </summary>
+    [Fact]
+    public async Task InvokeAsync_WhenDaprRespondsSuccessfully_ReturnsSuccessResult()
+    {
+        SetupDaprCreateRequest();
+
+        _daprClient
+            .Setup(d => d.InvokeMethodAsync<TaskInvokeResponse>(
+                It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TaskInvokeResponse
+            {
+                Success = true,
+                Result = TaskInvocationResult.Success(statusCode: 200, taskType: "HttpTask")
+            });
+
+        var service = CreateService();
+
+        var result = await service.InvokeAsync(
+            "HttpTask", "call-api",
+            CreateEnvelope(), CreateTraceContext(),
+            CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.IsSuccess.ShouldBeTrue();
+        result.Value.StatusCode.ShouldBe(200);
+    }
+}


### PR DESCRIPTION
## Summary
- Add a 300s execution budget to `TransitionJobHandler` with three-way cancellation handling: own budget expiry, Dapr/external cancel, and host shutdown (SIGTERM) are each handled differently
- Introduce per-invocation timeout (60s) in `RemoteInvokerService` so Dapr calls return a typed 408 failure instead of hanging indefinitely
- Add `JobTimeoutRecoveryService` that transitions stuck-Busy instances to Faulted, records a `JOB_EXECUTION_TIMEOUT` incident, and closes any open `InstanceTransition` record
- Bump Aether SDK to 1.0.25; wire `JobScheduleFailurePolicy` (5 retries, 30s interval) into `AsyncTransitionStrategy`; migrate Dapr Notification config from execution host to orchestration host

## Changes
- `src/.../BackgroundJobs/Handlers/TransitionJobHandler.cs` — execution budget CTS + result.IsSuccess check
- `src/.../BackgroundJobs/Options/WorkflowExecutionOptions.cs` — new config class
- `src/.../BackgroundJobs/Recovery/IJobTimeoutRecoveryService.cs` — new interface
- `src/.../BackgroundJobs/Recovery/JobTimeoutRecoveryService.cs` — new implementation
- `src/.../Tasks/Executors/Remote/RemoteInvokerService.cs` — per-invocation timeout
- `src/BBT.Workflow.Domain/Instances/InstanceTransition.cs` — `Failed()` domain method
- `src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs` — `JobTimedOut` + `JobCancelledByExternal` log methods
- `src/.../Strategy/AsyncTransitionStrategy.cs` — failure policy from options
- `test/...` — 15 new unit tests across 3 test classes; AsyncTransitionStrategyTests updated

## Test Plan
- [ ] Run `dotnet test test/BBT.Workflow.Application.Tests` — all tests green
- [ ] Trigger a long-running transition (>300s) and verify instance moves to Faulted with a `JOB_EXECUTION_TIMEOUT` incident
- [ ] Verify `timeout.layer=job` / `timeout.layer=remote` tags appear in structured logs on timeout paths
- [ ] Confirm `MarkAsProcessedAsync` always runs (even on timeout) by checking the job table after a forced timeout

## Notes
- Lock lease (`AsyncTransitionStrategy.DefaultLockLeaseSeconds`) remains at 30s — shorter than the 300s job budget. Lock lease alignment is tracked in #680 as a follow-up.
- Dapr sidecar HTTP read timeout should be set to ≥ 330s in `docker-compose.yml` to allow the application to clean up before Dapr disconnects (out of scope for this PR).

## Summary by Sourcery

Introduce layered timeout handling and recovery for workflow transition jobs and remote task invocations.

New Features:
- Add configurable per-invocation timeout for Dapr-based remote task calls that returns typed timeout failures instead of hanging.
- Introduce a configurable execution budget for transition jobs with differentiated handling for timeouts, external cancellations, and host shutdown.
- Add a job timeout recovery service that faults stuck Busy instances, records timeout incidents, and closes open transition records.

Enhancements:
- Wire workflow execution options and retry failure policy into async transition scheduling via configuration.
- Extend workflow logging with structured timeout and external cancellation events for jobs.
- Register background job recovery services and workflow execution options in the application DI setup.
- Add a failure terminal state helper on instance transitions to mark aborted transitions without a target state.
- Move Dapr notification configuration from the execution host to the orchestration host configuration.

Tests:
- Add unit tests for transition job handler timeout and cancellation behavior, including recovery and job completion marking.
- Add unit tests for remote invoker timeout handling, parent cancellation propagation, and Dapr error mapping.
- Add unit tests for job timeout recovery service behavior across missing, non-busy, and busy instances with and without open transitions.
- Update async transition strategy tests to cover the new configurable failure policy parameter in job scheduling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable background-job timeouts and automatic recovery for timed-out jobs
  * Per-invocation timeout for remote service calls

* **Bug Fixes**
  * Clearer handling between job timeouts, external/Dapr cancellations, and host shutdown
  * Improved cancellation propagation and consistent post-timeout processing

* **Chores**
  * Package version bumped to 1.0.25
  * Updated Dapr notification and execution timeout configuration settings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/burgan-tech/vnext/pull/681?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->