### PR TITLE
Add vocabulary-aware runtime schema validation

### DIFF
--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
@@ -4,6 +4,7 @@ using BBT.Aether.AspNetCore.Controllers;
 using BBT.Aether.AspNetCore.Results;
 using BBT.Workflow.Domain.Shared;
 using BBT.Workflow.Gateway;
+using BBT.Workflow.HttpApi.Results;
 using BBT.Workflow.Instances;
 using BBT.Workflow.SubFlow;
 using Microsoft.AspNetCore.Mvc;
@@ -66,7 +67,7 @@ public sealed class InstanceController(
         }
 
         var result = await commandAppService.StartAsync(input, cancellationToken);
-        return FromResult(result);
+        return WorkflowResultActionResultMapper.ToActionResult(result, HttpContext);
     }
 
     [ApiExplorerSettings(IgnoreApi = true)]
@@ -104,7 +105,7 @@ public sealed class InstanceController(
         }
 
         var result = await commandAppService.StartAsync(input, cancellationToken);
-        return FromResult(result);
+        return WorkflowResultActionResultMapper.ToActionResult(result, HttpContext);
     }
 
     [ApiExplorerSettings(IgnoreApi = true)]
@@ -233,7 +234,7 @@ public sealed class InstanceController(
             input,
             cancellationToken);
         
-        return FromResult(result);
+        return WorkflowResultActionResultMapper.ToActionResult(result, HttpContext);
     }
 
     /// <summary>
@@ -280,7 +281,7 @@ public sealed class InstanceController(
         };
 
         var result = await retryAppService.RetryAsync(input, cancellationToken);
-        return FromResult(result);
+        return WorkflowResultActionResultMapper.ToActionResult(result, HttpContext);
     }
     
     /// <summary>
@@ -430,4 +431,4 @@ public sealed class InstanceController(
 
         return FromResult(result.Result);
     }
-} 
+}

--- a/src/BBT.Workflow.Application/Execution/Transitions/Validation/TransitionValidationService.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Validation/TransitionValidationService.cs
@@ -58,7 +58,44 @@ public class TransitionValidationService(
         if (!schemaResult.IsSuccess)
             return Result.Fail(schemaResult.Error);
 
-        return schemaValidator.Validate(schemaResult.Value!.Schema, context.DataElement);
+        return schemaValidator.Validate(
+            schemaResult.Value!.Schema,
+            context.DataElement,
+            CreateSchemaValidationOptions(context.Headers));
+    }
+
+    private static SchemaValidationOptions CreateSchemaValidationOptions(IReadOnlyDictionary<string, string?>? headers)
+    {
+        return new SchemaValidationOptions(
+            Culture: ResolveCulture(headers),
+            IncludeVocabularyDetails: true,
+            CustomValidationEnabled: true);
+    }
+
+    private static string ResolveCulture(IReadOnlyDictionary<string, string?>? headers)
+    {
+        if (headers is null)
+            return "en-US";
+
+        if (!headers.TryGetValue("accept-language", out var acceptLanguage) &&
+            !headers.TryGetValue("Accept-Language", out acceptLanguage))
+        {
+            return "en-US";
+        }
+
+        if (string.IsNullOrWhiteSpace(acceptLanguage))
+            return "en-US";
+
+        var firstLanguage = acceptLanguage
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .FirstOrDefault();
+
+        if (string.IsNullOrWhiteSpace(firstLanguage))
+            return "en-US";
+
+        return firstLanguage
+            .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .FirstOrDefault() ?? "en-US";
     }
 
     /// <inheritdoc />

--- a/src/BBT.Workflow.Domain/Validation/CachedJsonSchemaValidator.cs
+++ b/src/BBT.Workflow.Domain/Validation/CachedJsonSchemaValidator.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using BBT.Aether.Results;
 using BBT.Workflow.Domain;
 using Json.Schema;
+using Microsoft.Extensions.Logging;
 
 namespace BBT.Workflow.Validation;
 
@@ -18,6 +19,18 @@ namespace BBT.Workflow.Validation;
 public sealed class CachedJsonSchemaValidator : IJsonSchemaValidator
 {
     private readonly ConcurrentDictionary<string, JsonSchema> _schemaCache = new();
+    private readonly IReadOnlyDictionary<string, IJsonSchemaCustomValidationRule> _customRules;
+    private readonly ILogger<CachedJsonSchemaValidator>? _logger;
+
+    public CachedJsonSchemaValidator(
+        IEnumerable<IJsonSchemaCustomValidationRule>? customRules = null,
+        ILogger<CachedJsonSchemaValidator>? logger = null)
+    {
+        _customRules = (customRules ?? [])
+            .GroupBy(rule => rule.Name, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
+        _logger = logger;
+    }
 
     /// <summary>
     /// Validates the given JSON data against the specified JSON schema using Result Pattern.
@@ -28,6 +41,9 @@ public sealed class CachedJsonSchemaValidator : IJsonSchemaValidator
     /// <param name="data">JSON data to be validated. If null, an empty JSON object "{}" is used for validation</param>
     /// <returns>Result containing validation outcome. On failure, Error.ValidationErrors contains detailed field-level errors.</returns>
     public Result Validate(JsonElement jsonSchema, JsonElement? data)
+        => Validate(jsonSchema, data, SchemaValidationOptions.Default);
+
+    public Result Validate(JsonElement jsonSchema, JsonElement? data, SchemaValidationOptions options)
     {
         // Compute cache key based on schema content
         var cacheKey = ComputeCacheKey(jsonSchema);
@@ -36,7 +52,7 @@ public sealed class CachedJsonSchemaValidator : IJsonSchemaValidator
         var schema = _schemaCache.GetOrAdd(cacheKey, _ => BuildSchema(jsonSchema));
         
         // Validate using cached schema
-        return ValidateInternal(schema, data);
+        return ValidateInternal(schema, jsonSchema, data, options, _customRules, _logger);
     }
 
     /// <summary>
@@ -53,7 +69,8 @@ public sealed class CachedJsonSchemaValidator : IJsonSchemaValidator
             SchemaRegistry = new SchemaRegistry() // Instance-level registry per schema
         };
         
-        return JsonSchema.Build(jsonSchema, options);
+        var schemaWithoutVocabulary = JsonSchemaVocabularySanitizer.RemoveVocabularyKeywords(jsonSchema);
+        return JsonSchema.Build(schemaWithoutVocabulary, options);
     }
 
     /// <summary>
@@ -63,7 +80,13 @@ public sealed class CachedJsonSchemaValidator : IJsonSchemaValidator
     /// <param name="schema">The pre-built JsonSchema</param>
     /// <param name="data">The data to validate</param>
     /// <returns>Result containing validation outcome</returns>
-    private static Result ValidateInternal(JsonSchema schema, JsonElement? data)
+    private static Result ValidateInternal(
+        JsonSchema schema,
+        JsonElement jsonSchema,
+        JsonElement? data,
+        SchemaValidationOptions options,
+        IReadOnlyDictionary<string, IJsonSchemaCustomValidationRule> customRules,
+        ILogger<CachedJsonSchemaValidator>? logger)
     {
         var json = JsonDocument.Parse(data?.GetRawText() ?? "{}");
 
@@ -73,18 +96,136 @@ public sealed class CachedJsonSchemaValidator : IJsonSchemaValidator
             RequireFormatValidation = true
         });
 
-        if (validationResult.IsValid)
+        var customValidationErrors = options.CustomValidationEnabled
+            ? EvaluateCustomRules(jsonSchema, json.RootElement, options, customRules, logger)
+            : [];
+
+        if (validationResult.IsValid && customValidationErrors.Count == 0)
         {
             return Result.Ok();
         }
 
+        if (options.IncludeVocabularyDetails)
+        {
+            var details = validationResult.ToSchemaValidationProblemDetails(jsonSchema, options, customValidationErrors);
+
+            return Result.Fail(
+                Error.Validation(
+                    WorkflowErrorCodes.ValidationErrors,
+                    "JSON schema validation failed",
+                    details.ToValidationResults().AsReadOnly())
+                    with
+                    {
+                        Detail = JsonSerializer.Serialize(details)
+                    });
+        }
+
         var validationErrors = validationResult.ToValidationResults();
+        validationErrors.AddRange(customValidationErrors.Select(error =>
+            new System.ComponentModel.DataAnnotations.ValidationResult(error.Message, [error.Path])));
 
         return Result.Fail(
             Error.Validation(
                 WorkflowErrorCodes.ValidationErrors,
                 "JSON schema validation failed",
                 validationErrors.AsReadOnly()));
+    }
+
+    private static List<SchemaValidationErrorDetail> EvaluateCustomRules(
+        JsonElement jsonSchema,
+        JsonElement data,
+        SchemaValidationOptions options,
+        IReadOnlyDictionary<string, IJsonSchemaCustomValidationRule> customRules,
+        ILogger<CachedJsonSchemaValidator>? logger)
+    {
+        var metadata = JsonSchemaVocabularyMetadataResolver.Resolve(jsonSchema);
+        var errors = new List<SchemaValidationErrorDetail>();
+        EvaluateCustomRulesRecursive(data, string.Empty, metadata, options, customRules, logger, errors);
+        return errors;
+    }
+
+    private static void EvaluateCustomRulesRecursive(
+        JsonElement value,
+        string path,
+        JsonSchemaVocabularyMetadataResolver metadata,
+        SchemaValidationOptions options,
+        IReadOnlyDictionary<string, IJsonSchemaCustomValidationRule> customRules,
+        ILogger<CachedJsonSchemaValidator>? logger,
+        List<SchemaValidationErrorDetail> errors)
+    {
+        if (!string.IsNullOrEmpty(path) &&
+            metadata.FindField(path) is { } field &&
+            field.GetValidation() is { } validation &&
+            validation.TryGetProperty("rule", out var ruleElement) &&
+            ruleElement.ValueKind == JsonValueKind.String)
+        {
+            var ruleName = ruleElement.GetString();
+            if (!string.IsNullOrWhiteSpace(ruleName))
+            {
+                if (customRules.TryGetValue(ruleName, out var rule))
+                {
+                    JsonElement? parameters = validation.TryGetProperty("parameters", out var parameterElement)
+                        ? parameterElement
+                        : null;
+
+                    if (!rule.IsValid(value, parameters))
+                    {
+                        var message = ResolveCustomRuleMessage(validation, options.EffectiveCulture)
+                                      ?? "Validation failed";
+
+                        errors.Add(new SchemaValidationErrorDetail(
+                            Path: path,
+                            Keyword: "x-validation",
+                            Code: $"schema.x-validation.{ruleName}",
+                            Message: message,
+                            Label: field.ResolveLabel(options.EffectiveCulture),
+                            SchemaPath: null,
+                            Parameters: parameters?.ValueKind == JsonValueKind.Object
+                                ? parameters.Value.EnumerateObject()
+                                    .ToDictionary(p => p.Name, p => p.Value.Clone(), StringComparer.Ordinal)
+                                : new Dictionary<string, JsonElement>(StringComparer.Ordinal)));
+                    }
+                }
+                else
+                {
+                    logger?.LogWarning(
+                        "JSON schema custom validation rule {RuleName} is not registered. Skipping runtime validation for {Path}",
+                        ruleName,
+                        path);
+                }
+            }
+        }
+
+        if (value.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var property in value.EnumerateObject())
+            {
+                var childPath = string.IsNullOrEmpty(path) ? property.Name : $"{path}.{property.Name}";
+                EvaluateCustomRulesRecursive(property.Value, childPath, metadata, options, customRules, logger, errors);
+            }
+        }
+        else if (value.ValueKind == JsonValueKind.Array)
+        {
+            var index = 0;
+            foreach (var item in value.EnumerateArray())
+            {
+                var childPath = string.IsNullOrEmpty(path) ? index.ToString() : $"{path}.{index}";
+                EvaluateCustomRulesRecursive(item, childPath, metadata, options, customRules, logger, errors);
+                index++;
+            }
+        }
+    }
+
+    private static string? ResolveCustomRuleMessage(JsonElement validation, string culture)
+    {
+        if (!validation.TryGetProperty("errorMessages", out var messages) ||
+            messages.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        var message = JsonSchemaVocabularyMetadataResolver.ResolveLocalizedText(messages, culture);
+        return string.IsNullOrWhiteSpace(message) ? null : message;
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Domain/Validation/Contracts/IJsonSchemaValidator.cs
+++ b/src/BBT.Workflow.Domain/Validation/Contracts/IJsonSchemaValidator.cs
@@ -17,4 +17,13 @@ public interface IJsonSchemaValidator
     /// <param name="data">JSON data to be validated. In case of null, an empty JSON object is used.</param>
     /// <returns>Result containing validation outcome. On failure, Error.ValidationErrors contains detailed field-level errors.</returns>
     Result Validate(JsonElement jsonSchema, JsonElement? data);
+
+    /// <summary>
+    /// Validates the given JSON data against the specified JSON schema using vocabulary-aware options.
+    /// </summary>
+    /// <param name="jsonSchema">JSON schema to be used for validation.</param>
+    /// <param name="data">JSON data to be validated. In case of null, an empty JSON object is used.</param>
+    /// <param name="options">Validation options controlling localization and custom validation.</param>
+    /// <returns>Result containing validation outcome.</returns>
+    Result Validate(JsonElement jsonSchema, JsonElement? data, SchemaValidationOptions options);
 }

--- a/src/BBT.Workflow.Domain/Validation/IJsonSchemaCustomValidationRule.cs
+++ b/src/BBT.Workflow.Domain/Validation/IJsonSchemaCustomValidationRule.cs
@@ -1,0 +1,10 @@
+using System.Text.Json;
+
+namespace BBT.Workflow.Validation;
+
+public interface IJsonSchemaCustomValidationRule
+{
+    string Name { get; }
+
+    bool IsValid(JsonElement value, JsonElement? parameters);
+}

--- a/src/BBT.Workflow.Domain/Validation/JsonSchemaValidationMapper.cs
+++ b/src/BBT.Workflow.Domain/Validation/JsonSchemaValidationMapper.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using Json.Schema;
 
@@ -11,6 +12,64 @@ namespace BBT.Workflow.Validation;
 /// </summary>
 public static class JsonSchemaValidationMapper
 {
+    public static SchemaValidationProblemDetails ToSchemaValidationProblemDetails(
+        this EvaluationResults evaluation,
+        JsonElement schemaRoot,
+        SchemaValidationOptions options,
+        IEnumerable<SchemaValidationErrorDetail>? additionalErrors = null)
+    {
+        var culture = options.EffectiveCulture;
+        var metadata = JsonSchemaVocabularyMetadataResolver.Resolve(schemaRoot);
+        var errors = new List<SchemaValidationErrorDetail>();
+
+        if (!evaluation.IsValid)
+        {
+            foreach (var detail in FlattenErrors(evaluation))
+            {
+                var path = ToMemberPath(detail.InstanceLocation.ToString());
+                if (detail.Errors is null || detail.Errors.Count == 0)
+                {
+                    errors.Add(new SchemaValidationErrorDetail(
+                        Path: path,
+                        Keyword: "validation",
+                        Code: "schema.validation",
+                        Message: "Validation failed",
+                        Label: metadata.FindField(path)?.ResolveLabel(culture),
+                        SchemaPath: detail.EvaluationPath.ToString(),
+                        Parameters: new Dictionary<string, JsonElement>(StringComparer.Ordinal)));
+                    continue;
+                }
+
+                foreach (var error in detail.Errors)
+                {
+                    var field = metadata.FindField(path);
+                    var message = field?.ResolveErrorMessage(error.Key, culture) ?? Regex.Unescape(error.Value);
+                    errors.Add(new SchemaValidationErrorDetail(
+                        Path: path,
+                        Keyword: error.Key,
+                        Code: $"schema.{error.Key}",
+                        Message: message,
+                        Label: field?.ResolveLabel(culture),
+                        SchemaPath: detail.EvaluationPath.ToString(),
+                        Parameters: field?.GetKeywordParameters(error.Key) ??
+                                    new Dictionary<string, JsonElement>(StringComparer.Ordinal)));
+                }
+            }
+        }
+
+        if (additionalErrors is not null)
+            errors.AddRange(additionalErrors);
+
+        return new SchemaValidationProblemDetails(culture, errors);
+    }
+
+    public static List<ValidationResult> ToValidationResults(this SchemaValidationProblemDetails details)
+    {
+        return details.Errors
+            .Select(error => new ValidationResult(error.Message, [error.Path]))
+            .ToList();
+    }
+
     /// <summary>
     /// Converts JSON schema evaluation results into a collection of ValidationResult objects.
     /// This extension method flattens the hierarchical validation errors and maps them to 
@@ -84,4 +143,20 @@ public static class JsonSchemaValidationMapper
 
         return list;
     }
+
+    private static string ToMemberPath(string instanceLocation)
+    {
+        var path = instanceLocation.TrimStart('/');
+        if (string.IsNullOrWhiteSpace(path))
+            return "root";
+
+        return string.Join(
+            ".",
+            path.Split('/', StringSplitOptions.RemoveEmptyEntries)
+                .Select(UnescapePointerSegment));
+    }
+
+    private static string UnescapePointerSegment(string segment)
+        => segment.Replace("~1", "/", StringComparison.Ordinal)
+            .Replace("~0", "~", StringComparison.Ordinal);
 }

--- a/src/BBT.Workflow.Domain/Validation/JsonSchemaValidator.cs
+++ b/src/BBT.Workflow.Domain/Validation/JsonSchemaValidator.cs
@@ -12,6 +12,9 @@ namespace BBT.Workflow.Validation;
 /// </summary>
 public sealed class JsonSchemaValidator : IJsonSchemaValidator
 {
+    public Result Validate(JsonElement jsonSchema, JsonElement? data)
+        => Validate(jsonSchema, data, SchemaValidationOptions.Default);
+
     /// <summary>
     /// Validates the given JSON data against the specified JSON schema using Result Pattern.
     /// Uses hierarchical output format and requires format validation for comprehensive validation.
@@ -20,9 +23,10 @@ public sealed class JsonSchemaValidator : IJsonSchemaValidator
     /// <param name="jsonSchema">JSON schema to be used for validation</param>
     /// <param name="data">JSON data to be validated. If null, an empty JSON object "{}" is used for validation</param>
     /// <returns>Result containing validation outcome. On failure, Error.ValidationErrors contains detailed field-level errors.</returns>
-    public Result Validate(JsonElement jsonSchema, JsonElement? data)
+    public Result Validate(JsonElement jsonSchema, JsonElement? data, SchemaValidationOptions options)
     {
-        var schema = JsonSchema.FromText(jsonSchema.GetRawText());
+        var schemaWithoutVocabulary = JsonSchemaVocabularySanitizer.RemoveVocabularyKeywords(jsonSchema);
+        var schema = JsonSchema.FromText(schemaWithoutVocabulary.GetRawText());
         var json = JsonDocument.Parse(data?.GetRawText() ?? "{}");
 
         var validationResult = schema.Evaluate(json.RootElement, new EvaluationOptions()
@@ -34,6 +38,20 @@ public sealed class JsonSchemaValidator : IJsonSchemaValidator
         if (validationResult.IsValid)
         {
             return Result.Ok();
+        }
+
+        if (options.IncludeVocabularyDetails)
+        {
+            var details = validationResult.ToSchemaValidationProblemDetails(jsonSchema, options);
+            return Result.Fail(
+                Error.Validation(
+                    WorkflowErrorCodes.ValidationErrors,
+                    "JSON schema validation failed",
+                    details.ToValidationResults().AsReadOnly())
+                    with
+                    {
+                        Detail = JsonSerializer.Serialize(details)
+                    });
         }
 
         var validationErrors = validationResult.ToValidationResults();

--- a/src/BBT.Workflow.Domain/Validation/JsonSchemaVocabularyMetadataResolver.cs
+++ b/src/BBT.Workflow.Domain/Validation/JsonSchemaVocabularyMetadataResolver.cs
@@ -1,0 +1,237 @@
+using System.Text.Json;
+
+namespace BBT.Workflow.Validation;
+
+internal sealed class JsonSchemaVocabularyMetadataResolver
+{
+    private const string PropertiesKey = "properties";
+    private const string ItemsKey = "items";
+    private const string LabelsKey = "x-labels";
+    private const string LegacyLabelsKey = "labels";
+    private const string ErrorMessagesKey = "x-errorMessages";
+    private const string ValidationKey = "x-validation";
+
+    private readonly Dictionary<string, JsonSchemaVocabularyField> _fields = new(StringComparer.Ordinal);
+
+    private JsonSchemaVocabularyMetadataResolver(JsonElement schemaRoot)
+    {
+        Parse(schemaRoot, string.Empty);
+    }
+
+    public static JsonSchemaVocabularyMetadataResolver Resolve(JsonElement schemaRoot) => new(schemaRoot);
+
+    public JsonSchemaVocabularyField? FindField(string path)
+    {
+        if (_fields.TryGetValue(path, out var field))
+            return field;
+
+        return _fields.TryGetValue(NormalizeArrayPath(path), out field) ? field : null;
+    }
+
+    public static string ResolveLocalizedText(JsonElement localizedText, string culture)
+    {
+        if (localizedText.ValueKind != JsonValueKind.Object)
+            return string.Empty;
+
+        var requested = string.IsNullOrWhiteSpace(culture) ? "en-US" : culture.Trim();
+        var neutral = requested.Split('-', 2)[0];
+
+        if (TryGetString(localizedText, requested, out var exact))
+            return exact;
+
+        if (TryGetString(localizedText, neutral, out var neutralExact))
+            return neutralExact;
+
+        foreach (var item in localizedText.EnumerateObject())
+        {
+            if (item.Name.StartsWith(neutral + "-", StringComparison.OrdinalIgnoreCase) &&
+                item.Value.ValueKind == JsonValueKind.String)
+            {
+                return item.Value.GetString()!;
+            }
+        }
+
+        if (TryGetString(localizedText, "en-US", out var english))
+            return english;
+
+        if (TryGetString(localizedText, "en", out var neutralEnglish))
+            return neutralEnglish;
+
+        foreach (var item in localizedText.EnumerateObject())
+        {
+            if (item.Value.ValueKind == JsonValueKind.String)
+                return item.Value.GetString()!;
+        }
+
+        return string.Empty;
+    }
+
+    private void Parse(JsonElement node, string path)
+    {
+        if (node.ValueKind != JsonValueKind.Object)
+            return;
+
+        if (!string.IsNullOrEmpty(path))
+        {
+            _fields[path] = new JsonSchemaVocabularyField(path, node);
+        }
+
+        if (node.TryGetProperty(PropertiesKey, out var properties) && properties.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var property in properties.EnumerateObject())
+            {
+                var childPath = string.IsNullOrEmpty(path) ? property.Name : $"{path}.{property.Name}";
+                Parse(property.Value, childPath);
+            }
+        }
+
+        if (node.TryGetProperty(ItemsKey, out var items) && items.ValueKind == JsonValueKind.Object)
+        {
+            Parse(items, string.IsNullOrEmpty(path) ? "[]" : $"{path}[]");
+        }
+    }
+
+    private static bool TryGetString(JsonElement element, string propertyName, out string value)
+    {
+        foreach (var property in element.EnumerateObject())
+        {
+            if (property.Name.Equals(propertyName, StringComparison.OrdinalIgnoreCase) &&
+                property.Value.ValueKind == JsonValueKind.String)
+            {
+                value = property.Value.GetString()!;
+                return true;
+            }
+        }
+
+        value = string.Empty;
+        return false;
+    }
+
+    private static string NormalizeArrayPath(string path)
+    {
+        var parts = path.Split('.', StringSplitOptions.RemoveEmptyEntries);
+        for (var i = 0; i < parts.Length; i++)
+        {
+            if (int.TryParse(parts[i], out _))
+            {
+                parts[i] = "[]";
+            }
+        }
+
+        return string.Join('.', parts).Replace(".[].", "[].", StringComparison.Ordinal);
+    }
+
+    internal sealed class JsonSchemaVocabularyField(string path, JsonElement schemaNode)
+    {
+        public string Path { get; } = path;
+
+        public JsonElement SchemaNode { get; } = schemaNode.Clone();
+
+        public string? ResolveLabel(string culture)
+        {
+            if (SchemaNode.TryGetProperty(LabelsKey, out var labels))
+            {
+                var label = ResolveLocalizedText(labels, culture);
+                if (!string.IsNullOrWhiteSpace(label))
+                    return label;
+            }
+
+            if (SchemaNode.TryGetProperty(LegacyLabelsKey, out var legacyLabels) &&
+                legacyLabels.ValueKind == JsonValueKind.Array)
+            {
+                return ResolveLegacyLabel(legacyLabels, culture);
+            }
+
+            return null;
+        }
+
+        public string? ResolveErrorMessage(string keyword, string culture)
+        {
+            if (!SchemaNode.TryGetProperty(ErrorMessagesKey, out var errorMessages) ||
+                errorMessages.ValueKind != JsonValueKind.Object ||
+                !TryGetProperty(errorMessages, keyword, out var localizedText))
+            {
+                return null;
+            }
+
+            var message = ResolveLocalizedText(localizedText, culture);
+            return string.IsNullOrWhiteSpace(message) ? null : message;
+        }
+
+        public JsonElement? GetValidation()
+        {
+            return SchemaNode.TryGetProperty(ValidationKey, out var validation) &&
+                   validation.ValueKind == JsonValueKind.Object
+                ? validation.Clone()
+                : null;
+        }
+
+        public IReadOnlyDictionary<string, JsonElement> GetKeywordParameters(string keyword)
+        {
+            var parameters = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+            if (SchemaNode.TryGetProperty(keyword, out var value))
+            {
+                parameters[keyword] = value.Clone();
+            }
+
+            return parameters;
+        }
+
+        private static bool TryGetProperty(JsonElement element, string propertyName, out JsonElement value)
+        {
+            foreach (var property in element.EnumerateObject())
+            {
+                if (property.Name.Equals(propertyName, StringComparison.Ordinal))
+                {
+                    value = property.Value;
+                    return true;
+                }
+            }
+
+            value = default;
+            return false;
+        }
+
+        private static string? ResolveLegacyLabel(JsonElement labels, string culture)
+        {
+            var requested = string.IsNullOrWhiteSpace(culture) ? "en-US" : culture.Trim();
+            var neutral = requested.Split('-', 2)[0];
+            string? first = null;
+            string? english = null;
+            string? neutralMatch = null;
+
+            foreach (var item in labels.EnumerateArray())
+            {
+                if (item.ValueKind != JsonValueKind.Object ||
+                    !item.TryGetProperty("language", out var languageElement) ||
+                    !item.TryGetProperty("label", out var labelElement) ||
+                    languageElement.ValueKind != JsonValueKind.String ||
+                    labelElement.ValueKind != JsonValueKind.String)
+                {
+                    continue;
+                }
+
+                var language = languageElement.GetString();
+                var label = labelElement.GetString();
+                if (string.IsNullOrWhiteSpace(language) || string.IsNullOrWhiteSpace(label))
+                    continue;
+
+                first ??= label;
+
+                if (language.Equals(requested, StringComparison.OrdinalIgnoreCase))
+                    return label;
+
+                if (language.Equals("en-US", StringComparison.OrdinalIgnoreCase))
+                    english ??= label;
+
+                if (language.Equals(neutral, StringComparison.OrdinalIgnoreCase) ||
+                    language.StartsWith(neutral + "-", StringComparison.OrdinalIgnoreCase))
+                {
+                    neutralMatch ??= label;
+                }
+            }
+
+            return neutralMatch ?? english ?? first;
+        }
+    }
+}

--- a/src/BBT.Workflow.Domain/Validation/JsonSchemaVocabularySanitizer.cs
+++ b/src/BBT.Workflow.Domain/Validation/JsonSchemaVocabularySanitizer.cs
@@ -1,0 +1,76 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace BBT.Workflow.Validation;
+
+internal static class JsonSchemaVocabularySanitizer
+{
+    private static readonly string[] SchemaMapKeywords =
+    [
+        "$defs",
+        "definitions",
+        "dependentSchemas",
+        "patternProperties",
+        "properties"
+    ];
+
+    private static readonly string[] VocabularyKeywords =
+    [
+        "labels",
+        "x-labels",
+        "x-errorMessages",
+        "x-enum",
+        "x-validation"
+    ];
+
+    public static JsonElement RemoveVocabularyKeywords(JsonElement schema)
+    {
+        var node = JsonNode.Parse(schema.GetRawText());
+        if (node is null)
+        {
+            return schema.Clone();
+        }
+
+        RemoveVocabularyKeywords(node, isSchemaMap: false);
+
+        using var document = JsonDocument.Parse(node.ToJsonString());
+        return document.RootElement.Clone();
+    }
+
+    private static void RemoveVocabularyKeywords(JsonNode node, bool isSchemaMap)
+    {
+        if (node is JsonObject obj)
+        {
+            if (!isSchemaMap)
+            {
+                foreach (var keyword in VocabularyKeywords)
+                {
+                    obj.Remove(keyword);
+                }
+            }
+
+            foreach (var property in obj.ToList())
+            {
+                if (property.Value is not null)
+                {
+                    RemoveVocabularyKeywords(
+                        property.Value,
+                        property.Value is JsonObject && IsSchemaMapKeyword(property.Key));
+                }
+            }
+        }
+        else if (node is JsonArray array)
+        {
+            foreach (var item in array)
+            {
+                if (item is not null)
+                {
+                    RemoveVocabularyKeywords(item, isSchemaMap: false);
+                }
+            }
+        }
+    }
+
+    private static bool IsSchemaMapKeyword(string keyword)
+        => SchemaMapKeywords.Any(item => item.Equals(keyword, StringComparison.Ordinal));
+}

--- a/src/BBT.Workflow.Domain/Validation/SchemaValidationOptions.cs
+++ b/src/BBT.Workflow.Domain/Validation/SchemaValidationOptions.cs
@@ -1,0 +1,11 @@
+namespace BBT.Workflow.Validation;
+
+public sealed record SchemaValidationOptions(
+    string? Culture = null,
+    bool IncludeVocabularyDetails = false,
+    bool CustomValidationEnabled = false)
+{
+    public static SchemaValidationOptions Default { get; } = new();
+
+    public string EffectiveCulture => string.IsNullOrWhiteSpace(Culture) ? "en-US" : Culture.Trim();
+}

--- a/src/BBT.Workflow.Domain/Validation/SchemaValidationProblemDetails.cs
+++ b/src/BBT.Workflow.Domain/Validation/SchemaValidationProblemDetails.cs
@@ -1,0 +1,16 @@
+using System.Text.Json;
+
+namespace BBT.Workflow.Validation;
+
+public sealed record SchemaValidationProblemDetails(
+    string Culture,
+    IReadOnlyList<SchemaValidationErrorDetail> Errors);
+
+public sealed record SchemaValidationErrorDetail(
+    string Path,
+    string Keyword,
+    string Code,
+    string Message,
+    string? Label,
+    string? SchemaPath,
+    IReadOnlyDictionary<string, JsonElement> Parameters);

--- a/src/BBT.Workflow.HttpApi.Shared/Results/WorkflowResultActionResultMapper.cs
+++ b/src/BBT.Workflow.HttpApi.Shared/Results/WorkflowResultActionResultMapper.cs
@@ -1,0 +1,107 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
+using BBT.Aether.AspNetCore.Results;
+using BBT.Aether.Results;
+using BBT.Workflow.Validation;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BBT.Workflow.HttpApi.Results;
+
+public static class WorkflowResultActionResultMapper
+{
+    private static readonly JsonSerializerOptions DetailJsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    public static IActionResult ToActionResult(Result result, HttpContext httpContext)
+    {
+        if (!result.IsSuccess && TryGetSchemaValidationDetails(result.Error, out var details))
+            return CreateSchemaValidationActionResult(result.Error, details, httpContext);
+
+        return result.ToActionResult(httpContext);
+    }
+
+    public static IActionResult ToActionResult<T>(Result<T> result, HttpContext httpContext)
+    {
+        if (!result.IsSuccess && TryGetSchemaValidationDetails(result.Error, out var details))
+            return CreateSchemaValidationActionResult(result.Error, details, httpContext);
+
+        return result.ToActionResult(httpContext);
+    }
+
+    private static IActionResult CreateSchemaValidationActionResult(
+        Error error,
+        SchemaValidationProblemDetails details,
+        HttpContext httpContext)
+    {
+        httpContext.Response.Headers["_aether_error_format"] = "true";
+
+        return new ObjectResult(new
+        {
+            Error = new
+            {
+                error.Prefix,
+                error.Code,
+                error.Message,
+                Details = (string?)null,
+                error.Target,
+                ValidationErrors = ToValidationErrorInfo(error.ValidationErrors),
+                Data = new
+                {
+                    Validation = new
+                    {
+                        details.Errors
+                    }
+                }
+            }
+        })
+        {
+            StatusCode = StatusCodes.Status400BadRequest
+        };
+    }
+
+    private static IReadOnlyList<object> ToValidationErrorInfo(IEnumerable<ValidationResult>? validationErrors)
+    {
+        var errors = validationErrors?.ToArray();
+        if (errors is null || errors.Length == 0)
+            return [];
+
+        return errors
+            .Select(error => new
+            {
+                Message = error.ErrorMessage,
+                Members = error.MemberNames.ToArray()
+            })
+            .Cast<object>()
+            .ToArray();
+    }
+
+    private static bool TryGetSchemaValidationDetails(
+        Error error,
+        out SchemaValidationProblemDetails details)
+    {
+        details = default!;
+
+        if (string.IsNullOrWhiteSpace(error.Detail))
+            return false;
+
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<SchemaValidationProblemDetails>(
+                error.Detail,
+                DetailJsonOptions);
+
+            if (parsed is null || parsed.Errors.Count == 0)
+                return false;
+
+            details = parsed;
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Validation/TransitionValidationServiceTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Validation/TransitionValidationServiceTests.cs
@@ -160,6 +160,41 @@ public class TransitionValidationServiceTests
         // Obsolete - logging is now tested in specification unit tests
     }
 
+    [Fact]
+    public async Task ValidateAsync_WithAcceptLanguageHeader_ShouldPassCultureToSchemaValidator()
+    {
+        // Arrange
+        var schemaRef = new Reference("test-schema", "test-domain", "sys-schemas", "1.0.0");
+        var context = CreateTransitionContextWithSchema(schemaRef, new Dictionary<string, string?>
+        {
+            ["accept-language"] = "tr-TR,tr;q=0.9,en-US;q=0.8"
+        });
+        var schemaDefinition = CreateMockSchemaDefinition("test-schema");
+        SchemaValidationOptions? capturedOptions = null;
+
+        _mockComponentCacheStore
+            .Setup(x => x.GetSchemaAsync(schemaRef.Domain, schemaRef.Key, schemaRef.Version, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<SchemaDefinition>.Ok(schemaDefinition));
+
+        _mockSchemaValidator
+            .Setup(x => x.Validate(
+                schemaDefinition.Schema,
+                It.IsAny<JsonElement?>(),
+                It.IsAny<SchemaValidationOptions>()))
+            .Callback<JsonElement, JsonElement?, SchemaValidationOptions>((_, _, options) => capturedOptions = options)
+            .Returns(Result.Ok());
+
+        // Act
+        var result = await _service.ValidateAsync(context, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        capturedOptions.ShouldNotBeNull();
+        capturedOptions!.Culture.ShouldBe("tr-TR");
+        capturedOptions.IncludeVocabularyDetails.ShouldBeTrue();
+        capturedOptions.CustomValidationEnabled.ShouldBeTrue();
+    }
+
     [Fact(Skip = "Extension methods cannot be mocked")]
     public async Task ValidateAsync_WithValidationErrors_ShouldIncludeTransitionKey()
     {
@@ -497,7 +532,8 @@ public class TransitionValidationServiceTests
         // Skipping policy validation tests as they're covered by specification unit tests
     }
 
-    private TransitionExecutionContext CreateValidTransitionContext()
+    private TransitionExecutionContext CreateValidTransitionContext(
+        IReadOnlyDictionary<string, string?>? headers = null)
     {
         var instanceId = Guid.NewGuid();
         var workflowKey = "test-workflow";
@@ -526,13 +562,16 @@ public class TransitionValidationServiceTests
             Instance = instance,
             Data = new { test = "data" },
             TraceId = Guid.NewGuid().ToString("N"),
-            SpanId = Guid.NewGuid().ToString("N")[..16]
+            SpanId = Guid.NewGuid().ToString("N")[..16],
+            Headers = headers ?? new Dictionary<string, string?>()
         };
     }
 
-    private TransitionExecutionContext CreateTransitionContextWithSchema(Reference schemaRef)
+    private TransitionExecutionContext CreateTransitionContextWithSchema(
+        Reference schemaRef,
+        IReadOnlyDictionary<string, string?>? headers = null)
     {
-        var context = CreateValidTransitionContext();
+        var context = CreateValidTransitionContext(headers);
         typeof(Transition)
             .GetProperty(nameof(Transition.Schema))!
             .SetValue(context.Transition, schemaRef);

--- a/test/BBT.Workflow.Application.Tests/HttpApi/Results/WorkflowResultActionResultMapperTests.cs
+++ b/test/BBT.Workflow.Application.Tests/HttpApi/Results/WorkflowResultActionResultMapperTests.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
+using BBT.Aether.Results;
+using BBT.Workflow.HttpApi.Results;
+using BBT.Workflow.Validation;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace BBT.Workflow.HttpApi.Results;
+
+public sealed class WorkflowResultActionResultMapperTests
+{
+    [Fact]
+    public void ToActionResult_WithSchemaValidationDetails_PreservesValidationErrorsAndAddsValidationData()
+    {
+        // Arrange
+        var validationErrors = new List<ValidationResult>
+        {
+            new("TCKN 11 karakter olmalıdır.", ["customer.identityNumber"])
+        };
+        var parameters = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>("""{"minLength":11}""")!;
+        var details = new SchemaValidationProblemDetails(
+            "tr-TR",
+            [
+                new SchemaValidationErrorDetail(
+                    Path: "customer.identityNumber",
+                    Keyword: "minLength",
+                    Code: "schema.minLength",
+                    Message: "TCKN 11 karakter olmalıdır.",
+                    Label: "TCKN",
+                    SchemaPath: "/properties/customer/properties/identityNumber/minLength",
+                    Parameters: parameters)
+            ]);
+        var error = Error.Validation(
+                WorkflowErrorCodes.ValidationErrors,
+                "JSON schema validation failed",
+                validationErrors)
+            with
+            {
+                Detail = JsonSerializer.Serialize(details)
+            };
+
+        // Act
+        var actionResult = WorkflowResultActionResultMapper.ToActionResult(
+            Result.Fail(error),
+            new DefaultHttpContext());
+
+        // Assert
+        var objectResult = Assert.IsType<ObjectResult>(actionResult);
+        Assert.Equal(StatusCodes.Status400BadRequest, objectResult.StatusCode);
+
+        var json = JsonSerializer.Serialize(
+            objectResult.Value,
+            new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement.GetProperty("error");
+
+        Assert.Equal(WorkflowErrorCodes.ValidationErrors, root.GetProperty("code").GetString());
+        Assert.Equal("JSON schema validation failed", root.GetProperty("message").GetString());
+        Assert.Equal("TCKN 11 karakter olmalıdır.",
+            root.GetProperty("validationErrors")[0].GetProperty("message").GetString());
+
+        var validation = root.GetProperty("data").GetProperty("validation");
+        Assert.False(validation.TryGetProperty("culture", out _));
+        var enrichedError = validation.GetProperty("errors")[0];
+        Assert.Equal("customer.identityNumber", enrichedError.GetProperty("path").GetString());
+        Assert.Equal("minLength", enrichedError.GetProperty("keyword").GetString());
+        Assert.Equal("schema.minLength", enrichedError.GetProperty("code").GetString());
+        Assert.Equal("TCKN", enrichedError.GetProperty("label").GetString());
+        Assert.Equal(11, enrichedError.GetProperty("parameters").GetProperty("minLength").GetInt32());
+    }
+}

--- a/test/BBT.Workflow.Domain.Tests/Validation/JsonSchemaValidatorTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Validation/JsonSchemaValidatorTests.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace BBT.Workflow.Validation;
@@ -305,5 +306,234 @@ public class JsonSchemaValidatorTests: DomainTestBase<DomainEntryPoint>
         // Assert
         Assert.True(validResult.IsSuccess);
         Assert.False(invalidResult.IsSuccess);
+    }
+
+    [Fact]
+    public void Validate_WithLocalizedVocabularyDetails_UsesRequestedCulture()
+    {
+        // Arrange
+        var schema = JsonDocument.Parse("""
+            {
+                "type": "object",
+                "properties": {
+                    "customer": {
+                        "type": "object",
+                        "properties": {
+                            "identityNumber": {
+                                "type": "string",
+                                "minLength": 11,
+                                "x-labels": {
+                                    "tr-TR": "TCKN",
+                                    "en-US": "Identity number"
+                                },
+                                "x-errorMessages": {
+                                    "minLength": {
+                                        "tr-TR": "TCKN 11 karakter olmalıdır.",
+                                        "en-US": "Identity number must be 11 characters."
+                                    }
+                                }
+                            }
+                        },
+                        "required": ["identityNumber"]
+                    }
+                }
+            }
+            """).RootElement;
+        var data = JsonDocument.Parse("""
+            {
+                "customer": {
+                    "identityNumber": "123"
+                }
+            }
+            """).RootElement;
+
+        // Act
+        var result = _validator.Validate(
+            schema,
+            data,
+            new SchemaValidationOptions(Culture: "tr-TR", IncludeVocabularyDetails: true));
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        var validationError = Assert.Single(result.Error.ValidationErrors!);
+        Assert.Equal("TCKN 11 karakter olmalıdır.", validationError.ErrorMessage);
+        Assert.Contains("customer.identityNumber", validationError.MemberNames);
+
+        var details = JsonSerializer.Deserialize<SchemaValidationProblemDetails>(result.Error.Detail!);
+        Assert.NotNull(details);
+        Assert.Equal("tr-TR", details!.Culture);
+        var error = Assert.Single(details.Errors);
+        Assert.Equal("customer.identityNumber", error.Path);
+        Assert.Equal("minLength", error.Keyword);
+        Assert.Equal("schema.minLength", error.Code);
+        Assert.Equal("TCKN", error.Label);
+        Assert.Equal("TCKN 11 karakter olmalıdır.", error.Message);
+        Assert.Equal(11, error.Parameters["minLength"].GetInt32());
+    }
+
+    [Fact]
+    public void Validate_WithUnsupportedCulture_FallsBackToEnglishVocabulary()
+    {
+        // Arrange
+        var schema = JsonDocument.Parse("""
+            {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "minLength": 5,
+                        "x-labels": {
+                            "tr-TR": "Ad",
+                            "en-US": "Name"
+                        },
+                        "x-errorMessages": {
+                            "minLength": {
+                                "tr-TR": "Ad en az 5 karakter olmalıdır.",
+                                "en-US": "Name must be at least 5 characters."
+                            }
+                        }
+                    }
+                }
+            }
+            """).RootElement;
+        var data = JsonDocument.Parse("""{"name":"abc"}""").RootElement;
+
+        // Act
+        var result = _validator.Validate(
+            schema,
+            data,
+            new SchemaValidationOptions(Culture: "de-DE", IncludeVocabularyDetails: true));
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        var validationError = Assert.Single(result.Error.ValidationErrors!);
+        Assert.Equal("Name must be at least 5 characters.", validationError.ErrorMessage);
+
+        var details = JsonSerializer.Deserialize<SchemaValidationProblemDetails>(result.Error.Detail!);
+        Assert.NotNull(details);
+        Assert.Equal("de-DE", details!.Culture);
+        Assert.Equal("Name", Assert.Single(details.Errors).Label);
+    }
+
+    [Fact]
+    public void Validate_WithBusinessPropertyNamedLabels_DoesNotStripPropertySchema()
+    {
+        // Arrange
+        var schema = JsonDocument.Parse("""
+            {
+                "type": "object",
+                "properties": {
+                    "labels": {
+                        "type": "string",
+                        "minLength": 3
+                    }
+                }
+            }
+            """).RootElement;
+        var data = JsonDocument.Parse("""{"labels":"ab"}""").RootElement;
+
+        // Act
+        var result = _validator.Validate(
+            schema,
+            data,
+            new SchemaValidationOptions(Culture: "en-US", IncludeVocabularyDetails: true));
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        var details = JsonSerializer.Deserialize<SchemaValidationProblemDetails>(result.Error.Detail!);
+        var error = Assert.Single(details!.Errors);
+        Assert.Equal("labels", error.Path);
+        Assert.Equal("minLength", error.Keyword);
+    }
+
+    [Fact]
+    public void Validate_WithRegisteredCustomValidationRule_ReturnsLocalizedRuleError()
+    {
+        // Arrange
+        var validator = new CachedJsonSchemaValidator(
+            [new BlockedValueSchemaValidationRule()],
+            NullLogger<CachedJsonSchemaValidator>.Instance);
+        var schema = JsonDocument.Parse("""
+            {
+                "type": "object",
+                "properties": {
+                    "code": {
+                        "type": "string",
+                        "x-validation": {
+                            "rule": "blockedValue",
+                            "parameters": { "blocked": "BLOCKED" },
+                            "errorMessages": {
+                                "tr-TR": "Bu değer kullanılamaz.",
+                                "en-US": "This value cannot be used."
+                            }
+                        }
+                    }
+                }
+            }
+            """).RootElement;
+        var data = JsonDocument.Parse("""{"code":"BLOCKED"}""").RootElement;
+
+        // Act
+        var result = validator.Validate(
+            schema,
+            data,
+            new SchemaValidationOptions(Culture: "tr-TR", IncludeVocabularyDetails: true, CustomValidationEnabled: true));
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Bu değer kullanılamaz.", Assert.Single(result.Error.ValidationErrors!).ErrorMessage);
+        var details = JsonSerializer.Deserialize<SchemaValidationProblemDetails>(result.Error.Detail!);
+        var error = Assert.Single(details!.Errors);
+        Assert.Equal("code", error.Path);
+        Assert.Equal("x-validation", error.Keyword);
+        Assert.Equal("schema.x-validation.blockedValue", error.Code);
+    }
+
+    [Fact]
+    public void Validate_WithUnknownCustomValidationRule_SkipsRule()
+    {
+        // Arrange
+        var validator = new CachedJsonSchemaValidator([], NullLogger<CachedJsonSchemaValidator>.Instance);
+        var schema = JsonDocument.Parse("""
+            {
+                "type": "object",
+                "properties": {
+                    "code": {
+                        "type": "string",
+                        "x-validation": {
+                            "rule": "missingRule",
+                            "errorMessages": {
+                                "en-US": "This should not be returned."
+                            }
+                        }
+                    }
+                }
+            }
+            """).RootElement;
+        var data = JsonDocument.Parse("""{"code":"BLOCKED"}""").RootElement;
+
+        // Act
+        var result = validator.Validate(
+            schema,
+            data,
+            new SchemaValidationOptions(Culture: "en-US", IncludeVocabularyDetails: true, CustomValidationEnabled: true));
+
+        // Assert
+        Assert.True(result.IsSuccess);
+    }
+
+    private sealed class BlockedValueSchemaValidationRule : IJsonSchemaCustomValidationRule
+    {
+        public string Name => "blockedValue";
+
+        public bool IsValid(JsonElement value, JsonElement? parameters)
+        {
+            var blocked = parameters is { ValueKind: JsonValueKind.Object } p &&
+                          p.TryGetProperty("blocked", out var blockedElement)
+                ? blockedElement.GetString()
+                : null;
+
+            return value.ValueKind != JsonValueKind.String || value.GetString() != blocked;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add vocabulary-aware runtime schema validation options and enriched validation problem details.
- Localize schema errors from `x-labels`, legacy `labels`, `x-errorMessages`, and custom `x-validation` rules.
- Preserve existing Aether validation errors while adding enriched details under `error.data.validation.errors` for start/transition/retry responses.

## Tests
- `dotnet test test/BBT.Workflow.Domain.Tests/BBT.Workflow.Domain.Tests.csproj --filter "FullyQualifiedName~JsonSchemaValidatorTests"`
- `dotnet test test/BBT.Workflow.Application.Tests/BBT.Workflow.Application.Tests.csproj --filter "FullyQualifiedName~WorkflowResultActionResultMapperTests"`
- `dotnet build orchestration/BBT.Workflow.Orchestration.HttpApi.Host/BBT.Workflow.Orchestration.HttpApi.Host.csproj`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for localized validation error messages based on `Accept-Language` request headers
  * Introduced custom validation rules framework for enhanced schema validation
  * Enhanced validation error responses with detailed error metadata and parameters

* **Bug Fixes**
  * Improved error response format for schema validation failures with structured problem details

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/burgan-tech/vnext/pull/692?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->