### PR TITLE
feat: add dedicated SoapTask with SOAP 1.1/1.2 support

### DIFF
--- a/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/TaskServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/TaskServiceCollectionExtensions.cs
@@ -67,8 +67,9 @@ public static class TaskServiceCollectionExtensions
         // Human task executor (no remote - state change only)
         services.AddTaskExecutor<HumanTaskExecutor>();
 
-        // HTTP and Dapr remote executors
+        // HTTP, SOAP and Dapr remote executors
         services.AddTaskExecutor<HttpTaskExecutor>();
+        services.AddTaskExecutor<SoapTaskExecutor>();
         services.AddTaskExecutor<DaprServiceTaskExecutor>();
         services.AddTaskExecutor<DaprBindingTaskExecutor>();
         services.AddTaskExecutor<DaprHttpEndpointTaskExecutor>();

--- a/src/BBT.Workflow.Application/Tasks/Executors/Http/SoapTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Http/SoapTaskExecutor.cs
@@ -1,0 +1,143 @@
+using BBT.Aether.Results;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Logging;
+using BBT.Workflow.Scripting;
+using BBT.Workflow.Tasks.Mapping;
+using Microsoft.Extensions.Logging;
+
+namespace BBT.Workflow.Tasks.Executors;
+
+/// <summary>
+/// Executor for SOAP tasks.
+/// Handles input/output mapping locally, then delegates to RemoteInvokerService for execution.
+/// </summary>
+public sealed class SoapTaskExecutor : TaskExecutorBase<SoapTask>
+{
+    private readonly IRemoteInvokerService _remoteInvoker;
+    private readonly IScriptEngine _scriptEngine;
+
+    public SoapTaskExecutor(
+        IRemoteInvokerService remoteInvoker,
+        IScriptEngine scriptEngine,
+        ILogger<SoapTaskExecutor> logger)
+        : base(logger)
+    {
+        _remoteInvoker = remoteInvoker;
+        _scriptEngine = scriptEngine;
+    }
+
+    /// <inheritdoc />
+    public override TaskType TaskType => TaskType.Soap;
+
+    /// <inheritdoc />
+    protected override async Task<Result<ScriptResponse?>> PrepareInputAsync(
+        SoapTask task,
+        TaskExecutorContext context,
+        CancellationToken cancellationToken)
+    {
+        var mapping = context.OnExecuteTask.Mapping;
+        if (mapping == null || string.IsNullOrEmpty(mapping.DecodedCode))
+        {
+            return Result<ScriptResponse?>.Ok(null);
+        }
+
+        var result = await ResultExtensions.TryAsync<ScriptResponse?>(async ct =>
+        {
+            var scriptRunner = await _scriptEngine.CompileToInstanceAsync<IMapping>(
+                mapping.DecodedCode,
+                cancellationToken: ct);
+
+            return await scriptRunner.InputHandler(task, context.ScriptContext);
+        }, cancellationToken, ex => Error.Failure(
+            WorkflowErrorCodes.TaskExecution,
+            $"Soap task input handler failed: {ex.Message}"));
+
+        if (!result.IsSuccess)
+        {
+            Logger.TaskInputHandlerFailed(
+                task.Key,
+                TaskType.ToString(),
+                context.ScriptContext.Instance.Id,
+                result.Error.Message ?? "Unknown error");
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    protected override async Task<Result<TaskInvocationResult>> InvokeAsync(
+        SoapTask task,
+        TaskExecutorContext context,
+        CancellationToken cancellationToken)
+    {
+        var envelopeResult = TaskBindingMapper.CreateEnvelope(task);
+        if (!envelopeResult.IsSuccess)
+        {
+            Logger.TaskEnvelopeCreationFailed(
+                task.Key,
+                TaskType.ToString(),
+                context.ScriptContext.Instance.Id,
+                envelopeResult.Error.Message ?? "Unknown error");
+            return Result<TaskInvocationResult>.Fail(envelopeResult.Error);
+        }
+
+        var traceContext = _remoteInvoker.CreateTraceContext(context.ScriptContext);
+
+        var result = await _remoteInvoker.InvokeAsync(
+            Execution.TaskTypes.Soap,
+            task.Key,
+            envelopeResult.Value!,
+            traceContext,
+            cancellationToken);
+
+        if (!result.IsSuccess)
+        {
+            Logger.TaskInvocationFailed(
+                task.Key,
+                TaskType.ToString(),
+                context.ScriptContext.Instance.Id,
+                result.Error.Message ?? "Unknown error");
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    protected override async Task<Result<object?>> ProcessOutputAsync(
+        SoapTask task,
+        TaskInvocationResult invocationResult,
+        TaskExecutorContext context,
+        CancellationToken cancellationToken)
+    {
+        var mapping = context.OnExecuteTask.Mapping;
+        if (mapping == null || string.IsNullOrEmpty(mapping.DecodedCode))
+        {
+            return Result<object?>.Ok(invocationResult.Data);
+        }
+
+        UpdateScriptContextWithResponse(task.Key, invocationResult, context.ScriptContext);
+
+        var result = await ResultExtensions.TryAsync<object?>(async ct =>
+        {
+            var scriptRunner = await _scriptEngine.CompileToInstanceAsync<IMapping>(
+                mapping.DecodedCode,
+                cancellationToken: ct);
+
+            var outputResponse = await scriptRunner.OutputHandler(context.ScriptContext);
+            return outputResponse.Data;
+        }, cancellationToken, ex => Error.Failure(
+            WorkflowErrorCodes.TaskExecution,
+            $"Soap task output handler failed: {ex.Message}"));
+
+        if (!result.IsSuccess)
+        {
+            Logger.TaskOutputHandlerFailed(
+                task.Key,
+                TaskType.ToString(),
+                context.ScriptContext.Instance.Id,
+                result.Error.Message ?? "Unknown error");
+        }
+
+        return result;
+    }
+}

--- a/src/BBT.Workflow.Application/Tasks/Mapping/TaskBindingMapper.cs
+++ b/src/BBT.Workflow.Application/Tasks/Mapping/TaskBindingMapper.cs
@@ -40,6 +40,7 @@ public static class TaskBindingMapper
             {
                 // Remote execution tasks
                 HttpTask http => (TaskTypes.Http, MapHttpTask(http)),
+                SoapTask soap => (TaskTypes.Soap, (object)MapSoapTask(soap)),
                 DaprServiceTask daprService => (TaskTypes.DaprService, MapDaprServiceTask(daprService)),
                 DaprBindingTask daprBinding => (TaskTypes.DaprBinding, MapDaprBindingTask(daprBinding)),
                 DaprHttpEndpointTask daprHttpEndpoint => (TaskTypes.DaprHttpEndpoint, MapDaprHttpEndpointTask(daprHttpEndpoint)),
@@ -170,6 +171,20 @@ public static class TaskBindingMapper
     };
 
     #endregion
+
+    /// <summary>
+    /// Maps SoapTask to SoapTaskBinding.
+    /// </summary>
+    private static SoapTaskBinding MapSoapTask(SoapTask task) => new()
+    {
+        Url = task.Url,
+        SoapAction = task.SoapAction,
+        SoapVersion = task.SoapVersion,
+        Body = task.Body,
+        Headers = task.Headers?.GetRawText(),
+        TimeoutSeconds = task.TimeoutSeconds,
+        ValidateSSL = task.ValidateSSL
+    };
 
     /// <summary>
     /// Maps HttpTask to HttpTaskBinding.

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/SoapTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/SoapTask.cs
@@ -1,0 +1,203 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace BBT.Workflow.Definitions;
+
+/// <summary>
+/// SOAP Task Definition — sends a SOAP 1.1 or 1.2 request to a web service endpoint.
+/// Body is stored as a raw XML string (not JsonElement) to support SOAP envelope templates.
+/// </summary>
+public sealed class SoapTask : WorkflowTask
+{
+    private SoapTask()
+    {
+    }
+
+    [JsonConstructor]
+    private SoapTask(JsonElement config) : base(config)
+    {
+        Type = ((int)TaskType.Soap).ToString();
+    }
+
+    /// <summary>Target SOAP endpoint URL.</summary>
+    public string Url { get; set; } = string.Empty;
+
+    /// <summary>
+    /// SOAPAction value. Required for SOAP 1.1 (sent as HTTP header).
+    /// For SOAP 1.2 it is embedded in the Content-Type action parameter.
+    /// </summary>
+    public string SoapAction { get; set; } = string.Empty;
+
+    /// <summary>SOAP protocol version: "1.1" or "1.2". Defaults to "1.1".</summary>
+    public string SoapVersion { get; private set; } = "1.1";
+
+    /// <summary>
+    /// SOAP envelope XML body as a raw string template.
+    /// Unlike HttpTask, this is a plain string — not JsonElement — to support arbitrary XML.
+    /// </summary>
+    public string? Body { get; private set; }
+
+    /// <summary>Additional HTTP headers (e.g. Authorization). Stored as JSON object.</summary>
+    public JsonElement? Headers { get; private set; }
+
+    /// <summary>Request timeout in seconds.</summary>
+    public int TimeoutSeconds { get; private set; } = 30;
+
+    /// <summary>Whether to validate the server SSL certificate.</summary>
+    public bool ValidateSSL { get; private set; } = true;
+
+    /// <summary>
+    /// HTTP status codes treated as successful even when they indicate errors.
+    /// SOAP faults are typically returned over HTTP 500, so ["500"] is a common value here.
+    /// Supports exact codes ("500") and wildcard patterns ("5xx", "50x").
+    /// </summary>
+    public IReadOnlyList<string>? AcceptedStatusCodes { get; private set; }
+
+    public void SetUrl(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+            throw new ArgumentNullException(nameof(url));
+
+        Url = url;
+    }
+
+    public void SetBody(string? body)
+    {
+        Body = body;
+    }
+
+    public void SetSoapAction(string soapAction)
+    {
+        SoapAction = soapAction ?? string.Empty;
+    }
+
+    public void SetHeaders(Dictionary<string, string?> headers)
+    {
+        Headers = JsonSerializer.SerializeToElement(headers);
+    }
+
+    /// <summary>Adds or updates a single header. Overwrites existing values for the same key.</summary>
+    public void AddHeader(string key, string? value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        var d = TaskHeadersHelper.ToMutableDictionary(Headers);
+        d[key] = value;
+        Headers = TaskHeadersHelper.FromDictionary(d);
+    }
+
+    /// <summary>Removes a header by key. Does nothing if the key does not exist.</summary>
+    public void RemoveHeader(string key)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        var d = TaskHeadersHelper.ToMutableDictionary(Headers);
+        d.Remove(key);
+        Headers = TaskHeadersHelper.FromDictionary(d);
+    }
+
+    // Internal setters for object pooling
+    internal void SetBodyInternal(string? body) => Body = body;
+    internal void SetSoapVersionInternal(string soapVersion) => SoapVersion = soapVersion;
+    internal void SetSoapActionInternal(string soapAction) => SoapAction = soapAction;
+    internal void SetHeadersInternal(JsonElement? headers) => Headers = headers;
+    internal void SetTimeoutSecondsInternal(int timeoutSeconds) => TimeoutSeconds = timeoutSeconds;
+    internal void SetValidateSSLInternal(bool validateSSL) => ValidateSSL = validateSSL;
+    internal void SetAcceptedStatusCodesInternal(IReadOnlyList<string>? codes) => AcceptedStatusCodes = codes;
+
+    protected override void Configure(JsonElement config)
+    {
+        base.Configure(config);
+
+        if (config.TryGetProperty("url", out var url))
+            Url = url.GetString() ?? throw new ArgumentNullException(nameof(url));
+
+        if (config.TryGetProperty("soapAction", out var soapAction))
+            SoapAction = soapAction.GetString() ?? string.Empty;
+
+        if (config.TryGetProperty("soapVersion", out var soapVersion))
+            SoapVersion = soapVersion.GetString() ?? "1.1";
+
+        if (config.TryGetProperty("body", out var body))
+            Body = body.ValueKind == JsonValueKind.String ? body.GetString() : null;
+
+        if (config.TryGetProperty("headers", out var headersElement))
+        {
+            var raw = headersElement.GetRawText();
+            Headers = string.IsNullOrWhiteSpace(raw) ? null : headersElement;
+        }
+
+        if (config.TryGetProperty("timeoutSeconds", out var timeoutSeconds))
+            TimeoutSeconds = timeoutSeconds.GetInt32();
+
+        if (config.TryGetProperty("validateSsl", out var validateSsl))
+            ValidateSSL = validateSsl.GetBoolean();
+
+        if (config.TryGetProperty("acceptedStatusCodes", out var acceptedCodesElement) &&
+            acceptedCodesElement.ValueKind == JsonValueKind.Array)
+        {
+            var codes = acceptedCodesElement.EnumerateArray()
+                .Select(e => e.GetString())
+                .Where(s => !string.IsNullOrWhiteSpace(s))
+                .Select(s => s!)
+                .ToList();
+            AcceptedStatusCodes = codes.Count > 0 ? codes : null;
+        }
+    }
+
+    public static SoapTask Create(JsonElement config)
+    {
+        return new SoapTask(config);
+    }
+
+    public override WorkflowTask Clone()
+    {
+        return CloneTyped();
+    }
+
+    public SoapTask CloneTyped()
+    {
+        var cloned = new SoapTask();
+        CopyBaseTo(cloned);
+
+        cloned.Url = Url;
+        cloned.SoapAction = SoapAction;
+        cloned.SoapVersion = SoapVersion;
+        cloned.Body = Body;
+        cloned.Headers = Headers;
+        cloned.TimeoutSeconds = TimeoutSeconds;
+        cloned.ValidateSSL = ValidateSSL;
+        cloned.AcceptedStatusCodes = AcceptedStatusCodes;
+
+        return cloned;
+    }
+
+    public void CopyFromInternal(SoapTask source)
+    {
+        source.CopyBaseToInternal(this);
+        Url = source.Url;
+        SetSoapActionInternal(source.SoapAction);
+        SetSoapVersionInternal(source.SoapVersion);
+        SetBodyInternal(source.Body);
+        SetHeadersInternal(source.Headers);
+        SetTimeoutSecondsInternal(source.TimeoutSeconds);
+        SetValidateSSLInternal(source.ValidateSSL);
+        SetAcceptedStatusCodesInternal(source.AcceptedStatusCodes);
+    }
+
+    public override void Reset()
+    {
+        base.Reset();
+        Url = string.Empty;
+        SoapAction = string.Empty;
+        SoapVersion = "1.1";
+        Body = null;
+        Headers = null;
+        TimeoutSeconds = 30;
+        ValidateSSL = true;
+        AcceptedStatusCodes = null;
+    }
+
+    public static SoapTask CreateEmpty()
+    {
+        return new SoapTask();
+    }
+}

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/TaskEnums.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/TaskEnums.cs
@@ -22,7 +22,8 @@ public enum TaskType
     DirectTrigger = 12,
     GetInstanceData = 13,
     SubProcess = 14,
-    GetInstances = 15
+    GetInstances = 15,
+    Soap = 16
 }
 
 /// <summary>

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/WorkflowTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/WorkflowTask.cs
@@ -22,6 +22,7 @@ namespace BBT.Workflow.Definitions;
 [JsonDerivedType(typeof(GetInstanceDataTask), typeDiscriminator: "13")]
 [JsonDerivedType(typeof(SubProcessTask), typeDiscriminator: "14")]
 [JsonDerivedType(typeof(GetInstancesTask), typeDiscriminator: "15")]
+[JsonDerivedType(typeof(SoapTask), typeDiscriminator: "16")]
 public abstract class WorkflowTask : IDomainEntity, ITaskReference, IReferenceSetter, ITaskClonable
 {
     protected WorkflowTask()

--- a/src/BBT.Workflow.Execution.Abstractions/Bindings/SoapTaskBinding.cs
+++ b/src/BBT.Workflow.Execution.Abstractions/Bindings/SoapTaskBinding.cs
@@ -1,0 +1,21 @@
+namespace BBT.Workflow.Execution.Bindings;
+
+/// <summary>
+/// Execution-ready binding for SOAP tasks.
+/// Carries all configuration needed by SoapTaskInvoker without any domain dependencies.
+/// </summary>
+public sealed record SoapTaskBinding
+{
+    public required string Url { get; init; }
+    public string SoapAction { get; init; } = string.Empty;
+    public string SoapVersion { get; init; } = "1.1";
+
+    /// <summary>Raw XML SOAP envelope body string.</summary>
+    public string? Body { get; init; }
+
+    /// <summary>Additional HTTP headers serialized as a JSON object string.</summary>
+    public string? Headers { get; init; }
+
+    public int TimeoutSeconds { get; init; } = 30;
+    public bool ValidateSSL { get; init; } = true;
+}

--- a/src/BBT.Workflow.Execution.Abstractions/TaskTypes.cs
+++ b/src/BBT.Workflow.Execution.Abstractions/TaskTypes.cs
@@ -13,6 +13,8 @@ public static class TaskTypes
     public const string DaprHttpEndpoint = "daprhttpendpoint";
     public const string DaprPubSub = "daprpubsub";
 
+    public const string Soap = "soap";
+
     // Trigger tasks (for cross-domain execution)
     public const string StartTrigger = "starttrigger";
     public const string DirectTrigger = "directtrigger";

--- a/src/BBT.Workflow.Execution/Invokers/SoapTaskInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/SoapTaskInvoker.cs
@@ -1,0 +1,301 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using System.Xml.Linq;
+using BBT.Workflow.Execution.Bindings;
+using BBT.Workflow.Execution.Metrics;
+using Microsoft.Extensions.Logging;
+
+namespace BBT.Workflow.Execution.Invokers;
+
+/// <summary>
+/// SOAP task invoker — stateless execution with strongly-typed binding.
+/// Handles SOAP 1.1 and 1.2 protocol differences for Content-Type and SOAPAction headers,
+/// parses XML responses, and detects SOAP Fault elements.
+/// </summary>
+public sealed class SoapTaskInvoker(
+    IHttpClientFactory httpClientFactory,
+    ILogger<SoapTaskInvoker> logger,
+    ITaskMetrics? metrics = null)
+    : ITaskInvoker<SoapTaskBinding>
+{
+    private static readonly XNamespace Soap11Ns = "http://schemas.xmlsoap.org/soap/envelope/";
+    private static readonly XNamespace Soap12Ns = "http://www.w3.org/2003/05/soap-envelope";
+
+    private readonly ITaskMetrics _metrics = metrics ?? NullTaskMetrics.Instance;
+
+    /// <inheritdoc />
+    public string TaskType => TaskTypes.Soap;
+
+    /// <inheritdoc />
+    public Type BindingType => typeof(SoapTaskBinding);
+
+    /// <inheritdoc />
+    public async Task<TaskInvocationResult> InvokeAsync(
+        TaskDescriptor<SoapTaskBinding> descriptor,
+        CancellationToken cancellationToken = default)
+    {
+        return await ExecuteAsync(descriptor.TaskKey, descriptor.Binding, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<TaskInvocationResult> InvokeAsync(
+        string? taskKey,
+        JsonElement binding,
+        CancellationToken cancellationToken = default)
+    {
+        var typedBinding = binding.Deserialize<SoapTaskBinding>()
+            ?? throw new InvalidOperationException("Failed to deserialize SoapTaskBinding");
+
+        return await ExecuteAsync(taskKey, typedBinding, cancellationToken);
+    }
+
+    private async Task<TaskInvocationResult> ExecuteAsync(
+        string? taskKey,
+        SoapTaskBinding binding,
+        CancellationToken cancellationToken)
+    {
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            var httpClient = CreateHttpClient(binding, taskKey);
+            var request = new HttpRequestMessage(HttpMethod.Post, binding.Url);
+
+            // Set SOAP-version-specific Content-Type and SOAPAction
+            var isSoap12 = string.Equals(binding.SoapVersion, "1.2", StringComparison.OrdinalIgnoreCase);
+
+            if (isSoap12)
+            {
+                var mediaType = string.IsNullOrEmpty(binding.SoapAction)
+                    ? "application/soap+xml; charset=utf-8"
+                    : $"application/soap+xml; charset=utf-8; action=\"{binding.SoapAction}\"";
+                request.Content = new StringContent(binding.Body ?? string.Empty, Encoding.UTF8);
+                request.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse(mediaType);
+            }
+            else
+            {
+                // SOAP 1.1: text/xml + separate SOAPAction header
+                request.Content = new StringContent(binding.Body ?? string.Empty, Encoding.UTF8, "text/xml");
+
+                if (!string.IsNullOrEmpty(binding.SoapAction))
+                    request.Headers.TryAddWithoutValidation("SOAPAction", $"\"{binding.SoapAction}\"");
+            }
+
+            // Add any additional HTTP headers (e.g. Authorization)
+            if (!string.IsNullOrEmpty(binding.Headers))
+            {
+                var headers = JsonSerializer.Deserialize<Dictionary<string, string>>(binding.Headers);
+                if (headers != null)
+                {
+                    foreach (var header in headers)
+                        request.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                }
+            }
+
+            var response = await httpClient.SendAsync(request, cancellationToken);
+
+            var responseHeaders = InvokerHelpers.MergeHeaders(response.Headers, response.Content.Headers);
+            var content = await response.Content.ReadAsStringAsync(cancellationToken);
+            stopwatch.Stop();
+
+            var (parsedData, isSoapFault, faultCode, faultString) = TryParseSoapResponse(content, isSoap12);
+
+            var metadata = new Dictionary<string, object>
+            {
+                ["Url"] = binding.Url,
+                ["Method"] = "POST",
+                ["ReasonPhrase"] = response.ReasonPhrase ?? string.Empty,
+                ["SoapVersion"] = binding.SoapVersion,
+                ["IsSoapFault"] = isSoapFault
+            };
+
+            if (isSoapFault)
+            {
+                if (faultCode != null) metadata["SoapFaultCode"] = faultCode;
+                if (faultString != null) metadata["SoapFaultString"] = faultString;
+            }
+
+            return response.IsSuccessStatusCode
+                ? TaskInvocationResult.Success(
+                    data: parsedData,
+                    body: content,
+                    statusCode: (int)response.StatusCode,
+                    executionDurationMs: stopwatch.ElapsedMilliseconds,
+                    taskType: TaskType,
+                    headers: responseHeaders,
+                    metadata: metadata)
+                : TaskInvocationResult.Failure(
+                    error: isSoapFault
+                        ? $"SOAP Fault: {faultString ?? faultCode ?? "Unknown fault"}"
+                        : $"HTTP {response.StatusCode}: {response.ReasonPhrase}",
+                    statusCode: (int)response.StatusCode,
+                    body: content,
+                    executionDurationMs: stopwatch.ElapsedMilliseconds,
+                    taskType: TaskType,
+                    headers: responseHeaders,
+                    data: parsedData,
+                    metadata: metadata);
+        }
+        catch (TaskCanceledException ex) when (cancellationToken.IsCancellationRequested)
+        {
+            stopwatch.Stop();
+            _metrics.RecordTaskExecution(TaskType, "cancelled");
+            logger.LogWarning("SOAP request was cancelled for task {TaskKey} - URL: {Url}", taskKey, binding.Url);
+
+            return TaskInvocationResult.Failure(
+                error: "SOAP request was cancelled",
+                executionDurationMs: stopwatch.ElapsedMilliseconds,
+                taskType: TaskType,
+                metadata: new Dictionary<string, object>
+                {
+                    ["Url"] = binding.Url,
+                    ["Method"] = "POST",
+                    ["Cancelled"] = true,
+                    ["ExceptionType"] = ex.GetType().Name
+                });
+        }
+        catch (HttpRequestException ex)
+        {
+            stopwatch.Stop();
+            _metrics.RecordTaskExecution(TaskType, "failure");
+            logger.LogError(ex, "SOAP task invocation failed for {TaskKey} - URL: {Url}", taskKey, binding.Url);
+
+            return TaskInvocationResult.Failure(
+                error: ex.Message,
+                executionDurationMs: stopwatch.ElapsedMilliseconds,
+                taskType: TaskType,
+                metadata: new Dictionary<string, object>
+                {
+                    ["Url"] = binding.Url,
+                    ["Method"] = "POST",
+                    ["ExceptionType"] = ex.GetType().Name,
+                    ["StackTrace"] = ex.StackTrace ?? string.Empty
+                });
+        }
+        catch (Exception ex)
+        {
+            stopwatch.Stop();
+            _metrics.RecordTaskExecution(TaskType, "failure");
+            logger.LogError(ex, "Unexpected error during SOAP task invocation for {TaskKey}", taskKey);
+
+            return TaskInvocationResult.Failure(
+                error: ex.Message,
+                executionDurationMs: stopwatch.ElapsedMilliseconds,
+                taskType: TaskType,
+                metadata: new Dictionary<string, object>
+                {
+                    ["Url"] = binding.Url,
+                    ["Method"] = "POST",
+                    ["ExceptionType"] = ex.GetType().Name,
+                    ["StackTrace"] = ex.StackTrace ?? string.Empty
+                });
+        }
+    }
+
+    /// <summary>
+    /// Parses the raw XML SOAP response. Returns structured data extracted from the Body element,
+    /// plus SOAP Fault details if present.
+    /// </summary>
+    private static (object? Data, bool IsSoapFault, string? FaultCode, string? FaultString)
+        TryParseSoapResponse(string content, bool isSoap12)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+            return (null, false, null, null);
+
+        try
+        {
+            var doc = XDocument.Parse(content);
+            var ns = isSoap12 ? Soap12Ns : Soap11Ns;
+
+            var body = doc.Descendants(ns + "Body").FirstOrDefault();
+            if (body == null)
+                return (XmlElementToDictionary(doc.Root), false, null, null);
+
+            // Detect SOAP Fault
+            var fault = body.Element(ns + "Fault");
+            if (fault != null)
+            {
+                string? faultCode = null;
+                string? faultString = null;
+
+                if (isSoap12)
+                {
+                    faultCode = fault.Element(ns + "Code")?.Element(ns + "Value")?.Value;
+                    faultString = fault.Element(ns + "Reason")?.Element(ns + "Text")?.Value;
+                }
+                else
+                {
+                    faultCode = fault.Element("faultcode")?.Value;
+                    faultString = fault.Element("faultstring")?.Value;
+                }
+
+                var faultData = XmlElementToDictionary(fault);
+                return (faultData, true, faultCode, faultString);
+            }
+
+            // Return body content as structured dictionary
+            var firstChild = body.Elements().FirstOrDefault();
+            var data = firstChild != null ? XmlElementToDictionary(firstChild) : XmlElementToDictionary(body);
+            return (data, false, null, null);
+        }
+        catch
+        {
+            // Non-parseable XML — return raw string as body only
+            return (null, false, null, null);
+        }
+    }
+
+    /// <summary>
+    /// Converts an XElement tree to a nested Dictionary for use as structured task output data.
+    /// </summary>
+    private static object XmlElementToDictionary(XElement? element)
+    {
+        if (element == null)
+            return new Dictionary<string, object>();
+
+        // Leaf node: return text value
+        if (!element.HasElements)
+            return element.Value;
+
+        var dict = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var child in element.Elements())
+        {
+            var localName = child.Name.LocalName;
+            var value = XmlElementToDictionary(child);
+
+            if (dict.TryGetValue(localName, out var existing))
+            {
+                // Multiple elements with same name → collect as list
+                if (existing is List<object> list)
+                    list.Add(value);
+                else
+                    dict[localName] = new List<object> { existing, value };
+            }
+            else
+            {
+                dict[localName] = value;
+            }
+        }
+
+        return dict;
+    }
+
+    private HttpClient CreateHttpClient(SoapTaskBinding binding, string? taskKey)
+    {
+        var clientName = binding.ValidateSSL
+            ? WorkflowHttpClientNames.Default
+            : WorkflowHttpClientNames.NoSslValidation;
+
+        if (!binding.ValidateSSL)
+        {
+            logger.LogDebug("SSL certificate validation is disabled for SOAP task {TaskKey} - URL: {Url}",
+                taskKey, binding.Url);
+        }
+
+        var client = httpClientFactory.CreateClient(clientName);
+        client.Timeout = TimeSpan.FromSeconds(binding.TimeoutSeconds);
+        return client;
+    }
+}

--- a/src/BBT.Workflow.Execution/Microsoft/Extensions/DependencyInjection/ExecutionServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Execution/Microsoft/Extensions/DependencyInjection/ExecutionServiceCollectionExtensions.cs
@@ -47,6 +47,7 @@ public static class ExecutionServiceCollectionExtensions
         
         // Register all built-in remote execution invokers
         services.AddSingleton<ITaskInvoker, HttpTaskInvoker>();
+        services.AddSingleton<ITaskInvoker, SoapTaskInvoker>();
         services.AddSingleton<ITaskInvoker, DaprServiceTaskInvoker>();
         services.AddSingleton<ITaskInvoker, DaprBindingTaskInvoker>();
         services.AddSingleton<ITaskInvoker, DaprHttpEndpointTaskInvoker>();

--- a/test/BBT.Workflow.Domain.Tests/Definitions/Tasks/SoapTaskTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Definitions/Tasks/SoapTaskTests.cs
@@ -1,0 +1,198 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using BBT.Workflow.Definitions;
+using Xunit;
+
+namespace BBT.Workflow.Definitions.Tasks;
+
+public class SoapTaskTests
+{
+    private static string MakeConfig(
+        string url = "http://example.com/service.asmx",
+        string soapAction = "http://example.com/GetData",
+        string soapVersion = "1.1",
+        string? body = null,
+        int timeoutSeconds = 30,
+        bool validateSsl = true,
+        string[]? acceptedStatusCodes = null)
+    {
+        var obj = new Dictionary<string, object>
+        {
+            ["url"] = url,
+            ["soapAction"] = soapAction,
+            ["soapVersion"] = soapVersion,
+            ["timeoutSeconds"] = timeoutSeconds,
+            ["validateSsl"] = validateSsl
+        };
+        if (body != null) obj["body"] = body;
+        if (acceptedStatusCodes != null) obj["acceptedStatusCodes"] = acceptedStatusCodes;
+        return JsonSerializer.Serialize(obj);
+    }
+
+    [Fact]
+    public void Create_ShouldParseAllPropertiesFromJson()
+    {
+        var config = MakeConfig(
+            url: "http://example.com/svc.asmx",
+            soapAction: "http://example.com/Op",
+            soapVersion: "1.2",
+            body: "<soap:Envelope/>",
+            timeoutSeconds: 60,
+            validateSsl: false,
+            acceptedStatusCodes: ["500"]);
+
+        var task = SoapTask.Create(config.ToJsonElement());
+
+        Assert.Equal("http://example.com/svc.asmx", task.Url);
+        Assert.Equal("http://example.com/Op", task.SoapAction);
+        Assert.Equal("1.2", task.SoapVersion);
+        Assert.Equal("<soap:Envelope/>", task.Body);
+        Assert.Equal(60, task.TimeoutSeconds);
+        Assert.False(task.ValidateSSL);
+        Assert.NotNull(task.AcceptedStatusCodes);
+        Assert.Contains("500", task.AcceptedStatusCodes);
+    }
+
+    [Fact]
+    public void Create_Defaults_ShouldBeSet()
+    {
+        var config = MakeConfig();
+        var task = SoapTask.Create(config.ToJsonElement());
+
+        Assert.Equal("1.1", task.SoapVersion);
+        Assert.Equal(30, task.TimeoutSeconds);
+        Assert.True(task.ValidateSSL);
+        Assert.Null(task.AcceptedStatusCodes);
+    }
+
+    [Fact]
+    public void Type_ShouldBe16()
+    {
+        var task = SoapTask.Create(MakeConfig().ToJsonElement());
+        Assert.Equal("16", task.Type);
+    }
+
+    [Fact]
+    public void CloneTyped_ShouldProduceDeepCopy()
+    {
+        var config = MakeConfig(body: "<Envelope/>", soapVersion: "1.2");
+        var original = SoapTask.Create(config.ToJsonElement());
+        original.AddHeader("Authorization", "Basic xxx");
+
+        var clone = original.CloneTyped();
+
+        Assert.Equal(original.Url, clone.Url);
+        Assert.Equal(original.SoapAction, clone.SoapAction);
+        Assert.Equal(original.SoapVersion, clone.SoapVersion);
+        Assert.Equal(original.Body, clone.Body);
+        Assert.Equal(original.TimeoutSeconds, clone.TimeoutSeconds);
+        Assert.Equal(original.ValidateSSL, clone.ValidateSSL);
+
+        // Modifying clone headers must not affect original
+        clone.AddHeader("X-Extra", "value");
+        var originalHeaders = GetHeadersDictionary(original);
+        Assert.False(originalHeaders.ContainsKey("X-Extra"));
+    }
+
+    [Fact]
+    public void AddHeader_WhenHeadersNull_ShouldAddNewHeader()
+    {
+        var task = SoapTask.CreateEmpty();
+
+        task.AddHeader("Authorization", "Bearer token");
+
+        var headers = GetHeadersDictionary(task);
+        Assert.Single(headers);
+        Assert.Equal("Bearer token", headers["Authorization"]);
+    }
+
+    [Fact]
+    public void AddHeader_WhenKeyExists_ShouldOverrideValue()
+    {
+        var task = SoapTask.CreateEmpty();
+        task.SetHeaders(new Dictionary<string, string?> { ["Authorization"] = "old" });
+
+        task.AddHeader("Authorization", "new");
+
+        var headers = GetHeadersDictionary(task);
+        Assert.Single(headers);
+        Assert.Equal("new", headers["Authorization"]);
+    }
+
+    [Fact]
+    public void RemoveHeader_WhenKeyExists_ShouldRemoveIt()
+    {
+        var task = SoapTask.CreateEmpty();
+        task.SetHeaders(new Dictionary<string, string?> { ["X-A"] = "a", ["X-B"] = "b" });
+
+        task.RemoveHeader("X-A");
+
+        var headers = GetHeadersDictionary(task);
+        Assert.Single(headers);
+        Assert.False(headers.ContainsKey("X-A"));
+    }
+
+    [Fact]
+    public void RemoveHeader_WhenKeyDoesNotExist_ShouldDoNothing()
+    {
+        var task = SoapTask.CreateEmpty();
+        task.SetHeaders(new Dictionary<string, string?> { ["X-A"] = "a" });
+
+        task.RemoveHeader("X-Missing");
+
+        var headers = GetHeadersDictionary(task);
+        Assert.Single(headers);
+    }
+
+    [Fact]
+    public void Reset_ShouldRestoreDefaults()
+    {
+        var task = SoapTask.Create(MakeConfig(
+            url: "http://example.com",
+            soapVersion: "1.2",
+            timeoutSeconds: 60,
+            validateSsl: false));
+
+        task.Reset();
+
+        Assert.Equal(string.Empty, task.Url);
+        Assert.Equal(string.Empty, task.SoapAction);
+        Assert.Equal("1.1", task.SoapVersion);
+        Assert.Null(task.Body);
+        Assert.Null(task.Headers);
+        Assert.Equal(30, task.TimeoutSeconds);
+        Assert.True(task.ValidateSSL);
+        Assert.Null(task.AcceptedStatusCodes);
+    }
+
+    [Fact]
+    public void AcceptedStatusCodes_WithWildcardPattern_ShouldParse()
+    {
+        var config = MakeConfig(acceptedStatusCodes: ["5xx", "404"]);
+        var task = SoapTask.Create(config.ToJsonElement());
+
+        Assert.NotNull(task.AcceptedStatusCodes);
+        Assert.Contains("5xx", task.AcceptedStatusCodes);
+        Assert.Contains("404", task.AcceptedStatusCodes);
+    }
+
+    [Fact]
+    public void SetBody_ShouldUpdateBody()
+    {
+        var task = SoapTask.CreateEmpty();
+        const string xml = "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\"><soap:Body/></soap:Envelope>";
+
+        task.SetBody(xml);
+
+        Assert.Equal(xml, task.Body);
+    }
+
+    private static Dictionary<string, string?> GetHeadersDictionary(SoapTask task)
+    {
+        if (!task.Headers.HasValue)
+            return new Dictionary<string, string?>();
+        var json = task.Headers.Value.GetRawText();
+        return JsonSerializer.Deserialize<Dictionary<string, string?>>(json)
+               ?? new Dictionary<string, string?>();
+    }
+}


### PR DESCRIPTION
Introduces SoapTask as a first-class task type (type discriminator "16") alongside a matching SoapTaskExecutor and SoapTaskInvoker. SoapTask stores the XML body as a plain string rather than JsonElement, sets correct Content-Type and SOAPAction headers per SOAP version, parses XML responses into structured dictionaries, and surfaces SOAP Fault details (faultcode, faultstring) in TaskInvocationResult metadata so output mapping scripts can inspect them.

Key changes:
- Domain: SoapTask, TaskType.Soap = 16, WorkflowTask JsonDerivedType("16")
- Execution.Abstractions: SoapTaskBinding, TaskTypes.Soap constant
- Application: SoapTaskExecutor (mirrors HttpTaskExecutor), TaskBindingMapper, DI registration
- Execution: SoapTaskInvoker with SOAP 1.1/1.2 protocol handling and XDocument-based XML/Fault parsing, DI registration
- Tests: SoapTaskTests covering configuration, clone, headers, reset, body

Closes #647

https://claude.ai/code/session_01DAfMKXzRWxrJQRb4F6nC6z

## Summary by Sourcery

Introduce a first-class SOAP task type with end-to-end support across domain, application, and execution layers, including XML-based request/response handling and SOAP fault surfacing.

New Features:
- Add SoapTask domain definition with SOAP 1.1/1.2 configuration, headers, timeouts, and accepted status codes.
- Introduce SoapTaskBinding, SoapTaskExecutor, and SoapTaskInvoker to execute SOAP requests via HTTP with appropriate content types and SOAPAction handling.
- Register SOAP task executor and invoker in the DI pipeline so workflows can run SOAP tasks alongside existing HTTP and Dapr tasks.

Enhancements:
- Extend workflow task type enums and JSON polymorphic configuration to include the new SoapTask discriminator.
- Update TaskBindingMapper to create SOAP task envelopes for remote execution.

Tests:
- Add unit tests for SoapTask covering JSON configuration parsing, cloning, header management, defaults, and reset behavior.