### PR TITLE
feat(soap): add dedicated SoapTask with SOAP 1.1/1.2 support

### DIFF
--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/ReservedTransitionResolver.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/ReservedTransitionResolver.cs
@@ -4,8 +4,9 @@ namespace BBT.Workflow.Execution;
 
 /// <summary>
 /// Identifies reserved transitions for instance locking behavior.
-/// Cancel, exit, updateData, and timeout transitions bypass locking; subflow resume
-/// is reserved but acquires an independent lock scope.
+/// All reserved transitions acquire their own type-specific lock key, independent of
+/// the main flow lock, so they can proceed even when the instance lock is held by a
+/// concurrent normal transition (e.g., sync subflow resume inside post-commit).
 /// </summary>
 public sealed class ReservedTransitionResolver : IReservedTransitionResolver
 {
@@ -20,6 +21,13 @@ public sealed class ReservedTransitionResolver : IReservedTransitionResolver
     }
 
     /// <inheritdoc />
-    public bool RequiresOwnLock(TransitionExecutionContext context)
-        => context.Directives.IsSubFlowResume;
+    public string GetOwnLockKey(TransitionExecutionContext context)
+    {
+        if (context.Directives.IsSubFlowResume)     return context.LockKey + ":resume";
+        if (context.IsCancelTransition())           return context.LockKey + ":cancel";
+        if (context.IsExitTransition())             return context.LockKey + ":exit";
+        if (context.IsUpdateDataTransition())       return context.LockKey + ":updatedata";
+        if (context.Directives.IsTimeoutTransition) return context.LockKey + ":timeout";
+        return context.LockKey + ":reserved";
+    }
 }

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/TransitionPipeline.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/TransitionPipeline.cs
@@ -82,27 +82,25 @@ public class TransitionPipeline
         if (context.SkipImmediateExecution)
             return Result<TransitionExecutionContext>.Ok(context);
 
-        // 2) Reserved transitions — bypass lock or use an independent scope (subflow resume)
+        // 2) Reserved transitions — each acquires its own type-specific lock that is independent
+        //    of the main flow lock, so they can run even while a normal transition holds L1
+        //    (e.g., sync subflow resume triggered inside the parent's post-commit phase).
         if (_reservedTransitionResolver.IsReserved(context))
         {
-            if (_reservedTransitionResolver.RequiresOwnLock(context))
+            var reservedKey = _reservedTransitionResolver.GetOwnLockKey(context);
+            await using var ownLock = await _lockScopeFactory.AcquireAsync(reservedKey, cancellationToken);
+            if (!ownLock.IsAcquired)
             {
-                await using var ownLock = await _lockScopeFactory.AcquireAsync(context.LockKey, cancellationToken);
-                if (!ownLock.IsAcquired)
-                {
-                    _logger.InstanceLockFailed(context.InstanceId.ToString());
-                    return Result<TransitionExecutionContext>.Fail(
-                        WorkflowErrors.InstanceLockConflict(context.InstanceId));
-                }
-
-                await _busyMarker.MarkBusyAsync(context.InstanceId, cancellationToken);
-                return await RunChainAsync(context, workflowContext, ownLock, cancellationToken);
+                _logger.InstanceLockFailed(context.InstanceId.ToString());
+                return Result<TransitionExecutionContext>.Fail(
+                    WorkflowErrors.InstanceLockConflict(context.InstanceId));
             }
 
-            _logger.LogDebug(
-                "Reserved transition {TransitionKey} for instance {InstanceId} — lock bypassed",
-                context.TransitionKey, context.InstanceId);
-            return await RunChainAsync(context, workflowContext, lockScope: null, cancellationToken);
+            // SubFlow Resume resumes an already-Busy instance; confirm the busy mark.
+            if (context.Directives.IsSubFlowResume)
+                await _busyMarker.MarkBusyAsync(context.InstanceId, cancellationToken);
+
+            return await RunChainAsync(context, workflowContext, ownLock, cancellationToken);
         }
 
         // 3) Normal transitions — acquire single lock for the entire chain

--- a/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/TaskServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/TaskServiceCollectionExtensions.cs
@@ -67,8 +67,9 @@ public static class TaskServiceCollectionExtensions
         // Human task executor (no remote - state change only)
         services.AddTaskExecutor<HumanTaskExecutor>();
 
-        // HTTP and Dapr remote executors
+        // HTTP, SOAP and Dapr remote executors
         services.AddTaskExecutor<HttpTaskExecutor>();
+        services.AddTaskExecutor<SoapTaskExecutor>();
         services.AddTaskExecutor<DaprServiceTaskExecutor>();
         services.AddTaskExecutor<DaprBindingTaskExecutor>();
         services.AddTaskExecutor<DaprHttpEndpointTaskExecutor>();

--- a/src/BBT.Workflow.Application/Tasks/Executors/Http/SoapTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Http/SoapTaskExecutor.cs
@@ -1,0 +1,143 @@
+using BBT.Aether.Results;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Logging;
+using BBT.Workflow.Scripting;
+using BBT.Workflow.Tasks.Mapping;
+using Microsoft.Extensions.Logging;
+
+namespace BBT.Workflow.Tasks.Executors;
+
+/// <summary>
+/// Executor for SOAP tasks.
+/// Handles input/output mapping locally, then delegates to RemoteInvokerService for execution.
+/// </summary>
+public sealed class SoapTaskExecutor : TaskExecutorBase<SoapTask>
+{
+    private readonly IRemoteInvokerService _remoteInvoker;
+    private readonly IScriptEngine _scriptEngine;
+
+    public SoapTaskExecutor(
+        IRemoteInvokerService remoteInvoker,
+        IScriptEngine scriptEngine,
+        ILogger<SoapTaskExecutor> logger)
+        : base(logger)
+    {
+        _remoteInvoker = remoteInvoker;
+        _scriptEngine = scriptEngine;
+    }
+
+    /// <inheritdoc />
+    public override TaskType TaskType => TaskType.Soap;
+
+    /// <inheritdoc />
+    protected override async Task<Result<ScriptResponse?>> PrepareInputAsync(
+        SoapTask task,
+        TaskExecutorContext context,
+        CancellationToken cancellationToken)
+    {
+        var mapping = context.OnExecuteTask.Mapping;
+        if (mapping == null || string.IsNullOrEmpty(mapping.DecodedCode))
+        {
+            return Result<ScriptResponse?>.Ok(null);
+        }
+
+        var result = await ResultExtensions.TryAsync<ScriptResponse?>(async ct =>
+        {
+            var scriptRunner = await _scriptEngine.CompileToInstanceAsync<IMapping>(
+                mapping.DecodedCode,
+                cancellationToken: ct);
+
+            return await scriptRunner.InputHandler(task, context.ScriptContext);
+        }, cancellationToken, ex => Error.Failure(
+            WorkflowErrorCodes.TaskExecution,
+            $"Soap task input handler failed: {ex.Message}"));
+
+        if (!result.IsSuccess)
+        {
+            Logger.TaskInputHandlerFailed(
+                task.Key,
+                TaskType.ToString(),
+                context.ScriptContext.Instance.Id,
+                result.Error.Message ?? "Unknown error");
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    protected override async Task<Result<TaskInvocationResult>> InvokeAsync(
+        SoapTask task,
+        TaskExecutorContext context,
+        CancellationToken cancellationToken)
+    {
+        var envelopeResult = TaskBindingMapper.CreateEnvelope(task);
+        if (!envelopeResult.IsSuccess)
+        {
+            Logger.TaskEnvelopeCreationFailed(
+                task.Key,
+                TaskType.ToString(),
+                context.ScriptContext.Instance.Id,
+                envelopeResult.Error.Message ?? "Unknown error");
+            return Result<TaskInvocationResult>.Fail(envelopeResult.Error);
+        }
+
+        var traceContext = _remoteInvoker.CreateTraceContext(context.ScriptContext);
+
+        var result = await _remoteInvoker.InvokeAsync(
+            Execution.TaskTypes.Soap,
+            task.Key,
+            envelopeResult.Value!,
+            traceContext,
+            cancellationToken);
+
+        if (!result.IsSuccess)
+        {
+            Logger.TaskInvocationFailed(
+                task.Key,
+                TaskType.ToString(),
+                context.ScriptContext.Instance.Id,
+                result.Error.Message ?? "Unknown error");
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    protected override async Task<Result<object?>> ProcessOutputAsync(
+        SoapTask task,
+        TaskInvocationResult invocationResult,
+        TaskExecutorContext context,
+        CancellationToken cancellationToken)
+    {
+        var mapping = context.OnExecuteTask.Mapping;
+        if (mapping == null || string.IsNullOrEmpty(mapping.DecodedCode))
+        {
+            return Result<object?>.Ok(invocationResult.Data);
+        }
+
+        UpdateScriptContextWithResponse(task.Key, invocationResult, context.ScriptContext);
+
+        var result = await ResultExtensions.TryAsync<object?>(async ct =>
+        {
+            var scriptRunner = await _scriptEngine.CompileToInstanceAsync<IMapping>(
+                mapping.DecodedCode,
+                cancellationToken: ct);
+
+            var outputResponse = await scriptRunner.OutputHandler(context.ScriptContext);
+            return outputResponse.Data;
+        }, cancellationToken, ex => Error.Failure(
+            WorkflowErrorCodes.TaskExecution,
+            $"Soap task output handler failed: {ex.Message}"));
+
+        if (!result.IsSuccess)
+        {
+            Logger.TaskOutputHandlerFailed(
+                task.Key,
+                TaskType.ToString(),
+                context.ScriptContext.Instance.Id,
+                result.Error.Message ?? "Unknown error");
+        }
+
+        return result;
+    }
+}

--- a/src/BBT.Workflow.Application/Tasks/Mapping/TaskBindingMapper.cs
+++ b/src/BBT.Workflow.Application/Tasks/Mapping/TaskBindingMapper.cs
@@ -183,7 +183,8 @@ public static class TaskBindingMapper
         Body = task.Body,
         Headers = task.Headers?.GetRawText(),
         TimeoutSeconds = task.TimeoutSeconds,
-        ValidateSSL = task.ValidateSSL
+        ValidateSSL = task.ValidateSSL,
+        AcceptedStatusCodes = task.AcceptedStatusCodes
     };
 
     /// <summary>

--- a/src/BBT.Workflow.Application/Tasks/Mapping/TaskBindingMapper.cs
+++ b/src/BBT.Workflow.Application/Tasks/Mapping/TaskBindingMapper.cs
@@ -40,6 +40,7 @@ public static class TaskBindingMapper
             {
                 // Remote execution tasks
                 HttpTask http => (TaskTypes.Http, MapHttpTask(http)),
+                SoapTask soap => (TaskTypes.Soap, (object)MapSoapTask(soap)),
                 DaprServiceTask daprService => (TaskTypes.DaprService, MapDaprServiceTask(daprService)),
                 DaprBindingTask daprBinding => (TaskTypes.DaprBinding, MapDaprBindingTask(daprBinding)),
                 DaprHttpEndpointTask daprHttpEndpoint => (TaskTypes.DaprHttpEndpoint, MapDaprHttpEndpointTask(daprHttpEndpoint)),
@@ -170,6 +171,20 @@ public static class TaskBindingMapper
     };
 
     #endregion
+
+    /// <summary>
+    /// Maps SoapTask to SoapTaskBinding.
+    /// </summary>
+    private static SoapTaskBinding MapSoapTask(SoapTask task) => new()
+    {
+        Url = task.Url,
+        SoapAction = task.SoapAction,
+        SoapVersion = task.SoapVersion,
+        Body = task.Body,
+        Headers = task.Headers?.GetRawText(),
+        TimeoutSeconds = task.TimeoutSeconds,
+        ValidateSSL = task.ValidateSSL
+    };
 
     /// <summary>
     /// Maps HttpTask to HttpTaskBinding.

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/SoapTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/SoapTask.cs
@@ -1,0 +1,203 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace BBT.Workflow.Definitions;
+
+/// <summary>
+/// SOAP Task Definition — sends a SOAP 1.1 or 1.2 request to a web service endpoint.
+/// Body is stored as a raw XML string (not JsonElement) to support SOAP envelope templates.
+/// </summary>
+public sealed class SoapTask : WorkflowTask
+{
+    private SoapTask()
+    {
+    }
+
+    [JsonConstructor]
+    private SoapTask(JsonElement config) : base(config)
+    {
+        Type = ((int)TaskType.Soap).ToString();
+    }
+
+    /// <summary>Target SOAP endpoint URL.</summary>
+    public string Url { get; set; } = string.Empty;
+
+    /// <summary>
+    /// SOAPAction value. Required for SOAP 1.1 (sent as HTTP header).
+    /// For SOAP 1.2 it is embedded in the Content-Type action parameter.
+    /// </summary>
+    public string SoapAction { get; set; } = string.Empty;
+
+    /// <summary>SOAP protocol version: "1.1" or "1.2". Defaults to "1.1".</summary>
+    public string SoapVersion { get; private set; } = "1.1";
+
+    /// <summary>
+    /// SOAP envelope XML body as a raw string template.
+    /// Unlike HttpTask, this is a plain string — not JsonElement — to support arbitrary XML.
+    /// </summary>
+    public string? Body { get; private set; }
+
+    /// <summary>Additional HTTP headers (e.g. Authorization). Stored as JSON object.</summary>
+    public JsonElement? Headers { get; private set; }
+
+    /// <summary>Request timeout in seconds.</summary>
+    public int TimeoutSeconds { get; private set; } = 30;
+
+    /// <summary>Whether to validate the server SSL certificate.</summary>
+    public bool ValidateSSL { get; private set; } = true;
+
+    /// <summary>
+    /// HTTP status codes treated as successful even when they indicate errors.
+    /// SOAP faults are typically returned over HTTP 500, so ["500"] is a common value here.
+    /// Supports exact codes ("500") and wildcard patterns ("5xx", "50x").
+    /// </summary>
+    public IReadOnlyList<string>? AcceptedStatusCodes { get; private set; }
+
+    public void SetUrl(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+            throw new ArgumentNullException(nameof(url));
+
+        Url = url;
+    }
+
+    public void SetBody(string? body)
+    {
+        Body = body;
+    }
+
+    public void SetSoapAction(string soapAction)
+    {
+        SoapAction = soapAction ?? string.Empty;
+    }
+
+    public void SetHeaders(Dictionary<string, string?> headers)
+    {
+        Headers = JsonSerializer.SerializeToElement(headers);
+    }
+
+    /// <summary>Adds or updates a single header. Overwrites existing values for the same key.</summary>
+    public void AddHeader(string key, string? value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        var d = TaskHeadersHelper.ToMutableDictionary(Headers);
+        d[key] = value;
+        Headers = TaskHeadersHelper.FromDictionary(d);
+    }
+
+    /// <summary>Removes a header by key. Does nothing if the key does not exist.</summary>
+    public void RemoveHeader(string key)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        var d = TaskHeadersHelper.ToMutableDictionary(Headers);
+        d.Remove(key);
+        Headers = TaskHeadersHelper.FromDictionary(d);
+    }
+
+    // Internal setters for object pooling
+    internal void SetBodyInternal(string? body) => Body = body;
+    internal void SetSoapVersionInternal(string soapVersion) => SoapVersion = soapVersion;
+    internal void SetSoapActionInternal(string soapAction) => SoapAction = soapAction;
+    internal void SetHeadersInternal(JsonElement? headers) => Headers = headers;
+    internal void SetTimeoutSecondsInternal(int timeoutSeconds) => TimeoutSeconds = timeoutSeconds;
+    internal void SetValidateSSLInternal(bool validateSSL) => ValidateSSL = validateSSL;
+    internal void SetAcceptedStatusCodesInternal(IReadOnlyList<string>? codes) => AcceptedStatusCodes = codes;
+
+    protected override void Configure(JsonElement config)
+    {
+        base.Configure(config);
+
+        if (config.TryGetProperty("url", out var url))
+            Url = url.GetString() ?? throw new ArgumentNullException(nameof(url));
+
+        if (config.TryGetProperty("soapAction", out var soapAction))
+            SoapAction = soapAction.GetString() ?? string.Empty;
+
+        if (config.TryGetProperty("soapVersion", out var soapVersion))
+            SoapVersion = soapVersion.GetString() ?? "1.1";
+
+        if (config.TryGetProperty("body", out var body))
+            Body = body.ValueKind == JsonValueKind.String ? body.GetString() : null;
+
+        if (config.TryGetProperty("headers", out var headersElement))
+        {
+            var raw = headersElement.GetRawText();
+            Headers = string.IsNullOrWhiteSpace(raw) ? null : headersElement;
+        }
+
+        if (config.TryGetProperty("timeoutSeconds", out var timeoutSeconds))
+            TimeoutSeconds = timeoutSeconds.GetInt32();
+
+        if (config.TryGetProperty("validateSsl", out var validateSsl))
+            ValidateSSL = validateSsl.GetBoolean();
+
+        if (config.TryGetProperty("acceptedStatusCodes", out var acceptedCodesElement) &&
+            acceptedCodesElement.ValueKind == JsonValueKind.Array)
+        {
+            var codes = acceptedCodesElement.EnumerateArray()
+                .Select(e => e.GetString())
+                .Where(s => !string.IsNullOrWhiteSpace(s))
+                .Select(s => s!)
+                .ToList();
+            AcceptedStatusCodes = codes.Count > 0 ? codes : null;
+        }
+    }
+
+    public static SoapTask Create(JsonElement config)
+    {
+        return new SoapTask(config);
+    }
+
+    public override WorkflowTask Clone()
+    {
+        return CloneTyped();
+    }
+
+    public SoapTask CloneTyped()
+    {
+        var cloned = new SoapTask();
+        CopyBaseTo(cloned);
+
+        cloned.Url = Url;
+        cloned.SoapAction = SoapAction;
+        cloned.SoapVersion = SoapVersion;
+        cloned.Body = Body;
+        cloned.Headers = Headers;
+        cloned.TimeoutSeconds = TimeoutSeconds;
+        cloned.ValidateSSL = ValidateSSL;
+        cloned.AcceptedStatusCodes = AcceptedStatusCodes;
+
+        return cloned;
+    }
+
+    public void CopyFromInternal(SoapTask source)
+    {
+        source.CopyBaseToInternal(this);
+        Url = source.Url;
+        SetSoapActionInternal(source.SoapAction);
+        SetSoapVersionInternal(source.SoapVersion);
+        SetBodyInternal(source.Body);
+        SetHeadersInternal(source.Headers);
+        SetTimeoutSecondsInternal(source.TimeoutSeconds);
+        SetValidateSSLInternal(source.ValidateSSL);
+        SetAcceptedStatusCodesInternal(source.AcceptedStatusCodes);
+    }
+
+    public override void Reset()
+    {
+        base.Reset();
+        Url = string.Empty;
+        SoapAction = string.Empty;
+        SoapVersion = "1.1";
+        Body = null;
+        Headers = null;
+        TimeoutSeconds = 30;
+        ValidateSSL = true;
+        AcceptedStatusCodes = null;
+    }
+
+    public static SoapTask CreateEmpty()
+    {
+        return new SoapTask();
+    }
+}

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/TaskEnums.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/TaskEnums.cs
@@ -22,7 +22,8 @@ public enum TaskType
     DirectTrigger = 12,
     GetInstanceData = 13,
     SubProcess = 14,
-    GetInstances = 15
+    GetInstances = 15,
+    Soap = 16
 }
 
 /// <summary>

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/WorkflowTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/WorkflowTask.cs
@@ -22,6 +22,7 @@ namespace BBT.Workflow.Definitions;
 [JsonDerivedType(typeof(GetInstanceDataTask), typeDiscriminator: "13")]
 [JsonDerivedType(typeof(SubProcessTask), typeDiscriminator: "14")]
 [JsonDerivedType(typeof(GetInstancesTask), typeDiscriminator: "15")]
+[JsonDerivedType(typeof(SoapTask), typeDiscriminator: "16")]
 public abstract class WorkflowTask : IDomainEntity, ITaskReference, IReferenceSetter, ITaskClonable
 {
     protected WorkflowTask()

--- a/src/BBT.Workflow.Domain/Execution/Transitions/Pipeline/IReservedTransitionResolver.cs
+++ b/src/BBT.Workflow.Domain/Execution/Transitions/Pipeline/IReservedTransitionResolver.cs
@@ -2,8 +2,8 @@ namespace BBT.Workflow.Execution.Pipeline;
 
 /// <summary>
 /// Determines whether a transition is "reserved" relative to instance locking.
-/// Most reserved transitions (cancel, exit, updateData, timeout) bypass the lock entirely.
-/// Subflow resume is reserved but uses its own lock scope via <see cref="RequiresOwnLock"/>.
+/// All reserved transitions acquire their own type-specific lock that is independent
+/// of the main flow lock, so they can run even while another transition holds the instance lock.
 /// </summary>
 public interface IReservedTransitionResolver
 {
@@ -14,9 +14,11 @@ public interface IReservedTransitionResolver
     bool IsReserved(TransitionExecutionContext context);
 
     /// <summary>
-    /// Returns <c>true</c> when the reserved transition must acquire its own instance lock scope
-    /// instead of bypassing locking (subflow resume only).
+    /// Returns the type-specific lock key for this reserved transition.
+    /// This key is independent from <see cref="TransitionExecutionContext.LockKey"/>
+    /// so the reserved transition never conflicts with the main flow lock, while still
+    /// serializing concurrent requests of the same reserved type per instance.
     /// </summary>
     /// <param name="context">The transition execution context.</param>
-    bool RequiresOwnLock(TransitionExecutionContext context);
+    string GetOwnLockKey(TransitionExecutionContext context);
 }

--- a/src/BBT.Workflow.Execution.Abstractions/Bindings/SoapTaskBinding.cs
+++ b/src/BBT.Workflow.Execution.Abstractions/Bindings/SoapTaskBinding.cs
@@ -1,0 +1,21 @@
+namespace BBT.Workflow.Execution.Bindings;
+
+/// <summary>
+/// Execution-ready binding for SOAP tasks.
+/// Carries all configuration needed by SoapTaskInvoker without any domain dependencies.
+/// </summary>
+public sealed record SoapTaskBinding
+{
+    public required string Url { get; init; }
+    public string SoapAction { get; init; } = string.Empty;
+    public string SoapVersion { get; init; } = "1.1";
+
+    /// <summary>Raw XML SOAP envelope body string.</summary>
+    public string? Body { get; init; }
+
+    /// <summary>Additional HTTP headers serialized as a JSON object string.</summary>
+    public string? Headers { get; init; }
+
+    public int TimeoutSeconds { get; init; } = 30;
+    public bool ValidateSSL { get; init; } = true;
+}

--- a/src/BBT.Workflow.Execution.Abstractions/Bindings/SoapTaskBinding.cs
+++ b/src/BBT.Workflow.Execution.Abstractions/Bindings/SoapTaskBinding.cs
@@ -18,4 +18,11 @@ public sealed record SoapTaskBinding
 
     public int TimeoutSeconds { get; init; } = 30;
     public bool ValidateSSL { get; init; } = true;
+
+    /// <summary>
+    /// HTTP status codes treated as successful even when outside the 2xx range.
+    /// Supports exact codes ("500") and wildcard patterns ("5xx", "50x").
+    /// SOAP faults typically come back over HTTP 500, so ["500"] is a common value.
+    /// </summary>
+    public IReadOnlyList<string>? AcceptedStatusCodes { get; init; }
 }

--- a/src/BBT.Workflow.Execution.Abstractions/TaskTypes.cs
+++ b/src/BBT.Workflow.Execution.Abstractions/TaskTypes.cs
@@ -13,6 +13,8 @@ public static class TaskTypes
     public const string DaprHttpEndpoint = "daprhttpendpoint";
     public const string DaprPubSub = "daprpubsub";
 
+    public const string Soap = "soap";
+
     // Trigger tasks (for cross-domain execution)
     public const string StartTrigger = "starttrigger";
     public const string DirectTrigger = "directtrigger";

--- a/src/BBT.Workflow.Execution/Invokers/SoapTaskInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/SoapTaskInvoker.cs
@@ -1,0 +1,301 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using System.Xml.Linq;
+using BBT.Workflow.Execution.Bindings;
+using BBT.Workflow.Execution.Metrics;
+using Microsoft.Extensions.Logging;
+
+namespace BBT.Workflow.Execution.Invokers;
+
+/// <summary>
+/// SOAP task invoker — stateless execution with strongly-typed binding.
+/// Handles SOAP 1.1 and 1.2 protocol differences for Content-Type and SOAPAction headers,
+/// parses XML responses, and detects SOAP Fault elements.
+/// </summary>
+public sealed class SoapTaskInvoker(
+    IHttpClientFactory httpClientFactory,
+    ILogger<SoapTaskInvoker> logger,
+    ITaskMetrics? metrics = null)
+    : ITaskInvoker<SoapTaskBinding>
+{
+    private static readonly XNamespace Soap11Ns = "http://schemas.xmlsoap.org/soap/envelope/";
+    private static readonly XNamespace Soap12Ns = "http://www.w3.org/2003/05/soap-envelope";
+
+    private readonly ITaskMetrics _metrics = metrics ?? NullTaskMetrics.Instance;
+
+    /// <inheritdoc />
+    public string TaskType => TaskTypes.Soap;
+
+    /// <inheritdoc />
+    public Type BindingType => typeof(SoapTaskBinding);
+
+    /// <inheritdoc />
+    public async Task<TaskInvocationResult> InvokeAsync(
+        TaskDescriptor<SoapTaskBinding> descriptor,
+        CancellationToken cancellationToken = default)
+    {
+        return await ExecuteAsync(descriptor.TaskKey, descriptor.Binding, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<TaskInvocationResult> InvokeAsync(
+        string? taskKey,
+        JsonElement binding,
+        CancellationToken cancellationToken = default)
+    {
+        var typedBinding = binding.Deserialize<SoapTaskBinding>()
+            ?? throw new InvalidOperationException("Failed to deserialize SoapTaskBinding");
+
+        return await ExecuteAsync(taskKey, typedBinding, cancellationToken);
+    }
+
+    private async Task<TaskInvocationResult> ExecuteAsync(
+        string? taskKey,
+        SoapTaskBinding binding,
+        CancellationToken cancellationToken)
+    {
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            var httpClient = CreateHttpClient(binding, taskKey);
+            var request = new HttpRequestMessage(HttpMethod.Post, binding.Url);
+
+            // Set SOAP-version-specific Content-Type and SOAPAction
+            var isSoap12 = string.Equals(binding.SoapVersion, "1.2", StringComparison.OrdinalIgnoreCase);
+
+            if (isSoap12)
+            {
+                var mediaType = string.IsNullOrEmpty(binding.SoapAction)
+                    ? "application/soap+xml; charset=utf-8"
+                    : $"application/soap+xml; charset=utf-8; action=\"{binding.SoapAction}\"";
+                request.Content = new StringContent(binding.Body ?? string.Empty, Encoding.UTF8);
+                request.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse(mediaType);
+            }
+            else
+            {
+                // SOAP 1.1: text/xml + separate SOAPAction header
+                request.Content = new StringContent(binding.Body ?? string.Empty, Encoding.UTF8, "text/xml");
+
+                if (!string.IsNullOrEmpty(binding.SoapAction))
+                    request.Headers.TryAddWithoutValidation("SOAPAction", $"\"{binding.SoapAction}\"");
+            }
+
+            // Add any additional HTTP headers (e.g. Authorization)
+            if (!string.IsNullOrEmpty(binding.Headers))
+            {
+                var headers = JsonSerializer.Deserialize<Dictionary<string, string>>(binding.Headers);
+                if (headers != null)
+                {
+                    foreach (var header in headers)
+                        request.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                }
+            }
+
+            var response = await httpClient.SendAsync(request, cancellationToken);
+
+            var responseHeaders = InvokerHelpers.MergeHeaders(response.Headers, response.Content.Headers);
+            var content = await response.Content.ReadAsStringAsync(cancellationToken);
+            stopwatch.Stop();
+
+            var (parsedData, isSoapFault, faultCode, faultString) = TryParseSoapResponse(content, isSoap12);
+
+            var metadata = new Dictionary<string, object>
+            {
+                ["Url"] = binding.Url,
+                ["Method"] = "POST",
+                ["ReasonPhrase"] = response.ReasonPhrase ?? string.Empty,
+                ["SoapVersion"] = binding.SoapVersion,
+                ["IsSoapFault"] = isSoapFault
+            };
+
+            if (isSoapFault)
+            {
+                if (faultCode != null) metadata["SoapFaultCode"] = faultCode;
+                if (faultString != null) metadata["SoapFaultString"] = faultString;
+            }
+
+            return response.IsSuccessStatusCode
+                ? TaskInvocationResult.Success(
+                    data: parsedData,
+                    body: content,
+                    statusCode: (int)response.StatusCode,
+                    executionDurationMs: stopwatch.ElapsedMilliseconds,
+                    taskType: TaskType,
+                    headers: responseHeaders,
+                    metadata: metadata)
+                : TaskInvocationResult.Failure(
+                    error: isSoapFault
+                        ? $"SOAP Fault: {faultString ?? faultCode ?? "Unknown fault"}"
+                        : $"HTTP {response.StatusCode}: {response.ReasonPhrase}",
+                    statusCode: (int)response.StatusCode,
+                    body: content,
+                    executionDurationMs: stopwatch.ElapsedMilliseconds,
+                    taskType: TaskType,
+                    headers: responseHeaders,
+                    data: parsedData,
+                    metadata: metadata);
+        }
+        catch (TaskCanceledException ex) when (cancellationToken.IsCancellationRequested)
+        {
+            stopwatch.Stop();
+            _metrics.RecordTaskExecution(TaskType, "cancelled");
+            logger.LogWarning("SOAP request was cancelled for task {TaskKey} - URL: {Url}", taskKey, binding.Url);
+
+            return TaskInvocationResult.Failure(
+                error: "SOAP request was cancelled",
+                executionDurationMs: stopwatch.ElapsedMilliseconds,
+                taskType: TaskType,
+                metadata: new Dictionary<string, object>
+                {
+                    ["Url"] = binding.Url,
+                    ["Method"] = "POST",
+                    ["Cancelled"] = true,
+                    ["ExceptionType"] = ex.GetType().Name
+                });
+        }
+        catch (HttpRequestException ex)
+        {
+            stopwatch.Stop();
+            _metrics.RecordTaskExecution(TaskType, "failure");
+            logger.LogError(ex, "SOAP task invocation failed for {TaskKey} - URL: {Url}", taskKey, binding.Url);
+
+            return TaskInvocationResult.Failure(
+                error: ex.Message,
+                executionDurationMs: stopwatch.ElapsedMilliseconds,
+                taskType: TaskType,
+                metadata: new Dictionary<string, object>
+                {
+                    ["Url"] = binding.Url,
+                    ["Method"] = "POST",
+                    ["ExceptionType"] = ex.GetType().Name,
+                    ["StackTrace"] = ex.StackTrace ?? string.Empty
+                });
+        }
+        catch (Exception ex)
+        {
+            stopwatch.Stop();
+            _metrics.RecordTaskExecution(TaskType, "failure");
+            logger.LogError(ex, "Unexpected error during SOAP task invocation for {TaskKey}", taskKey);
+
+            return TaskInvocationResult.Failure(
+                error: ex.Message,
+                executionDurationMs: stopwatch.ElapsedMilliseconds,
+                taskType: TaskType,
+                metadata: new Dictionary<string, object>
+                {
+                    ["Url"] = binding.Url,
+                    ["Method"] = "POST",
+                    ["ExceptionType"] = ex.GetType().Name,
+                    ["StackTrace"] = ex.StackTrace ?? string.Empty
+                });
+        }
+    }
+
+    /// <summary>
+    /// Parses the raw XML SOAP response. Returns structured data extracted from the Body element,
+    /// plus SOAP Fault details if present.
+    /// </summary>
+    private static (object? Data, bool IsSoapFault, string? FaultCode, string? FaultString)
+        TryParseSoapResponse(string content, bool isSoap12)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+            return (null, false, null, null);
+
+        try
+        {
+            var doc = XDocument.Parse(content);
+            var ns = isSoap12 ? Soap12Ns : Soap11Ns;
+
+            var body = doc.Descendants(ns + "Body").FirstOrDefault();
+            if (body == null)
+                return (XmlElementToDictionary(doc.Root), false, null, null);
+
+            // Detect SOAP Fault
+            var fault = body.Element(ns + "Fault");
+            if (fault != null)
+            {
+                string? faultCode = null;
+                string? faultString = null;
+
+                if (isSoap12)
+                {
+                    faultCode = fault.Element(ns + "Code")?.Element(ns + "Value")?.Value;
+                    faultString = fault.Element(ns + "Reason")?.Element(ns + "Text")?.Value;
+                }
+                else
+                {
+                    faultCode = fault.Element("faultcode")?.Value;
+                    faultString = fault.Element("faultstring")?.Value;
+                }
+
+                var faultData = XmlElementToDictionary(fault);
+                return (faultData, true, faultCode, faultString);
+            }
+
+            // Return body content as structured dictionary
+            var firstChild = body.Elements().FirstOrDefault();
+            var data = firstChild != null ? XmlElementToDictionary(firstChild) : XmlElementToDictionary(body);
+            return (data, false, null, null);
+        }
+        catch
+        {
+            // Non-parseable XML — return raw string as body only
+            return (null, false, null, null);
+        }
+    }
+
+    /// <summary>
+    /// Converts an XElement tree to a nested Dictionary for use as structured task output data.
+    /// </summary>
+    private static object XmlElementToDictionary(XElement? element)
+    {
+        if (element == null)
+            return new Dictionary<string, object>();
+
+        // Leaf node: return text value
+        if (!element.HasElements)
+            return element.Value;
+
+        var dict = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var child in element.Elements())
+        {
+            var localName = child.Name.LocalName;
+            var value = XmlElementToDictionary(child);
+
+            if (dict.TryGetValue(localName, out var existing))
+            {
+                // Multiple elements with same name → collect as list
+                if (existing is List<object> list)
+                    list.Add(value);
+                else
+                    dict[localName] = new List<object> { existing, value };
+            }
+            else
+            {
+                dict[localName] = value;
+            }
+        }
+
+        return dict;
+    }
+
+    private HttpClient CreateHttpClient(SoapTaskBinding binding, string? taskKey)
+    {
+        var clientName = binding.ValidateSSL
+            ? WorkflowHttpClientNames.Default
+            : WorkflowHttpClientNames.NoSslValidation;
+
+        if (!binding.ValidateSSL)
+        {
+            logger.LogDebug("SSL certificate validation is disabled for SOAP task {TaskKey} - URL: {Url}",
+                taskKey, binding.Url);
+        }
+
+        var client = httpClientFactory.CreateClient(clientName);
+        client.Timeout = TimeSpan.FromSeconds(binding.TimeoutSeconds);
+        return client;
+    }
+}

--- a/src/BBT.Workflow.Execution/Invokers/SoapTaskInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/SoapTaskInvoker.cs
@@ -116,7 +116,10 @@ public sealed class SoapTaskInvoker(
                 if (faultString != null) metadata["SoapFaultString"] = faultString;
             }
 
-            return response.IsSuccessStatusCode
+            var isSuccess = response.IsSuccessStatusCode
+                || IsAcceptedStatusCode((int)response.StatusCode, binding.AcceptedStatusCodes);
+
+            return isSuccess
                 ? TaskInvocationResult.Success(
                     data: parsedData,
                     body: content,
@@ -280,6 +283,41 @@ public sealed class SoapTaskInvoker(
         }
 
         return dict;
+    }
+
+    /// <summary>
+    /// Returns true when <paramref name="statusCode"/> matches any entry in <paramref name="acceptedCodes"/>.
+    /// Supports exact matches ("500") and single-character wildcards ("5xx", "50x").
+    /// </summary>
+    private static bool IsAcceptedStatusCode(int statusCode, IReadOnlyList<string>? acceptedCodes)
+    {
+        if (acceptedCodes == null || acceptedCodes.Count == 0)
+            return false;
+
+        var codeStr = statusCode.ToString();
+
+        foreach (var pattern in acceptedCodes)
+        {
+            if (string.IsNullOrWhiteSpace(pattern) || pattern.Length != codeStr.Length)
+                continue;
+
+            var matched = true;
+            for (var i = 0; i < pattern.Length; i++)
+            {
+                if (pattern[i] == 'x' || pattern[i] == 'X')
+                    continue;
+
+                if (pattern[i] != codeStr[i])
+                {
+                    matched = false;
+                    break;
+                }
+            }
+
+            if (matched) return true;
+        }
+
+        return false;
     }
 
     private HttpClient CreateHttpClient(SoapTaskBinding binding, string? taskKey)

--- a/src/BBT.Workflow.Execution/Microsoft/Extensions/DependencyInjection/ExecutionServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Execution/Microsoft/Extensions/DependencyInjection/ExecutionServiceCollectionExtensions.cs
@@ -47,6 +47,7 @@ public static class ExecutionServiceCollectionExtensions
         
         // Register all built-in remote execution invokers
         services.AddSingleton<ITaskInvoker, HttpTaskInvoker>();
+        services.AddSingleton<ITaskInvoker, SoapTaskInvoker>();
         services.AddSingleton<ITaskInvoker, DaprServiceTaskInvoker>();
         services.AddSingleton<ITaskInvoker, DaprBindingTaskInvoker>();
         services.AddSingleton<ITaskInvoker, DaprHttpEndpointTaskInvoker>();

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/ReservedTransitionResolverTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/ReservedTransitionResolverTests.cs
@@ -10,7 +10,7 @@ namespace BBT.Workflow.Application.Tests.Execution.Transitions.Pipeline;
 /// <summary>
 /// Tests for <see cref="ReservedTransitionResolver"/>.
 /// Validates reserved transition detection for cancel, exit, updateData,
-/// timeout, and subflow resume, and <see cref="IReservedTransitionResolver.RequiresOwnLock"/>.
+/// timeout, and subflow resume, and lock key isolation via GetOwnLockKey.
 /// </summary>
 public class ReservedTransitionResolverTests
 {
@@ -61,40 +61,72 @@ public class ReservedTransitionResolverTests
     }
 
     [Fact]
-    public void RequiresOwnLock_WithSubFlowResume_ShouldReturnTrue()
-    {
-        var ctx = CreateContext(transitionKey: "resume");
-        ctx.Directives.MarkAsSubFlowResume();
-        _resolver.RequiresOwnLock(ctx).ShouldBeTrue();
-    }
-
-    [Fact]
-    public void RequiresOwnLock_WithTimeoutTransition_ShouldReturnFalse()
-    {
-        var ctx = CreateContext(transitionKey: "$timeout");
-        ctx.Directives.MarkAsTimeoutTransition();
-        _resolver.RequiresOwnLock(ctx).ShouldBeFalse();
-    }
-
-    [Fact]
-    public void RequiresOwnLock_WithCancelTransition_ShouldReturnFalse()
-    {
-        var ctx = CreateContext(cancelKey: "cancel", transitionKey: "cancel");
-        _resolver.RequiresOwnLock(ctx).ShouldBeFalse();
-    }
-
-    [Fact]
-    public void RequiresOwnLock_WithNormalTransition_ShouldReturnFalse()
-    {
-        var ctx = CreateContext(transitionKey: "approve");
-        _resolver.RequiresOwnLock(ctx).ShouldBeFalse();
-    }
-
-    [Fact]
     public void IsReserved_WithMismatchedKey_ShouldReturnFalse()
     {
         var ctx = CreateContext(cancelKey: "cancel", transitionKey: "not-cancel");
         _resolver.IsReserved(ctx).ShouldBeFalse();
+    }
+
+    // GetOwnLockKey — type-label tests
+
+    [Fact]
+    public void GetOwnLockKey_WithSubFlowResume_ShouldUseResumeLabel()
+    {
+        var ctx = CreateContext(transitionKey: "resume");
+        ctx.Directives.MarkAsSubFlowResume();
+        _resolver.GetOwnLockKey(ctx).ShouldBe(ctx.LockKey + ":resume");
+    }
+
+    [Fact]
+    public void GetOwnLockKey_WithSubFlowResume_ShouldDifferFromMainFlowLockKey()
+    {
+        var ctx = CreateContext(transitionKey: "resume");
+        ctx.Directives.MarkAsSubFlowResume();
+        _resolver.GetOwnLockKey(ctx).ShouldNotBe(ctx.LockKey);
+    }
+
+    [Fact]
+    public void GetOwnLockKey_WithCancelTransition_ShouldUseCancelLabel()
+    {
+        var ctx = CreateContext(cancelKey: "cancel", transitionKey: "cancel");
+        _resolver.GetOwnLockKey(ctx).ShouldBe(ctx.LockKey + ":cancel");
+    }
+
+    [Fact]
+    public void GetOwnLockKey_WithExitTransition_ShouldUseExitLabel()
+    {
+        var ctx = CreateContext(exitKey: "exit", transitionKey: "exit");
+        _resolver.GetOwnLockKey(ctx).ShouldBe(ctx.LockKey + ":exit");
+    }
+
+    [Fact]
+    public void GetOwnLockKey_WithUpdateDataTransition_ShouldUseUpdateDataLabel()
+    {
+        var ctx = CreateContext(updateDataKey: "updateData", transitionKey: "updateData");
+        _resolver.GetOwnLockKey(ctx).ShouldBe(ctx.LockKey + ":updatedata");
+    }
+
+    [Fact]
+    public void GetOwnLockKey_WithTimeoutTransition_ShouldUseTimeoutLabel()
+    {
+        var ctx = CreateContext(transitionKey: "$timeout");
+        ctx.Directives.MarkAsTimeoutTransition();
+        _resolver.GetOwnLockKey(ctx).ShouldBe(ctx.LockKey + ":timeout");
+    }
+
+    [Fact]
+    public void GetOwnLockKey_AllReservedTypes_ShouldDifferFromMainFlowLockKey()
+    {
+        var ctxCancel = CreateContext(cancelKey: "cancel", transitionKey: "cancel");
+        var ctxExit = CreateContext(exitKey: "exit", transitionKey: "exit");
+        var ctxUpdate = CreateContext(updateDataKey: "updateData", transitionKey: "updateData");
+        var ctxTimeout = CreateContext(transitionKey: "$timeout");
+        ctxTimeout.Directives.MarkAsTimeoutTransition();
+
+        _resolver.GetOwnLockKey(ctxCancel).ShouldNotBe(ctxCancel.LockKey);
+        _resolver.GetOwnLockKey(ctxExit).ShouldNotBe(ctxExit.LockKey);
+        _resolver.GetOwnLockKey(ctxUpdate).ShouldNotBe(ctxUpdate.LockKey);
+        _resolver.GetOwnLockKey(ctxTimeout).ShouldNotBe(ctxTimeout.LockKey);
     }
 
     private static TransitionExecutionContext CreateContext(

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/TransitionPipelineTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/TransitionPipelineTests.cs
@@ -20,7 +20,7 @@ namespace BBT.Workflow.Application.Tests.Execution.Transitions.Pipeline;
 
 /// <summary>
 /// Unit tests for TransitionPipeline.
-/// Validates request-scoped lock, reserved transition bypass, auto-chain under single lock,
+/// Validates request-scoped lock, reserved transition own lock, auto-chain under single lock,
 /// busy marking, and fault handling.
 /// </summary>
 public class TransitionPipelineTests
@@ -67,6 +67,11 @@ public class TransitionPipelineTests
         _mockReservedResolver
             .IsReserved(Arg.Any<TransitionExecutionContext>())
             .Returns(false);
+
+        // Default: own lock key = main lock key + ":reserved"
+        _mockReservedResolver
+            .GetOwnLockKey(Arg.Any<TransitionExecutionContext>())
+            .Returns(ctx => ctx.ArgAt<TransitionExecutionContext>(0).LockKey + ":reserved");
 
         // Default: busy marker succeeds silently
         _mockBusyMarker
@@ -184,11 +189,12 @@ public class TransitionPipelineTests
     #region Reserved Transition Tests
 
     [Fact]
-    public async Task RunAsync_WhenReservedTransition_ShouldBypassLockAndBusy()
+    public async Task RunAsync_WhenReservedTransition_ShouldAcquireOwnLockKeyNotMainLockKey()
     {
         // Arrange
         var context = CreateTransitionExecutionContext("cancel");
         var workflowContext = CreateWorkflowExecutionContext(context);
+        var expectedOwnKey = context.LockKey + ":reserved";
 
         SetupContextFactory(context);
         SetupStepsToSucceed();
@@ -203,13 +209,91 @@ public class TransitionPipelineTests
         // Assert
         result.IsSuccess.ShouldBeTrue();
 
-        // Lock should NOT be acquired
-        await _mockLockScopeFactory.DidNotReceive()
-            .AcquireAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        // Must acquire the own (type-specific) key, not the main flow lock key
+        await _mockLockScopeFactory.Received(1)
+            .AcquireAsync(expectedOwnKey, Arg.Any<CancellationToken>());
 
-        // Busy should NOT be marked
+        await _mockLockScopeFactory.DidNotReceive()
+            .AcquireAsync(context.LockKey, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenReservedNonResume_ShouldNotMarkBusy()
+    {
+        // Arrange
+        var context = CreateTransitionExecutionContext("cancel");
+        var workflowContext = CreateWorkflowExecutionContext(context);
+
+        SetupContextFactory(context);
+        SetupStepsToSucceed();
+
+        _mockReservedResolver
+            .IsReserved(Arg.Any<TransitionExecutionContext>())
+            .Returns(true);
+
+        // Act
+        await _pipeline.RunAsync(workflowContext, CancellationToken.None);
+
+        // Assert: busy NOT marked for non-subflow-resume reserved transitions
         await _mockBusyMarker.DidNotReceive()
             .MarkBusyAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenSubFlowResume_ShouldAcquireResumeKeyAndMarkBusy()
+    {
+        // Arrange
+        var context = CreateTransitionExecutionContext("resume");
+        context.Directives.MarkAsSubFlowResume();
+        var workflowContext = CreateWorkflowExecutionContext(context);
+        var expectedOwnKey = context.LockKey + ":reserved"; // default mock returns :reserved
+
+        SetupContextFactory(context);
+        SetupStepsToSucceed();
+
+        _mockReservedResolver
+            .IsReserved(Arg.Any<TransitionExecutionContext>())
+            .Returns(true);
+
+        // Act
+        var result = await _pipeline.RunAsync(workflowContext, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+
+        await _mockLockScopeFactory.Received(1)
+            .AcquireAsync(expectedOwnKey, Arg.Any<CancellationToken>());
+
+        // Busy MUST be marked for subflow resume
+        await _mockBusyMarker.Received(1)
+            .MarkBusyAsync(context.InstanceId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenReservedLockFails_ShouldReturnConflictError()
+    {
+        // Arrange
+        var context = CreateTransitionExecutionContext("cancel");
+        var workflowContext = CreateWorkflowExecutionContext(context);
+
+        SetupContextFactory(context);
+        SetupStepsToSucceed();
+
+        _mockReservedResolver
+            .IsReserved(Arg.Any<TransitionExecutionContext>())
+            .Returns(true);
+
+        var failedScope = CreateNotAcquiredLockScope();
+        _mockLockScopeFactory
+            .AcquireAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(failedScope);
+
+        // Act
+        var result = await _pipeline.RunAsync(workflowContext, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeFalse();
+        result.Error.Code.ShouldBe(WorkflowErrorCodes.ConflictWorkflow);
     }
 
     #endregion

--- a/test/BBT.Workflow.Domain.Tests/Definitions/Tasks/SoapTaskTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Definitions/Tasks/SoapTaskTests.cs
@@ -1,0 +1,198 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using BBT.Workflow.Definitions;
+using Xunit;
+
+namespace BBT.Workflow.Definitions.Tasks;
+
+public class SoapTaskTests
+{
+    private static string MakeConfig(
+        string url = "http://example.com/service.asmx",
+        string soapAction = "http://example.com/GetData",
+        string soapVersion = "1.1",
+        string? body = null,
+        int timeoutSeconds = 30,
+        bool validateSsl = true,
+        string[]? acceptedStatusCodes = null)
+    {
+        var obj = new Dictionary<string, object>
+        {
+            ["url"] = url,
+            ["soapAction"] = soapAction,
+            ["soapVersion"] = soapVersion,
+            ["timeoutSeconds"] = timeoutSeconds,
+            ["validateSsl"] = validateSsl
+        };
+        if (body != null) obj["body"] = body;
+        if (acceptedStatusCodes != null) obj["acceptedStatusCodes"] = acceptedStatusCodes;
+        return JsonSerializer.Serialize(obj);
+    }
+
+    [Fact]
+    public void Create_ShouldParseAllPropertiesFromJson()
+    {
+        var config = MakeConfig(
+            url: "http://example.com/svc.asmx",
+            soapAction: "http://example.com/Op",
+            soapVersion: "1.2",
+            body: "<soap:Envelope/>",
+            timeoutSeconds: 60,
+            validateSsl: false,
+            acceptedStatusCodes: ["500"]);
+
+        var task = SoapTask.Create(config.ToJsonElement());
+
+        Assert.Equal("http://example.com/svc.asmx", task.Url);
+        Assert.Equal("http://example.com/Op", task.SoapAction);
+        Assert.Equal("1.2", task.SoapVersion);
+        Assert.Equal("<soap:Envelope/>", task.Body);
+        Assert.Equal(60, task.TimeoutSeconds);
+        Assert.False(task.ValidateSSL);
+        Assert.NotNull(task.AcceptedStatusCodes);
+        Assert.Contains("500", task.AcceptedStatusCodes);
+    }
+
+    [Fact]
+    public void Create_Defaults_ShouldBeSet()
+    {
+        var config = MakeConfig();
+        var task = SoapTask.Create(config.ToJsonElement());
+
+        Assert.Equal("1.1", task.SoapVersion);
+        Assert.Equal(30, task.TimeoutSeconds);
+        Assert.True(task.ValidateSSL);
+        Assert.Null(task.AcceptedStatusCodes);
+    }
+
+    [Fact]
+    public void Type_ShouldBe16()
+    {
+        var task = SoapTask.Create(MakeConfig().ToJsonElement());
+        Assert.Equal("16", task.Type);
+    }
+
+    [Fact]
+    public void CloneTyped_ShouldProduceDeepCopy()
+    {
+        var config = MakeConfig(body: "<Envelope/>", soapVersion: "1.2");
+        var original = SoapTask.Create(config.ToJsonElement());
+        original.AddHeader("Authorization", "Basic xxx");
+
+        var clone = original.CloneTyped();
+
+        Assert.Equal(original.Url, clone.Url);
+        Assert.Equal(original.SoapAction, clone.SoapAction);
+        Assert.Equal(original.SoapVersion, clone.SoapVersion);
+        Assert.Equal(original.Body, clone.Body);
+        Assert.Equal(original.TimeoutSeconds, clone.TimeoutSeconds);
+        Assert.Equal(original.ValidateSSL, clone.ValidateSSL);
+
+        // Modifying clone headers must not affect original
+        clone.AddHeader("X-Extra", "value");
+        var originalHeaders = GetHeadersDictionary(original);
+        Assert.False(originalHeaders.ContainsKey("X-Extra"));
+    }
+
+    [Fact]
+    public void AddHeader_WhenHeadersNull_ShouldAddNewHeader()
+    {
+        var task = SoapTask.CreateEmpty();
+
+        task.AddHeader("Authorization", "Bearer token");
+
+        var headers = GetHeadersDictionary(task);
+        Assert.Single(headers);
+        Assert.Equal("Bearer token", headers["Authorization"]);
+    }
+
+    [Fact]
+    public void AddHeader_WhenKeyExists_ShouldOverrideValue()
+    {
+        var task = SoapTask.CreateEmpty();
+        task.SetHeaders(new Dictionary<string, string?> { ["Authorization"] = "old" });
+
+        task.AddHeader("Authorization", "new");
+
+        var headers = GetHeadersDictionary(task);
+        Assert.Single(headers);
+        Assert.Equal("new", headers["Authorization"]);
+    }
+
+    [Fact]
+    public void RemoveHeader_WhenKeyExists_ShouldRemoveIt()
+    {
+        var task = SoapTask.CreateEmpty();
+        task.SetHeaders(new Dictionary<string, string?> { ["X-A"] = "a", ["X-B"] = "b" });
+
+        task.RemoveHeader("X-A");
+
+        var headers = GetHeadersDictionary(task);
+        Assert.Single(headers);
+        Assert.False(headers.ContainsKey("X-A"));
+    }
+
+    [Fact]
+    public void RemoveHeader_WhenKeyDoesNotExist_ShouldDoNothing()
+    {
+        var task = SoapTask.CreateEmpty();
+        task.SetHeaders(new Dictionary<string, string?> { ["X-A"] = "a" });
+
+        task.RemoveHeader("X-Missing");
+
+        var headers = GetHeadersDictionary(task);
+        Assert.Single(headers);
+    }
+
+    [Fact]
+    public void Reset_ShouldRestoreDefaults()
+    {
+        var task = SoapTask.Create(MakeConfig(
+            url: "http://example.com",
+            soapVersion: "1.2",
+            timeoutSeconds: 60,
+            validateSsl: false));
+
+        task.Reset();
+
+        Assert.Equal(string.Empty, task.Url);
+        Assert.Equal(string.Empty, task.SoapAction);
+        Assert.Equal("1.1", task.SoapVersion);
+        Assert.Null(task.Body);
+        Assert.Null(task.Headers);
+        Assert.Equal(30, task.TimeoutSeconds);
+        Assert.True(task.ValidateSSL);
+        Assert.Null(task.AcceptedStatusCodes);
+    }
+
+    [Fact]
+    public void AcceptedStatusCodes_WithWildcardPattern_ShouldParse()
+    {
+        var config = MakeConfig(acceptedStatusCodes: ["5xx", "404"]);
+        var task = SoapTask.Create(config.ToJsonElement());
+
+        Assert.NotNull(task.AcceptedStatusCodes);
+        Assert.Contains("5xx", task.AcceptedStatusCodes);
+        Assert.Contains("404", task.AcceptedStatusCodes);
+    }
+
+    [Fact]
+    public void SetBody_ShouldUpdateBody()
+    {
+        var task = SoapTask.CreateEmpty();
+        const string xml = "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\"><soap:Body/></soap:Envelope>";
+
+        task.SetBody(xml);
+
+        Assert.Equal(xml, task.Body);
+    }
+
+    private static Dictionary<string, string?> GetHeadersDictionary(SoapTask task)
+    {
+        if (!task.Headers.HasValue)
+            return new Dictionary<string, string?>();
+        var json = task.Headers.Value.GetRawText();
+        return JsonSerializer.Deserialize<Dictionary<string, string?>>(json)
+               ?? new Dictionary<string, string?>();
+    }
+}

--- a/test/BBT.Workflow.Domain.Tests/Definitions/Tasks/SoapTaskTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Definitions/Tasks/SoapTaskTests.cs
@@ -149,9 +149,10 @@ public class SoapTaskTests
     {
         var task = SoapTask.Create(MakeConfig(
             url: "http://example.com",
+            soapAction: "",
             soapVersion: "1.2",
             timeoutSeconds: 60,
-            validateSsl: false));
+            validateSsl: false).ToJsonElement());
 
         task.Reset();
 


### PR DESCRIPTION
## Summary
- Add a first-class `SoapTask` supporting both SOAP 1.1 and SOAP 1.2 with envelope construction, action routing, and fault parsing
- Add `AcceptedStatusCodes` to `SoapTaskBinding` for treating non-2xx HTTP responses (e.g. `500`) as successful — required when SOAP faults carry a valid business payload over HTTP 500
- Fix a deadlock in `TransitionPipeline`: reserved transitions (subflow resume, cancel, exit, updateData, timeout) now acquire independent type-specific lock keys instead of re-acquiring or bypassing the main flow lock

## Changes
- `src/BBT.Workflow.Domain/Definitions/Tasks/SoapTask.cs` — new domain task model
- `src/BBT.Workflow.Execution.Abstractions/Bindings/SoapTaskBinding.cs` — binding record with `AcceptedStatusCodes`
- `src/BBT.Workflow.Execution/Invokers/SoapTaskInvoker.cs` — full SOAP invoker with wildcard status matching
- `src/BBT.Workflow.Application/Tasks/Executors/Http/SoapTaskExecutor.cs` — application-layer executor
- `src/BBT.Workflow.Application/Tasks/Mapping/TaskBindingMapper.cs` — mapping for new fields
- `src/BBT.Workflow.Domain/Execution/Transitions/Pipeline/IReservedTransitionResolver.cs` — `RequiresOwnLock` → `GetOwnLockKey`
- `src/BBT.Workflow.Application/Execution/Transitions/Pipeline/ReservedTransitionResolver.cs` — type-labelled keys (`:resume`, `:cancel`, `:exit`, `:updatedata`, `:timeout`)
- `src/BBT.Workflow.Application/Execution/Transitions/Pipeline/TransitionPipeline.cs` — single reserved path using `GetOwnLockKey`

## Test Plan
- [ ] `dotnet test test/BBT.Workflow.Domain.Tests` — SoapTask domain tests
- [ ] `dotnet test test/BBT.Workflow.Application.Tests --filter "ReservedTransitionResolverTests|TransitionPipelineTests"` — lock key tests
- [ ] Deploy to dev, configure a SoapTask pointing to a SOAP 1.1 and a SOAP 1.2 endpoint, verify success parsing
- [ ] Trigger a SOAP fault (HTTP 500); verify it succeeds when `acceptedStatusCodes: ["500"]` is set
- [ ] Verify a sync subflow scenario no longer throws `InstanceLockConflict`

## Notes
`IReservedTransitionResolver.RequiresOwnLock` has been removed — any external mock or implementation of this interface must be updated to implement `GetOwnLockKey(context)` instead.

## Summary by Sourcery

Introduce first-class SOAP task support and adjust reserved transition locking semantics to avoid instance lock conflicts.

New Features:
- Add a dedicated SoapTask domain model with SOAP 1.1/1.2 configuration, custom headers, and accepted HTTP status codes.
- Introduce SoapTaskBinding, SoapTaskInvoker, and SoapTaskExecutor to execute SOAP endpoints with envelope handling, fault detection, and wildcard-accepted status codes.
- Register SOAP as a workflow task type across task enums, task type strings, DI registration, and task envelope mapping.

Bug Fixes:
- Change reserved transition handling so each reserved transition type acquires its own lock key and subflow resume still marks the instance busy, preventing deadlocks and lock conflicts.

Enhancements:
- Replace IReservedTransitionResolver.RequiresOwnLock with GetOwnLockKey to centralize reserved lock key calculation and support type-specific keys for cancel, exit, updateData, timeout, and resume.

Tests:
- Add unit tests for SoapTask configuration, headers, cloning, and accepted status codes.
- Expand ReservedTransitionResolver and TransitionPipeline tests to cover type-specific reserved lock keys, busy marking behavior, and conflict handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added SOAP task support to workflows, enabling integration of SOAP web services with configurable endpoints, SOAP actions, versions, request bodies, headers, timeouts, and SSL validation. Supports wildcard patterns for accepted HTTP status codes.

## Improvements
* Enhanced reserved transition locking strategy for improved concurrent execution control during workflow state transitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/burgan-tech/vnext/pull/685?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->