### PR TITLE
feat(functions): support accepted status raw responses

### DIFF
--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs
@@ -81,9 +81,11 @@ public sealed class FunctionController(
             return await handler.HandleAsync(request, cancellationToken);
         }
 
-        return FromResult(await functionAppService.GetFunctionByInstanceAsync(
+        var result = await functionAppService.GetFunctionByInstanceAsync(
             function, workflow, domain, instance,
-            requestContext.Headers, requestContext.QueryParameters, null, cancellationToken));
+            requestContext.Headers, requestContext.QueryParameters, null, cancellationToken);
+
+        return FunctionResponseActionResultMapper.ToActionResult(result, HttpContext);
     }
 
     [HttpPost("{domain}/functions/{function}")]
@@ -144,8 +146,10 @@ public sealed class FunctionController(
             return await handler.HandleAsync(request, cancellationToken);
         }
 
-        return FromResult(await functionAppService.GetFunctionByInstanceAsync(
+        var result = await functionAppService.GetFunctionByInstanceAsync(
             function, workflow, domain, instance,
-            requestContext.Headers, requestContext.QueryParameters, body, cancellationToken));
+            requestContext.Headers, requestContext.QueryParameters, body, cancellationToken);
+
+        return FunctionResponseActionResultMapper.ToActionResult(result, HttpContext);
     }
 }

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionResponseActionResultMapper.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionResponseActionResultMapper.cs
@@ -11,9 +11,13 @@ internal static class FunctionResponseActionResultMapper
     {
         "connection",
         "content-length",
+        "content-type",         // ObjectResult negotiates this via output formatters
+        "date",                 // server writes its own
+        "host",                 // upstream internal hostname must not leak
         "keep-alive",
         "proxy-authenticate",
         "proxy-authorization",
+        "server",               // orchestrator sets its own Server header
         "te",
         "trailer",
         "transfer-encoding",

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionResponseActionResultMapper.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionResponseActionResultMapper.cs
@@ -1,0 +1,52 @@
+using BBT.Aether.AspNetCore.Results;
+using BBT.Aether.Results;
+using BBT.Workflow.Functions;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BBT.Workflow.Controllers.Instances;
+
+internal static class FunctionResponseActionResultMapper
+{
+    private static readonly HashSet<string> RestrictedResponseHeaders = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "connection",
+        "content-length",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "upgrade"
+    };
+
+    public static IActionResult ToActionResult(
+        Result<FunctionResponseOutput> result,
+        HttpContext httpContext)
+    {
+        if (!result.IsSuccess)
+            return result.ToActionResult(httpContext);
+
+        var output = result.Value!;
+        ApplyHeaders(output, httpContext);
+
+        return new ObjectResult(output.Data)
+        {
+            StatusCode = output.StatusCode ?? StatusCodes.Status200OK
+        };
+    }
+
+    private static void ApplyHeaders(FunctionResponseOutput output, HttpContext httpContext)
+    {
+        if (output.Headers is null || output.Headers.Count == 0)
+            return;
+
+        foreach (var (key, value) in output.Headers)
+        {
+            if (RestrictedResponseHeaders.Contains(key))
+                continue;
+
+            httpContext.Response.Headers[key] = value;
+        }
+    }
+}

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/DefaultDomainFunctionHandler.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/DefaultDomainFunctionHandler.cs
@@ -1,4 +1,3 @@
-using BBT.Aether.AspNetCore.Results;
 using BBT.Workflow.Functions;
 using Microsoft.AspNetCore.Mvc;
 
@@ -25,6 +24,6 @@ public sealed class DefaultDomainFunctionHandler(
             request.Body,
             cancellationToken);
 
-        return result.ToActionResult(request.HttpContext);
+        return FunctionResponseActionResultMapper.ToActionResult(result, request.HttpContext);
     }
 }

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/ViewFunctionHandler.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/ViewFunctionHandler.cs
@@ -23,7 +23,8 @@ public sealed class ViewFunctionHandler(
             Instance = request.Instance,
             Version = request.Parameters.Version,
             Headers = request.Headers,
-            QueryParameters = request.QueryParameters
+            QueryParameters = request.QueryParameters,
+            Role = request.CurrentUser.Roles?.FirstOrDefault()
         };
 
         var result = await queryAppService.GetViewAsync(

--- a/src/BBT.Workflow.Application/BBT.Workflow.Application.csproj
+++ b/src/BBT.Workflow.Application/BBT.Workflow.Application.csproj
@@ -19,4 +19,7 @@
     <ProjectReference Include="..\BBT.Workflow.Execution.Abstractions\BBT.Workflow.Execution.Abstractions.csproj" />
     <PackageReference Include="OpenTelemetry.Api" Version="$(OpenTelemetryPackageVersion)" />
   </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="BBT.Workflow.Application.Tests" />
+  </ItemGroup>
 </Project>

--- a/src/BBT.Workflow.Application/Functions/DTOs/FunctionResponseOutput.cs
+++ b/src/BBT.Workflow.Application/Functions/DTOs/FunctionResponseOutput.cs
@@ -5,7 +5,7 @@ namespace BBT.Workflow.Functions;
 /// </summary>
 public sealed class FunctionResponseOutput
 {
-    public Dictionary<string, dynamic?> Data { get; init; } = [];
+    public object? Data { get; init; }
 
     public int? StatusCode { get; init; }
 

--- a/src/BBT.Workflow.Application/Functions/DTOs/FunctionResponseOutput.cs
+++ b/src/BBT.Workflow.Application/Functions/DTOs/FunctionResponseOutput.cs
@@ -1,0 +1,13 @@
+namespace BBT.Workflow.Functions;
+
+/// <summary>
+/// HTTP-aware function response payload.
+/// </summary>
+public sealed class FunctionResponseOutput
+{
+    public Dictionary<string, dynamic?> Data { get; init; } = [];
+
+    public int? StatusCode { get; init; }
+
+    public Dictionary<string, string>? Headers { get; init; }
+}

--- a/src/BBT.Workflow.Application/Functions/FunctionAppService.cs
+++ b/src/BBT.Workflow.Application/Functions/FunctionAppService.cs
@@ -173,7 +173,7 @@ public sealed class FunctionAppService(
                 return Result<FunctionResponseOutput>.Ok(CreateRawResponse(
                     function,
                     scriptContext,
-                    ToRawDictionary(scriptResponse.Data)));
+                    scriptResponse.Data));
 
             return Result<FunctionResponseOutput>.Ok(new FunctionResponseOutput
             {
@@ -280,7 +280,7 @@ public sealed class FunctionAppService(
     internal static FunctionResponseOutput CreateRawResponse(
         Function function,
         ScriptContext scriptContext,
-        Dictionary<string, dynamic?> data)
+        object? data)
     {
         var (statusCode, headers) = ExtractSingleTaskHttpMetadata(function, scriptContext);
 
@@ -349,7 +349,7 @@ public sealed class FunctionAppService(
             return value switch
             {
                 int statusCode => statusCode,
-                long statusCode => checked((int)statusCode),
+                long statusCode when statusCode is >= int.MinValue and <= int.MaxValue => (int)statusCode,
                 string statusCode when int.TryParse(statusCode, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) => parsed,
                 _ => null
             };
@@ -374,14 +374,21 @@ public sealed class FunctionAppService(
         if (response is IDictionary<string, object?> dictionary &&
             TryGetDictionaryValue(dictionary, "headers", out var value))
         {
-            return value switch
+            try
             {
-                Dictionary<string, string> typedHeaders => typedHeaders,
-                IDictionary<string, object?> objectHeaders => objectHeaders
-                    .Where(header => header.Value != null)
-                    .ToDictionary(header => header.Key, header => Convert.ToString(header.Value, CultureInfo.InvariantCulture) ?? string.Empty),
-                _ => JsonSerializer.Deserialize<Dictionary<string, string>>(JsonSerializer.Serialize(value))
-            };
+                return value switch
+                {
+                    Dictionary<string, string> typedHeaders => typedHeaders,
+                    IDictionary<string, object?> objectHeaders => objectHeaders
+                        .Where(header => header.Value != null)
+                        .ToDictionary(header => header.Key, header => Convert.ToString(header.Value, CultureInfo.InvariantCulture) ?? string.Empty),
+                    _ => JsonSerializer.Deserialize<Dictionary<string, string>>(JsonSerializer.Serialize(value))
+                };
+            }
+            catch
+            {
+                return null;
+            }
         }
 
         return null;

--- a/src/BBT.Workflow.Application/Functions/FunctionAppService.cs
+++ b/src/BBT.Workflow.Application/Functions/FunctionAppService.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json;
+using System.Globalization;
 using BBT.Aether.Application.Services;
 using BBT.Aether.MultiSchema;
 using BBT.Aether.Results;
@@ -27,7 +28,7 @@ public sealed class FunctionAppService(
     IScriptEngine scriptEngine) : ApplicationService(serviceProvider), IFunctionAppService
 {
     /// <inheritdoc />
-    public async Task<Result<Dictionary<string, dynamic?>>> GetFunctionByKeyAsync(
+    public async Task<Result<FunctionResponseOutput>> GetFunctionByKeyAsync(
         string key,
         string domain,
         string? version = null,
@@ -47,7 +48,7 @@ public sealed class FunctionAppService(
     }
 
     /// <inheritdoc />
-    public async Task<Result<Dictionary<string, dynamic?>>> GetFunctionByInstanceAsync(
+    public async Task<Result<FunctionResponseOutput>> GetFunctionByInstanceAsync(
         string key,
         string flow,
         string domain,
@@ -62,7 +63,7 @@ public sealed class FunctionAppService(
         {
             var instance = await instanceRepository.FindByIdentifierAsync(instanceKey, cancellationToken);
             if (instance == null)
-                return Result<Dictionary<string, dynamic?>>.Fail(WorkflowErrors.InstanceNotFound(instanceKey));
+                return Result<FunctionResponseOutput>.Fail(WorkflowErrors.InstanceNotFound(instanceKey));
 
             return await componentCacheStore
                 .GetFlowAsync(domain, flow, instance.FlowVersion, cancellationToken)
@@ -88,7 +89,7 @@ public sealed class FunctionAppService(
     /// Resolves the function reference from the workflow and delegates to <see cref="ExecuteFunctionAsync"/>.
     /// Guards against the function not being registered in the given workflow.
     /// </summary>
-    private Task<Result<Dictionary<string, dynamic?>>> ResolveFunctionAndExecuteAsync(
+    private Task<Result<FunctionResponseOutput>> ResolveFunctionAndExecuteAsync(
         string domain,
         string key,
         Instance instance,
@@ -108,7 +109,7 @@ public sealed class FunctionAppService(
     /// <summary>
     /// Builds the script context, executes all function tasks, and extracts the response.
     /// </summary>
-    private async Task<Result<Dictionary<string, dynamic?>>> ExecuteFunctionAsync(
+    private async Task<Result<FunctionResponseOutput>> ExecuteFunctionAsync(
         Function function,
         Instance? instance,
         Definitions.Workflow? workflow,
@@ -122,7 +123,7 @@ public sealed class FunctionAppService(
             !function.Scope.Equals(TaskScope.Domain) &&
             !workflow.Functions.Any(f => f.Key == function.Key))
         {
-            return Result<Dictionary<string, dynamic?>>.Fail(
+            return Result<FunctionResponseOutput>.Fail(
                 WorkflowErrors.FunctionNotInWorkflow(function.Key, workflow.Key));
         }
 
@@ -147,7 +148,7 @@ public sealed class FunctionAppService(
             cancellationToken);
 
         if (!executeResult.IsSuccess)
-            return Result<Dictionary<string, dynamic?>>.Fail(executeResult.Error);
+            return Result<FunctionResponseOutput>.Fail(executeResult.Error);
 
         return await BuildResponseAsync(function, scriptContext, cancellationToken);
     }
@@ -157,7 +158,7 @@ public sealed class FunctionAppService(
     /// legacy single-task extraction from <see cref="ScriptContext.OutputResponse"/>.
     /// When <see cref="Function.RawResponse"/> is <c>true</c>, data is returned unwrapped.
     /// </summary>
-    private async Task<Result<Dictionary<string, dynamic?>>> BuildResponseAsync(
+    private async Task<Result<FunctionResponseOutput>> BuildResponseAsync(
         Function function,
         ScriptContext scriptContext,
         CancellationToken cancellationToken)
@@ -169,22 +170,30 @@ public sealed class FunctionAppService(
             var scriptResponse = await handler.OutputHandler(scriptContext);
 
             if (function.RawResponse)
-                return Result<Dictionary<string, dynamic?>>.Ok(ToRawDictionary(scriptResponse.Data));
+                return Result<FunctionResponseOutput>.Ok(CreateRawResponse(
+                    function,
+                    scriptContext,
+                    ToRawDictionary(scriptResponse.Data)));
 
-            return Result<Dictionary<string, dynamic?>>.Ok(
-                new Dictionary<string, dynamic?> { [function.Key.ToVariableName()] = scriptResponse.Data });
+            return Result<FunctionResponseOutput>.Ok(new FunctionResponseOutput
+            {
+                Data = new Dictionary<string, dynamic?> { [function.Key.ToVariableName()] = scriptResponse.Data }
+            });
         }
 
         if (function.RawResponse)
-            return Result<Dictionary<string, dynamic?>>.Ok(ExtractRawFunctionResponse(function, scriptContext));
+            return Result<FunctionResponseOutput>.Ok(CreateRawResponse(
+                function,
+                scriptContext,
+                ExtractRawFunctionResponse(function, scriptContext)));
 
-        return Result<Dictionary<string, dynamic?>>.Ok(ExtractFunctionResponse(function, scriptContext));
+        return Result<FunctionResponseOutput>.Ok(CreateWrappedResponse(function, scriptContext));
     }
 
     /// <summary>
     /// Converts an arbitrary object to a flat <c>Dictionary&lt;string, dynamic?&gt;</c> for raw responses.
     /// </summary>
-    private static Dictionary<string, dynamic?> ToRawDictionary(object? data)
+    internal static Dictionary<string, dynamic?> ToRawDictionary(object? data)
     {
         if (data is Dictionary<string, dynamic?> dict)
             return dict;
@@ -197,11 +206,13 @@ public sealed class FunctionAppService(
     /// Raw variant of legacy single-task extraction: returns the task value directly
     /// without wrapping it in the function-key dictionary.
     /// </summary>
-    private static Dictionary<string, dynamic?> ExtractRawFunctionResponse(
+    internal static Dictionary<string, dynamic?> ExtractRawFunctionResponse(
         Function function,
         ScriptContext scriptContext)
     {
-        var variableKeyTask = function.Task!.Task.Key.ToVariableName();
+        var variableKeyTask = GetSingleTaskVariableKey(function);
+        if (variableKeyTask == null)
+            return [];
 
         if (!scriptContext.OutputResponse.TryGetValue(variableKeyTask, out var value))
             return [];
@@ -220,6 +231,13 @@ public sealed class FunctionAppService(
 
             if (value is Dictionary<string, dynamic?> d)
                 return d;
+
+            if (value is IDictionary<string, object?> objectDictionary)
+                return objectDictionary.ToDictionary(
+                    item => item.Key,
+                    item => (dynamic?)item.Value);
+
+            return ToRawDictionary(value);
         }
         catch { /* ignore */ }
 
@@ -230,13 +248,15 @@ public sealed class FunctionAppService(
     /// Legacy single-task output extraction from <see cref="ScriptContext.OutputResponse"/>.
     /// Unwraps the inner <c>data</c> property when the value is a JSON element wrapper.
     /// </summary>
-    private static Dictionary<string, dynamic?> ExtractFunctionResponse(
+    internal static Dictionary<string, dynamic?> ExtractFunctionResponse(
         Function function,
         ScriptContext scriptContext)
     {
         var response = new Dictionary<string, dynamic?>();
         var variableKeyFunction = function.Key.ToVariableName();
-        var variableKeyTask = function.Task!.Task.Key.ToVariableName();
+        var variableKeyTask = GetSingleTaskVariableKey(function);
+        if (variableKeyTask == null)
+            return response;
 
         if (scriptContext.OutputResponse.TryGetValue(variableKeyTask, out var value))
         {
@@ -255,5 +275,133 @@ public sealed class FunctionAppService(
         }
 
         return response;
+    }
+
+    internal static FunctionResponseOutput CreateRawResponse(
+        Function function,
+        ScriptContext scriptContext,
+        Dictionary<string, dynamic?> data)
+    {
+        var (statusCode, headers) = ExtractSingleTaskHttpMetadata(function, scriptContext);
+
+        return new FunctionResponseOutput
+        {
+            Data = data,
+            StatusCode = statusCode,
+            Headers = headers
+        };
+    }
+
+    internal static FunctionResponseOutput CreateWrappedResponse(
+        Function function,
+        ScriptContext scriptContext) => new()
+    {
+        Data = ExtractFunctionResponse(function, scriptContext)
+    };
+
+    private static (int? StatusCode, Dictionary<string, string>? Headers) ExtractSingleTaskHttpMetadata(
+        Function function,
+        ScriptContext scriptContext)
+    {
+        var variableKeyTask = GetSingleTaskVariableKey(function);
+        if (variableKeyTask == null)
+        {
+            return (null, null);
+        }
+
+        if (!scriptContext.TaskResponse.TryGetValue(variableKeyTask, out var response) ||
+            response is not object taskResponse)
+        {
+            return (null, null);
+        }
+
+        return (ExtractStatusCode(taskResponse), ExtractHeaders(taskResponse));
+    }
+
+    private static string? GetSingleTaskVariableKey(Function function)
+    {
+        var tasks = function.GetExecuteTasks();
+        return tasks.Count == 1
+            ? tasks[0].Task.Key.ToVariableName()
+            : null;
+    }
+
+    private static int? ExtractStatusCode(object response)
+    {
+        if (response is StandardTaskResponse standardResponse)
+            return standardResponse.StatusCode;
+
+        if (response is JsonElement jsonElement)
+        {
+            if (jsonElement.TryGetProperty("statusCode", out var statusCodeProperty) &&
+                statusCodeProperty.ValueKind == JsonValueKind.Number &&
+                statusCodeProperty.TryGetInt32(out var statusCode))
+            {
+                return statusCode;
+            }
+
+            return null;
+        }
+
+        if (response is IDictionary<string, object?> dictionary &&
+            TryGetDictionaryValue(dictionary, "statusCode", out var value))
+        {
+            return value switch
+            {
+                int statusCode => statusCode,
+                long statusCode => checked((int)statusCode),
+                string statusCode when int.TryParse(statusCode, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) => parsed,
+                _ => null
+            };
+        }
+
+        return null;
+    }
+
+    private static Dictionary<string, string>? ExtractHeaders(object response)
+    {
+        if (response is StandardTaskResponse standardResponse)
+            return standardResponse.Headers;
+
+        if (response is JsonElement jsonElement)
+        {
+            return jsonElement.TryGetProperty("headers", out var headersProperty) &&
+                   headersProperty.ValueKind == JsonValueKind.Object
+                ? JsonSerializer.Deserialize<Dictionary<string, string>>(headersProperty.GetRawText())
+                : null;
+        }
+
+        if (response is IDictionary<string, object?> dictionary &&
+            TryGetDictionaryValue(dictionary, "headers", out var value))
+        {
+            return value switch
+            {
+                Dictionary<string, string> typedHeaders => typedHeaders,
+                IDictionary<string, object?> objectHeaders => objectHeaders
+                    .Where(header => header.Value != null)
+                    .ToDictionary(header => header.Key, header => Convert.ToString(header.Value, CultureInfo.InvariantCulture) ?? string.Empty),
+                _ => JsonSerializer.Deserialize<Dictionary<string, string>>(JsonSerializer.Serialize(value))
+            };
+        }
+
+        return null;
+    }
+
+    private static bool TryGetDictionaryValue(
+        IDictionary<string, object?> dictionary,
+        string key,
+        out object? value)
+    {
+        foreach (var item in dictionary)
+        {
+            if (string.Equals(item.Key, key, StringComparison.OrdinalIgnoreCase))
+            {
+                value = item.Value;
+                return true;
+            }
+        }
+
+        value = null;
+        return false;
     }
 }

--- a/src/BBT.Workflow.Application/Functions/IFunctionAppService.cs
+++ b/src/BBT.Workflow.Application/Functions/IFunctionAppService.cs
@@ -19,7 +19,7 @@ public interface IFunctionAppService : IApplicationService
     /// <param name="headers">Request Headers</param>
     /// <param name="queryParameters">Request Query Params</param>
     /// <param name="cancellationToken">Cancellation Token</param>
-    Task<Result<Dictionary<string, dynamic?>>> GetFunctionByKeyAsync(
+    Task<Result<FunctionResponseOutput>> GetFunctionByKeyAsync(
         string key,
         string domain,
         string? version = null,
@@ -38,7 +38,7 @@ public interface IFunctionAppService : IApplicationService
     /// <param name="headers">Request Headers</param>
     /// <param name="queryParameters">Request Query Params</param>
     /// <param name="cancellationToken">Cancellation Token</param>
-    Task<Result<Dictionary<string, dynamic?>>> GetFunctionByInstanceAsync(
+    Task<Result<FunctionResponseOutput>> GetFunctionByInstanceAsync(
         string key,
         string flow,
         string domain,

--- a/src/BBT.Workflow.Application/Instances/DTOs/GetInstanceStateOutput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/GetInstanceStateOutput.cs
@@ -23,6 +23,11 @@ public sealed class GetInstanceStateOutput
     public string State { get; set; } = string.Empty;
 
     /// <summary>
+    /// Current state's type in camelCase.
+    /// </summary>
+    public string StateType { get; set; } = string.Empty;
+
+    /// <summary>
     /// Instance status
     /// </summary>
     public InstanceStatus? Status { get; set; }

--- a/src/BBT.Workflow.Application/Instances/DTOs/GetViewInput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/GetViewInput.cs
@@ -31,5 +31,9 @@ public sealed class GetViewInput : IHasDomain
     /// Query parameters for rule evaluation
     /// </summary>
     public Dictionary<string, string?>? QueryParameters { get; set; }
-}
 
+    /// <summary>
+    /// Caller role for wizard view transition filtering.
+    /// </summary>
+    public string? Role { get; set; }
+}

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -369,6 +369,7 @@ public sealed class InstanceQueryAppService(
                 return new SubFlowStateInfo(
                     AvailableTransitions: availableTransitions,
                     CurrentState: subFlowValue.State,
+                    StateType: subFlowValue.StateType,
                     Status: subFlowValue.Status,
                     SubFlowData: subFlowValue.Data,
                     SubFlowView: subFlowValue.View,
@@ -444,6 +445,7 @@ public sealed class InstanceQueryAppService(
         return new SubFlowStateInfo(
             AvailableTransitions: availableTransitions,
             CurrentState: currentState,
+            StateType: null,
             Status: status);
     }
 
@@ -639,11 +641,11 @@ public sealed class InstanceQueryAppService(
     /// Gets the view definition for rule-based view selection.
     /// Returns the view definition from the transition (if transitionKey is provided) or from the state.
     /// </summary>
-    private ViewDefinition? GetViewDefinition(
-        Instance instance,
+    private static ViewDefinition? GetViewDefinition(
         Definitions.Workflow currentWorkflow,
         State currentState,
-        string? transitionKey = null)
+        string? transitionKey,
+        IReadOnlyList<string>? authorizedAvailableTransitionKeys)
     {
         if (!transitionKey.IsNullOrWhiteSpace())
         {
@@ -651,31 +653,92 @@ public sealed class InstanceQueryAppService(
             return transition?.View;
         }
 
-        bool isWizardState = currentState is { StateType: StateType.Wizard };
+        return ResolveWizardViewSelection(currentState, authorizedAvailableTransitionKeys ?? [])
+            .ViewDefinition ?? currentState.View;
+    }
 
-        // Get available transitions
-        var availableTransitions = new List<string>();
+    private static WizardViewSelection ResolveWizardViewSelection(
+        State currentState,
+        IReadOnlyList<string> authorizedAvailableTransitionKeys)
+    {
+        if (currentState.StateType != StateType.Wizard)
+            return new WizardViewSelection(null, null);
 
-        if (instance.Status.Equals(InstanceStatus.Active))
+        var stateTransitions = authorizedAvailableTransitionKeys
+            .Select(currentState.FindTransition)
+            .Where(transition => transition != null)
+            .Cast<Transition>()
+            .ToList();
+
+        if (stateTransitions.Count == 1)
         {
-            availableTransitions = currentWorkflow.GetAvailableUserTransitionKeys(currentState);
+            var transition = stateTransitions[0];
+            if (transition.View is { Views.Count: > 0 })
+                return new WizardViewSelection(transition.View, transition.Key);
         }
 
-        ViewDefinition? viewDefinition = null;
+        return new WizardViewSelection(currentState.View, null);
+    }
 
-        // If there's exactly one transition, get its view
-        if (isWizardState)
-        {
-            var transition = currentState.FindTransition(availableTransitions[0]);
-            viewDefinition = transition?.View;
-        }
-        // If there are multiple transitions or no transitions, get the state view
-        else if (!string.IsNullOrEmpty(instance.CurrentState) && currentState.View != null)
-        {
-            viewDefinition = currentState.View;
-        }
+    private static string ToCamelCaseName<TEnum>(TEnum value) where TEnum : struct, Enum
+    {
+        var name = value.ToString();
+        return string.IsNullOrEmpty(name)
+            ? string.Empty
+            : char.ToLowerInvariant(name[0]) + name[1..];
+    }
 
-        return viewDefinition;
+    private static string ResolveTransitionKind(
+        Definitions.Workflow workflow,
+        State currentState,
+        string transitionKey)
+    {
+        if (IsTransitionKey(workflow.Cancel, transitionKey) ||
+            transitionKey.Equals(WellKnownTransitionKeys.Cancel, StringComparison.OrdinalIgnoreCase))
+            return WellKnownTransitionKeys.Cancel;
+
+        if (IsTransitionKey(workflow.Exit, transitionKey) ||
+            transitionKey.Equals(WellKnownTransitionKeys.Exit, StringComparison.OrdinalIgnoreCase))
+            return WellKnownTransitionKeys.Exit;
+
+        if (IsTransitionKey(workflow.UpdateData, transitionKey) ||
+            transitionKey.Equals(WellKnownTransitionKeys.UpdateData, StringComparison.OrdinalIgnoreCase))
+            return WellKnownTransitionKeys.UpdateData;
+
+        if (workflow.Timeout?.Key.Equals(transitionKey, StringComparison.OrdinalIgnoreCase) == true ||
+            transitionKey.Equals(WellKnownTransitionKeys.Timeout, StringComparison.OrdinalIgnoreCase))
+            return WellKnownTransitionKeys.Timeout;
+
+        if (currentState.FindTransition(transitionKey) != null)
+            return "state-transition";
+
+        if (workflow.FindSharedTransition(transitionKey) != null)
+            return "shared-transition";
+
+        return "state-transition";
+    }
+
+    private static bool IsTransitionKey(Transition? transition, string transitionKey) =>
+        transition?.Key.Equals(transitionKey, StringComparison.OrdinalIgnoreCase) == true;
+
+    private async Task<IReadOnlyList<string>> GetAuthorizedAvailableTransitionKeysAsync(
+        Instance instance,
+        Definitions.Workflow currentWorkflow,
+        State currentState,
+        string? role,
+        CancellationToken cancellationToken)
+    {
+        if (!instance.Status.Equals(InstanceStatus.Active))
+            return [];
+
+        var availableTransitionKeys = currentWorkflow.GetAvailableUserTransitionKeys(currentState);
+        return await transitionAuthorizationManager.FilterAuthorizedTransitionKeysAsync(
+            currentWorkflow,
+            currentState,
+            instance,
+            availableTransitionKeys,
+            role,
+            cancellationToken);
     }
 
     public async Task<ConditionalResult<GetInstanceStateOutput>> GetInstanceStateAsync(
@@ -830,6 +893,8 @@ public sealed class InstanceQueryAppService(
             }
         }
 
+        var wizardViewSelection = ResolveWizardViewSelection(currentStateValue, keysForTransitions);
+
         List<TransitionItem> transitionItems;
         if (subFlowStateInfo.SubFlowTransitionItems != null)
         {
@@ -856,9 +921,15 @@ public sealed class InstanceQueryAppService(
                         hasSchema = transition?.Schema != null;
                         annotations = transition?.Annotations;
                     }
+                    if (key.Equals(wizardViewSelection.TransitionViewKey, StringComparison.Ordinal))
+                        hasView = false;
+
                     return new TransitionItem
                     {
                         Name = key,
+                        Kind = !string.IsNullOrWhiteSpace(subFlowItem?.Kind)
+                            ? subFlowItem.Kind
+                            : ResolveTransitionKind(currentWorkflow, currentStateValue, key),
                         Href = urlTemplateBuilder.BuildTransitionUrl(input.Domain, input.Workflow,
                             instance.Id.ToString(), key),
                         View = new ViewHref
@@ -889,13 +960,14 @@ public sealed class InstanceQueryAppService(
                 return new TransitionItem
                 {
                     Name = transitionKey,
+                    Kind = ResolveTransitionKind(currentWorkflow, currentStateValue, transitionKey),
                     Href = urlTemplateBuilder.BuildTransitionUrl(input.Domain, input.Workflow, instance.Id.ToString(),
                         transitionKey),
                     View = new ViewHref
                     {
                         Href = urlTemplateBuilder.BuildViewUrl(input.Domain, input.Workflow, instance.Id.ToString(),
                             transitionKey),
-                        HasView = hasView
+                        HasView = !transitionKey.Equals(wizardViewSelection.TransitionViewKey, StringComparison.Ordinal) && hasView
                     },
                     Schema = new SchemaHref
                     {
@@ -908,7 +980,7 @@ public sealed class InstanceQueryAppService(
             }).ToList();
         }
 
-        var viewDefinition = GetViewDefinition(instance, currentWorkflow, currentStateValue);
+        var viewDefinition = wizardViewSelection.ViewDefinition ?? currentStateValue.View;
         var firstViewEntry = viewDefinition?.Views.FirstOrDefault();
         var viewExtensions = firstViewEntry?.Extensions ?? [];
         var viewLoadData = firstViewEntry?.LoadData ?? false;
@@ -955,6 +1027,9 @@ public sealed class InstanceQueryAppService(
             Data = dataHref,
             View = viewHref,
             State = subFlowStateInfo.CurrentState ?? string.Empty,
+            StateType = subFlowStateInfo.StateType.IsNullOrWhiteSpace()
+                ? ToCamelCaseName(currentStateValue.StateType)
+                : subFlowStateInfo.StateType!,
             Status = subFlowStateInfo.Status,
             ActiveCorrelations = allActiveCorrelations,
             Transitions = transitionItems
@@ -1239,6 +1314,7 @@ public sealed class InstanceQueryAppService(
                 currentState,
                 input.Domain,
                 transitionKey,
+                input.Role,
                 input.Headers,
                 input.QueryParameters,
                 cancellationToken);
@@ -1249,8 +1325,21 @@ public sealed class InstanceQueryAppService(
             }
         }
 
+        var authorizedAvailableTransitionKeys = transitionKey.IsNullOrWhiteSpace()
+            ? await GetAuthorizedAvailableTransitionKeysAsync(
+                instance,
+                currentWorkflow,
+                currentState,
+                input.Role,
+                cancellationToken)
+            : [];
+
         // Get view definition
-        var viewDefinition = GetViewDefinition(instance, currentWorkflow, currentState, transitionKey);
+        var viewDefinition = GetViewDefinition(
+            currentWorkflow,
+            currentState,
+            transitionKey,
+            authorizedAvailableTransitionKeys);
 
         if (viewDefinition == null || viewDefinition.Views.Count == 0)
         {
@@ -1338,6 +1427,7 @@ public sealed class InstanceQueryAppService(
         State currentState,
         string requestDomain,
         string? transitionKey = null,
+        string? role = null,
         Dictionary<string, string?>? headers = null,
         Dictionary<string, string?>? queryParams = null,
         CancellationToken cancellationToken = default)
@@ -1350,7 +1440,8 @@ public sealed class InstanceQueryAppService(
                 Workflow = instance.Subflow!.SubFlowName,
                 Version = instance.Subflow!.SubFlowVersion,
                 Headers = headers ?? new Dictionary<string, string?>(),
-                QueryParams = queryParams ?? new Dictionary<string, string?>()
+                QueryParams = queryParams ?? new Dictionary<string, string?>(),
+                Role = role
             },
             transitionKey,
             cancellationToken);
@@ -1740,6 +1831,7 @@ public sealed class InstanceQueryAppService(
     /// </summary>
     /// <param name="AvailableTransitions">Available transitions from the flow</param>
     /// <param name="CurrentState">Current state of the flow</param>
+    /// <param name="StateType">State type from the active SubFlow response, when applicable</param>
     /// <param name="Status">Status of the instance (always from main instance)</param>
     /// <param name="SubFlowData">Data href from SubFlow (contains extensions info) - null for main flow</param>
     /// <param name="SubFlowView">View href from SubFlow - null for main flow</param>
@@ -1748,11 +1840,16 @@ public sealed class InstanceQueryAppService(
     private sealed record SubFlowStateInfo(
         List<string> AvailableTransitions,
         string? CurrentState,
+        string? StateType,
         InstanceStatus? Status,
         DataHref? SubFlowData = null,
         ViewHref? SubFlowView = null,
         List<ActiveCorrelationHref>? SubFlowActiveCorrelations = null,
         List<TransitionItem>? SubFlowTransitionItems = null);
+
+    private sealed record WizardViewSelection(
+        ViewDefinition? ViewDefinition,
+        string? TransitionViewKey);
 
     private static Dictionary<string, SubFlowTransitionOverride>? TryGetParentTransitionRoleOverrides(Instance instance)
     {

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -710,12 +710,12 @@ public sealed class InstanceQueryAppService(
             return WellKnownTransitionKeys.Timeout;
 
         if (currentState.FindTransition(transitionKey) != null)
-            return "state-transition";
+            return "stateTransition";
 
         if (workflow.FindSharedTransition(transitionKey) != null)
-            return "shared-transition";
+            return "sharedTransition";
 
-        return "state-transition";
+        return "stateTransition";
     }
 
     private static bool IsTransitionKey(Transition? transition, string transitionKey) =>

--- a/src/BBT.Workflow.Application/Tasks/Executors/Http/HttpTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Http/HttpTaskExecutor.cs
@@ -114,14 +114,13 @@ public sealed class HttpTaskExecutor : TaskExecutorBase<HttpTask>
         TaskExecutorContext context,
         CancellationToken cancellationToken)
     {
+        UpdateScriptContextWithResponse(task.Key, invocationResult, context.ScriptContext);
+
         var mapping = context.OnExecuteTask.Mapping;
         if (mapping == null || string.IsNullOrEmpty(mapping.DecodedCode))
         {
             return Result<object?>.Ok(invocationResult.Data);
         }
-
-        // Update script context with response for output handler
-        UpdateScriptContextWithResponse(task.Key, invocationResult, context.ScriptContext);
 
         var result = await ResultExtensions.TryAsync<object?>(async ct =>
         {
@@ -147,4 +146,3 @@ public sealed class HttpTaskExecutor : TaskExecutorBase<HttpTask>
         return result;
     }
 }
-

--- a/src/BBT.Workflow.Application/Tasks/Executors/Trigger/DirectTriggerTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Trigger/DirectTriggerTaskExecutor.cs
@@ -348,7 +348,8 @@ public sealed class DirectTriggerTaskExecutor : TriggerTaskExecutorBase<DirectTr
             TimeoutSeconds = binding.TimeoutSeconds,
             Headers = binding.Headers,
             BaseUrl = endpoint.BaseUrl.ToString(),
-            DaprAppId = endpoint.DaprAppId
+            DaprAppId = endpoint.DaprAppId,
+            AcceptedStatusCodes = binding.AcceptedStatusCodes
         };
 
         return Result.Ok(new TaskEnvelope

--- a/src/BBT.Workflow.Application/Tasks/Executors/Trigger/GetInstanceDataTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Trigger/GetInstanceDataTaskExecutor.cs
@@ -262,7 +262,8 @@ public sealed class GetInstanceDataTaskExecutor : TriggerTaskExecutorBase<GetIns
             TimeoutSeconds = binding.TimeoutSeconds,
             Headers = binding.Headers,
             BaseUrl = endpoint.BaseUrl.ToString(),
-            DaprAppId = endpoint.DaprAppId
+            DaprAppId = endpoint.DaprAppId,
+            AcceptedStatusCodes = binding.AcceptedStatusCodes
         };
 
         return Result.Ok(new TaskEnvelope

--- a/src/BBT.Workflow.Application/Tasks/Executors/Trigger/GetInstancesTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Trigger/GetInstancesTaskExecutor.cs
@@ -245,7 +245,8 @@ public sealed class GetInstancesTaskExecutor : TriggerTaskExecutorBase<GetInstan
             TimeoutSeconds = binding.TimeoutSeconds,
             Headers = binding.Headers,
             BaseUrl = endpoint.BaseUrl.ToString(),
-            DaprAppId = endpoint.DaprAppId
+            DaprAppId = endpoint.DaprAppId,
+            AcceptedStatusCodes = binding.AcceptedStatusCodes
         };
 
         return Result.Ok(new TaskEnvelope

--- a/src/BBT.Workflow.Application/Tasks/Executors/Trigger/StartTriggerTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Trigger/StartTriggerTaskExecutor.cs
@@ -215,7 +215,8 @@ public sealed class StartTriggerTaskExecutor : TriggerTaskExecutorBase<StartTask
             TimeoutSeconds = binding.TimeoutSeconds,
             Headers = binding.Headers,
             BaseUrl = endpoint.BaseUrl.ToString(),
-            DaprAppId = endpoint.DaprAppId
+            DaprAppId = endpoint.DaprAppId,
+            AcceptedStatusCodes = binding.AcceptedStatusCodes
         };
 
         return Result.Ok(new TaskEnvelope

--- a/src/BBT.Workflow.Application/Tasks/Executors/Trigger/SubProcessTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Trigger/SubProcessTaskExecutor.cs
@@ -336,7 +336,8 @@ public sealed class SubProcessTaskExecutor : TriggerTaskExecutorBase<SubProcessT
             ExtraProperties = BuildExtraPropertiesAsDictionary(context.ScriptContext, task),
             Headers = binding.Headers,
             BaseUrl = endpoint.BaseUrl.ToString(),
-            DaprAppId = endpoint.DaprAppId
+            DaprAppId = endpoint.DaprAppId,
+            AcceptedStatusCodes = binding.AcceptedStatusCodes
         };
 
         return Result.Ok(new TaskEnvelope

--- a/src/BBT.Workflow.Application/Tasks/Mapping/TaskBindingMapper.cs
+++ b/src/BBT.Workflow.Application/Tasks/Mapping/TaskBindingMapper.cs
@@ -95,6 +95,7 @@ public static class TaskBindingMapper
         ValidateSSL = task.ValidateSSL,
         Headers = task.Headers?.GetRawText(),
         TimeoutSeconds = task.TimeoutSeconds,
+        AcceptedStatusCodes = task.AcceptedStatusCodes
     };
     
     /// <summary>
@@ -113,7 +114,8 @@ public static class TaskBindingMapper
         UseDapr = task.UseDapr,
         ValidateSSL = task.ValidateSSL,
         Headers = task.Headers?.GetRawText(),
-        TimeoutSeconds = task.TimeoutSeconds
+        TimeoutSeconds = task.TimeoutSeconds,
+        AcceptedStatusCodes = task.AcceptedStatusCodes
     };
     
     /// <summary>
@@ -133,7 +135,8 @@ public static class TaskBindingMapper
         UseDapr = task.UseDapr,
         ValidateSSL = task.ValidateSSL,
         Headers = task.Headers?.GetRawText(),
-        TimeoutSeconds = task.TimeoutSeconds
+        TimeoutSeconds = task.TimeoutSeconds,
+        AcceptedStatusCodes = task.AcceptedStatusCodes
     };
     
     /// <summary>
@@ -150,7 +153,8 @@ public static class TaskBindingMapper
         ValidateSSL = task.ValidateSSL,
         UseDapr = task.UseDapr,
         Headers = task.Headers?.GetRawText(),
-        TimeoutSeconds = task.TimeoutSeconds
+        TimeoutSeconds = task.TimeoutSeconds,
+        AcceptedStatusCodes = task.AcceptedStatusCodes
     };
 
     /// <summary>
@@ -167,7 +171,8 @@ public static class TaskBindingMapper
         UseDapr = task.UseDapr,
         Headers = task.Headers?.GetRawText(),
         TimeoutSeconds = task.TimeoutSeconds,
-        ETag = null
+        ETag = null,
+        AcceptedStatusCodes = task.AcceptedStatusCodes
     };
 
     #endregion
@@ -197,7 +202,8 @@ public static class TaskBindingMapper
         Headers = task.Headers?.GetRawText(),
         Body = task.Body?.GetRawText(),
         TimeoutSeconds = task.TimeoutSeconds,
-        ValidateSSL = task.ValidateSSL
+        ValidateSSL = task.ValidateSSL,
+        AcceptedStatusCodes = task.AcceptedStatusCodes
     };
 
     /// <summary>
@@ -211,7 +217,8 @@ public static class TaskBindingMapper
         Method = task.HttpVerb,  // HttpVerb → Method
         QueryString = task.QueryString,
         Headers = task.Headers?.GetRawText(),
-        Body = task.Body?.GetRawText()
+        Body = task.Body?.GetRawText(),
+        AcceptedStatusCodes = task.AcceptedStatusCodes
     };
 
     /// <summary>

--- a/src/BBT.Workflow.Domain/Shared/HrefBase.cs
+++ b/src/BBT.Workflow.Domain/Shared/HrefBase.cs
@@ -25,6 +25,11 @@ public sealed class TransitionItem : HrefBase
     public string Name { get; set; } = string.Empty;
 
     /// <summary>
+    /// Transition category for client behavior, e.g. stateTransition, sharedTransition, cancel, exit, updateData, timeout.
+    /// </summary>
+    public string Kind { get; set; } = string.Empty;
+
+    /// <summary>
     /// View href for this transition. When HasView is true, the view endpoint returns meaningful content when called with this transition key.
     /// </summary>
     public ViewHref? View { get; set; }

--- a/src/BBT.Workflow.Execution.Abstractions/AcceptedStatusCodeMatcher.cs
+++ b/src/BBT.Workflow.Execution.Abstractions/AcceptedStatusCodeMatcher.cs
@@ -1,0 +1,44 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace BBT.Workflow.Execution;
+
+/// <summary>
+/// Matches HTTP status codes against accepted status code patterns.
+/// </summary>
+public static class AcceptedStatusCodeMatcher
+{
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromMilliseconds(100);
+
+    public static bool IsAccepted(int? statusCode, IReadOnlyList<string>? acceptedCodes)
+    {
+        if (statusCode is null || acceptedCodes is null || acceptedCodes.Count == 0)
+            return false;
+
+        var statusCodeText = statusCode.Value.ToString(CultureInfo.InvariantCulture);
+
+        foreach (var acceptedCode in acceptedCodes)
+        {
+            if (string.IsNullOrWhiteSpace(acceptedCode))
+                continue;
+
+            var pattern = ToRegexPattern(acceptedCode.Trim());
+            if (Regex.IsMatch(statusCodeText, pattern, RegexOptions.CultureInvariant | RegexOptions.IgnoreCase, RegexTimeout))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static string ToRegexPattern(string acceptedCode)
+    {
+        var wildcardPattern = Regex.Replace(
+            Regex.Escape(acceptedCode),
+            "x",
+            "\\d",
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant,
+            RegexTimeout);
+
+        return $"^{wildcardPattern}$";
+    }
+}

--- a/src/BBT.Workflow.Execution.Abstractions/Bindings/DaprServiceBinding.cs
+++ b/src/BBT.Workflow.Execution.Abstractions/Bindings/DaprServiceBinding.cs
@@ -34,5 +34,10 @@ public sealed class DaprServiceBinding
     /// Request body as JSON string.
     /// </summary>
     public string? Body { get; init; }
-}
 
+    /// <summary>
+    /// HTTP status codes that should be treated as successful task invocation results.
+    /// Supports exact codes such as "400" and wildcard patterns such as "4xx".
+    /// </summary>
+    public IReadOnlyList<string>? AcceptedStatusCodes { get; init; }
+}

--- a/src/BBT.Workflow.Execution.Abstractions/Bindings/DirectTriggerBinding.cs
+++ b/src/BBT.Workflow.Execution.Abstractions/Bindings/DirectTriggerBinding.cs
@@ -79,8 +79,13 @@ public sealed class DirectTriggerBinding
     public string? DaprAppId { get; init; }
 
     /// <summary>
+    /// HTTP status codes that should be treated as successful task invocation results.
+    /// Supports exact codes such as "400" and wildcard patterns such as "4xx".
+    /// </summary>
+    public IReadOnlyList<string>? AcceptedStatusCodes { get; init; }
+
+    /// <summary>
     /// Identifier of the target workflow instance.
     /// </summary>
     public string? Identifier => InstanceId.HasValue ? InstanceId.Value.ToString() : Key;
 }
-

--- a/src/BBT.Workflow.Execution.Abstractions/Bindings/GetInstanceDataBinding.cs
+++ b/src/BBT.Workflow.Execution.Abstractions/Bindings/GetInstanceDataBinding.cs
@@ -60,5 +60,10 @@ public sealed class GetInstanceDataBinding
     /// Dapr application ID for service invocation.
     /// </summary>
     public string? DaprAppId { get; init; }
-}
 
+    /// <summary>
+    /// HTTP status codes that should be treated as successful task invocation results.
+    /// Supports exact codes such as "400" and wildcard patterns such as "4xx".
+    /// </summary>
+    public IReadOnlyList<string>? AcceptedStatusCodes { get; init; }
+}

--- a/src/BBT.Workflow.Execution.Abstractions/Bindings/GetInstancesBinding.cs
+++ b/src/BBT.Workflow.Execution.Abstractions/Bindings/GetInstancesBinding.cs
@@ -65,4 +65,10 @@ public sealed class GetInstancesBinding
     /// Dapr application ID for service invocation.
     /// </summary>
     public string? DaprAppId { get; init; }
+
+    /// <summary>
+    /// HTTP status codes that should be treated as successful task invocation results.
+    /// Supports exact codes such as "400" and wildcard patterns such as "4xx".
+    /// </summary>
+    public IReadOnlyList<string>? AcceptedStatusCodes { get; init; }
 }

--- a/src/BBT.Workflow.Execution.Abstractions/Bindings/HttpTaskBinding.cs
+++ b/src/BBT.Workflow.Execution.Abstractions/Bindings/HttpTaskBinding.cs
@@ -34,5 +34,10 @@ public sealed class HttpTaskBinding
     /// Whether to validate SSL certificates.
     /// </summary>
     public bool ValidateSSL { get; init; } = true;
-}
 
+    /// <summary>
+    /// HTTP status codes that should be treated as successful task invocation results.
+    /// Supports exact codes such as "400" and wildcard patterns such as "4xx".
+    /// </summary>
+    public IReadOnlyList<string>? AcceptedStatusCodes { get; init; }
+}

--- a/src/BBT.Workflow.Execution.Abstractions/Bindings/StartTriggerBinding.cs
+++ b/src/BBT.Workflow.Execution.Abstractions/Bindings/StartTriggerBinding.cs
@@ -72,5 +72,10 @@ public sealed class StartTriggerBinding
     /// Dapr application ID for service invocation.
     /// </summary>
     public string? DaprAppId { get; init; }
-}
 
+    /// <summary>
+    /// HTTP status codes that should be treated as successful task invocation results.
+    /// Supports exact codes such as "400" and wildcard patterns such as "4xx".
+    /// </summary>
+    public IReadOnlyList<string>? AcceptedStatusCodes { get; init; }
+}

--- a/src/BBT.Workflow.Execution.Abstractions/Bindings/SubProcessBinding.cs
+++ b/src/BBT.Workflow.Execution.Abstractions/Bindings/SubProcessBinding.cs
@@ -88,5 +88,10 @@ public sealed class SubProcessBinding
     /// Dapr application ID for service invocation.
     /// </summary>
     public string? DaprAppId { get; init; }
-}
 
+    /// <summary>
+    /// HTTP status codes that should be treated as successful task invocation results.
+    /// Supports exact codes such as "400" and wildcard patterns such as "4xx".
+    /// </summary>
+    public IReadOnlyList<string>? AcceptedStatusCodes { get; init; }
+}

--- a/src/BBT.Workflow.Execution/Invokers/DaprServiceTaskInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/DaprServiceTaskInvoker.cs
@@ -107,15 +107,18 @@ public sealed class DaprServiceTaskInvoker(
                 ["ReasonPhrase"] = response.ReasonPhrase ?? string.Empty
             };
 
+            var isSuccess = response.IsSuccessStatusCode
+                || AcceptedStatusCodeMatcher.IsAccepted((int)response.StatusCode, binding.AcceptedStatusCodes);
+
             // Record metrics based on success/failure
             _metrics.RecordDaprServiceInvocation(
                 binding.AppId, 
                 binding.MethodName, 
-                response.IsSuccessStatusCode ? "success" : "failure");
+                isSuccess ? "success" : "failure");
             
             // Always return result with full response details - let output mapping handle error scenarios
             // All HTTP responses (2xx, 4xx, 5xx) include headers, body, and parsed data
-            return response.IsSuccessStatusCode
+            return isSuccess
                 ? TaskInvocationResult.Success(
                     data: responseData,
                     body: content,

--- a/src/BBT.Workflow.Execution/Invokers/DirectTriggerRemoteInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/DirectTriggerRemoteInvoker.cs
@@ -255,13 +255,15 @@ public sealed class DirectTriggerRemoteInvoker : ITaskInvoker<DirectTriggerBindi
         var responseHeaders = InvokerHelpers.MergeHeaders(response.Headers, response.Content.Headers);
         var content = await response.Content.ReadAsStringAsync(cancellationToken);
         var responseData = InvokerHelpers.TryParseJson(content);
-        var metadata = response.IsSuccessStatusCode
+        var isSuccess = response.IsSuccessStatusCode
+            || AcceptedStatusCodeMatcher.IsAccepted((int)response.StatusCode, binding.AcceptedStatusCodes);
+        var metadata = isSuccess
             ? CreateMetadata(binding)
             : CreateMetadata(binding, statusCode: (int)response.StatusCode);
 
-        _metrics.RecordTaskExecution(TaskType, response.IsSuccessStatusCode ? "success" : "failure");
+        _metrics.RecordTaskExecution(TaskType, isSuccess ? "success" : "failure");
 
-        return response.IsSuccessStatusCode
+        return isSuccess
             ? TaskInvocationResult.Success(
                 data: responseData,
                 body: content,

--- a/src/BBT.Workflow.Execution/Invokers/GetInstanceDataRemoteInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/GetInstanceDataRemoteInvoker.cs
@@ -188,10 +188,12 @@ public sealed class GetInstanceDataRemoteInvoker : ITaskInvoker<GetInstanceDataB
         var content = await response.ReadDecompressedContentAsync(cancellationToken);
         var responseData = InvokerHelpers.TryParseJson(content);
         var metadata = CreateMetadata(binding, reasonPhrase: response.ReasonPhrase);
+        var isSuccess = response.IsSuccessStatusCode
+            || AcceptedStatusCodeMatcher.IsAccepted((int)response.StatusCode, binding.AcceptedStatusCodes);
 
-        _metrics.RecordTaskExecution(TaskType, response.IsSuccessStatusCode ? "success" : "failure");
+        _metrics.RecordTaskExecution(TaskType, isSuccess ? "success" : "failure");
 
-        return response.IsSuccessStatusCode
+        return isSuccess
             ? TaskInvocationResult.Success(
                 data: responseData,
                 body: content,

--- a/src/BBT.Workflow.Execution/Invokers/GetInstancesRemoteInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/GetInstancesRemoteInvoker.cs
@@ -188,10 +188,12 @@ public sealed class GetInstancesRemoteInvoker : ITaskInvoker<GetInstancesBinding
         var content = await response.ReadDecompressedContentAsync(cancellationToken);
         var responseData = InvokerHelpers.TryParseJson(content);
         var metadata = CreateMetadata(binding, reasonPhrase: response.ReasonPhrase);
+        var isSuccess = response.IsSuccessStatusCode
+            || AcceptedStatusCodeMatcher.IsAccepted((int)response.StatusCode, binding.AcceptedStatusCodes);
 
-        _metrics.RecordTaskExecution(TaskType, response.IsSuccessStatusCode ? "success" : "failure");
+        _metrics.RecordTaskExecution(TaskType, isSuccess ? "success" : "failure");
 
-        return response.IsSuccessStatusCode
+        return isSuccess
             ? TaskInvocationResult.Success(
                 data: responseData,
                 body: content,

--- a/src/BBT.Workflow.Execution/Invokers/HttpTaskInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/HttpTaskInvoker.cs
@@ -96,9 +96,12 @@ public sealed class HttpTaskInvoker(
                 ["ReasonPhrase"] = response.ReasonPhrase ?? string.Empty
             };
 
+            var isSuccess = response.IsSuccessStatusCode
+                || AcceptedStatusCodeMatcher.IsAccepted((int)response.StatusCode, binding.AcceptedStatusCodes);
+
             // Always return result with full response details - let output mapping handle error scenarios
             // All HTTP responses (2xx, 4xx, 5xx) include headers, body, and parsed data
-            return response.IsSuccessStatusCode
+            return isSuccess
                 ? TaskInvocationResult.Success(
                     data: responseData,
                     body: content,

--- a/src/BBT.Workflow.Execution/Invokers/SoapTaskInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/SoapTaskInvoker.cs
@@ -117,7 +117,7 @@ public sealed class SoapTaskInvoker(
             }
 
             var isSuccess = response.IsSuccessStatusCode
-                || IsAcceptedStatusCode((int)response.StatusCode, binding.AcceptedStatusCodes);
+                || AcceptedStatusCodeMatcher.IsAccepted((int)response.StatusCode, binding.AcceptedStatusCodes);
 
             return isSuccess
                 ? TaskInvocationResult.Success(
@@ -283,41 +283,6 @@ public sealed class SoapTaskInvoker(
         }
 
         return dict;
-    }
-
-    /// <summary>
-    /// Returns true when <paramref name="statusCode"/> matches any entry in <paramref name="acceptedCodes"/>.
-    /// Supports exact matches ("500") and single-character wildcards ("5xx", "50x").
-    /// </summary>
-    private static bool IsAcceptedStatusCode(int statusCode, IReadOnlyList<string>? acceptedCodes)
-    {
-        if (acceptedCodes == null || acceptedCodes.Count == 0)
-            return false;
-
-        var codeStr = statusCode.ToString();
-
-        foreach (var pattern in acceptedCodes)
-        {
-            if (string.IsNullOrWhiteSpace(pattern) || pattern.Length != codeStr.Length)
-                continue;
-
-            var matched = true;
-            for (var i = 0; i < pattern.Length; i++)
-            {
-                if (pattern[i] == 'x' || pattern[i] == 'X')
-                    continue;
-
-                if (pattern[i] != codeStr[i])
-                {
-                    matched = false;
-                    break;
-                }
-            }
-
-            if (matched) return true;
-        }
-
-        return false;
     }
 
     private HttpClient CreateHttpClient(SoapTaskBinding binding, string? taskKey)

--- a/src/BBT.Workflow.Execution/Invokers/StartTriggerRemoteInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/StartTriggerRemoteInvoker.cs
@@ -189,10 +189,12 @@ public sealed class StartTriggerRemoteInvoker : ITaskInvoker<StartTriggerBinding
         var content = await response.Content.ReadAsStringAsync(cancellationToken);
         var responseData = InvokerHelpers.TryParseJson(content);
         var metadata = CreateMetadata(binding, reasonPhrase: response.ReasonPhrase);
+        var isSuccess = response.IsSuccessStatusCode
+            || AcceptedStatusCodeMatcher.IsAccepted((int)response.StatusCode, binding.AcceptedStatusCodes);
 
-        _metrics.RecordTaskExecution(TaskType, response.IsSuccessStatusCode ? "success" : "failure");
+        _metrics.RecordTaskExecution(TaskType, isSuccess ? "success" : "failure");
 
-        return response.IsSuccessStatusCode
+        return isSuccess
             ? TaskInvocationResult.Success(
                 data: responseData,
                 body: content,

--- a/src/BBT.Workflow.Execution/Invokers/SubProcessRemoteInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/SubProcessRemoteInvoker.cs
@@ -191,10 +191,12 @@ public sealed class SubProcessRemoteInvoker : ITaskInvoker<SubProcessBinding>
         var content = await response.Content.ReadAsStringAsync(cancellationToken);
         var responseData = InvokerHelpers.TryParseJson(content);
         var metadata = CreateMetadata(binding, reasonPhrase: response.ReasonPhrase);
+        var isSuccess = response.IsSuccessStatusCode
+            || AcceptedStatusCodeMatcher.IsAccepted((int)response.StatusCode, binding.AcceptedStatusCodes);
 
-        _metrics.RecordTaskExecution(TaskType, response.IsSuccessStatusCode ? "success" : "failure");
+        _metrics.RecordTaskExecution(TaskType, isSuccess ? "success" : "failure");
 
-        return response.IsSuccessStatusCode
+        return isSuccess
             ? TaskInvocationResult.Success(
                 data: responseData,
                 body: content,

--- a/src/BBT.Workflow.Infrastructure/Gateway/LocalInstanceQueryGateway.cs
+++ b/src/BBT.Workflow.Infrastructure/Gateway/LocalInstanceQueryGateway.cs
@@ -118,7 +118,8 @@ public sealed class LocalInstanceQueryGateway : IInstanceQueryGateway
                     Version = input.Version,
                     Instance = input.Instance,
                     Headers = input.Headers,
-                    QueryParameters = input.QueryParams
+                    QueryParameters = input.QueryParams,
+                    Role = input.Role
                 };
                 return await queryService.GetViewAsync(viewInput, transitionKey, ct);
             }, cancellationToken);

--- a/test/BBT.Workflow.Application.Tests/BBT.Workflow.Application.Tests.csproj
+++ b/test/BBT.Workflow.Application.Tests/BBT.Workflow.Application.Tests.csproj
@@ -14,6 +14,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\..\src\BBT.Workflow.Application\BBT.Workflow.Application.csproj" />
+      <ProjectReference Include="..\..\src\BBT.Workflow.Execution\BBT.Workflow.Execution.csproj" />
       <ProjectReference Include="..\..\src\BBT.Workflow.HttpApi.Shared\BBT.Workflow.HttpApi.Shared.csproj" />
       <ProjectReference Include="..\BBT.Workflow.Domain.Tests\BBT.Workflow.Domain.Tests.csproj" />
     </ItemGroup>

--- a/test/BBT.Workflow.Application.Tests/Definitions/Validators/FunctionComponentValidatorTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Definitions/Validators/FunctionComponentValidatorTests.cs
@@ -47,7 +47,7 @@ public class FunctionComponentValidatorTests
         // Arrange
         var functionJson = """
         {
-            "scope": "W",
+            "scope": "F",
             "task": {
                 "type": "6",
                 "config": {
@@ -72,7 +72,7 @@ public class FunctionComponentValidatorTests
         // Arrange
         var functionJson = """
         {
-            "scope": "W"
+            "scope": "F"
         }
         """;
         var attributes = JsonDocument.Parse(functionJson).RootElement;

--- a/test/BBT.Workflow.Application.Tests/Functions/FunctionOutputHandlerTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Functions/FunctionOutputHandlerTests.cs
@@ -212,8 +212,8 @@ public class FunctionOutputHandlerTests
         response.StatusCode.ShouldBe(400);
         response.Headers.ShouldNotBeNull();
         response.Headers!["x-validation-source"].ShouldBe("schema");
-        ((object?)response.Data["title"]).ShouldBe("Validation failed");
-        ((object?)response.Data["status"]).ShouldBe(400L);
+        ((object?)((Dictionary<string, dynamic?>)response.Data)["title"]).ShouldBe("Validation failed");
+        ((object?)((Dictionary<string, dynamic?>)response.Data)["status"]).ShouldBe(400L);
     }
 
     [Fact]
@@ -235,7 +235,7 @@ public class FunctionOutputHandlerTests
 
         response.StatusCode.ShouldBeNull();
         response.Headers.ShouldBeNull();
-        response.Data.ShouldContainKey(function.Key.ToVariableName());
+        ((Dictionary<string, dynamic?>)response.Data).ShouldContainKey(function.Key.ToVariableName());
     }
 
     private static Function CreateFunction(bool rawResponse)

--- a/test/BBT.Workflow.Application.Tests/Functions/FunctionOutputHandlerTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Functions/FunctionOutputHandlerTests.cs
@@ -1,6 +1,9 @@
+using System.Collections.Generic;
 using System.Text.Json;
+using System.Text;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Scripting;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Shouldly;
 using Xunit;
@@ -183,4 +186,65 @@ public class FunctionOutputHandlerTests
         function.ShouldNotBeNull();
         function!.RawResponse.ShouldBeTrue();
     }
+
+    [Fact]
+    public void CreateRawResponse_UsesSingleTaskStatusCodeAndHeaders()
+    {
+        var function = CreateFunction(rawResponse: true);
+        var context = CreateScriptContext();
+        var taskKey = TaskRef.Key.ToVariableName();
+        var payload = new Dictionary<string, object?>
+        {
+            ["title"] = "Validation failed",
+            ["status"] = 400
+        };
+        context.SetStandardResponse(new StandardTaskResponse
+        {
+            Data = payload,
+            StatusCode = 400,
+            Headers = new Dictionary<string, string> { ["x-validation-source"] = "schema" }
+        }, taskKey);
+        context.SetOutputResponse(payload, taskKey);
+
+        var rawData = FunctionAppService.ExtractRawFunctionResponse(function, context);
+        var response = FunctionAppService.CreateRawResponse(function, context, rawData);
+
+        response.StatusCode.ShouldBe(400);
+        response.Headers.ShouldNotBeNull();
+        response.Headers!["x-validation-source"].ShouldBe("schema");
+        ((object?)response.Data["title"]).ShouldBe("Validation failed");
+        ((object?)response.Data["status"]).ShouldBe(400L);
+    }
+
+    [Fact]
+    public void CreateWrappedResponse_DoesNotForwardTaskStatusCode()
+    {
+        var function = CreateFunction(rawResponse: false);
+        var context = CreateScriptContext();
+        var taskKey = TaskRef.Key.ToVariableName();
+        var payload = new Dictionary<string, object?> { ["title"] = "Validation failed" };
+        context.SetStandardResponse(new StandardTaskResponse
+        {
+            Data = payload,
+            StatusCode = 400,
+            Headers = new Dictionary<string, string> { ["x-validation-source"] = "schema" }
+        }, taskKey);
+        context.SetOutputResponse(payload, taskKey);
+
+        var response = FunctionAppService.CreateWrappedResponse(function, context);
+
+        response.StatusCode.ShouldBeNull();
+        response.Headers.ShouldBeNull();
+        response.Data.ShouldContainKey(function.Key.ToVariableName());
+    }
+
+    private static Function CreateFunction(bool rawResponse)
+    {
+        var function = new Function(TaskScope.Domain, CreateTask(1, TaskRef), rawResponse: rawResponse);
+        function.SetReference(new Reference("send-otp", "test-domain", "sys-functions", "1.0.0"));
+        return function;
+    }
+
+    private static ScriptContext CreateScriptContext() =>
+        new(NullLogger<ScriptContext>.Instance);
 }

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceStateTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceStateTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using BBT.Aether.DependencyInjection;
@@ -41,6 +42,8 @@ public class InstanceQueryAppServiceStateTests : IDisposable
     private readonly IInstanceQueryGateway _instanceQueryGateway;
     private readonly IRepresentationEtagService _representationEtagService;
     private readonly IUrlTemplateBuilder _urlTemplateBuilder;
+    private readonly IViewContentResolutionService _viewContentResolutionService;
+    private readonly ITransitionAuthorizationManager _transitionAuthorizationManager;
     private readonly InstanceQueryAppService _service;
     private readonly IServiceProvider _ambientServiceProvider;
     private readonly IServiceProvider? _previousAmbientServiceProvider;
@@ -58,6 +61,8 @@ public class InstanceQueryAppServiceStateTests : IDisposable
         _instanceQueryGateway = Substitute.For<IInstanceQueryGateway>();
         _representationEtagService = Substitute.For<IRepresentationEtagService>();
         _urlTemplateBuilder = Substitute.For<IUrlTemplateBuilder>();
+        _viewContentResolutionService = Substitute.For<IViewContentResolutionService>();
+        _transitionAuthorizationManager = Substitute.For<ITransitionAuthorizationManager>();
 
         // Set up AmbientServiceProvider.Current needed by PostSharp UnitOfWorkAttribute
         var mockUoW = Substitute.For<IUnitOfWork>();
@@ -83,11 +88,11 @@ public class InstanceQueryAppServiceStateTests : IDisposable
             instanceExtensionService: Substitute.For<IInstanceExtensionService>(),
             scriptContextFactory: Substitute.For<IScriptContextFactory>(),
             instanceQueryGateway: _instanceQueryGateway,
-            viewContentResolutionService: Substitute.For<IViewContentResolutionService>(),
+            viewContentResolutionService: _viewContentResolutionService,
             taskConditionService: Substitute.For<ITaskConditionService>(),
             urlTemplateBuilder: _urlTemplateBuilder,
             currentSchema: Substitute.For<ICurrentSchema>(),
-            transitionAuthorizationManager: Substitute.For<ITransitionAuthorizationManager>(),
+            transitionAuthorizationManager: _transitionAuthorizationManager,
             representationEtagService: _representationEtagService,
             schemaFieldFilterService: Substitute.For<ISchemaFieldFilterService>(),
             currentUser: Substitute.For<ICurrentUser>(),
@@ -197,6 +202,212 @@ public class InstanceQueryAppServiceStateTests : IDisposable
         result.Result.Value!.State.ShouldBe("sub-review");
     }
 
+    [Fact]
+    public async Task GetInstanceStateAsync_WhenCurrentStateIsWizard_ReturnsStateTypeAsCamelCase()
+    {
+        // Arrange
+        var instanceId = Guid.NewGuid();
+        var instance = Instance.Create(instanceId, TestWorkflow, TestVersion, "test-key");
+        var state = State.Create(TestState, StateType.Wizard, StateSubType.None,
+            VersionStrategy.IncreaseMinor.Code);
+        instance.ChangeState(state);
+
+        var workflow = BuildWorkflow(state);
+        SetupCommonMocks(instance, workflow);
+
+        var input = CreateInput(instance.Id.ToString());
+
+        // Act
+        var result = await _service.GetInstanceStateAsync(input, CancellationToken.None);
+
+        // Assert
+        result.Result.IsSuccess.ShouldBeTrue();
+        result.Result.Value!.StateType.ShouldBe("wizard");
+    }
+
+    [Fact]
+    public async Task GetInstanceStateAsync_WhenTransitionsAreAvailable_ReturnsTransitionKind()
+    {
+        // Arrange
+        var instanceId = Guid.NewGuid();
+        var instance = Instance.Create(instanceId, TestWorkflow, TestVersion, "test-key");
+        var state = State.Create(TestState, StateType.Intermediate, StateSubType.None,
+            VersionStrategy.IncreaseMinor.Code);
+        var stateTransition = Transition.Create("approve", TestState, "approved", TriggerType.Manual,
+            VersionStrategy.IncreasePatch.Code);
+        state.AddTransition(stateTransition);
+        instance.ChangeState(state);
+
+        var workflow = BuildWorkflow(state);
+        workflow.AddSharedTransition(Transition.Create("add-note", null, "$self", TriggerType.Manual,
+            VersionStrategy.IncreasePatch.Code));
+        workflow.SetCancel(Transition.Create("cancel-request", null, "cancelled", TriggerType.Manual,
+            VersionStrategy.IncreasePatch.Code));
+        SetupCommonMocks(instance, workflow);
+
+        var input = CreateInput(instance.Id.ToString());
+
+        // Act
+        var result = await _service.GetInstanceStateAsync(input, CancellationToken.None);
+
+        // Assert
+        result.Result.IsSuccess.ShouldBeTrue();
+        var transitions = result.Result.Value!.Transitions.ToDictionary(t => t.Name);
+        transitions["approve"].Kind.ShouldBe("stateTransition");
+        transitions["add-note"].Kind.ShouldBe("sharedTransition");
+        transitions["cancel-request"].Kind.ShouldBe("cancel");
+    }
+
+    [Fact]
+    public async Task GetInstanceStateAsync_WhenWizardStateTransitionHasView_ReturnsStateHasViewAndHidesTransitionView()
+    {
+        // Arrange
+        var instanceId = Guid.NewGuid();
+        var instance = Instance.Create(instanceId, TestWorkflow, TestVersion, "test-key");
+        var state = State.Create(TestState, StateType.Wizard, StateSubType.None,
+            VersionStrategy.IncreaseMinor.Code);
+        var transition = Transition.Create("continue", TestState, "next", TriggerType.Manual,
+            VersionStrategy.IncreasePatch.Code);
+        transition.SetView(ViewDefinition.CreateDefault(
+            new Reference("transition-view", TestDomain, "sys-views", TestVersion),
+            loadData: true));
+        state.AddTransition(transition);
+        instance.ChangeState(state);
+
+        var workflow = BuildWorkflow(state);
+        SetupCommonMocks(instance, workflow);
+
+        var input = CreateInput(instance.Id.ToString());
+
+        // Act
+        var result = await _service.GetInstanceStateAsync(input, CancellationToken.None);
+
+        // Assert
+        result.Result.IsSuccess.ShouldBeTrue();
+        var output = result.Result.Value!;
+        output.View.HasView.ShouldBeTrue();
+        output.View.LoadData.ShouldBeTrue();
+        output.Transitions.Single().View!.HasView.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task GetInstanceStateAsync_WhenWizardStateTransitionHasNoView_FallsBackToStateView()
+    {
+        // Arrange
+        var instanceId = Guid.NewGuid();
+        var instance = Instance.Create(instanceId, TestWorkflow, TestVersion, "test-key");
+        var state = State.Create(TestState, StateType.Wizard, StateSubType.None,
+            VersionStrategy.IncreaseMinor.Code);
+        state.SetView(ViewDefinition.CreateDefault(
+            new Reference("state-view", TestDomain, "sys-views", TestVersion),
+            loadData: false));
+        state.AddTransition(Transition.Create("continue", TestState, "next", TriggerType.Manual,
+            VersionStrategy.IncreasePatch.Code));
+        instance.ChangeState(state);
+
+        var workflow = BuildWorkflow(state);
+        SetupCommonMocks(instance, workflow);
+
+        var input = CreateInput(instance.Id.ToString());
+
+        // Act
+        var result = await _service.GetInstanceStateAsync(input, CancellationToken.None);
+
+        // Assert
+        result.Result.IsSuccess.ShouldBeTrue();
+        var output = result.Result.Value!;
+        output.View.HasView.ShouldBeTrue();
+        output.View.LoadData.ShouldBeFalse();
+        output.Transitions.Single().View!.HasView.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task GetViewAsync_WhenWizardStateTransitionHasView_ReturnsTransitionView()
+    {
+        // Arrange
+        var instanceId = Guid.NewGuid();
+        var instance = Instance.Create(instanceId, TestWorkflow, TestVersion, "test-key");
+        var state = State.Create(TestState, StateType.Wizard, StateSubType.None,
+            VersionStrategy.IncreaseMinor.Code);
+        var transitionViewRef = new Reference("transition-view", TestDomain, "sys-views", TestVersion);
+        var stateViewRef = new Reference("state-view", TestDomain, "sys-views", TestVersion);
+        var transition = Transition.Create("continue", TestState, "next", TriggerType.Manual,
+            VersionStrategy.IncreasePatch.Code);
+        transition.SetView(ViewDefinition.CreateDefault(transitionViewRef));
+        state.SetView(ViewDefinition.CreateDefault(stateViewRef));
+        state.AddTransition(transition);
+        instance.ChangeState(state);
+
+        var workflow = BuildWorkflow(state);
+        SetupCommonMocks(instance, workflow);
+        _viewContentResolutionService
+            .ResolveViewContentAsync(transitionViewRef, TestDomain, Arg.Any<Dictionary<string, string?>?>(),
+                Arg.Any<Dictionary<string, string?>?>(), Arg.Any<CancellationToken>())
+            .Returns(Result<GetViewOutput>.Ok(new GetViewOutput
+            {
+                Key = "transition-view",
+                Type = "Json",
+                Display = "Page",
+                Label = string.Empty
+            }));
+
+        // Act
+        var result = await _service.GetViewAsync(new GetViewInput
+        {
+            Domain = TestDomain,
+            Workflow = TestWorkflow,
+            Instance = instance.Id.ToString(),
+            Headers = new Dictionary<string, string?>(),
+            QueryParameters = new Dictionary<string, string?>()
+        }, transitionKey: null, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.Key.ShouldBe("transition-view");
+    }
+
+    [Fact]
+    public async Task GetViewAsync_WhenWizardStateTransitionHasNoView_ReturnsStateView()
+    {
+        // Arrange
+        var instanceId = Guid.NewGuid();
+        var instance = Instance.Create(instanceId, TestWorkflow, TestVersion, "test-key");
+        var state = State.Create(TestState, StateType.Wizard, StateSubType.None,
+            VersionStrategy.IncreaseMinor.Code);
+        var stateViewRef = new Reference("state-view", TestDomain, "sys-views", TestVersion);
+        state.SetView(ViewDefinition.CreateDefault(stateViewRef));
+        state.AddTransition(Transition.Create("continue", TestState, "next", TriggerType.Manual,
+            VersionStrategy.IncreasePatch.Code));
+        instance.ChangeState(state);
+
+        var workflow = BuildWorkflow(state);
+        SetupCommonMocks(instance, workflow);
+        _viewContentResolutionService
+            .ResolveViewContentAsync(stateViewRef, TestDomain, Arg.Any<Dictionary<string, string?>?>(),
+                Arg.Any<Dictionary<string, string?>?>(), Arg.Any<CancellationToken>())
+            .Returns(Result<GetViewOutput>.Ok(new GetViewOutput
+            {
+                Key = "state-view",
+                Type = "Json",
+                Display = "Page",
+                Label = string.Empty
+            }));
+
+        // Act
+        var result = await _service.GetViewAsync(new GetViewInput
+        {
+            Domain = TestDomain,
+            Workflow = TestWorkflow,
+            Instance = instance.Id.ToString(),
+            Headers = new Dictionary<string, string?>(),
+            QueryParameters = new Dictionary<string, string?>()
+        }, transitionKey: null, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.Key.ShouldBe("state-view");
+    }
+
     /// <summary>
     /// When there is no active SubFlow correlation, the parent's own status is used normally.
     /// </summary>
@@ -260,6 +471,8 @@ public class InstanceQueryAppServiceStateTests : IDisposable
         var workflow = Definitions.Workflow.Create();
         workflow.SetReference(new Reference(TestWorkflow, TestDomain, "sys-flows", TestVersion));
         workflow.SetType("F");
+        workflow.SetStartTransition(Transition.Create("start", null, state.Key, TriggerType.Manual,
+            VersionStrategy.IncreasePatch.Code));
         workflow.AddState(state);
         return workflow;
     }
@@ -278,6 +491,22 @@ public class InstanceQueryAppServiceStateTests : IDisposable
             .Returns("https://data-url");
         _urlTemplateBuilder.BuildViewUrl(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
             .Returns("https://view-url");
+        _urlTemplateBuilder.BuildViewUrl(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
+            .Returns("https://transition-view-url");
+        _urlTemplateBuilder.BuildTransitionUrl(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
+            .Returns("https://transition-url");
+        _urlTemplateBuilder.BuildSchemaUrl(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
+            .Returns("https://schema-url");
+
+        _transitionAuthorizationManager
+            .FilterAuthorizedTransitionKeysAsync(
+                Arg.Any<Definitions.Workflow>(),
+                Arg.Any<State>(),
+                Arg.Any<Instance?>(),
+                Arg.Any<IReadOnlyList<string>>(),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo => Task.FromResult(callInfo.ArgAt<IReadOnlyList<string>>(3)));
 
         _representationEtagService.Generate(Arg.Any<object>()).Returns((string?)null);
     }

--- a/test/BBT.Workflow.Application.Tests/Tasks/AcceptedStatusCodeMatcherTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Tasks/AcceptedStatusCodeMatcherTests.cs
@@ -1,0 +1,27 @@
+using BBT.Workflow.Execution;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Tasks;
+
+public sealed class AcceptedStatusCodeMatcherTests
+{
+    [Theory]
+    [InlineData(400, "400")]
+    [InlineData(400, "4xx")]
+    [InlineData(404, "40x")]
+    [InlineData(500, "5XX")]
+    public void IsAccepted_WithExactOrWildcardPattern_ReturnsTrue(int statusCode, string pattern)
+    {
+        AcceptedStatusCodeMatcher.IsAccepted(statusCode, [pattern]).ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(400, "5xx")]
+    [InlineData(404, "41x")]
+    [InlineData(500, "400")]
+    public void IsAccepted_WhenPatternDoesNotMatch_ReturnsFalse(int statusCode, string pattern)
+    {
+        AcceptedStatusCodeMatcher.IsAccepted(statusCode, [pattern]).ShouldBeFalse();
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/Tasks/Invokers/HttpTaskInvokerAcceptedStatusCodesTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Tasks/Invokers/HttpTaskInvokerAcceptedStatusCodesTests.cs
@@ -1,0 +1,109 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Workflow.Execution;
+using BBT.Workflow.Execution.Bindings;
+using BBT.Workflow.Execution.Invokers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Tasks.Invokers;
+
+public sealed class HttpTaskInvokerAcceptedStatusCodesTests
+{
+    [Fact]
+    public async Task InvokeAsync_WithAcceptedExact400_ReturnsSuccessWithResponseDetails()
+    {
+        var invoker = CreateInvoker(HttpStatusCode.BadRequest);
+        var descriptor = CreateDescriptor(["400"]);
+
+        var result = await invoker.InvokeAsync(descriptor);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.StatusCode.ShouldBe(400);
+        result.Body.ShouldContain("Validation failed");
+        result.Headers.ShouldNotBeNull();
+        result.Headers!["x-validation-source"].ShouldBe("schema");
+        result.Data.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WithUnaccepted400_ReturnsFailure()
+    {
+        var invoker = CreateInvoker(HttpStatusCode.BadRequest);
+        var descriptor = CreateDescriptor(null);
+
+        var result = await invoker.InvokeAsync(descriptor);
+
+        result.IsSuccess.ShouldBeFalse();
+        result.StatusCode.ShouldBe(400);
+        result.Body.ShouldContain("Validation failed");
+        result.Data.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WithAcceptedWildcard4xx_ReturnsSuccess()
+    {
+        var invoker = CreateInvoker(HttpStatusCode.BadRequest);
+        var descriptor = CreateDescriptor(["4xx"]);
+
+        var result = await invoker.InvokeAsync(descriptor);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.StatusCode.ShouldBe(400);
+    }
+
+    private static HttpTaskInvoker CreateInvoker(HttpStatusCode statusCode)
+    {
+        var response = new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent("""
+                {
+                  "type": "https://tools.ietf.org/html/rfc9110#section-15.5.1",
+                  "title": "Validation failed",
+                  "status": 400,
+                  "errors": {
+                    "$.phoneNumber": [ "Phone number is required." ]
+                  }
+                }
+                """)
+        };
+        response.Headers.TryAddWithoutValidation("x-validation-source", "schema");
+
+        return new HttpTaskInvoker(
+            new FakeHttpClientFactory(response),
+            NullLogger<HttpTaskInvoker>.Instance);
+    }
+
+    private static TaskDescriptor<HttpTaskBinding> CreateDescriptor(IReadOnlyList<string>? acceptedStatusCodes) =>
+        new()
+        {
+            TaskType = TaskTypes.Http,
+            TaskKey = "send-otp",
+            Binding = new HttpTaskBinding
+            {
+                Url = "https://workflow.local/functions/send-otp",
+                Method = "POST",
+                Body = "{}",
+                AcceptedStatusCodes = acceptedStatusCodes
+            }
+        };
+
+    private sealed class FakeHttpClientFactory(HttpResponseMessage response) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(new StubHttpMessageHandler(response));
+    }
+
+    private sealed class StubHttpMessageHandler(HttpResponseMessage response) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/Tasks/Mapping/TaskBindingMapperAcceptedStatusCodesTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Tasks/Mapping/TaskBindingMapperAcceptedStatusCodesTests.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Execution.Bindings;
+using BBT.Workflow.Tasks.Mapping;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Tasks.Mapping;
+
+public sealed class TaskBindingMapperAcceptedStatusCodesTests
+{
+    [Fact]
+    public void CreateEnvelope_MapsDaprServiceAcceptedStatusCodes()
+    {
+        var task = DaprServiceTask.Create("""
+            {
+              "appId": "workflow-api",
+              "methodName": "/api/v1/test/workflows/order/instances/start",
+              "httpVerb": "POST",
+              "acceptedStatusCodes": [ "400", "4xx" ]
+            }
+            """.ToJsonElement());
+        task.SetReference(new Reference("start-via-dapr", "test-domain", "sys-tasks", "1.0.0"));
+
+        var binding = CreateBinding<DaprServiceBinding>(task);
+
+        binding.AcceptedStatusCodes.ShouldBe(["400", "4xx"]);
+    }
+
+    [Theory]
+    [MemberData(nameof(TriggerTasks))]
+    public void CreateEnvelope_MapsTriggerTaskAcceptedStatusCodes(
+        WorkflowTask task,
+        Type bindingType)
+    {
+        task.SetReference(new Reference(bindingType.Name, "test-domain", "sys-tasks", "1.0.0"));
+
+        var envelope = TaskBindingMapper.CreateEnvelope(task);
+
+        envelope.IsSuccess.ShouldBeTrue();
+        var binding = envelope.Value!.Binding.Deserialize(bindingType);
+        var acceptedStatusCodes = (IReadOnlyList<string>)bindingType
+            .GetProperty("AcceptedStatusCodes")!
+            .GetValue(binding)!;
+        acceptedStatusCodes.ShouldBe(["400", "4xx"]);
+    }
+
+    public static TheoryData<WorkflowTask, Type> TriggerTasks() => new()
+    {
+        {
+            StartTask.Create("""
+                {
+                  "domain": "test-domain",
+                  "flow": "order",
+                  "acceptedStatusCodes": [ "400", "4xx" ]
+                }
+                """.ToJsonElement()),
+            typeof(StartTriggerBinding)
+        },
+        {
+            DirectTriggerTask.Create("""
+                {
+                  "domain": "test-domain",
+                  "flow": "order",
+                  "transitionName": "approve",
+                  "key": "order-1",
+                  "acceptedStatusCodes": [ "400", "4xx" ]
+                }
+                """.ToJsonElement()),
+            typeof(DirectTriggerBinding)
+        },
+        {
+            SubProcessTask.Create("""
+                {
+                  "domain": "test-domain",
+                  "flow": "child",
+                  "acceptedStatusCodes": [ "400", "4xx" ]
+                }
+                """.ToJsonElement()),
+            typeof(SubProcessBinding)
+        },
+        {
+            GetInstancesTask.Create("""
+                {
+                  "domain": "test-domain",
+                  "flow": "order",
+                  "acceptedStatusCodes": [ "400", "4xx" ]
+                }
+                """.ToJsonElement()),
+            typeof(GetInstancesBinding)
+        },
+        {
+            GetInstanceDataTask.Create("""
+                {
+                  "domain": "test-domain",
+                  "flow": "order",
+                  "instance": "order-1",
+                  "acceptedStatusCodes": [ "400", "4xx" ]
+                }
+                """.ToJsonElement()),
+            typeof(GetInstanceDataBinding)
+        }
+    };
+
+    private static TBinding CreateBinding<TBinding>(WorkflowTask task)
+    {
+        var envelope = TaskBindingMapper.CreateEnvelope(task);
+        envelope.IsSuccess.ShouldBeTrue();
+        return envelope.Value!.Binding.Deserialize<TBinding>()!;
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/Tasks/Mapping/TaskBindingMapperHttpTaskTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Tasks/Mapping/TaskBindingMapperHttpTaskTests.cs
@@ -1,0 +1,34 @@
+using System.Text.Json;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Execution.Bindings;
+using BBT.Workflow.Tasks.Mapping;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Tasks.Mapping;
+
+public sealed class TaskBindingMapperHttpTaskTests
+{
+    [Fact]
+    public void CreateEnvelope_MapsHttpTaskAcceptedStatusCodes()
+    {
+        var config = """
+            {
+              "url": "https://workflow.local/functions/send-otp",
+              "method": "POST",
+              "acceptedStatusCodes": [ "400", "4xx" ],
+              "timeoutSeconds": 30
+            }
+            """;
+        var task = HttpTask.Create(config.ToJsonElement());
+        task.SetReference(new Reference("send-otp", "test-domain", "sys-tasks", "1.0.0"));
+
+        var result = TaskBindingMapper.CreateEnvelope(task);
+
+        result.IsSuccess.ShouldBeTrue();
+        var binding = result.Value!.Binding.Deserialize<HttpTaskBinding>();
+        binding.ShouldNotBeNull();
+        binding.AcceptedStatusCodes.ShouldNotBeNull();
+        binding.AcceptedStatusCodes.ShouldBe(["400", "4xx"]);
+    }
+}


### PR DESCRIPTION
## Summary
- Add accepted status code propagation for HttpTask and other supported task bindings/invokers
- Add raw function response forwarding so accepted downstream HTTP statuses can be returned to clients
- Extend wizard state/view behavior with state type, transition kind, and loop-safe view resolution

## Changes
- Add shared accepted status matching via `AcceptedStatusCodeMatcher`
- Map `acceptedStatusCodes` into execution bindings for HTTP, SOAP-compatible, Dapr service, and remote trigger task flows
- Add HTTP-aware function response output and controller result mapping for forwarded status codes and headers
- Update wizard state and view resolution to prioritize transition views while keeping transition `hasView=false`
- Add tests for accepted status matching, task binding mapping, HttpTask invocation behavior, function responses, and wizard state behavior

## Test Plan
- [x] `dotnet test test/BBT.Workflow.Application.Tests --filter "FullyQualifiedName~Function"`
- [x] `dotnet test test/BBT.Workflow.Application.Tests --filter "FullyQualifiedName~HttpTask" --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- [x] `dotnet test test/BBT.Workflow.Application.Tests --filter "FullyQualifiedName~AcceptedStatusCode" --no-restore --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- [x] `dotnet build orchestration/BBT.Workflow.Orchestration.HttpApi.Host --no-restore --disable-build-servers -m:1 -v:minimal -p:UseSharedCompilation=false`
- [x] `git diff --check`

## Notes
- Closes #697
- Accepted status codes are treated as successful task results, so ErrorBoundary retry/fallback handling is not triggered for those statuses.
- `rawResponse=false` keeps the existing wrapped HTTP 200 behavior.

## Summary by Sourcery

Add support for configuring HTTP accepted status codes across task bindings and invokers and propagate raw HTTP metadata through function responses and the HTTP API, while enriching wizard state/view handling in instance queries.

New Features:
- Expose an HTTP-aware function response model that can carry raw data, status codes, and headers through to HTTP responses.
- Allow workflow HTTP, Dapr service, remote trigger, and instance query tasks to configure accepted HTTP status codes that are treated as successful results.
- Include state type and categorized transition metadata in instance state outputs to improve client-side behavior for wizard flows.

Enhancements:
- Refine wizard view resolution so transition views take precedence for single-transition wizard states while suppressing duplicate transition views in state responses.
- Derive transition kind semantics (state, shared, cancel, exit, updateData, timeout) for each transition item and surface them on the API.
- Propagate caller role through view resolution to support role-aware wizard transition filtering.

Tests:
- Add unit tests covering accepted status code pattern matching and mapping across task bindings and HTTP task invocation.
- Extend function output handler tests to verify raw and wrapped response behaviors and HTTP metadata forwarding.
- Add instance query tests validating wizard state type exposure, transition kinds, and view resolution semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Functions can return HTTP status codes, headers, and either raw or wrapped payloads.
  * Tasks can declare accepted status codes (exact or wildcard like "4xx") so non-2xx responses may be treated as successful.
  * Instance state includes StateType; transitions include Kind; view selection is role-aware with improved wizard handling.

* **Bug Fixes**
  * More consistent function response handling and safer header forwarding.

* **Tests**
  * Expanded unit tests for function responses, accepted-status-code behavior, and wizard/transition view logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/burgan-tech/vnext/pull/698?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->