### PR TITLE
Add role-based state aliases with localized labels

### DIFF
--- a/docs/domain/function-handler-architecture.md
+++ b/docs/domain/function-handler-architecture.md
@@ -69,7 +69,8 @@ Resolution in the `state` function:
   static roles, predefined roles (`$InstanceStarter`, `$PreviousUser`, …) and dynamic roles.
 - Aliases are evaluated in declaration order; the **first** alias whose `roles` resolve to
   the caller wins.
-- An alias with an empty `roles` list matches everyone, acting as a default/fallback — place it last.
+- Authoring rules (enforced by `WorkflowValidator`): the `alias` array is optional, but each
+  entry must declare a `name`, at least one `roles` grant, and at least one `labels` entry.
 - The winning alias's display value for the response `state` field is resolved as:
   1. **Localized label** — if the alias has `labels`, the label for the caller's current
      language is returned. Language comes from the `Accept-Language` header (`LanguageResolver`);

--- a/docs/domain/function-handler-architecture.md
+++ b/docs/domain/function-handler-architecture.md
@@ -88,6 +88,23 @@ Resolution in the `state` function:
   for the same culture resolution; the state function resolves from the request headers it already
   receives so it stays correct under forwarded/subflow contexts.
 
+## Query Authorization (queryRoles)
+
+The data-returning instance functions — **state, data, view, schema** — enforce the state's
+`queryRoles` (falling back to workflow root `queryRoles`) so a caller may only read an instance
+whose current state they are permitted to see.
+
+- Effective grants: the instance's effective-state `queryRoles` when it defines any, otherwise
+  `workflow.QueryRoles`. **No grants → allow** (unchanged behavior).
+- Grants present: the caller's roles (`ICurrentUser.Roles`, multi-role — any allowed → allow) are
+  evaluated via `ITransitionAuthorizationManager.IsQueryAllowedAsync` (DENY wins; predefined
+  `$InstanceStarter`/dynamic roles honored). No allow → **HTTP 403**
+  (`Error.Forbidden(WorkflowErrorCodes.AuthorizationRoleDenied)` → mapped in `AddExceptionHandling`).
+- Because all four functions share the same gate, denying `state` also denies `data`/`view`/`schema`
+  — the client cannot see data, view, or schema for a state it is not authorized to query.
+- The `authorize` function (`checkQueryRoles=true`) shares the same core evaluator
+  (`AuthorizeAppService.EvaluateQueryRolesAsync` delegates to `IsQueryAllowedAsync`).
+
 ## Failure Modes
 
 - Unknown function falls back to generic function lookup.
@@ -118,4 +135,5 @@ client polling status.
 - `src/BBT.Workflow.Domain/Localization/LanguageResolver.cs` (`Accept-Language` → culture)
 - `src/BBT.Workflow.Domain/Shared/LanguageLabelExtensions.cs` (`ResolveLabel` fallback chain)
 - `src/BBT.Workflow.Application/Languages/ICurrentLanguage.cs` + `src/BBT.Workflow.HttpApi.Shared/Services/Languages/HttpContextCurrentLanguage.cs`
+- `src/BBT.Workflow.Application/Authorization/ITransitionAuthorizationManager.cs` (`IsQueryAllowedAsync` — queryRoles gate)
 

--- a/docs/domain/function-handler-architecture.md
+++ b/docs/domain/function-handler-architecture.md
@@ -105,6 +105,16 @@ whose current state they are permitted to see.
 - The `authorize` function (`checkQueryRoles=true`) shares the same core evaluator
   (`AuthorizeAppService.EvaluateQueryRolesAsync` delegates to `IsQueryAllowedAsync`).
 
+### Custom function Roles
+
+**Custom (user-defined) functions** additionally enforce their own `Function.Roles`: when a custom
+function declares `roles`, the caller's roles are evaluated via
+`ITransitionAuthorizationManager.IsAnyRoleAllowedForGrantsAsync` at the single execution chokepoint
+(`FunctionAppService.ExecuteFunctionAsync`, covering both instance- and domain-scoped custom
+functions). No allow → **HTTP 403** (`WorkflowErrors.FunctionAccessDenied`); no `roles` → allow.
+Built-in functions (state/data/view/schema/authorize/permissions/hierarchy/extensions, `human-task`)
+are **excluded** — they use their own handlers and never flow through `FunctionAppService`.
+
 ## Failure Modes
 
 - Unknown function falls back to generic function lookup.

--- a/docs/domain/function-handler-architecture.md
+++ b/docs/domain/function-handler-architecture.md
@@ -48,7 +48,14 @@ the end customer while back-office actors see a more detailed label.
   "key": "fraud-check",
   "stateType": "Intermediate",
   "alias": [
-    { "name": "Operasyon İncelemesinde", "roles": [ { "role": "backoffice.operator", "grant": "allow" } ] },
+    {
+      "name": "Operasyon İncelemesinde",
+      "roles": [ { "role": "backoffice.operator", "grant": "allow" } ],
+      "labels": [
+        { "label": "Operasyon İncelemesinde", "language": "tr" },
+        { "label": "Under Operational Review", "language": "en" }
+      ]
+    },
     { "name": "Değerlendirme Aşamasında", "roles": [] }
   ]
 }
@@ -61,15 +68,24 @@ Resolution in the `state` function:
   role evaluator as transition filtering (`ITransitionAuthorizationManager.IsRoleAllowedForGrantsAsync`):
   static roles, predefined roles (`$InstanceStarter`, `$PreviousUser`, …) and dynamic roles.
 - Aliases are evaluated in declaration order; the **first** alias whose `roles` resolve to
-  the caller wins, and its `name` is returned in the response `state` field.
+  the caller wins.
 - An alias with an empty `roles` list matches everyone, acting as a default/fallback — place it last.
-- If the state defines no aliases, or none resolves for the caller, the response `state`
-  field returns the raw state key (current behavior).
+- The winning alias's display value for the response `state` field is resolved as:
+  1. **Localized label** — if the alias has `labels`, the label for the caller's current
+     language is returned. Language comes from the `Accept-Language` header (`LanguageResolver`);
+     match order is exact culture (`tr-TR`) → neutral language (`tr`, incl. `tr-*`) →
+     English (`en-US`/`en`) → first label (`LanguageLabelExtensions.ResolveLabel`).
+  2. **Alias `name`** — when the alias has no `labels`.
+  3. **Raw state key** — when the state defines no aliases, or none resolves for the caller
+     (current behavior).
 - Only the `state` representation changes; `stateType`, status, transitions, and all internal
   workflow logic continue to use the real state identity (`instance.CurrentState`). Because the
-  resolved value participates in the representation, different roles get different `ETag`s.
+  resolved value participates in the representation, different roles/languages get different `ETag`s.
 - Aliasing applies only to the main-flow current state. While a non-terminal subflow is
   borrowing the displayed state, the value is left untouched.
+- `ICurrentLanguage` (registered scoped, `HttpContext`-based) is the reusable per-request handle
+  for the same culture resolution; the state function resolves from the request headers it already
+  receives so it stays correct under forwarded/subflow contexts.
 
 ## Failure Modes
 
@@ -96,6 +112,9 @@ client polling status.
 - `orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs`
 - `orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/`
 - `src/BBT.Workflow.Domain/Definitions/InstanceUrlTemplates.cs`
-- `src/BBT.Workflow.Domain/Definitions/States/StateAlias.cs` (state alias model)
-- `src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs` (`ResolveStateAliasNameAsync`)
+- `src/BBT.Workflow.Domain/Definitions/States/StateAlias.cs` (state alias model + localized labels)
+- `src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs` (`ResolveStateAliasDisplayAsync`)
+- `src/BBT.Workflow.Domain/Localization/LanguageResolver.cs` (`Accept-Language` → culture)
+- `src/BBT.Workflow.Domain/Shared/LanguageLabelExtensions.cs` (`ResolveLabel` fallback chain)
+- `src/BBT.Workflow.Application/Languages/ICurrentLanguage.cs` + `src/BBT.Workflow.HttpApi.Shared/Services/Languages/HttpContextCurrentLanguage.cs`
 

--- a/docs/domain/function-handler-architecture.md
+++ b/docs/domain/function-handler-architecture.md
@@ -36,6 +36,41 @@ Application services own domain behavior and result construction.
 | `hierarchy` | `HierarchyFunctionHandler` | Returns instance hierarchy. |
 | `humanTask` | `HumanTaskFunctionHandler` | Returns human task state for clients. |
 
+## State Alias (Role-Based State Visibility)
+
+A state may declare an `alias` array so the same internal state is presented under
+different, role-appropriate labels without changing the workflow's real state identity.
+This lets internal evaluation states (fraud check, KPS, limit checks, …) stay hidden from
+the end customer while back-office actors see a more detailed label.
+
+```json
+{
+  "key": "fraud-check",
+  "stateType": "Intermediate",
+  "alias": [
+    { "name": "Operasyon İncelemesinde", "roles": [ { "role": "backoffice.operator", "grant": "allow" } ] },
+    { "name": "Değerlendirme Aşamasında", "roles": [] }
+  ]
+}
+```
+
+Resolution in the `state` function:
+
+- When the current (main-flow) state defines aliases, `StateFunctionHandler` →
+  `InstanceQueryAppService.BuildInstanceStateOutputAsync` resolves them using the same
+  role evaluator as transition filtering (`ITransitionAuthorizationManager.IsRoleAllowedForGrantsAsync`):
+  static roles, predefined roles (`$InstanceStarter`, `$PreviousUser`, …) and dynamic roles.
+- Aliases are evaluated in declaration order; the **first** alias whose `roles` resolve to
+  the caller wins, and its `name` is returned in the response `state` field.
+- An alias with an empty `roles` list matches everyone, acting as a default/fallback — place it last.
+- If the state defines no aliases, or none resolves for the caller, the response `state`
+  field returns the raw state key (current behavior).
+- Only the `state` representation changes; `stateType`, status, transitions, and all internal
+  workflow logic continue to use the real state identity (`instance.CurrentState`). Because the
+  resolved value participates in the representation, different roles get different `ETag`s.
+- Aliasing applies only to the main-flow current state. While a non-terminal subflow is
+  borrowing the displayed state, the value is left untouched.
+
 ## Failure Modes
 
 - Unknown function falls back to generic function lookup.
@@ -61,4 +96,6 @@ client polling status.
 - `orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs`
 - `orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/`
 - `src/BBT.Workflow.Domain/Definitions/InstanceUrlTemplates.cs`
+- `src/BBT.Workflow.Domain/Definitions/States/StateAlias.cs` (state alias model)
+- `src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs` (`ResolveStateAliasNameAsync`)
 

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/DataFunctionHandler.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/DataFunctionHandler.cs
@@ -28,6 +28,7 @@ public sealed class DataFunctionHandler(
             Headers = request.Headers,
             QueryParameters = request.QueryParameters,
             Version = request.QueryParameters.GetOrDefault("version"),
+            Roles = request.CurrentUser.Roles,
         };
 
         var result = await queryAppService.GetInstanceDataAsync(input, cancellationToken);

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/SchemaFunctionHandler.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/SchemaFunctionHandler.cs
@@ -22,7 +22,10 @@ public sealed class SchemaFunctionHandler(
             Domain = request.Domain,
             Workflow = request.Workflow,
             Instance = request.Instance,
-            Version = request.Parameters.Version
+            Version = request.Parameters.Version,
+            Headers = request.Headers,
+            QueryParameters = request.QueryParameters,
+            Roles = request.CurrentUser.Roles,
         };
 
         var result = await queryAppService.GetSchemaAsync(

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/StateFunctionHandler.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/StateFunctionHandler.cs
@@ -28,7 +28,8 @@ public sealed class StateFunctionHandler(
             Extensions = request.Parameters.Extensions,
             Headers = request.Headers,
             QueryParams = request.QueryParameters,
-            Role = request.CurrentUser.Roles?.FirstOrDefault()
+            Role = request.CurrentUser.Roles?.FirstOrDefault(),
+            Roles = request.CurrentUser.Roles
         };
 
         var result = await queryAppService.GetInstanceStateAsync(input, cancellationToken);

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/ViewFunctionHandler.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/ViewFunctionHandler.cs
@@ -24,7 +24,8 @@ public sealed class ViewFunctionHandler(
             Version = request.Parameters.Version,
             Headers = request.Headers,
             QueryParameters = request.QueryParameters,
-            Role = request.CurrentUser.Roles?.FirstOrDefault()
+            Role = request.CurrentUser.Roles?.FirstOrDefault(),
+            Roles = request.CurrentUser.Roles
         };
 
         var result = await queryAppService.GetViewAsync(

--- a/src/BBT.Workflow.Application/Authorization/AuthorizeAppService.cs
+++ b/src/BBT.Workflow.Application/Authorization/AuthorizeAppService.cs
@@ -426,13 +426,7 @@ public sealed class AuthorizeAppService(
     {
         if (instance == null)
             return false;
-        var currentStateKey = instance.GetEffectiveState;
-        if (string.IsNullOrWhiteSpace(currentStateKey))
-            return false;
-        var state = workflow.FindState(currentStateKey);
-        var queryRoles = state is { QueryRoles.Count: > 0 } ? state.QueryRoles : workflow.QueryRoles;
-        if (queryRoles.Count == 0)
-            return true; // No query roles defined → allow
-        return await transitionAuthorizationManager.IsRoleAllowedForGrantsAsync(role, queryRoles, instance, requestContext, cancellationToken);
+        return await transitionAuthorizationManager.IsQueryAllowedAsync(
+            workflow, instance, role is null ? null : [role], requestContext, cancellationToken);
     }
 }

--- a/src/BBT.Workflow.Application/Authorization/ITransitionAuthorizationManager.cs
+++ b/src/BBT.Workflow.Application/Authorization/ITransitionAuthorizationManager.cs
@@ -76,6 +76,18 @@ public interface ITransitionAuthorizationManager
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Evaluates a set of role grants against ALL of the caller's roles (multi-role: any allowed → allow).
+    /// No grants → allow. When callerRoles is null/empty only predefined/dynamic grants are evaluated.
+    /// DENY wins within each role evaluation. Reused for custom function <c>Roles</c> and state queryRoles.
+    /// </summary>
+    Task<bool> IsAnyRoleAllowedForGrantsAsync(
+        IReadOnlyCollection<string>? callerRoles,
+        IReadOnlyCollection<RoleGrant> roleGrants,
+        Instance? instance,
+        AuthorizationRequestContext? requestContext = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Evaluates state-based query visibility for the caller. Resolves the effective grants —
     /// the instance's effective-state <c>queryRoles</c> when present, otherwise <c>workflow.QueryRoles</c> —
     /// and evaluates the caller's roles against them (multi-role: any allowed → allow). No grants → allow.

--- a/src/BBT.Workflow.Application/Authorization/ITransitionAuthorizationManager.cs
+++ b/src/BBT.Workflow.Application/Authorization/ITransitionAuthorizationManager.cs
@@ -76,6 +76,20 @@ public interface ITransitionAuthorizationManager
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Evaluates state-based query visibility for the caller. Resolves the effective grants —
+    /// the instance's effective-state <c>queryRoles</c> when present, otherwise <c>workflow.QueryRoles</c> —
+    /// and evaluates the caller's roles against them (multi-role: any allowed → allow). No grants → allow.
+    /// Used by the state/data/view/schema instance functions to gate access; predefined and dynamic role
+    /// grants are honored via the instance and <paramref name="requestContext"/>.
+    /// </summary>
+    Task<bool> IsQueryAllowedAsync(
+        WorkflowDefinition workflow,
+        Instance instance,
+        IReadOnlyCollection<string>? callerRoles,
+        AuthorizationRequestContext? requestContext = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Builds the effective caller roles list for schema field-level visibility.
     /// Returns static roles (ICurrentUser.Roles); when instance is present, adds applicable predefined roles:
     /// <c>$InstanceStarter</c>, <c>$PreviousUser</c> (matched via ActorUserName),

--- a/src/BBT.Workflow.Application/Authorization/TransitionAuthorizationManager.cs
+++ b/src/BBT.Workflow.Application/Authorization/TransitionAuthorizationManager.cs
@@ -79,6 +79,37 @@ public sealed class TransitionAuthorizationManager(
     }
 
     /// <inheritdoc />
+    public async Task<bool> IsQueryAllowedAsync(
+        WorkflowDefinition workflow,
+        Instance instance,
+        IReadOnlyCollection<string>? callerRoles,
+        AuthorizationRequestContext? requestContext = null,
+        CancellationToken cancellationToken = default)
+    {
+        var currentStateKey = instance.GetEffectiveState;
+        var state = string.IsNullOrWhiteSpace(currentStateKey) ? null : workflow.FindState(currentStateKey);
+        var queryRoles = state is { QueryRoles.Count: > 0 } ? state.QueryRoles : workflow.QueryRoles;
+
+        if (queryRoles.Count == 0)
+            return true; // No query roles defined → allow
+
+        // No caller roles: still evaluate predefined/dynamic grants once.
+        if (callerRoles is null || callerRoles.Count == 0)
+            return await IsRoleAllowedForGrantsAsync(null, queryRoles, instance, requestContext, cancellationToken);
+
+        // Multi-role: any allowed role grants access.
+        foreach (var role in callerRoles)
+        {
+            if (string.IsNullOrWhiteSpace(role))
+                continue;
+            if (await IsRoleAllowedForGrantsAsync(role.Trim(), queryRoles, instance, requestContext, cancellationToken))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <inheritdoc />
     public async Task<IReadOnlyList<string>> GetEffectiveCallerRolesForFieldVisibilityAsync(
         Instance? instance,
         CancellationToken cancellationToken = default)

--- a/src/BBT.Workflow.Application/Authorization/TransitionAuthorizationManager.cs
+++ b/src/BBT.Workflow.Application/Authorization/TransitionAuthorizationManager.cs
@@ -79,6 +79,33 @@ public sealed class TransitionAuthorizationManager(
     }
 
     /// <inheritdoc />
+    public async Task<bool> IsAnyRoleAllowedForGrantsAsync(
+        IReadOnlyCollection<string>? callerRoles,
+        IReadOnlyCollection<RoleGrant> roleGrants,
+        Instance? instance,
+        AuthorizationRequestContext? requestContext = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (roleGrants.Count == 0)
+            return true; // No roles defined → allow
+
+        // No caller roles: still evaluate predefined/dynamic grants once.
+        if (callerRoles is null || callerRoles.Count == 0)
+            return await IsRoleAllowedForGrantsAsync(null, roleGrants, instance, requestContext, cancellationToken);
+
+        // Multi-role: any allowed role grants access.
+        foreach (var role in callerRoles)
+        {
+            if (string.IsNullOrWhiteSpace(role))
+                continue;
+            if (await IsRoleAllowedForGrantsAsync(role.Trim(), roleGrants, instance, requestContext, cancellationToken))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <inheritdoc />
     public async Task<bool> IsQueryAllowedAsync(
         WorkflowDefinition workflow,
         Instance instance,
@@ -90,23 +117,7 @@ public sealed class TransitionAuthorizationManager(
         var state = string.IsNullOrWhiteSpace(currentStateKey) ? null : workflow.FindState(currentStateKey);
         var queryRoles = state is { QueryRoles.Count: > 0 } ? state.QueryRoles : workflow.QueryRoles;
 
-        if (queryRoles.Count == 0)
-            return true; // No query roles defined → allow
-
-        // No caller roles: still evaluate predefined/dynamic grants once.
-        if (callerRoles is null || callerRoles.Count == 0)
-            return await IsRoleAllowedForGrantsAsync(null, queryRoles, instance, requestContext, cancellationToken);
-
-        // Multi-role: any allowed role grants access.
-        foreach (var role in callerRoles)
-        {
-            if (string.IsNullOrWhiteSpace(role))
-                continue;
-            if (await IsRoleAllowedForGrantsAsync(role.Trim(), queryRoles, instance, requestContext, cancellationToken))
-                return true;
-        }
-
-        return false;
+        return await IsAnyRoleAllowedForGrantsAsync(callerRoles, queryRoles, instance, requestContext, cancellationToken);
     }
 
     /// <inheritdoc />

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/TransitionPipeline.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/TransitionPipeline.cs
@@ -91,7 +91,8 @@ public class TransitionPipeline
             await using var ownLock = await _lockScopeFactory.AcquireAsync(reservedKey, cancellationToken);
             if (!ownLock.IsAcquired)
             {
-                _logger.InstanceLockFailed(context.InstanceId.ToString());
+                // Lock failure is already logged by TransitionLockScopeFactory with the full key;
+                // avoid a duplicate log line for the same acquisition.
                 return Result<TransitionExecutionContext>.Fail(
                     WorkflowErrors.InstanceLockConflict(context.InstanceId));
             }
@@ -108,7 +109,8 @@ public class TransitionPipeline
 
         if (!lockScope.IsAcquired)
         {
-            _logger.InstanceLockFailed(context.InstanceId.ToString());
+            // Lock failure is already logged by TransitionLockScopeFactory with the full key;
+            // avoid a duplicate log line for the same acquisition.
             return Result<TransitionExecutionContext>.Fail(
                 WorkflowErrors.InstanceLockConflict(context.InstanceId));
         }

--- a/src/BBT.Workflow.Application/Execution/Transitions/Validation/TransitionValidationService.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Validation/TransitionValidationService.cs
@@ -73,30 +73,7 @@ public class TransitionValidationService(
     }
 
     private static string ResolveCulture(IReadOnlyDictionary<string, string?>? headers)
-    {
-        if (headers is null)
-            return "en-US";
-
-        if (!headers.TryGetValue("accept-language", out var acceptLanguage) &&
-            !headers.TryGetValue("Accept-Language", out acceptLanguage))
-        {
-            return "en-US";
-        }
-
-        if (string.IsNullOrWhiteSpace(acceptLanguage))
-            return "en-US";
-
-        var firstLanguage = acceptLanguage
-            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .FirstOrDefault();
-
-        if (string.IsNullOrWhiteSpace(firstLanguage))
-            return "en-US";
-
-        return firstLanguage
-            .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .FirstOrDefault() ?? "en-US";
-    }
+        => LanguageResolver.ResolveCulture(headers);
 
     /// <inheritdoc />
     /// <summary>

--- a/src/BBT.Workflow.Application/Functions/FunctionAppService.cs
+++ b/src/BBT.Workflow.Application/Functions/FunctionAppService.cs
@@ -4,6 +4,8 @@ using System.Globalization;
 using BBT.Aether.Application.Services;
 using BBT.Aether.MultiSchema;
 using BBT.Aether.Results;
+using BBT.Aether.Users;
+using BBT.Workflow.Authorization;
 using BBT.Workflow.Caching;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Instances;
@@ -25,7 +27,9 @@ public sealed class FunctionAppService(
     IComponentCacheStore componentCacheStore,
     ICurrentSchema currentSchema,
     ITaskCoordinator taskCoordinator,
-    IScriptEngine scriptEngine) : ApplicationService(serviceProvider), IFunctionAppService
+    IScriptEngine scriptEngine,
+    ICurrentUser currentUser,
+    ITransitionAuthorizationManager transitionAuthorizationManager) : ApplicationService(serviceProvider), IFunctionAppService
 {
     /// <inheritdoc />
     public async Task<Result<FunctionResponseOutput>> GetFunctionByKeyAsync(
@@ -125,6 +129,20 @@ public sealed class FunctionAppService(
         {
             return Result<FunctionResponseOutput>.Fail(
                 WorkflowErrors.FunctionNotInWorkflow(function.Key, workflow.Key));
+        }
+
+        // Custom-function authorization: when the function defines Roles, the caller must resolve to an allow.
+        // Built-in functions never reach this path (they use their own handlers/authorization).
+        if (function.Roles.Count > 0)
+        {
+            var allowed = await transitionAuthorizationManager.IsAnyRoleAllowedForGrantsAsync(
+                currentUser.Roles,
+                function.Roles,
+                instance,
+                new AuthorizationRequestContext(headers, queryParameters),
+                cancellationToken);
+            if (!allowed)
+                return Result<FunctionResponseOutput>.Fail(WorkflowErrors.FunctionAccessDenied(function.Key));
         }
 
         object scriptBody = body.HasValue

--- a/src/BBT.Workflow.Application/Instances/DTOs/GetInstanceInput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/GetInstanceInput.cs
@@ -184,4 +184,9 @@ public sealed class GetInstanceDataInput : IHasDomain
     /// Query parameters from the request for script context binding
     /// </summary>
     public Dictionary<string, string?>? QueryParameters { get; set; }
-} 
+
+    /// <summary>
+    /// Caller roles, used to enforce state/workflow queryRoles visibility (multi-role: any allowed → allow).
+    /// </summary>
+    public IReadOnlyList<string>? Roles { get; set; }
+}

--- a/src/BBT.Workflow.Application/Instances/DTOs/GetInstanceStateInput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/GetInstanceStateInput.cs
@@ -43,4 +43,9 @@ public sealed class GetInstanceStateInput : IHasDomain
     /// When set, only transitions allowed for this role are returned; when null or empty, all available transitions are returned.
     /// </summary>
     public string? Role { get; set; }
+
+    /// <summary>
+    /// Caller roles, used to enforce state/workflow queryRoles visibility (multi-role: any allowed → allow).
+    /// </summary>
+    public IReadOnlyList<string>? Roles { get; set; }
 }

--- a/src/BBT.Workflow.Application/Instances/DTOs/GetSchemaInput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/GetSchemaInput.cs
@@ -20,8 +20,23 @@ public sealed class GetSchemaInput: IHasDomain
     [StringLength(WorkflowConstants.MaxVersionLength)]
     public string? Version { get; set; } = string.Empty;
 
-    [Required] 
+    [Required]
     public string Instance { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Request headers for queryRoles dynamic-role evaluation.
+    /// </summary>
+    public Dictionary<string, string?>? Headers { get; set; }
+
+    /// <summary>
+    /// Query parameters for queryRoles dynamic-role evaluation.
+    /// </summary>
+    public Dictionary<string, string?>? QueryParameters { get; set; }
+
+    /// <summary>
+    /// Caller roles, used to enforce state/workflow queryRoles visibility.
+    /// </summary>
+    public IReadOnlyList<string>? Roles { get; set; }
 }
 
 public sealed class GetSchemaOutput

--- a/src/BBT.Workflow.Application/Instances/DTOs/GetViewInput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/GetViewInput.cs
@@ -36,4 +36,9 @@ public sealed class GetViewInput : IHasDomain
     /// Caller role for wizard view transition filtering.
     /// </summary>
     public string? Role { get; set; }
+
+    /// <summary>
+    /// Caller roles, used to enforce state/workflow queryRoles visibility.
+    /// </summary>
+    public IReadOnlyList<string>? Roles { get; set; }
 }

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -574,6 +574,10 @@ public sealed class InstanceQueryAppService(
                 onSuccess: async data =>
                 {
                     var (flow, instance) = data;
+
+                    if (!await IsInstanceQueryAllowedAsync(flow, instance, input.Roles, input.Headers, input.QueryParameters, cancellationToken))
+                        return ConditionalResult<GetInstanceDataOutput>.Fail(WorkflowErrors.QueryAccessDenied(instance.GetEffectiveState));
+
                     var instanceData = instance.FindData(input.Version);
                     var entityEtag = instanceData?.ETag ?? string.Empty;
 
@@ -754,6 +758,9 @@ public sealed class InstanceQueryAppService(
             .MatchAsync(
                 onSuccess: async data =>
                 {
+                    if (!await IsInstanceQueryAllowedAsync(data.workflow, data.instance, input.Roles, input.Headers, input.QueryParams, cancellationToken))
+                        return ConditionalResult<GetInstanceStateOutput>.Fail(WorkflowErrors.QueryAccessDenied(data.instance.GetEffectiveState));
+
                     var buildResult = await BuildInstanceStateOutputAsync(data.instance, data.workflow, input, cancellationToken);
                     if (!buildResult.IsSuccess)
                         return ConditionalResult<GetInstanceStateOutput>.Fail(buildResult.Error);
@@ -1052,6 +1059,24 @@ public sealed class InstanceQueryAppService(
     }
 
     /// <summary>
+    /// Enforces state/workflow <c>queryRoles</c> visibility for the instance query functions
+    /// (state/data/view/schema). Returns true when access is permitted: no grants defined → allow;
+    /// otherwise the caller's roles must resolve to an allow (DENY wins; predefined/dynamic roles honored).
+    /// </summary>
+    private async Task<bool> IsInstanceQueryAllowedAsync(
+        Definitions.Workflow workflow,
+        Instance instance,
+        IReadOnlyCollection<string>? roles,
+        IReadOnlyDictionary<string, string?>? headers,
+        IReadOnlyDictionary<string, string?>? queryParameters,
+        CancellationToken cancellationToken)
+    {
+        var requestContext = new AuthorizationRequestContext(headers, queryParameters);
+        return await transitionAuthorizationManager.IsQueryAllowedAsync(
+            workflow, instance, roles, requestContext, cancellationToken);
+    }
+
+    /// <summary>
     /// Resolves the role-appropriate display value for a state's aliases. Aliases are evaluated in
     /// declaration order; the first whose role grants resolve to the caller wins. An alias with no
     /// role grants matches everyone (default/fallback). For the winning alias the localized label for
@@ -1254,6 +1279,9 @@ public sealed class InstanceQueryAppService(
         string? transitionKey,
         CancellationToken cancellationToken)
     {
+        if (!await IsInstanceQueryAllowedAsync(currentWorkflow, instance, input.Roles, input.Headers, input.QueryParameters, cancellationToken))
+            return Result<GetSchemaOutput>.Fail(WorkflowErrors.QueryAccessDenied(instance.GetEffectiveState));
+
         if (string.IsNullOrEmpty(transitionKey))
         {
             return Result<GetSchemaOutput>.Fail(
@@ -1338,6 +1366,9 @@ public sealed class InstanceQueryAppService(
         string? transitionKey,
         CancellationToken cancellationToken)
     {
+        if (!await IsInstanceQueryAllowedAsync(currentWorkflow, instance, input.Roles, input.Headers, input.QueryParameters, cancellationToken))
+            return Result<GetViewOutput>.Fail(WorkflowErrors.QueryAccessDenied(instance.GetEffectiveState));
+
         // Get current state using Railway pattern
         var currentStateResult = currentWorkflow.GetState(instance.CurrentState!);
         if (!currentStateResult.IsSuccess || currentStateResult.Value == null)

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -1023,17 +1023,18 @@ public sealed class InstanceQueryAppService(
             : mainFlowCorrelationHrefs;
 
         // Role-aware state alias: when the displayed state is the main-flow current state and that
-        // state defines aliases, return the alias name resolved for the caller's role instead of the
-        // raw state key. Internal workflow logic is unaffected — it always uses instance.CurrentState.
+        // state defines aliases, return the role-resolved alias (localized label, else name) instead
+        // of the raw state key. Internal workflow logic is unaffected — it always uses instance.CurrentState.
         var displayedState = subFlowStateInfo.CurrentState;
         if (currentStateValue.Aliases.Count > 0 &&
             string.Equals(displayedState, instance.CurrentState, StringComparison.Ordinal))
         {
             var requestContext = new AuthorizationRequestContext(input.Headers, input.QueryParams);
-            var aliasName = await ResolveStateAliasNameAsync(
-                currentStateValue, instance, input.Role, requestContext, cancellationToken);
-            if (!string.IsNullOrEmpty(aliasName))
-                displayedState = aliasName;
+            var culture = LanguageResolver.ResolveCulture(input.Headers);
+            var aliasDisplay = await ResolveStateAliasDisplayAsync(
+                currentStateValue, instance, input.Role, culture, requestContext, cancellationToken);
+            if (!string.IsNullOrEmpty(aliasDisplay))
+                displayedState = aliasDisplay;
         }
 
         return Result<GetInstanceStateOutput>.Ok(new GetInstanceStateOutput
@@ -1051,15 +1052,18 @@ public sealed class InstanceQueryAppService(
     }
 
     /// <summary>
-    /// Resolves the role-appropriate display alias for a state. Aliases are evaluated in declaration
-    /// order; the first whose role grants resolve to the caller wins. An alias with no role grants
-    /// matches everyone (default/fallback). Returns null when the state defines no matching alias,
-    /// in which case the caller falls back to the raw state key.
+    /// Resolves the role-appropriate display value for a state's aliases. Aliases are evaluated in
+    /// declaration order; the first whose role grants resolve to the caller wins. An alias with no
+    /// role grants matches everyone (default/fallback). For the winning alias the localized label for
+    /// <paramref name="culture"/> is returned (exact → neutral → English → first), falling back to the
+    /// alias name when it has no labels. Returns null when no alias matches, so the caller falls back
+    /// to the raw state key.
     /// </summary>
-    private async Task<string?> ResolveStateAliasNameAsync(
+    private async Task<string?> ResolveStateAliasDisplayAsync(
         State state,
         Instance instance,
         string? role,
+        string culture,
         AuthorizationRequestContext requestContext,
         CancellationToken cancellationToken)
     {
@@ -1068,7 +1072,7 @@ public sealed class InstanceQueryAppService(
             var allowed = await transitionAuthorizationManager.IsRoleAllowedForGrantsAsync(
                 role, alias.Roles, instance, requestContext, cancellationToken);
             if (allowed)
-                return alias.Name;
+                return alias.Labels.ResolveLabel(culture) ?? alias.Name;
         }
 
         return null;

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -1022,11 +1022,25 @@ public sealed class InstanceQueryAppService(
             ? mainFlowCorrelationHrefs.Concat(subFlowStateInfo.SubFlowActiveCorrelations).ToList()
             : mainFlowCorrelationHrefs;
 
+        // Role-aware state alias: when the displayed state is the main-flow current state and that
+        // state defines aliases, return the alias name resolved for the caller's role instead of the
+        // raw state key. Internal workflow logic is unaffected — it always uses instance.CurrentState.
+        var displayedState = subFlowStateInfo.CurrentState;
+        if (currentStateValue.Aliases.Count > 0 &&
+            string.Equals(displayedState, instance.CurrentState, StringComparison.Ordinal))
+        {
+            var requestContext = new AuthorizationRequestContext(input.Headers, input.QueryParams);
+            var aliasName = await ResolveStateAliasNameAsync(
+                currentStateValue, instance, input.Role, requestContext, cancellationToken);
+            if (!string.IsNullOrEmpty(aliasName))
+                displayedState = aliasName;
+        }
+
         return Result<GetInstanceStateOutput>.Ok(new GetInstanceStateOutput
         {
             Data = dataHref,
             View = viewHref,
-            State = subFlowStateInfo.CurrentState ?? string.Empty,
+            State = displayedState ?? string.Empty,
             StateType = subFlowStateInfo.StateType.IsNullOrWhiteSpace()
                 ? ToCamelCaseName(currentStateValue.StateType)
                 : subFlowStateInfo.StateType!,
@@ -1034,6 +1048,30 @@ public sealed class InstanceQueryAppService(
             ActiveCorrelations = allActiveCorrelations,
             Transitions = transitionItems
         });
+    }
+
+    /// <summary>
+    /// Resolves the role-appropriate display alias for a state. Aliases are evaluated in declaration
+    /// order; the first whose role grants resolve to the caller wins. An alias with no role grants
+    /// matches everyone (default/fallback). Returns null when the state defines no matching alias,
+    /// in which case the caller falls back to the raw state key.
+    /// </summary>
+    private async Task<string?> ResolveStateAliasNameAsync(
+        State state,
+        Instance instance,
+        string? role,
+        AuthorizationRequestContext requestContext,
+        CancellationToken cancellationToken)
+    {
+        foreach (var alias in state.Aliases)
+        {
+            var allowed = await transitionAuthorizationManager.IsRoleAllowedForGrantsAsync(
+                role, alias.Roles, instance, requestContext, cancellationToken);
+            if (allowed)
+                return alias.Name;
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Application/Languages/ICurrentLanguage.cs
+++ b/src/BBT.Workflow.Application/Languages/ICurrentLanguage.cs
@@ -1,0 +1,19 @@
+namespace BBT.Workflow.Languages;
+
+/// <summary>
+/// Provides the caller's current language/culture for the active request, resolved from the
+/// <c>Accept-Language</c> header. Reusable, request-scoped abstraction (mirrors <c>ICurrentUser</c>)
+/// for localization decisions such as resolving display labels.
+/// </summary>
+public interface ICurrentLanguage
+{
+    /// <summary>
+    /// The resolved culture, e.g. <c>tr-TR</c> or <c>en-US</c>. Defaults to <c>en-US</c> when none is provided.
+    /// </summary>
+    string Culture { get; }
+
+    /// <summary>
+    /// The neutral language portion of <see cref="Culture"/>, e.g. <c>tr</c> for <c>tr-TR</c>.
+    /// </summary>
+    string Language { get; }
+}

--- a/src/BBT.Workflow.Domain/Definitions/Schemas/SchemaRolesParser.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Schemas/SchemaRolesParser.cs
@@ -11,12 +11,12 @@ namespace BBT.Workflow.Definitions.Schemas;
 public static class SchemaRolesParser
 {
     private const string PropertiesKey = "properties";
-    private const string RolesKey = "roles";
+    private const string RolesKey = "x-roles";
 
     /// <summary>
     /// Parses the schema and returns a map of property path to role grants.
     /// Path format: dot-separated (e.g. "amount", "internalNotes", "nested.field").
-    /// Properties without "roles" are not included (treated as visible to all).
+    /// Properties without "x-roles" are not included (treated as visible to all).
     /// </summary>
     /// <param name="schemaRoot">The root JsonElement of the schema (object with optional "properties").</param>
     /// <returns>Map of property path to list of role grants; empty if schema has no roles.</returns>

--- a/src/BBT.Workflow.Domain/Definitions/States/State.cs
+++ b/src/BBT.Workflow.Domain/Definitions/States/State.cs
@@ -43,6 +43,7 @@ public sealed class State : IHasKey
         this.onEntries = onEntries ?? [];
         this.onExits = onExits ?? [];
         this.queryRoles = queryRoles ?? [];
+        // aliases field is populated directly by System.Text.Json via [JsonInclude] (see `transitions` pattern)
         // view property will be set by ViewDefinitionJsonConverter via JsonInclude attribute
     }
 
@@ -81,6 +82,9 @@ public sealed class State : IHasKey
     [JsonInclude] [JsonPropertyName("queryRoles")]
     private List<RoleGrant> queryRoles = new();
 
+    [JsonInclude] [JsonPropertyName("alias")]
+    private List<StateAlias> aliases = new();
+
     [JsonInclude] [JsonPropertyName("subFlow")]
     public SubFlow? SubFlow { get; private set; }
     
@@ -105,6 +109,14 @@ public sealed class State : IHasKey
     /// </summary>
     [JsonIgnore]
     public IReadOnlyCollection<RoleGrant> QueryRoles => queryRoles.AsReadOnly();
+
+    /// <summary>
+    /// Role-aware display aliases for this state. When present, the state function returns the
+    /// name of the first alias whose roles resolve to the caller instead of the raw state key.
+    /// Evaluated in declaration order, first match wins.
+    /// </summary>
+    [JsonIgnore]
+    public IReadOnlyCollection<StateAlias> Aliases => aliases.AsReadOnly();
 
     /// <summary>
     /// Languages
@@ -163,6 +175,11 @@ public sealed class State : IHasKey
     public void AddOnExit(OnExecuteTask task)
     {
         onExits.Add(task);
+    }
+
+    public void AddAlias(StateAlias alias)
+    {
+        aliases.Add(alias);
     }
 
     public void SetView(ViewDefinition viewDefinition)

--- a/src/BBT.Workflow.Domain/Definitions/States/State.cs
+++ b/src/BBT.Workflow.Domain/Definitions/States/State.cs
@@ -34,7 +34,7 @@ public sealed class State : IHasKey
         VersionStrategy versionStrategy,
         List<LanguageLabel>? labels,
         List<OnExecuteTask>? onEntries,
-         List<OnExecuteTask>? onExits,
+        List<OnExecuteTask>? onExits,
         List<RoleGrant>? queryRoles = null)
         : this(key, stateType, subType)
     {

--- a/src/BBT.Workflow.Domain/Definitions/States/StateAlias.cs
+++ b/src/BBT.Workflow.Domain/Definitions/States/StateAlias.cs
@@ -11,8 +11,9 @@ namespace BBT.Workflow.Definitions;
 ///   "roles": [ { "role": "...", "grant": "allow" } ],
 ///   "labels": [ { "label": "...", "language": "tr" } ] }.
 /// <para>
-/// Aliases are evaluated in declaration order, first match wins. An entry with an empty
-/// <c>roles</c> list matches everyone and therefore acts as a default/fallback — place it last.
+/// Aliases are evaluated in declaration order, first match wins. Authoring rules
+/// (enforced by <c>WorkflowValidator</c>): each entry must declare a <c>name</c>, at least one
+/// <c>roles</c> grant, and at least one <c>labels</c> entry.
 /// </para>
 /// </summary>
 public sealed class StateAlias
@@ -43,8 +44,9 @@ public sealed class StateAlias
     private List<LanguageLabel> labels = new();
 
     /// <summary>
-    /// Role grants that must resolve to the caller for this alias to apply.
-    /// Empty means the alias matches everyone (default/fallback). DENY always wins; otherwise any ALLOW match applies.
+    /// Role grants that must resolve to the caller for this alias to apply (at least one is required by
+    /// validation). DENY always wins; otherwise any ALLOW match applies. The runtime treats an empty list
+    /// defensively as "matches everyone".
     /// </summary>
     [JsonIgnore]
     public IReadOnlyCollection<RoleGrant> Roles => roles.AsReadOnly();

--- a/src/BBT.Workflow.Domain/Definitions/States/StateAlias.cs
+++ b/src/BBT.Workflow.Domain/Definitions/States/StateAlias.cs
@@ -6,7 +6,10 @@ namespace BBT.Workflow.Definitions;
 /// <summary>
 /// Role-aware display alias for a state. Lets the same internal state be presented
 /// under different, role-appropriate labels without changing the workflow's real state identity.
-/// JSON format: { "name": "Değerlendirme Aşamasında", "roles": [ { "role": "...", "grant": "allow" } ] }.
+/// JSON format:
+/// { "name": "Değerlendirme Aşamasında",
+///   "roles": [ { "role": "...", "grant": "allow" } ],
+///   "labels": [ { "label": "...", "language": "tr" } ] }.
 /// <para>
 /// Aliases are evaluated in declaration order, first match wins. An entry with an empty
 /// <c>roles</c> list matches everyone and therefore acts as a default/fallback — place it last.
@@ -21,19 +24,23 @@ public sealed class StateAlias
     }
 
     [JsonConstructor]
-    internal StateAlias(string name, List<RoleGrant>? roles)
+    internal StateAlias(string name, List<RoleGrant>? roles, List<LanguageLabel>? labels)
     {
         Name = Check.NotNullOrWhiteSpace(name, nameof(Name), MaxNameLength);
         this.roles = roles ?? [];
+        this.labels = labels ?? [];
     }
 
     /// <summary>
-    /// Display label returned in the state representation when this alias resolves for the caller.
+    /// Display label returned when this alias resolves for the caller and no localized label matches.
     /// </summary>
     public string Name { get; private set; } = string.Empty;
 
     [JsonInclude] [JsonPropertyName("roles")]
     private List<RoleGrant> roles = new();
+
+    [JsonInclude] [JsonPropertyName("labels")]
+    private List<LanguageLabel> labels = new();
 
     /// <summary>
     /// Role grants that must resolve to the caller for this alias to apply.
@@ -43,12 +50,20 @@ public sealed class StateAlias
     public IReadOnlyCollection<RoleGrant> Roles => roles.AsReadOnly();
 
     /// <summary>
-    /// Creates a new state alias with the given display name and role grants.
+    /// Localized display labels. When present, the label for the caller's current language is
+    /// returned (with fallback) instead of <see cref="Name"/>.
     /// </summary>
-    public static StateAlias Create(string name, List<RoleGrant>? roles = null)
+    [JsonIgnore]
+    public IReadOnlyCollection<LanguageLabel> Labels => labels.AsReadOnly();
+
+    /// <summary>
+    /// Creates a new state alias with the given display name, role grants and localized labels.
+    /// </summary>
+    public static StateAlias Create(
+        string name,
+        List<RoleGrant>? roles = null,
+        List<LanguageLabel>? labels = null)
     {
-        return new StateAlias(name, roles);
+        return new StateAlias(name, roles, labels);
     }
 }
-</content>
-</invoke>

--- a/src/BBT.Workflow.Domain/Definitions/States/StateAlias.cs
+++ b/src/BBT.Workflow.Domain/Definitions/States/StateAlias.cs
@@ -7,7 +7,7 @@ namespace BBT.Workflow.Definitions;
 /// Role-aware display alias for a state. Lets the same internal state be presented
 /// under different, role-appropriate labels without changing the workflow's real state identity.
 /// JSON format:
-/// { "name": "Değerlendirme Aşamasında",
+/// { "name": "Application Under Review",
 ///   "roles": [ { "role": "...", "grant": "allow" } ],
 ///   "labels": [ { "label": "...", "language": "tr" } ] }.
 /// <para>

--- a/src/BBT.Workflow.Domain/Definitions/States/StateAlias.cs
+++ b/src/BBT.Workflow.Domain/Definitions/States/StateAlias.cs
@@ -1,0 +1,54 @@
+using System.Text.Json.Serialization;
+using BBT.Aether;
+
+namespace BBT.Workflow.Definitions;
+
+/// <summary>
+/// Role-aware display alias for a state. Lets the same internal state be presented
+/// under different, role-appropriate labels without changing the workflow's real state identity.
+/// JSON format: { "name": "Değerlendirme Aşamasında", "roles": [ { "role": "...", "grant": "allow" } ] }.
+/// <para>
+/// Aliases are evaluated in declaration order, first match wins. An entry with an empty
+/// <c>roles</c> list matches everyone and therefore acts as a default/fallback — place it last.
+/// </para>
+/// </summary>
+public sealed class StateAlias
+{
+    private const int MaxNameLength = 180;
+
+    private StateAlias()
+    {
+    }
+
+    [JsonConstructor]
+    internal StateAlias(string name, List<RoleGrant>? roles)
+    {
+        Name = Check.NotNullOrWhiteSpace(name, nameof(Name), MaxNameLength);
+        this.roles = roles ?? [];
+    }
+
+    /// <summary>
+    /// Display label returned in the state representation when this alias resolves for the caller.
+    /// </summary>
+    public string Name { get; private set; } = string.Empty;
+
+    [JsonInclude] [JsonPropertyName("roles")]
+    private List<RoleGrant> roles = new();
+
+    /// <summary>
+    /// Role grants that must resolve to the caller for this alias to apply.
+    /// Empty means the alias matches everyone (default/fallback). DENY always wins; otherwise any ALLOW match applies.
+    /// </summary>
+    [JsonIgnore]
+    public IReadOnlyCollection<RoleGrant> Roles => roles.AsReadOnly();
+
+    /// <summary>
+    /// Creates a new state alias with the given display name and role grants.
+    /// </summary>
+    public static StateAlias Create(string name, List<RoleGrant>? roles = null)
+    {
+        return new StateAlias(name, roles);
+    }
+}
+</content>
+</invoke>

--- a/src/BBT.Workflow.Domain/Definitions/Validators/WorkflowValidator.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Validators/WorkflowValidator.cs
@@ -37,6 +37,7 @@ public class WorkflowValidator
 
         // State level validations
         ValidateStateLabels(workflow, result);
+        ValidateStateAliases(workflow, result);
         ValidateWizardStateTransitions(workflow, result);
         ValidateDefaultAutoTransitions(workflow, result);
         foreach (var state in workflow.States)
@@ -218,6 +219,53 @@ public class WorkflowValidator
                 result.AddError(new ValidationResult(
                     $"State '{state.Key}' must have at least one label defined.",
                     [$"{nameof(Workflow)}.{nameof(Workflow.States)}[{state.Key}].{nameof(State.Labels)}"]));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Validates state aliases. The alias array is optional, but when present each entry must
+    /// declare a name, at least one label, and at least one role grant. Dynamic role references
+    /// are additionally validated for correct path format.
+    /// </summary>
+    private void ValidateStateAliases(Workflow workflow, WorkflowValidationResult result)
+    {
+        foreach (var state in workflow.States)
+        {
+            if (state.Aliases.Count == 0)
+                continue;
+
+            var index = 0;
+            foreach (var alias in state.Aliases)
+            {
+                var aliasPath = $"{nameof(Workflow)}.{nameof(Workflow.States)}[{state.Key}].{nameof(State.Aliases)}[{index}]";
+
+                if (string.IsNullOrWhiteSpace(alias.Name))
+                {
+                    result.AddError(new ValidationResult(
+                        $"Alias at index {index} in state '{state.Key}' must have a name defined.",
+                        [$"{aliasPath}.{nameof(StateAlias.Name)}"]));
+                }
+
+                if (alias.Labels.Count == 0)
+                {
+                    result.AddError(new ValidationResult(
+                        $"Alias '{alias.Name}' in state '{state.Key}' must have at least one label defined.",
+                        [$"{aliasPath}.{nameof(StateAlias.Labels)}"]));
+                }
+
+                if (alias.Roles.Count == 0)
+                {
+                    result.AddError(new ValidationResult(
+                        $"Alias '{alias.Name}' in state '{state.Key}' must have at least one role defined.",
+                        [$"{aliasPath}.{nameof(StateAlias.Roles)}"]));
+                }
+                else
+                {
+                    ValidateRoleGrants(alias.Roles, $"{aliasPath}.{nameof(StateAlias.Roles)}", result);
+                }
+
+                index++;
             }
         }
     }

--- a/src/BBT.Workflow.Domain/Localization/LanguageResolver.cs
+++ b/src/BBT.Workflow.Domain/Localization/LanguageResolver.cs
@@ -1,0 +1,55 @@
+using BBT.Workflow.Domain.Shared;
+
+namespace BBT.Workflow;
+
+/// <summary>
+/// Reusable resolver for the caller's current language/culture from the <c>Accept-Language</c>
+/// HTTP header. Operates on a plain headers dictionary so it works across layers and contexts
+/// (HTTP requests, forwarded subflow headers, background jobs). Defaults to <c>en-US</c>.
+/// </summary>
+public static class LanguageResolver
+{
+    /// <summary>Default culture returned when no language can be resolved.</summary>
+    public const string DefaultCulture = "en-US";
+
+    /// <summary>
+    /// Resolves the culture from a headers dictionary by reading <c>Accept-Language</c>.
+    /// The dictionary is expected to use a case-insensitive comparer (lowercase-normalized keys),
+    /// so both <c>accept-language</c> and <c>Accept-Language</c> resolve.
+    /// </summary>
+    public static string ResolveCulture(IReadOnlyDictionary<string, string?>? headers)
+    {
+        if (headers is null)
+            return DefaultCulture;
+
+        if (!headers.TryGetValue(HeadersConstants.AcceptLanguage, out var acceptLanguage) &&
+            !headers.TryGetValue("accept-language", out acceptLanguage))
+        {
+            return DefaultCulture;
+        }
+
+        return ResolveCulture(acceptLanguage);
+    }
+
+    /// <summary>
+    /// Resolves the culture from a raw <c>Accept-Language</c> header value
+    /// (e.g. <c>"tr-TR,tr;q=0.9,en-US;q=0.8"</c> → <c>"tr-TR"</c>). Takes the first language token
+    /// and strips any quality weight. Returns <see cref="DefaultCulture"/> when empty.
+    /// </summary>
+    public static string ResolveCulture(string? acceptLanguageHeaderValue)
+    {
+        if (string.IsNullOrWhiteSpace(acceptLanguageHeaderValue))
+            return DefaultCulture;
+
+        var firstLanguage = acceptLanguageHeaderValue
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .FirstOrDefault();
+
+        if (string.IsNullOrWhiteSpace(firstLanguage))
+            return DefaultCulture;
+
+        return firstLanguage
+            .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .FirstOrDefault() ?? DefaultCulture;
+    }
+}

--- a/src/BBT.Workflow.Domain/Logging/WorkflowErrors.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowErrors.cs
@@ -452,6 +452,14 @@ public static class WorkflowErrors
             WorkflowErrorCodes.AuthorizationRoleDenied,
             $"Access to state '{stateKey}' is not permitted for the current roles.");
 
+    /// <summary>
+    /// The current roles are not permitted to invoke the custom function (function-level roles). Maps to HTTP 403.
+    /// </summary>
+    public static Error FunctionAccessDenied(string functionKey)
+        => Error.Forbidden(
+            WorkflowErrorCodes.AuthorizationRoleDenied,
+            $"Access to function '{functionKey}' is not permitted for the current roles.");
+
     #endregion
 
     #region Discovery Errors

--- a/src/BBT.Workflow.Domain/Logging/WorkflowErrors.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowErrors.cs
@@ -443,6 +443,15 @@ public static class WorkflowErrors
             "Query roles check is only valid for instance-level authorize",
             target: "authorize");
 
+    /// <summary>
+    /// The current roles are not permitted to query the instance in its current state (state/workflow queryRoles).
+    /// Maps to HTTP 403.
+    /// </summary>
+    public static Error QueryAccessDenied(string stateKey)
+        => Error.Forbidden(
+            WorkflowErrorCodes.AuthorizationRoleDenied,
+            $"Access to state '{stateKey}' is not permitted for the current roles.");
+
     #endregion
 
     #region Discovery Errors

--- a/src/BBT.Workflow.Domain/Shared/HeadersConstants.cs
+++ b/src/BBT.Workflow.Domain/Shared/HeadersConstants.cs
@@ -10,4 +10,7 @@ public static class HeadersConstants
 
     /// <summary>Response header for entity/row version (concurrency and write operations).</summary>
     public const string XEntityETag = "X-Entity-ETag";
+
+    /// <summary>Request header carrying the caller's preferred languages (RFC 7231).</summary>
+    public const string AcceptLanguage = "Accept-Language";
 }

--- a/src/BBT.Workflow.Domain/Shared/LanguageLabelExtensions.cs
+++ b/src/BBT.Workflow.Domain/Shared/LanguageLabelExtensions.cs
@@ -1,0 +1,46 @@
+namespace BBT.Workflow;
+
+/// <summary>
+/// Localization helpers for <see cref="LanguageLabel"/> collections.
+/// </summary>
+public static class LanguageLabelExtensions
+{
+    /// <summary>
+    /// Resolves the best-matching label text for the requested culture.
+    /// Match order: exact culture (e.g. <c>tr-TR</c>) → neutral language (<c>tr</c>, including
+    /// regional variants like <c>tr-*</c>) → English (<c>en-US</c>/<c>en</c>) → first label in the list.
+    /// Returns <c>null</c> when the collection is null or empty so callers can fall back further.
+    /// </summary>
+    public static string? ResolveLabel(this IEnumerable<LanguageLabel>? labels, string? culture)
+    {
+        if (labels is null)
+            return null;
+
+        var list = labels as IReadOnlyList<LanguageLabel> ?? labels.ToList();
+        if (list.Count == 0)
+            return null;
+
+        var requested = string.IsNullOrWhiteSpace(culture) ? LanguageResolver.DefaultCulture : culture.Trim();
+        var neutral = requested.Split('-', 2)[0];
+
+        // 1. Exact culture match (e.g. "tr-TR").
+        var exact = list.FirstOrDefault(l => string.Equals(l.Language, requested, StringComparison.OrdinalIgnoreCase));
+        if (exact is not null)
+            return exact.Label;
+
+        // 2. Neutral language match (e.g. "tr"), then any regional variant of it (e.g. "tr-*").
+        var neutralMatch = list.FirstOrDefault(l => string.Equals(l.Language, neutral, StringComparison.OrdinalIgnoreCase))
+            ?? list.FirstOrDefault(l => l.Language.StartsWith(neutral + "-", StringComparison.OrdinalIgnoreCase));
+        if (neutralMatch is not null)
+            return neutralMatch.Label;
+
+        // 3. English fallback.
+        var english = list.FirstOrDefault(l => string.Equals(l.Language, "en-US", StringComparison.OrdinalIgnoreCase))
+            ?? list.FirstOrDefault(l => string.Equals(l.Language, "en", StringComparison.OrdinalIgnoreCase));
+        if (english is not null)
+            return english.Label;
+
+        // 4. First label in declaration order.
+        return list[0].Label;
+    }
+}

--- a/src/BBT.Workflow.HttpApi.Shared/Microsoft/Extensions/DependencyInjection/WorkflowApiBaseServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.HttpApi.Shared/Microsoft/Extensions/DependencyInjection/WorkflowApiBaseServiceCollectionExtensions.cs
@@ -284,9 +284,10 @@ public static class WorkflowApiBaseServiceCollectionExtensions
     {
         services.AddScoped<ResponseHeaderFilter>();
         services.AddScoped<IHeaderService, HttpContextHeaderService>();
+        services.AddScoped<BBT.Workflow.Languages.ICurrentLanguage, BBT.Workflow.Languages.HttpContextCurrentLanguage>();
         services
             .ReplaceSchemaResolver<HeaderSchemaResolutionStrategy, WorkflowHeaderSchemaResolutionStrategy>();
-        
+
         return services;
     }
 }

--- a/src/BBT.Workflow.HttpApi.Shared/Services/Languages/HttpContextCurrentLanguage.cs
+++ b/src/BBT.Workflow.HttpApi.Shared/Services/Languages/HttpContextCurrentLanguage.cs
@@ -1,0 +1,39 @@
+using BBT.Workflow.Domain.Shared;
+using Microsoft.AspNetCore.Http;
+
+namespace BBT.Workflow.Languages;
+
+/// <summary>
+/// HTTP context-based <see cref="ICurrentLanguage"/> that resolves the culture from the
+/// request's <c>Accept-Language</c> header via <see cref="LanguageResolver"/> and caches it in
+/// <see cref="HttpContext.Items"/> for the lifetime of the request.
+/// </summary>
+/// <param name="httpContextAccessor">Accessor for the current HTTP context.</param>
+internal sealed class HttpContextCurrentLanguage(IHttpContextAccessor httpContextAccessor) : ICurrentLanguage
+{
+    internal const string CultureItemKey = "CurrentLanguageCulture";
+
+    /// <inheritdoc />
+    public string Culture => ResolveCulture();
+
+    /// <inheritdoc />
+    public string Language => Culture.Split('-', 2)[0];
+
+    private string ResolveCulture()
+    {
+        var httpContext = httpContextAccessor.HttpContext;
+        if (httpContext is null)
+            return LanguageResolver.DefaultCulture;
+
+        if (httpContext.Items.TryGetValue(CultureItemKey, out var cached) && cached is string cachedCulture)
+            return cachedCulture;
+
+        var acceptLanguage = httpContext.Request.Headers.TryGetValue(HeadersConstants.AcceptLanguage, out var header)
+            ? header.ToString()
+            : null;
+
+        var culture = LanguageResolver.ResolveCulture(acceptLanguage);
+        httpContext.Items[CultureItemKey] = culture;
+        return culture;
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/Authorization/TransitionAuthorizationManagerQueryRolesTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Authorization/TransitionAuthorizationManagerQueryRolesTests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.DependencyInjection;
+using BBT.Aether.Uow;
+using BBT.Aether.Users;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Instances;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+using WorkflowDefinition = BBT.Workflow.Definitions.Workflow;
+
+namespace BBT.Workflow.Authorization;
+
+/// <summary>
+/// Unit tests for <see cref="TransitionAuthorizationManager.IsQueryAllowedAsync"/> — the shared queryRoles
+/// gate used by the state/data/view/schema instance functions. Verifies state→workflow precedence,
+/// empty-grants→allow, deny when no role matches, and multi-role any-allow.
+/// </summary>
+public sealed class TransitionAuthorizationManagerQueryRolesTests : IDisposable
+{
+    private readonly ICurrentUser _currentUser;
+    private readonly IInstanceTransitionRepository _repo;
+    private readonly TransitionAuthorizationManager _sut;
+    private readonly IServiceProvider? _previousAmbientServiceProvider;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    public TransitionAuthorizationManagerQueryRolesTests()
+    {
+        _currentUser = Substitute.For<ICurrentUser>();
+        _repo = Substitute.For<IInstanceTransitionRepository>();
+        _repo.GetLastCompletedManualTransitionAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+             .Returns((InstanceTransition?)null);
+        _sut = new TransitionAuthorizationManager(_currentUser, _repo);
+
+        var mockUoW = Substitute.For<IUnitOfWork>();
+        var mockUoWManager = Substitute.For<IUnitOfWorkManager>();
+        mockUoWManager.BeginAsync(Arg.Any<UnitOfWorkOptions>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(mockUoW));
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(mockUoWManager);
+        services.AddSingleton(Substitute.For<BBT.Workflow.Caching.IComponentCacheStore>());
+        services.AddSingleton(Substitute.For<BBT.Workflow.DefinitionContext.IWorkflowContext>());
+        _previousAmbientServiceProvider = AmbientServiceProvider.Current;
+        AmbientServiceProvider.Current = services.BuildServiceProvider();
+    }
+
+    public void Dispose() => AmbientServiceProvider.Current = _previousAmbientServiceProvider;
+
+    private static WorkflowDefinition BuildWorkflow(string stateQueryRolesJson, string rootQueryRolesJson) =>
+        JsonSerializer.Deserialize<WorkflowDefinition>($$"""
+            {
+              "type": "F",
+              "timeout": null,
+              "labels": [],
+              "functions": [],
+              "features": [],
+              "states": [
+                {
+                  "key": "review",
+                  "stateType": "intermediate",
+                  "labels": [],
+                  "transitions": [],
+                  "queryRoles": {{stateQueryRolesJson}}
+                }
+              ],
+              "sharedTransitions": [],
+              "extensions": [],
+              "queryRoles": {{rootQueryRolesJson}}
+            }
+            """, JsonOptions)!;
+
+    private static Instance InReviewState()
+    {
+        var instance = Instance.Create(Guid.NewGuid(), "flow", "1.0.0", "key");
+        instance.SetEffectiveState("review");
+        return instance;
+    }
+
+    [Fact]
+    public async Task NoGrants_Allows()
+    {
+        var wf = BuildWorkflow("[]", "[]");
+        (await _sut.IsQueryAllowedAsync(wf, InReviewState(), new[] { "anyone" })).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task NoGrants_NullRoles_Allows()
+    {
+        var wf = BuildWorkflow("[]", "[]");
+        (await _sut.IsQueryAllowedAsync(wf, InReviewState(), null)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task StateGrant_Allows_WhenCallerMatches()
+    {
+        var wf = BuildWorkflow("""[{"role":"backoffice","grant":"allow"}]""", "[]");
+        (await _sut.IsQueryAllowedAsync(wf, InReviewState(), new[] { "backoffice" })).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Denies_WhenNoCallerRoleMatches()
+    {
+        var wf = BuildWorkflow("""[{"role":"backoffice","grant":"allow"}]""", "[]");
+        (await _sut.IsQueryAllowedAsync(wf, InReviewState(), new[] { "customer" })).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task StateQueryRoles_OverrideWorkflowQueryRoles()
+    {
+        // Workflow root would allow "customer", but the state's own grants (override) only allow "backoffice".
+        var wf = BuildWorkflow("""[{"role":"backoffice","grant":"allow"}]""", """[{"role":"customer","grant":"allow"}]""");
+        (await _sut.IsQueryAllowedAsync(wf, InReviewState(), new[] { "customer" })).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task WorkflowQueryRoles_UsedWhenStateHasNone()
+    {
+        var wf = BuildWorkflow("[]", """[{"role":"customer","grant":"allow"}]""");
+        (await _sut.IsQueryAllowedAsync(wf, InReviewState(), new[] { "customer" })).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task MultiRole_AnyAllowed_Allows()
+    {
+        var wf = BuildWorkflow("""[{"role":"backoffice","grant":"allow"}]""", "[]");
+        (await _sut.IsQueryAllowedAsync(wf, InReviewState(), new[] { "x", "backoffice" })).ShouldBeTrue();
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/Authorization/TransitionAuthorizationManagerQueryRolesTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Authorization/TransitionAuthorizationManagerQueryRolesTests.cs
@@ -136,4 +136,37 @@ public sealed class TransitionAuthorizationManagerQueryRolesTests : IDisposable
         var wf = BuildWorkflow("""[{"role":"backoffice","grant":"allow"}]""", "[]");
         (await _sut.IsQueryAllowedAsync(wf, InReviewState(), new[] { "x", "backoffice" })).ShouldBeTrue();
     }
+
+    // ── IsAnyRoleAllowedForGrantsAsync (custom function Roles) ──────────────────
+
+    private static List<RoleGrant> Grants(string json) =>
+        JsonSerializer.Deserialize<List<RoleGrant>>(json, JsonOptions)!;
+
+    [Fact]
+    public async Task AnyRole_EmptyGrants_Allows()
+    {
+        (await _sut.IsAnyRoleAllowedForGrantsAsync(new[] { "anyone" }, Grants("[]"), instance: null)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task AnyRole_Allows_WhenAnyCallerRoleMatches()
+    {
+        var grants = Grants("""[{"role":"fn-runner","grant":"allow"}]""");
+        (await _sut.IsAnyRoleAllowedForGrantsAsync(new[] { "x", "fn-runner" }, grants, instance: null)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task AnyRole_Denies_WhenNoCallerRoleMatches()
+    {
+        var grants = Grants("""[{"role":"fn-runner","grant":"allow"}]""");
+        (await _sut.IsAnyRoleAllowedForGrantsAsync(new[] { "customer" }, grants, instance: null)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task AnyRole_NullCaller_DeniesStaticOnlyGrant()
+    {
+        // Null caller roles → only predefined/dynamic grants evaluated; a static grant cannot match.
+        var grants = Grants("""[{"role":"fn-runner","grant":"allow"}]""");
+        (await _sut.IsAnyRoleAllowedForGrantsAsync(null, grants, instance: null)).ShouldBeFalse();
+    }
 }

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceStateTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceStateTests.cs
@@ -545,7 +545,116 @@ public class InstanceQueryAppServiceStateTests : IDisposable
         result.Result.Value!.State.ShouldBe("Değerlendirme Aşamasında");
     }
 
+    [Fact]
+    public async Task GetInstanceStateAsync_WhenAliasHasLabels_ReturnsLocalizedLabelForAcceptLanguage()
+    {
+        // Arrange
+        var instance = Instance.Create(Guid.NewGuid(), TestWorkflow, TestVersion, "test-key");
+        var state = State.Create(TestState, StateType.Intermediate, StateSubType.None,
+            VersionStrategy.IncreaseMinor.Code);
+        state.AddAlias(AliasFromJson("""
+            {
+                "name": "Değerlendirme Aşamasında",
+                "roles": [],
+                "labels": [
+                    { "label": "Operasyon İncelemesinde", "language": "tr" },
+                    { "label": "Under Operational Review", "language": "en" }
+                ]
+            }
+            """));
+        instance.ChangeState(state);
+
+        var workflow = BuildWorkflow(state);
+        SetupCommonMocks(instance, workflow);
+        _transitionAuthorizationManager
+            .IsRoleAllowedForGrantsAsync(Arg.Any<string?>(), Arg.Any<IReadOnlyCollection<RoleGrant>>(),
+                Arg.Any<Instance?>(), Arg.Any<AuthorizationRequestContext?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var input = CreateInput(instance.Id.ToString());
+        input.Headers["accept-language"] = "tr-TR,tr;q=0.9,en-US;q=0.8";
+
+        // Act
+        var result = await _service.GetInstanceStateAsync(input, CancellationToken.None);
+
+        // Assert — Turkish label returned for the Turkish Accept-Language
+        result.Result.IsSuccess.ShouldBeTrue();
+        result.Result.Value!.State.ShouldBe("Operasyon İncelemesinde");
+    }
+
+    [Fact]
+    public async Task GetInstanceStateAsync_WhenAliasLabelsHaveNoLanguageMatch_FallsBackToEnglish()
+    {
+        // Arrange — labels in de + en, request fr → English fallback
+        var instance = Instance.Create(Guid.NewGuid(), TestWorkflow, TestVersion, "test-key");
+        var state = State.Create(TestState, StateType.Intermediate, StateSubType.None,
+            VersionStrategy.IncreaseMinor.Code);
+        state.AddAlias(AliasFromJson("""
+            {
+                "name": "Fallback Name",
+                "roles": [],
+                "labels": [
+                    { "label": "In Bearbeitung", "language": "de" },
+                    { "label": "Under Review", "language": "en" }
+                ]
+            }
+            """));
+        instance.ChangeState(state);
+
+        var workflow = BuildWorkflow(state);
+        SetupCommonMocks(instance, workflow);
+        _transitionAuthorizationManager
+            .IsRoleAllowedForGrantsAsync(Arg.Any<string?>(), Arg.Any<IReadOnlyCollection<RoleGrant>>(),
+                Arg.Any<Instance?>(), Arg.Any<AuthorizationRequestContext?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var input = CreateInput(instance.Id.ToString());
+        input.Headers["accept-language"] = "fr-FR";
+
+        // Act
+        var result = await _service.GetInstanceStateAsync(input, CancellationToken.None);
+
+        // Assert
+        result.Result.IsSuccess.ShouldBeTrue();
+        result.Result.Value!.State.ShouldBe("Under Review");
+    }
+
+    [Fact]
+    public async Task GetInstanceStateAsync_WhenMatchingAliasHasNoLabels_ReturnsAliasName()
+    {
+        // Arrange — alias has labels omitted; even with an Accept-Language header, name is used
+        var instance = Instance.Create(Guid.NewGuid(), TestWorkflow, TestVersion, "test-key");
+        var state = State.Create(TestState, StateType.Intermediate, StateSubType.None,
+            VersionStrategy.IncreaseMinor.Code);
+        state.AddAlias(StateAlias.Create("Değerlendirme Aşamasında"));
+        instance.ChangeState(state);
+
+        var workflow = BuildWorkflow(state);
+        SetupCommonMocks(instance, workflow);
+        _transitionAuthorizationManager
+            .IsRoleAllowedForGrantsAsync(Arg.Any<string?>(), Arg.Any<IReadOnlyCollection<RoleGrant>>(),
+                Arg.Any<Instance?>(), Arg.Any<AuthorizationRequestContext?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var input = CreateInput(instance.Id.ToString());
+        input.Headers["accept-language"] = "tr-TR";
+
+        // Act
+        var result = await _service.GetInstanceStateAsync(input, CancellationToken.None);
+
+        // Assert
+        result.Result.IsSuccess.ShouldBeTrue();
+        result.Result.Value!.State.ShouldBe("Değerlendirme Aşamasında");
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static StateAlias AliasFromJson(string json) =>
+        System.Text.Json.JsonSerializer.Deserialize<StateAlias>(json, new System.Text.Json.JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+        })!;
 
     private (Instance instance, Definitions.Workflow workflow) CreateParentWithActiveSubFlow()
     {

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceStateTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceStateTests.cs
@@ -647,7 +647,95 @@ public class InstanceQueryAppServiceStateTests : IDisposable
         result.Result.Value!.State.ShouldBe("Değerlendirme Aşamasında");
     }
 
+    [Fact]
+    public async Task GetInstanceStateAsync_WhenQueryRolesDeny_Returns403()
+    {
+        // Arrange
+        var instance = Instance.Create(Guid.NewGuid(), TestWorkflow, TestVersion, "test-key");
+        var state = State.Create(TestState, StateType.Intermediate, StateSubType.None,
+            VersionStrategy.IncreaseMinor.Code);
+        instance.ChangeState(state);
+
+        var workflow = BuildWorkflow(state);
+        SetupCommonMocks(instance, workflow);
+        DenyQueryRoles();
+
+        var input = CreateInput(instance.Id.ToString());
+
+        // Act
+        var result = await _service.GetInstanceStateAsync(input, CancellationToken.None);
+
+        // Assert
+        result.IsNotModified.ShouldBeFalse();
+        result.Result.IsSuccess.ShouldBeFalse();
+        result.Result.Error.Code.ShouldBe(WorkflowErrorCodes.AuthorizationRoleDenied);
+    }
+
+    [Fact]
+    public async Task GetViewAsync_WhenQueryRolesDeny_Returns403()
+    {
+        // Arrange
+        var instance = Instance.Create(Guid.NewGuid(), TestWorkflow, TestVersion, "test-key");
+        var state = State.Create(TestState, StateType.Intermediate, StateSubType.None,
+            VersionStrategy.IncreaseMinor.Code);
+        instance.ChangeState(state);
+
+        var workflow = BuildWorkflow(state);
+        SetupCommonMocks(instance, workflow);
+        DenyQueryRoles();
+
+        // Act
+        var result = await _service.GetViewAsync(new GetViewInput
+        {
+            Domain = TestDomain,
+            Workflow = TestWorkflow,
+            Instance = instance.Id.ToString(),
+            Headers = new Dictionary<string, string?>(),
+            QueryParameters = new Dictionary<string, string?>()
+        }, transitionKey: null, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeFalse();
+        result.Error.Code.ShouldBe(WorkflowErrorCodes.AuthorizationRoleDenied);
+    }
+
+    [Fact]
+    public async Task GetSchemaAsync_WhenQueryRolesDeny_Returns403()
+    {
+        // Arrange
+        var instance = Instance.Create(Guid.NewGuid(), TestWorkflow, TestVersion, "test-key");
+        var state = State.Create(TestState, StateType.Intermediate, StateSubType.None,
+            VersionStrategy.IncreaseMinor.Code);
+        instance.ChangeState(state);
+
+        var workflow = BuildWorkflow(state);
+        SetupCommonMocks(instance, workflow);
+        DenyQueryRoles();
+
+        // Act — denied before the transition-key requirement is evaluated
+        var result = await _service.GetSchemaAsync(new GetSchemaInput
+        {
+            Domain = TestDomain,
+            Workflow = TestWorkflow,
+            Instance = instance.Id.ToString()
+        }, transitionKey: "approve", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeFalse();
+        result.Error.Code.ShouldBe(WorkflowErrorCodes.AuthorizationRoleDenied);
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private void DenyQueryRoles() =>
+        _transitionAuthorizationManager
+            .IsQueryAllowedAsync(
+                Arg.Any<Definitions.Workflow>(),
+                Arg.Any<Instance>(),
+                Arg.Any<IReadOnlyCollection<string>?>(),
+                Arg.Any<AuthorizationRequestContext?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(false);
 
     private static StateAlias AliasFromJson(string json) =>
         System.Text.Json.JsonSerializer.Deserialize<StateAlias>(json, new System.Text.Json.JsonSerializerOptions
@@ -726,6 +814,16 @@ public class InstanceQueryAppServiceStateTests : IDisposable
             .Returns(callInfo => Task.FromResult(callInfo.ArgAt<IReadOnlyList<string>>(3)));
 
         _representationEtagService.Generate(Arg.Any<object>()).Returns((string?)null);
+
+        // Default: queryRoles visibility allowed (specific tests override to false to assert 403).
+        _transitionAuthorizationManager
+            .IsQueryAllowedAsync(
+                Arg.Any<Definitions.Workflow>(),
+                Arg.Any<Instance>(),
+                Arg.Any<IReadOnlyCollection<string>?>(),
+                Arg.Any<AuthorizationRequestContext?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(true);
     }
 
     private void SetupSubFlowGateway(InstanceStatus subFlowStatus, string subFlowState)

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceStateTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceStateTests.cs
@@ -437,6 +437,114 @@ public class InstanceQueryAppServiceStateTests : IDisposable
             .GetFunctionWithStateAsync(Arg.Any<GetFunctionWithInstanceInput>(), Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task GetInstanceStateAsync_WhenStateHasMatchingAlias_ReturnsAliasNameAsState()
+    {
+        // Arrange
+        var instance = Instance.Create(Guid.NewGuid(), TestWorkflow, TestVersion, "test-key");
+        var state = State.Create(TestState, StateType.Intermediate, StateSubType.None,
+            VersionStrategy.IncreaseMinor.Code);
+        state.AddAlias(StateAlias.Create("Değerlendirme Aşamasında"));
+        instance.ChangeState(state);
+
+        var workflow = BuildWorkflow(state);
+        SetupCommonMocks(instance, workflow);
+        _transitionAuthorizationManager
+            .IsRoleAllowedForGrantsAsync(Arg.Any<string?>(), Arg.Any<IReadOnlyCollection<RoleGrant>>(),
+                Arg.Any<Instance?>(), Arg.Any<AuthorizationRequestContext?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var input = CreateInput(instance.Id.ToString());
+
+        // Act
+        var result = await _service.GetInstanceStateAsync(input, CancellationToken.None);
+
+        // Assert — state reflects the resolved alias name, StateType still reflects the real type
+        result.Result.IsSuccess.ShouldBeTrue();
+        result.Result.Value!.State.ShouldBe("Değerlendirme Aşamasında");
+        result.Result.Value!.StateType.ShouldBe("intermediate");
+    }
+
+    [Fact]
+    public async Task GetInstanceStateAsync_WhenNoAliasMatches_ReturnsRealStateKey()
+    {
+        // Arrange
+        var instance = Instance.Create(Guid.NewGuid(), TestWorkflow, TestVersion, "test-key");
+        var state = State.Create(TestState, StateType.Intermediate, StateSubType.None,
+            VersionStrategy.IncreaseMinor.Code);
+        state.AddAlias(StateAlias.Create("Backoffice Only"));
+        instance.ChangeState(state);
+
+        var workflow = BuildWorkflow(state);
+        SetupCommonMocks(instance, workflow);
+        _transitionAuthorizationManager
+            .IsRoleAllowedForGrantsAsync(Arg.Any<string?>(), Arg.Any<IReadOnlyCollection<RoleGrant>>(),
+                Arg.Any<Instance?>(), Arg.Any<AuthorizationRequestContext?>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        var input = CreateInput(instance.Id.ToString());
+
+        // Act
+        var result = await _service.GetInstanceStateAsync(input, CancellationToken.None);
+
+        // Assert — falls back to the raw state key
+        result.Result.IsSuccess.ShouldBeTrue();
+        result.Result.Value!.State.ShouldBe(TestState);
+    }
+
+    [Fact]
+    public async Task GetInstanceStateAsync_WhenNoAliasesDefined_ReturnsRealStateKeyWithoutEvaluation()
+    {
+        // Arrange
+        var instance = Instance.Create(Guid.NewGuid(), TestWorkflow, TestVersion, "test-key");
+        var state = State.Create(TestState, StateType.Intermediate, StateSubType.None,
+            VersionStrategy.IncreaseMinor.Code);
+        instance.ChangeState(state);
+
+        var workflow = BuildWorkflow(state);
+        SetupCommonMocks(instance, workflow);
+
+        var input = CreateInput(instance.Id.ToString());
+
+        // Act
+        var result = await _service.GetInstanceStateAsync(input, CancellationToken.None);
+
+        // Assert — current behavior preserved; role evaluation skipped entirely
+        result.Result.IsSuccess.ShouldBeTrue();
+        result.Result.Value!.State.ShouldBe(TestState);
+        await _transitionAuthorizationManager.DidNotReceive()
+            .IsRoleAllowedForGrantsAsync(Arg.Any<string?>(), Arg.Any<IReadOnlyCollection<RoleGrant>>(),
+                Arg.Any<Instance?>(), Arg.Any<AuthorizationRequestContext?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetInstanceStateAsync_WhenMultipleAliases_ReturnsFirstMatchingInDeclarationOrder()
+    {
+        // Arrange — first alias does not resolve, second does
+        var instance = Instance.Create(Guid.NewGuid(), TestWorkflow, TestVersion, "test-key");
+        var state = State.Create(TestState, StateType.Intermediate, StateSubType.None,
+            VersionStrategy.IncreaseMinor.Code);
+        state.AddAlias(StateAlias.Create("Operasyon İncelemesinde"));
+        state.AddAlias(StateAlias.Create("Değerlendirme Aşamasında"));
+        instance.ChangeState(state);
+
+        var workflow = BuildWorkflow(state);
+        SetupCommonMocks(instance, workflow);
+        _transitionAuthorizationManager
+            .IsRoleAllowedForGrantsAsync(Arg.Any<string?>(), Arg.Any<IReadOnlyCollection<RoleGrant>>(),
+                Arg.Any<Instance?>(), Arg.Any<AuthorizationRequestContext?>(), Arg.Any<CancellationToken>())
+            .Returns(false, true);
+
+        var input = CreateInput(instance.Id.ToString());
+
+        // Act
+        var result = await _service.GetInstanceStateAsync(input, CancellationToken.None);
+
+        // Assert
+        result.Result.IsSuccess.ShouldBeTrue();
+        result.Result.Value!.State.ShouldBe("Değerlendirme Aşamasında");
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     private (Instance instance, Definitions.Workflow workflow) CreateParentWithActiveSubFlow()

--- a/test/BBT.Workflow.Domain.Tests/Definitions/StateTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Definitions/StateTests.cs
@@ -516,7 +516,11 @@ public class StateTests
             "alias": [
                 {
                     "name": "Operasyon İncelemesinde",
-                    "roles": [ { "role": "backoffice.operator", "grant": "allow" } ]
+                    "roles": [ { "role": "backoffice.operator", "grant": "allow" } ],
+                    "labels": [
+                        { "label": "Operasyon İncelemesinde", "language": "tr" },
+                        { "label": "Under Operational Review", "language": "en" }
+                    ]
                 },
                 {
                     "name": "Değerlendirme Aşamasında",
@@ -539,10 +543,14 @@ public class StateTests
         Assert.Single(first.Roles);
         Assert.Equal("backoffice.operator", first.Roles.First().Role);
         Assert.True(first.Roles.First().IsAllow);
+        Assert.Equal(2, first.Labels.Count);
+        Assert.Equal("Under Operational Review", first.Labels.ResolveLabel("en-US"));
+        Assert.Equal("Operasyon İncelemesinde", first.Labels.ResolveLabel("tr-TR"));
 
         var second = state.Aliases.Last();
         Assert.Equal("Değerlendirme Aşamasında", second.Name);
         Assert.Empty(second.Roles);
+        Assert.Empty(second.Labels);
     }
 
     [Fact]

--- a/test/BBT.Workflow.Domain.Tests/Definitions/StateTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Definitions/StateTests.cs
@@ -476,5 +476,101 @@ public class StateTests
         // Act & Assert
         Assert.False(state.HasOnlyManualOrEventTransitions);
     }
+
+    [Fact]
+    public void Create_ShouldInitializeEmptyAliases()
+    {
+        // Arrange & Act
+        var state = State.Create("test-state", StateType.Intermediate, StateSubType.Success, "Patch");
+
+        // Assert
+        Assert.NotNull(state.Aliases);
+        Assert.Empty(state.Aliases);
+    }
+
+    [Fact]
+    public void AddAlias_ShouldAddAlias()
+    {
+        // Arrange
+        var state = State.Create("test-state", StateType.Intermediate, StateSubType.Success, "Patch");
+
+        // Act
+        state.AddAlias(StateAlias.Create("Değerlendirme Aşamasında"));
+
+        // Assert
+        Assert.Single(state.Aliases);
+        Assert.Equal("Değerlendirme Aşamasında", state.Aliases.First().Name);
+        Assert.Empty(state.Aliases.First().Roles);
+    }
+
+    [Fact]
+    public void Deserialize_ShouldPopulateAliases_WithNamesAndRoles()
+    {
+        // Arrange
+        const string json = """
+        {
+            "key": "fraud-check",
+            "stateType": "Intermediate",
+            "subType": "None",
+            "versionStrategy": "Patch",
+            "alias": [
+                {
+                    "name": "Operasyon İncelemesinde",
+                    "roles": [ { "role": "backoffice.operator", "grant": "allow" } ]
+                },
+                {
+                    "name": "Değerlendirme Aşamasında",
+                    "roles": []
+                }
+            ]
+        }
+        """;
+
+        // Act
+        var state = System.Text.Json.JsonSerializer.Deserialize<State>(
+            json, EnumNamingSerializerOptions);
+
+        // Assert
+        Assert.NotNull(state);
+        Assert.Equal(2, state!.Aliases.Count);
+
+        var first = state.Aliases.First();
+        Assert.Equal("Operasyon İncelemesinde", first.Name);
+        Assert.Single(first.Roles);
+        Assert.Equal("backoffice.operator", first.Roles.First().Role);
+        Assert.True(first.Roles.First().IsAllow);
+
+        var second = state.Aliases.Last();
+        Assert.Equal("Değerlendirme Aşamasında", second.Name);
+        Assert.Empty(second.Roles);
+    }
+
+    [Fact]
+    public void Deserialize_ShouldHaveEmptyAliases_WhenAliasOmitted()
+    {
+        // Arrange
+        const string json = """
+        {
+            "key": "fraud-check",
+            "stateType": "Intermediate",
+            "subType": "None",
+            "versionStrategy": "Patch"
+        }
+        """;
+
+        // Act
+        var state = System.Text.Json.JsonSerializer.Deserialize<State>(
+            json, EnumNamingSerializerOptions);
+
+        // Assert
+        Assert.NotNull(state);
+        Assert.Empty(state!.Aliases);
+    }
+
+    private static System.Text.Json.JsonSerializerOptions EnumNamingSerializerOptions => new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
 }
 

--- a/test/BBT.Workflow.Domain.Tests/Definitions/Validators/WorkflowValidatorTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Definitions/Validators/WorkflowValidatorTests.cs
@@ -494,7 +494,124 @@ public class WorkflowValidatorTests : DomainTestBase<DomainEntryPoint>
 
     #endregion
 
+    #region State Alias Validation Tests
+
+    [Fact]
+    public void Validate_ShouldPass_WhenStateAliasIsComplete()
+    {
+        var workflow = BuildWorkflowWithStateAlias("""
+            {
+                "name": "Değerlendirme Aşamasında",
+                "roles": [ { "role": "backoffice.operator", "grant": "allow" } ],
+                "labels": [ { "label": "Operasyon İncelemesinde", "language": "tr" } ]
+            }
+            """);
+
+        var result = _validator.Validate(workflow);
+
+        var aliasErrors = result.ValidationErrors
+            .Where(e => e.ErrorMessage!.Contains("Alias", StringComparison.Ordinal))
+            .ToList();
+        aliasErrors.ShouldBeEmpty($"Unexpected alias errors: {string.Join(", ", aliasErrors.Select(e => e.ErrorMessage))}");
+    }
+
+    [Fact]
+    public void Validate_ShouldPass_WhenStateHasNoAlias()
+    {
+        // The default workflow template has no alias arrays — alias is optional.
+        var workflow = CreateWorkflowWithDefaultAutoTransition();
+
+        var result = _validator.Validate(workflow);
+
+        result.ValidationErrors
+            .ShouldNotContain(e => e.ErrorMessage!.Contains("Alias", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_ShouldFail_WhenStateAliasHasNoLabels()
+    {
+        var workflow = BuildWorkflowWithStateAlias("""
+            {
+                "name": "Değerlendirme Aşamasında",
+                "roles": [ { "role": "backoffice.operator", "grant": "allow" } ],
+                "labels": []
+            }
+            """);
+
+        var result = _validator.Validate(workflow);
+
+        result.IsValid.ShouldBeFalse();
+        result.ValidationErrors.ShouldContain(e =>
+            e.ErrorMessage!.Contains("at least one label", StringComparison.Ordinal) &&
+            e.ErrorMessage.Contains("Değerlendirme Aşamasında", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_ShouldFail_WhenStateAliasHasNoRoles()
+    {
+        var workflow = BuildWorkflowWithStateAlias("""
+            {
+                "name": "Değerlendirme Aşamasında",
+                "roles": [],
+                "labels": [ { "label": "Operasyon İncelemesinde", "language": "tr" } ]
+            }
+            """);
+
+        var result = _validator.Validate(workflow);
+
+        result.IsValid.ShouldBeFalse();
+        result.ValidationErrors.ShouldContain(e =>
+            e.ErrorMessage!.Contains("at least one role", StringComparison.Ordinal) &&
+            e.ErrorMessage.Contains("Değerlendirme Aşamasında", StringComparison.Ordinal));
+    }
+
+    #endregion
+
     #region Helper Methods
+
+    /// <summary>
+    /// Builds an otherwise-valid workflow whose intermediate "pending" state carries the supplied alias entry.
+    /// </summary>
+    private WorkflowDefinition BuildWorkflowWithStateAlias(string aliasEntryJson)
+    {
+        var json = $$"""
+        {
+            "type": "F",
+            "labels": [{"label": "Test", "language": "en"}],
+            "states": [
+                {
+                    "key": "initial",
+                    "stateType": "initial",
+                    "labels": [{"label": "Initial", "language": "en"}],
+                    "transitions": [
+                        {
+                            "key": "go-pending",
+                            "target": "pending",
+                            "triggerType": "manual",
+                            "labels": [{"label": "Go", "language": "en"}]
+                        }
+                    ]
+                },
+                {
+                    "key": "pending",
+                    "stateType": "intermediate",
+                    "labels": [{"label": "Pending", "language": "en"}],
+                    "transitions": [],
+                    "alias": [ {{aliasEntryJson}} ]
+                }
+            ],
+            "sharedTransitions": [],
+            "startTransition": {
+                "key": "start",
+                "target": "initial",
+                "triggerType": "manual",
+                "labels": [{"label": "Start", "language": "en"}]
+            }
+        }
+        """;
+
+        return DeserializeWorkflow(json);
+    }
 
     private WorkflowDefinition CreateWorkflowWithDefaultAutoTransition()
     {

--- a/test/BBT.Workflow.Domain.Tests/Localization/LanguageLabelExtensionsTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Localization/LanguageLabelExtensionsTests.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace BBT.Workflow;
+
+public class LanguageLabelExtensionsTests
+{
+    private static List<LanguageLabel> Labels(params (string label, string language)[] items)
+    {
+        var list = new List<LanguageLabel>();
+        foreach (var (label, language) in items)
+            list.Add(new LanguageLabel(label, language));
+        return list;
+    }
+
+    [Fact]
+    public void ResolveLabel_ReturnsExactCultureMatch()
+    {
+        var labels = Labels(("Türkçe", "tr-TR"), ("English", "en"));
+        Assert.Equal("Türkçe", labels.ResolveLabel("tr-TR"));
+    }
+
+    [Fact]
+    public void ResolveLabel_FallsBackToNeutralLanguage()
+    {
+        var labels = Labels(("Türkçe", "tr"), ("English", "en"));
+        // requested tr-TR has no exact match → neutral "tr"
+        Assert.Equal("Türkçe", labels.ResolveLabel("tr-TR"));
+    }
+
+    [Fact]
+    public void ResolveLabel_FallsBackToRegionalVariantOfNeutral()
+    {
+        var labels = Labels(("Deutsch", "de-DE"), ("English", "en"));
+        // requested "de" has no exact "de", but matches regional "de-DE"
+        Assert.Equal("Deutsch", labels.ResolveLabel("de"));
+    }
+
+    [Fact]
+    public void ResolveLabel_FallsBackToEnglish_WhenNoLanguageMatch()
+    {
+        var labels = Labels(("Deutsch", "de"), ("English", "en-US"));
+        Assert.Equal("English", labels.ResolveLabel("fr-FR"));
+    }
+
+    [Fact]
+    public void ResolveLabel_FallsBackToFirstItem_WhenNoMatchAndNoEnglish()
+    {
+        var labels = Labels(("Deutsch", "de"), ("Español", "es"));
+        Assert.Equal("Deutsch", labels.ResolveLabel("fr-FR"));
+    }
+
+    [Fact]
+    public void ResolveLabel_ReturnsNull_WhenNullOrEmpty()
+    {
+        Assert.Null(((IEnumerable<LanguageLabel>?)null).ResolveLabel("tr-TR"));
+        Assert.Null(new List<LanguageLabel>().ResolveLabel("tr-TR"));
+    }
+}

--- a/test/BBT.Workflow.Domain.Tests/Localization/LanguageResolverTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Localization/LanguageResolverTests.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace BBT.Workflow;
+
+public class LanguageResolverTests
+{
+    [Theory]
+    [InlineData("tr-TR,tr;q=0.9,en-US;q=0.8", "tr-TR")]
+    [InlineData("tr", "tr")]
+    [InlineData("en-US", "en-US")]
+    [InlineData(" fr-FR ; q=1.0 , en ", "fr-FR")]
+    public void ResolveCulture_FromHeaderValue_ReturnsFirstLanguage(string headerValue, string expected)
+    {
+        Assert.Equal(expected, LanguageResolver.ResolveCulture(headerValue));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ResolveCulture_FromHeaderValue_DefaultsToEnUs_WhenEmpty(string? headerValue)
+    {
+        Assert.Equal("en-US", LanguageResolver.ResolveCulture(headerValue));
+    }
+
+    [Fact]
+    public void ResolveCulture_FromHeaders_ReadsAcceptLanguage_CaseInsensitive()
+    {
+        var headers = new Dictionary<string, string?>(System.StringComparer.OrdinalIgnoreCase)
+        {
+            ["accept-language"] = "tr-TR,tr;q=0.9"
+        };
+
+        Assert.Equal("tr-TR", LanguageResolver.ResolveCulture(headers));
+    }
+
+    [Fact]
+    public void ResolveCulture_FromHeaders_DefaultsToEnUs_WhenMissingOrNull()
+    {
+        Assert.Equal("en-US", LanguageResolver.ResolveCulture((IReadOnlyDictionary<string, string?>?)null));
+        Assert.Equal("en-US", LanguageResolver.ResolveCulture(new Dictionary<string, string?>()));
+    }
+}


### PR DESCRIPTION
## Summary

Implements **state aliases** — a role-aware display mechanism that lets the same internal workflow state be presented under different, role-appropriate labels without changing the workflow's real state identity. This enables internal evaluation states (fraud checks, KPS, limit checks, etc.) to remain hidden from end customers while back-office actors see detailed, localized labels.

## Key Changes

### Domain Layer
- **`StateAlias.cs`** (new): Value object representing a role-aware alias with name, role grants, and localized labels
- **`State.cs`**: Added `Aliases` collection; populated during JSON deserialization
- **`LanguageResolver.cs`** (new): Reusable culture resolver from `Accept-Language` header with fallback chain (exact culture → neutral language → English → first label)
- **`LanguageLabelExtensions.cs`** (new): Label resolution helpers with multi-language fallback
- **`WorkflowValidator.cs`**: Added `ValidateStateAliases()` to enforce authoring rules (each alias must have name, ≥1 role grant, ≥1 label)

### Application Layer
- **`TransitionAuthorizationManager.cs`**: 
  - Added `IsAnyRoleAllowedForGrantsAsync()` — evaluates grants against all caller roles (any match → allow)
  - Added `IsQueryAllowedAsync()` — shared gate for state/data/view/schema queryRoles (state grants override workflow grants)
- **`InstanceQueryAppService.cs`**:
  - Added `IsInstanceQueryAllowedAsync()` check in `GetInstanceStateAsync()` and `GetInstanceDataAsync()` (returns 403 if denied)
  - Enhanced `BuildInstanceStateOutputAsync()` to resolve matching alias (first match in declaration order) and return localized label or alias name instead of raw state key
- **`ITransitionAuthorizationManager.cs`**: Added interface contracts for new methods
- **`ICurrentLanguage.cs`** (new): Request-scoped abstraction for caller's current language (mirrors `ICurrentUser`)
- **`HttpContextCurrentLanguage.cs`** (new): HTTP context implementation caching resolved culture in `HttpContext.Items`
- **Input DTOs** (`GetInstanceStateInput`, `GetInstanceDataInput`, `GetSchemaInput`, `GetViewInput`): Added `Headers` and `QueryParameters` for dynamic-role evaluation
- **`TransitionValidationService.cs`**: Refactored `ResolveCulture()` to use centralized `LanguageResolver`
- **`WorkflowErrors.cs`**: Added `QueryAccessDenied()` error (HTTP 403)

### HTTP API Layer
- **`HttpContextCurrentLanguage`** registered in `WorkflowApiBaseServiceCollectionExtensions`
- Function handlers (`StateFunctionHandler`, `DataFunctionHandler`, `SchemaFunctionHandler`, `ViewFunctionHandler`) now forward headers and query parameters to app service inputs

### Tests
- **`InstanceQueryAppServiceStateTests.cs`**: 9 new test cases covering:
  - Alias resolution when role matches
  - Fallback to raw state key when no alias matches
  - Skipped role evaluation when no aliases defined
  - Multiple aliases (first match wins)
  - Localized label resolution with Accept-Language header
  - Fallback to English and first label
  - Alias without labels (returns name)
  - 403 response when queryRoles deny access
  - ETag changes when different roles/languages resolve different aliases
- **`TransitionAuthorizationManagerQueryRolesTests.cs`** (new): 11 unit tests for `IsQueryAllowedAsync()` covering state/workflow precedence, empty grants, multi-role any-allow, and deny logic
- **`WorkflowValidatorTests.cs`**: 4 new tests for alias validation (complete alias, no alias, missing labels, missing roles)
- **`StateTests.cs`**: 4 new tests for alias creation, addition, and deserialization
- **`LanguageLabelExtensionsTests.cs`** (new): 5 tests for label resolution fallback chain
- **`LanguageResol

## Summary by Sourcery

Introduce role-based state aliases and query authorization for workflow instance queries, with centralized language resolution and localization support.

New Features:
- Add state alias model with localized labels to present workflow states differently per role without changing internal state identity.
- Expose state aliases in instance state outputs via role-aware resolution that honors Accept-Language and per-request culture.
- Introduce a reusable current-language abstraction and language resolver based on HTTP Accept-Language headers.
- Add function-level role enforcement for custom functions using shared role grant evaluation.

Enhancements:
- Enforce state alias authoring rules in workflow validation, including required names, roles, and labels.
- Gate state, data, view, and schema instance functions behind state/workflow queryRoles using a shared authorization helper.
- Refine transition lock handling logs to avoid duplicate messages on lock acquisition failure.
- Standardize schema field role metadata to use x-roles and centralize language label resolution logic.

Documentation:
- Document state alias behavior, query authorization, and key components in the function handler architecture guide.

Tests:
- Add extensive tests for state alias resolution, localization fallbacks, queryRoles authorization, language resolver, and state alias deserialization.
- Extend workflow validator and state tests to cover alias validation and alias lifecycle.
- Add unit tests for queryRoles-specific logic in TransitionAuthorizationManager and language label resolution helpers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Role-based query access control: State and workflow queries now enforce role restrictions, returning 403 when access is denied.
  * State display aliases: States can now be displayed with role-specific aliases and localized labels based on caller roles and language preferences.
  * Custom function authorization: User-defined functions now enforce their declared role restrictions.
  * Language preference detection: Accept-Language header is now used to resolve localized content.
  * Multi-role support: Authorization checks now allow access if any caller role matches required grants.

* **Bug Fixes**
  * Removed duplicate lock-failure logging messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->