### PR TITLE
Refresh ScriptContext snapshot after state changes in pipeline

### DIFF
--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ChangeStateStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ChangeStateStep.cs
@@ -78,6 +78,9 @@ public sealed class ChangeStateStep(
 
         // Sync context to reflect the applied state (mirrors UpdateTargetStateInContext)
         context.Current = context.Target;
+        // The state has changed; re-base any cached ScriptContext snapshot so that
+        // OnEntry tasks (and state-level error boundary resolution) see the new state.
+        context.RefreshScriptContextInstance();
 
         RecordStateEntryMetric(context);
 
@@ -151,6 +154,9 @@ public sealed class ChangeStateStep(
             {
                 context.Current = state;
                 context.Target = state;
+                // The state has changed; re-base any cached ScriptContext snapshot so that
+                // OnEntry tasks (and state-level error boundary resolution) see the new state.
+                context.RefreshScriptContextInstance();
                 return context;
             });
         return Task.FromResult(result);

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ClearBusyOnResumeStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ClearBusyOnResumeStep.cs
@@ -50,6 +50,9 @@ public sealed class ClearBusyOnResumeStep() : ITransitionStep
             .Map(state =>
             {
                 context.Target = state;
+                // Resume sets the target state here (ChangeStateStep is skipped for resume);
+                // re-base any cached ScriptContext snapshot so it reflects the resumed state.
+                context.RefreshScriptContextInstance();
                 return context;
             });
     }

--- a/src/BBT.Workflow.Domain/Execution/Transitions/Context/TransitionExecutionContext.cs
+++ b/src/BBT.Workflow.Domain/Execution/Transitions/Context/TransitionExecutionContext.cs
@@ -164,6 +164,23 @@ public sealed class TransitionExecutionContext
     }
 
     /// <summary>
+    /// Re-bases the cached <see cref="ScriptContext"/>'s instance snapshot onto the current
+    /// (live) <see cref="Instance"/>. Call this after a state change so that subsequent steps
+    /// reusing the cached ScriptContext (e.g. OnEntry tasks and state-level error boundary
+    /// resolution) observe the new <c>CurrentState</c> rather than the snapshot frozen before
+    /// the change. No-op when no ScriptContext has been built yet, so the lazy-build behavior
+    /// of <see cref="GetOrBuildScriptContextAsync"/> is preserved.
+    /// </summary>
+    public void RefreshScriptContextInstance()
+    {
+        if (Instance is null)
+            return;
+
+        if (Cache.TryGetValue("ScriptContext", out var cached) && cached is ScriptContext scriptContext)
+            scriptContext.RefreshInstance(Instance);
+    }
+
+    /// <summary>
     /// Extracts pending distributed events from the Instance aggregate and defers them
     /// in <see cref="Directives"/> for explicit publishing after UoW commit.
     /// Clears the aggregate's event list so they won't be dispatched automatically via IDomainEventSink/SaveChanges.

--- a/src/BBT.Workflow.Domain/Scripting/Models.cs
+++ b/src/BBT.Workflow.Domain/Scripting/Models.cs
@@ -481,6 +481,31 @@ public class ScriptContext(ILogger<ScriptContext> logger) : IDisposable, IAsyncD
     }
 
     /// <summary>
+    /// Re-bases the frozen <see cref="Instance"/> snapshot onto the supplied live instance.
+    /// Used after a state change within the same transition so that downstream steps
+    /// (e.g. OnEntry tasks and state-level error boundary resolution) observe the new
+    /// <c>CurrentState</c> instead of the stale snapshot captured before the change.
+    /// Mirrors <c>Builder.SetInstance</c>: takes a fresh snapshot and recomputes the
+    /// <see cref="Incident"/> projection. Accumulated <see cref="TaskResponse"/>,
+    /// <see cref="OutputResponse"/> and <see cref="MetaData"/> are intentionally preserved.
+    /// </summary>
+    /// <param name="instance">The live instance whose current state should be reflected.</param>
+    public void RefreshInstance(Instance instance)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(instance);
+
+        var snapshot = instance.CreateSnapshot();
+        Instance = snapshot;
+        Incident = new ScriptIncidentInfo
+        {
+            HasActiveIncident = snapshot.HasActiveIncident,
+            ActiveIncident = snapshot.Incidents.LastOrDefault(i => !i.IsResolved),
+            TotalIncidentCount = snapshot.Incidents.Count
+        };
+    }
+
+    /// <summary>
     /// Sets the standardized response body for the script context.
     /// </summary>
     /// <param name="response">The standardized task response.</param>

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/Steps/ChangeStateStepTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/Steps/ChangeStateStepTests.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Execution;
+using BBT.Workflow.Execution.Pipeline;
+using BBT.Workflow.Execution.Pipeline.Steps;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Monitoring;
+using BBT.Workflow.Scripting;
+using BBT.Workflow.Shared;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Application.Tests.Execution.Transitions.Pipeline.Steps;
+
+/// <summary>
+/// Unit tests for <see cref="ChangeStateStep"/>.
+/// Focuses on the cached ScriptContext snapshot being re-based to the new state after a
+/// state change, which is what allows OnEntry tasks and state-level error boundary resolution
+/// to observe the target state rather than the stale (source) snapshot.
+/// </summary>
+public class ChangeStateStepTests
+{
+    private const string Domain = "test-domain";
+    private const string WorkflowKey = "test-workflow";
+
+    private readonly IInstanceRepository _mockInstanceRepository;
+    private readonly IWorkflowMetrics _mockMetrics;
+    private readonly ChangeStateStep _step;
+
+    public ChangeStateStepTests()
+    {
+        _mockInstanceRepository = Substitute.For<IInstanceRepository>();
+        _mockMetrics = Substitute.For<IWorkflowMetrics>();
+        _step = new ChangeStateStep(
+            _mockInstanceRepository,
+            _mockMetrics,
+            Substitute.For<ILogger<ChangeStateStep>>());
+    }
+
+    [Fact]
+    public void Order_ShouldBeChangeState()
+    {
+        _step.Order.ShouldBe(LifecycleOrder.ChangeState);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenStateChanges_ShouldRefreshCachedScriptContextToTargetState()
+    {
+        // Arrange: instance currently in state1, cached ScriptContext frozen at state1.
+        var context = CreateContext(out var workflow, out var instance);
+        instance.ChangeState(workflow.GetState("state1").Value!);
+
+        var scriptContext = new ScriptContext.Builder(NullLogger<ScriptContext>.Instance)
+            .SetWorkflow(workflow)
+            .SetInstance(instance.CreateSnapshot()) // frozen snapshot at state1 (mirrors WithInstance)
+            .SetTaskResponse(new Dictionary<string, object?> { ["onExecuteTask"] = "result" })
+            .Build();
+
+        scriptContext.Instance!.CurrentState.ShouldBe("state1");
+        context.Cache["ScriptContext"] = scriptContext;
+
+        // Act: transition state1 -> state2.
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        context.Instance.GetCurrentState.ShouldBe("state2");
+
+        // Same cached ScriptContext object retained, but its snapshot now reflects the target state.
+        var cached = (ScriptContext)context.Cache["ScriptContext"]!;
+        ReferenceEquals(cached, scriptContext).ShouldBeTrue();
+        cached.Instance!.CurrentState.ShouldBe("state2");
+
+        // Accumulated task responses are preserved across the refresh.
+        cached.TaskResponse.ShouldContainKey("onExecuteTask");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_TimeoutTransition_ShouldRefreshCachedScriptContextToTargetState()
+    {
+        // Arrange: timeout path pre-resolves the target state and bypasses the normal flow.
+        var context = CreateContext(out var workflow, out var instance);
+        instance.ChangeState(workflow.GetState("state1").Value!);
+        context.Directives.MarkAsTimeoutTransition();
+        context.Target = workflow.GetState("state2").Value!;
+
+        var scriptContext = new ScriptContext.Builder(NullLogger<ScriptContext>.Instance)
+            .SetWorkflow(workflow)
+            .SetInstance(instance.CreateSnapshot())
+            .Build();
+        scriptContext.Instance!.CurrentState.ShouldBe("state1");
+        context.Cache["ScriptContext"] = scriptContext;
+
+        // Act
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        context.Instance.GetCurrentState.ShouldBe("state2");
+        ((ScriptContext)context.Cache["ScriptContext"]!).Instance!.CurrentState.ShouldBe("state2");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenNoScriptContextCached_ShouldStillChangeStateWithoutBuildingOne()
+    {
+        // Arrange
+        var context = CreateContext(out var workflow, out var instance);
+        instance.ChangeState(workflow.GetState("state1").Value!);
+
+        // Act
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        // Assert: state changed, and the refresh helper did not force-build a ScriptContext.
+        result.IsSuccess.ShouldBeTrue();
+        context.Instance.GetCurrentState.ShouldBe("state2");
+        context.Cache.ContainsKey("ScriptContext").ShouldBeFalse();
+    }
+
+    private TransitionExecutionContext CreateContext(out Definitions.Workflow workflow, out Instance instance)
+    {
+        var instanceId = Guid.NewGuid();
+        workflow = CreateWorkflow();
+        instance = Instance.Create(instanceId, WorkflowKey, "1.0.0");
+        var transition = Transition.Create("test-transition", "state1", "state2", TriggerType.Manual, "Patch");
+
+        return new TransitionExecutionContext
+        {
+            InstanceId = instanceId,
+            Domain = Domain,
+            WorkflowKey = WorkflowKey,
+            TransitionKey = "test-transition",
+            Trigger = TriggerType.Manual,
+            Actor = ExecutionActor.User,
+            CorrelationId = Guid.NewGuid().ToString("N"),
+            ExecutionChainId = Guid.NewGuid().ToString("N"),
+            RequestedAt = DateTimeOffset.UtcNow,
+            Workflow = workflow,
+            Current = workflow.GetState("state1").Value!,
+            Transition = transition,
+            Instance = instance,
+            TraceId = Guid.NewGuid().ToString("N"),
+            SpanId = Guid.NewGuid().ToString("N")[..16]
+        };
+    }
+
+    private static Definitions.Workflow CreateWorkflow()
+    {
+        var json = """
+                   {
+                       "type": "F",
+                       "timeout": null,
+                       "labels": [],
+                       "functions": [],
+                       "features": [],
+                       "states": [
+                           { "key": "state1", "stateType": "Intermediate", "transitions": [] },
+                           { "key": "state2", "stateType": "Intermediate", "transitions": [] }
+                       ],
+                       "sharedTransitions": [],
+                       "extensions": [],
+                       "startTransition": {"key": "start", "from": null, "target": "state1", "triggerType": "Manual", "versionStrategy": "Patch", "labels": [], "onExecutionTasks": [], "view": null}
+                   }
+                   """;
+
+        var options = new System.Text.Json.JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+        };
+        var workflow = System.Text.Json.JsonSerializer.Deserialize<Definitions.Workflow>(json, options)!;
+        workflow.SetReference(new Reference(WorkflowKey, Domain, "sys-flows", "1.0.0"));
+        return workflow;
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/Steps/ClearBusyOnResumeStepTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/Steps/ClearBusyOnResumeStepTests.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Execution;
+using BBT.Workflow.Execution.Pipeline;
+using BBT.Workflow.Execution.Pipeline.Steps;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Scripting;
+using BBT.Workflow.Shared;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Application.Tests.Execution.Transitions.Pipeline.Steps;
+
+/// <summary>
+/// Unit tests for <see cref="ClearBusyOnResumeStep"/>.
+/// On the subflow-resume path the state is established here (ChangeStateStep is skipped), so the
+/// cached ScriptContext snapshot must be re-based to the resumed state for downstream consumers.
+/// </summary>
+public class ClearBusyOnResumeStepTests
+{
+    private const string Domain = "test-domain";
+    private const string WorkflowKey = "test-workflow";
+
+    private readonly ClearBusyOnResumeStep _step = new();
+
+    [Fact]
+    public void Order_ShouldBeClearBusyOnResumeStep()
+    {
+        _step.Order.ShouldBe(LifecycleOrder.ClearBusyOnResumeStep);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_OnSubFlowResume_ShouldRefreshCachedScriptContextToResumedState()
+    {
+        // Arrange: instance resumed in state2; cached ScriptContext still frozen at state1.
+        var instanceId = Guid.NewGuid();
+        var workflow = CreateWorkflow();
+        var instance = Instance.Create(instanceId, WorkflowKey, "1.0.0");
+        instance.ChangeState(workflow.GetState("state1").Value!);
+
+        var scriptContext = new ScriptContext.Builder(NullLogger<ScriptContext>.Instance)
+            .SetWorkflow(workflow)
+            .SetInstance(instance.CreateSnapshot())
+            .Build();
+        scriptContext.Instance!.CurrentState.ShouldBe("state1");
+
+        // Now the instance is actually resumed in state2.
+        instance.ChangeState(workflow.GetState("state2").Value!);
+
+        var context = new TransitionExecutionContext
+        {
+            InstanceId = instanceId,
+            Domain = Domain,
+            WorkflowKey = WorkflowKey,
+            TransitionKey = "resume",
+            Trigger = TriggerType.Manual,
+            Actor = ExecutionActor.System,
+            CorrelationId = Guid.NewGuid().ToString("N"),
+            ExecutionChainId = Guid.NewGuid().ToString("N"),
+            RequestedAt = DateTimeOffset.UtcNow,
+            Workflow = workflow,
+            Current = workflow.GetState("state2").Value!,
+            Instance = instance,
+            TraceId = Guid.NewGuid().ToString("N"),
+            SpanId = Guid.NewGuid().ToString("N")[..16]
+        };
+        context.Cache["ScriptContext"] = scriptContext;
+        context.Directives.MarkAsSubFlowResume();
+
+        // Act
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        ((ScriptContext)context.Cache["ScriptContext"]!).Instance!.CurrentState.ShouldBe("state2");
+    }
+
+    private static Definitions.Workflow CreateWorkflow()
+    {
+        var json = """
+                   {
+                       "type": "F",
+                       "timeout": null,
+                       "labels": [],
+                       "functions": [],
+                       "features": [],
+                       "states": [
+                           { "key": "state1", "stateType": "Intermediate", "transitions": [] },
+                           { "key": "state2", "stateType": "Intermediate", "transitions": [] }
+                       ],
+                       "sharedTransitions": [],
+                       "extensions": [],
+                       "startTransition": {"key": "start", "from": null, "target": "state1", "triggerType": "Manual", "versionStrategy": "Patch", "labels": [], "onExecutionTasks": [], "view": null}
+                   }
+                   """;
+
+        var options = new System.Text.Json.JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+        };
+        var workflow = System.Text.Json.JsonSerializer.Deserialize<Definitions.Workflow>(json, options)!;
+        workflow.SetReference(new Reference(WorkflowKey, Domain, "sys-flows", "1.0.0"));
+        return workflow;
+    }
+}


### PR DESCRIPTION
Closes #705

## Summary

Ensures that cached `ScriptContext` snapshots are re-based to reflect the current instance state after state transitions within the same pipeline execution. This allows downstream steps (OnEntry tasks, state-level error boundary resolution) to observe the target state rather than the stale snapshot captured before the state change.

## Key Changes

- **ScriptContext.RefreshInstance()** — New method that re-bases the frozen instance snapshot onto a live instance while preserving accumulated task responses, output responses, and metadata. Recomputes the `Incident` projection to reflect the new state.

- **TransitionExecutionContext.RefreshScriptContextInstance()** — New helper method that conditionally refreshes the cached ScriptContext if one exists. No-op when no ScriptContext has been built yet, preserving lazy-build semantics.

- **ChangeStateStep** — Calls `RefreshScriptContextInstance()` after applying state changes (both normal transitions and timeout paths) to ensure OnEntry tasks and error boundary resolution see the new state.

- **ClearBusyOnResumeStep** — Calls `RefreshScriptContextInstance()` after establishing the resumed state. On the subflow-resume path, ChangeStateStep is skipped, so this step is responsible for the refresh.

- **Unit Tests** — Added comprehensive test coverage:
  - `ChangeStateStepTests` — Verifies cached ScriptContext is refreshed to target state, timeout transitions are handled, and no ScriptContext is built if none was cached.
  - `ClearBusyOnResumeStepTests` — Verifies cached ScriptContext is refreshed on subflow resume.

## Implementation Details

- The refresh preserves the same `ScriptContext` object reference (no replacement), only updating its internal `Instance` snapshot and `Incident` projection.
- Accumulated `TaskResponse`, `OutputResponse`, and `MetaData` are intentionally preserved across the refresh to maintain context continuity.
- The implementation follows the existing pattern used in `Builder.SetInstance()` for consistency.

## Summary by Sourcery

Refresh ScriptContext snapshots after in-pipeline state changes so downstream steps see the updated workflow state.

New Features:
- Add the ability to re-base a ScriptContext&#39;s instance snapshot onto the current live instance without losing accumulated responses or metadata.

Enhancements:
- Update transition execution context steps to refresh any cached ScriptContext after state changes, including timeout transitions and subflow resume paths.

Tests:
- Add unit tests for ChangeStateStep and ClearBusyOnResumeStep to verify ScriptContext snapshots are refreshed correctly and lazy caching behavior is preserved.