### PR TITLE
feat(soap): add xml scripting helpers and expose raw response body

### DIFF
--- a/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Functions/ScriptBase.cs
+++ b/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Functions/ScriptBase.cs
@@ -4,6 +4,7 @@ using System.Dynamic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using System.Xml;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
@@ -568,6 +569,41 @@ public abstract class ScriptBase
 
         return [];
     }
+
+    #endregion
+
+    #region XML Helper Functions
+
+    /// <summary>
+    /// Parses an XML string into an <see cref="XmlDocument"/>.
+    /// Returns <c>null</c> for null/whitespace input or any parse error — never throws.
+    /// </summary>
+    /// <param name="xmlString">Raw XML string to parse</param>
+    /// <returns>Parsed <see cref="XmlDocument"/>, or <c>null</c> on failure</returns>
+    protected static XmlDocument? ParseXml(string? xmlString)
+    {
+        if (string.IsNullOrWhiteSpace(xmlString))
+            return null;
+
+        try
+        {
+            var doc = new XmlDocument();
+            doc.LoadXml(xmlString);
+            return doc;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Serializes an <see cref="XmlDocument"/> to its XML string representation.
+    /// Returns <c>null</c> for a null input.
+    /// </summary>
+    /// <param name="xmlDoc">The document to serialize</param>
+    /// <returns>XML string, or <c>null</c> if <paramref name="xmlDoc"/> is null</returns>
+    protected static string? XmlToString(XmlDocument? xmlDoc) => xmlDoc?.OuterXml;
 
     #endregion
 

--- a/src/BBT.Workflow.Application/Scripting/ScriptEngine.cs
+++ b/src/BBT.Workflow.Application/Scripting/ScriptEngine.cs
@@ -50,6 +50,8 @@ public sealed class ScriptEngine(
         MetadataReference.CreateFromFile(typeof(ScriptBase).Assembly.Location),
         MetadataReference.CreateFromFile(typeof(JsonSerializableAttribute).Assembly.Location),
         MetadataReference.CreateFromFile(typeof(System.Text.Encodings.Web.JavaScriptEncoder).Assembly.Location),
+        MetadataReference.CreateFromFile(typeof(System.Xml.XmlDocument).Assembly.Location),
+        MetadataReference.CreateFromFile(typeof(System.Xml.Linq.XDocument).Assembly.Location),
     ]);
 
     /// <summary>
@@ -75,7 +77,9 @@ public sealed class ScriptEngine(
         "BBT.Workflow.Instances",
         "BBT.Workflow.Runtime",
         "BBT.Workflow.Scripting.Functions",
-        "BBT.Workflow.Definitions.Timer"
+        "BBT.Workflow.Definitions.Timer",
+        "System.Xml",
+        "System.Xml.Linq"
     };
     
     /// <summary>

--- a/src/BBT.Workflow.Application/Tasks/Executors/Core/TaskExecutorBase.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Core/TaskExecutorBase.cs
@@ -295,6 +295,7 @@ public abstract class TaskExecutorBase<TTask>(ILogger logger) : ITaskExecutor
         {
             IsSuccess = result?.IsSuccess == true,
             Data = result?.Data,
+            Body = result?.Body,
             StatusCode = result?.StatusCode,
             Headers = result?.Headers,
             ErrorMessage = result?.ErrorMessage,

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/SoapTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/SoapTask.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Xml;
 
 namespace BBT.Workflow.Definitions;
 
@@ -64,6 +65,12 @@ public sealed class SoapTask : WorkflowTask
     public void SetBody(string? body)
     {
         Body = body;
+    }
+
+    /// <summary>Serializes <paramref name="xmlDoc"/> to its outer XML and sets it as the request body.</summary>
+    public void SetBody(XmlDocument? xmlDoc)
+    {
+        Body = xmlDoc?.OuterXml;
     }
 
     public void SetSoapAction(string soapAction)

--- a/src/BBT.Workflow.Domain/Scripting/Models.cs
+++ b/src/BBT.Workflow.Domain/Scripting/Models.cs
@@ -108,6 +108,13 @@ public sealed class StandardTaskResponse
     /// Task type identifier.
     /// </summary>
     public string? TaskType { get; set; }
+
+    /// <summary>
+    /// Raw response body as a string. For SOAP/XML tasks this is the unparsed XML string;
+    /// for HTTP tasks it is the raw JSON/text payload. Use <c>ParseXml(Body)</c> in scripts
+    /// to convert to an <c>XmlDocument</c>.
+    /// </summary>
+    public string? Body { get; set; }
 }
 
 /// <summary>

--- a/test/BBT.Workflow.Domain.Tests/Definitions/Tasks/SoapTaskTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Definitions/Tasks/SoapTaskTests.cs
@@ -77,6 +77,9 @@ public class SoapTaskTests
     {
         var config = MakeConfig(body: "<Envelope/>", soapVersion: "1.2");
         var original = SoapTask.Create(config.ToJsonElement());
+        original.SetKeyInternal("testSoapTask");
+        original.SetDomainInternal("test");
+        original.SetVersionInternal("1.0.0");
         original.AddHeader("Authorization", "Basic xxx");
 
         var clone = original.CloneTyped();


### PR DESCRIPTION
## Summary
- Add `ParseXml` / `XmlToString` helpers to `ScriptBase` so mapping scripts can convert between raw XML strings and `XmlDocument` without try/catch boilerplate
- Add `SetBody(XmlDocument?)` overload on `SoapTask` for type-safe body construction
- Register `System.Xml` and `System.Xml.Linq` assemblies/namespaces in `ScriptEngine` defaults so XML types are available in all compiled mapping scripts out of the box
- Expose raw response body via `StandardTaskResponse.Body` so output handlers can access the unparsed XML/text string alongside the already-parsed `Data` dictionary

## Changes
- `modules/.../ScriptBase.cs` — new `#region XML Helper Functions` with `ParseXml` and `XmlToString`
- `src/BBT.Workflow.Application/Scripting/ScriptEngine.cs` — added `System.Xml` / `System.Xml.Linq` to default references and usings
- `src/BBT.Workflow.Domain/Definitions/Tasks/SoapTask.cs` — `SetBody(XmlDocument?)` overload
- `src/BBT.Workflow.Domain/Scripting/Models.cs` — `Body` property on `StandardTaskResponse`
- `src/BBT.Workflow.Application/Tasks/Executors/Core/TaskExecutorBase.cs` — map `result.Body` into `StandardTaskResponse`
- `test/.../SoapTaskTests.cs` — fix pre-existing `CloneTyped` test failure (missing key/domain/version setup)

## Test Plan
- [ ] Build solution: `dotnet build`
- [ ] Run Domain tests: `dotnet test test/BBT.Workflow.Domain.Tests` — all SoapTask tests pass
- [ ] In a mapping script, call `ParseXml(context.TaskResponse["task"].Body)` and verify `XmlDocument` is returned
- [ ] Verify `context.TaskResponse["task"].Body` contains the raw XML string in output handler

## Summary by Sourcery

Add XML scripting helpers and raw body support to SOAP task responses and scripts.

New Features:
- Provide ParseXml and XmlToString helper methods on ScriptBase for safe XML string and XmlDocument conversion in mapping scripts.
- Add a SoapTask.SetBody(XmlDocument?) overload to build SOAP request bodies from XmlDocument instances.
- Expose the raw response body string on StandardTaskResponse and propagate it from task execution results so scripts and handlers can access unparsed payloads.
- Make System.Xml and System.Xml.Linq assemblies and namespaces available by default in ScriptEngine-compiled scripts.

Tests:
- Adjust SoapTask cloning test setup to ensure CloneTyped deep copy validation passes with required key, domain, and version metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scripts now support XML and LINQ to XML processing
  * Task execution responses now include the raw response body
  * SOAP tasks can accept XML documents as request bodies

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/burgan-tech/vnext/pull/687?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->