### PR TITLE
feat(functions): enforce FunctionScope on function invocation

### DIFF
--- a/src/BBT.Workflow.Application/Functions/FunctionAppService.cs
+++ b/src/BBT.Workflow.Application/Functions/FunctionAppService.cs
@@ -122,13 +122,20 @@ public sealed class FunctionAppService(
         JsonElement? body,
         CancellationToken cancellationToken)
     {
-        if (instance != null &&
-            workflow!.Key != RuntimeSysSchemaInfo.Functions &&
-            !function.Scope.Equals(TaskScope.Domain) &&
-            !workflow.Functions.Any(f => f.Key == function.Key))
+        // Scope enforcement. Domain is exempt; Instance/Flow require an instance;
+        // Flow additionally requires the function to be declared in the instance's flow.
+        if (!function.Scope.Equals(TaskScope.Domain))
         {
-            return Result<FunctionResponseOutput>.Fail(
-                WorkflowErrors.FunctionNotInWorkflow(function.Key, workflow.Key));
+            if (instance == null)
+                return Result<FunctionResponseOutput>.Fail(
+                    WorkflowErrors.FunctionScopeNotSatisfied(function.Key, function.Scope.Description));
+
+            if (function.Scope.Equals(TaskScope.Flow) &&
+                !(workflow?.Functions.Any(f => f.Key == function.Key) ?? false))
+            {
+                return Result<FunctionResponseOutput>.Fail(
+                    WorkflowErrors.FunctionScopeNotSatisfied(function.Key, function.Scope.Description));
+            }
         }
 
         // Custom-function authorization: when the function defines Roles, the caller must resolve to an allow.

--- a/src/BBT.Workflow.Domain/Logging/WorkflowErrors.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowErrors.cs
@@ -421,6 +421,18 @@ public static class WorkflowErrors
             $"Function '{functionKey}' is not defined for workflow '{workflowKey}'",
             target: functionKey);
 
+    /// <summary>
+    /// The function's scope requirements are not satisfied for the current request
+    /// (e.g. an Instance/Flow-scoped function invoked without an instance, or a
+    /// Flow-scoped function not declared in the instance's flow). Maps to HTTP 403.
+    /// </summary>
+    /// <param name="functionKey">The key of the function whose scope was violated.</param>
+    /// <param name="scope">The scope description of the function.</param>
+    public static Error FunctionScopeNotSatisfied(string functionKey, string scope)
+        => Error.Forbidden(
+            WorkflowErrorCodes.FunctionScopeNotSatisfied,
+            $"Function '{functionKey}' with scope '{scope}' cannot be invoked in this context.");
+
     #endregion
 
     #region Authorization Errors

--- a/src/BBT.Workflow.Domain/WorkflowErrorCodes.cs
+++ b/src/BBT.Workflow.Domain/WorkflowErrorCodes.cs
@@ -127,7 +127,8 @@ public static class WorkflowErrorCodes
     #region Function Errors (800xxx)
     
     public const string FunctionNotInWorkflow = "Function:800001";
-    
+    public const string FunctionScopeNotSatisfied = "Function:800002";
+
     #endregion
 
     #region Authorization Errors (110xxx)

--- a/test/BBT.Workflow.Application.Tests/Functions/FunctionAppServiceScopeTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Functions/FunctionAppServiceScopeTests.cs
@@ -1,0 +1,249 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.DependencyInjection;
+using BBT.Aether.MultiSchema;
+using BBT.Aether.Results;
+using BBT.Aether.Uow;
+using BBT.Aether.Users;
+using BBT.Workflow.Authorization;
+using BBT.Workflow.Caching;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Runtime;
+using BBT.Workflow.Scripting;
+using BBT.Workflow.Tasks.Coordinator;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Functions;
+
+/// <summary>
+/// Unit tests for function scope enforcement in <see cref="FunctionAppService"/>:
+/// <list type="bullet">
+/// <item>Domain — always runs (exempt from every scope restriction).</item>
+/// <item>Instance — only runs when an instance exists.</item>
+/// <item>Flow — requires an instance and the function to be declared in the instance's flow.</item>
+/// </list>
+/// Violations return <see cref="WorkflowErrorCodes.FunctionScopeNotSatisfied"/> (HTTP 403).
+/// </summary>
+public sealed class FunctionAppServiceScopeTests : IDisposable
+{
+    private const string TestDomain = "test-domain";
+    private const string TestFlow = "test-flow";
+    private const string TestVersion = "1.0.0";
+    private const string FunctionKey = "send-otp";
+
+    private readonly IInstanceRepository _instanceRepository;
+    private readonly IComponentCacheStore _componentCacheStore;
+    private readonly ITaskCoordinator _taskCoordinator;
+    private readonly FunctionAppService _service;
+
+    private readonly IServiceProvider _ambientServiceProvider;
+    private readonly IServiceProvider? _previousAmbientServiceProvider;
+
+    public FunctionAppServiceScopeTests()
+    {
+        _instanceRepository = Substitute.For<IInstanceRepository>();
+        _componentCacheStore = Substitute.For<IComponentCacheStore>();
+        _taskCoordinator = Substitute.For<ITaskCoordinator>();
+
+        // Ambient provider needed by PostSharp UnitOfWork interception.
+        var mockUoW = Substitute.For<IUnitOfWork>();
+        var mockUoWManager = Substitute.For<IUnitOfWorkManager>();
+        mockUoWManager
+            .BeginAsync(Arg.Any<UnitOfWorkOptions>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(mockUoW));
+        var services = new ServiceCollection();
+        services.AddSingleton(mockUoWManager);
+        _ambientServiceProvider = services.BuildServiceProvider();
+        _previousAmbientServiceProvider = AmbientServiceProvider.Current;
+        AmbientServiceProvider.Current = _ambientServiceProvider;
+
+        // Successful task execution + a buildable script context for the allow paths.
+        var scriptContext = new ScriptContext(NullLogger<ScriptContext>.Instance);
+        var builder = Substitute.For<IScriptContextBuilder>();
+        builder.WithRuntime(Arg.Any<IRuntimeInfoProvider>()).Returns(builder);
+        builder.WithWorkflow(Arg.Any<Definitions.Workflow?>()).Returns(builder);
+        builder.WithInstance(Arg.Any<Instance?>()).Returns(builder);
+        builder.WithBody(Arg.Any<object?>()).Returns(builder);
+        builder.WithHeaders(Arg.Any<Dictionary<string, string?>?>()).Returns(builder);
+        builder.WithQueryParameters(Arg.Any<Dictionary<string, string?>?>()).Returns(builder);
+        builder.BuildAsync(Arg.Any<CancellationToken>()).Returns(scriptContext);
+
+        var scriptContextFactory = Substitute.For<IScriptContextFactory>();
+        scriptContextFactory.NewBuilder(Arg.Any<IInstanceRepository>()).Returns(builder);
+
+        _taskCoordinator
+            .ExecuteAsync(
+                Arg.Any<IEnumerable<OnExecuteTask>>(),
+                Arg.Any<Guid?>(),
+                Arg.Any<TaskTrigger>(),
+                Arg.Any<ScriptContext>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Result.Ok());
+
+        _service = new FunctionAppService(
+            serviceProvider: _ambientServiceProvider,
+            runtimeInfoProvider: Substitute.For<IRuntimeInfoProvider>(),
+            instanceRepository: _instanceRepository,
+            scriptContextFactory: scriptContextFactory,
+            componentCacheStore: _componentCacheStore,
+            currentSchema: Substitute.For<ICurrentSchema>(),
+            taskCoordinator: _taskCoordinator,
+            scriptEngine: Substitute.For<IScriptEngine>(),
+            currentUser: Substitute.For<ICurrentUser>(),
+            transitionAuthorizationManager: Substitute.For<ITransitionAuthorizationManager>());
+    }
+
+    public void Dispose()
+    {
+        AmbientServiceProvider.Current = _previousAmbientServiceProvider;
+        (_ambientServiceProvider as IDisposable)?.Dispose();
+    }
+
+    // ─── Domain-level endpoint (GetFunctionByKeyAsync — no instance) ────────────
+
+    [Fact]
+    public async Task ByKey_DomainScope_Succeeds()
+    {
+        SetupFunction(TaskScope.Domain);
+
+        var result = await _service.GetFunctionByKeyAsync(FunctionKey, TestDomain);
+
+        result.IsSuccess.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ByKey_InstanceScope_Returns403()
+    {
+        SetupFunction(TaskScope.Instance);
+
+        var result = await _service.GetFunctionByKeyAsync(FunctionKey, TestDomain);
+
+        result.IsSuccess.ShouldBeFalse();
+        result.Error.Code.ShouldBe(WorkflowErrorCodes.FunctionScopeNotSatisfied);
+    }
+
+    [Fact]
+    public async Task ByKey_FlowScope_Returns403()
+    {
+        SetupFunction(TaskScope.Flow);
+
+        var result = await _service.GetFunctionByKeyAsync(FunctionKey, TestDomain);
+
+        result.IsSuccess.ShouldBeFalse();
+        result.Error.Code.ShouldBe(WorkflowErrorCodes.FunctionScopeNotSatisfied);
+    }
+
+    // ─── Instance-level endpoint (GetFunctionByInstanceAsync) ───────────────────
+
+    [Fact]
+    public async Task ByInstance_DomainScope_NotInFlow_Succeeds()
+    {
+        var instance = SetupInstance();
+        SetupFlow(declareFunction: false);
+        SetupFunction(TaskScope.Domain);
+
+        var result = await _service.GetFunctionByInstanceAsync(
+            FunctionKey, TestFlow, TestDomain, instance.Id.ToString());
+
+        result.IsSuccess.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ByInstance_InstanceScope_Succeeds()
+    {
+        var instance = SetupInstance();
+        SetupFlow(declareFunction: false);
+        SetupFunction(TaskScope.Instance);
+
+        var result = await _service.GetFunctionByInstanceAsync(
+            FunctionKey, TestFlow, TestDomain, instance.Id.ToString());
+
+        result.IsSuccess.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ByInstance_FlowScope_DeclaredInFlow_Succeeds()
+    {
+        var instance = SetupInstance();
+        SetupFlow(declareFunction: true);
+        SetupFunction(TaskScope.Flow);
+
+        var result = await _service.GetFunctionByInstanceAsync(
+            FunctionKey, TestFlow, TestDomain, instance.Id.ToString());
+
+        result.IsSuccess.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ByInstance_FlowScope_NotDeclaredInFlow_Returns403()
+    {
+        var instance = SetupInstance();
+        SetupFlow(declareFunction: false);
+        SetupFunction(TaskScope.Flow);
+
+        var result = await _service.GetFunctionByInstanceAsync(
+            FunctionKey, TestFlow, TestDomain, instance.Id.ToString());
+
+        result.IsSuccess.ShouldBeFalse();
+        result.Error.Code.ShouldBe(WorkflowErrorCodes.FunctionScopeNotSatisfied);
+    }
+
+    [Fact]
+    public async Task ByInstance_InstanceNotFound_ReturnsInstanceNotFound()
+    {
+        _instanceRepository
+            .FindByIdentifierAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns((Instance?)null);
+
+        var result = await _service.GetFunctionByInstanceAsync(
+            FunctionKey, TestFlow, TestDomain, "missing-key");
+
+        result.IsSuccess.ShouldBeFalse();
+        result.Error.Code.ShouldBe(WorkflowErrorCodes.NotFoundInstanceData);
+    }
+
+    // ─── Helpers ────────────────────────────────────────────────────────────────
+
+    private void SetupFunction(TaskScope scope)
+    {
+        var task = OnExecuteTask.Create(
+            1,
+            new Reference("my-task", TestDomain, "sys-tasks", TestVersion),
+            ScriptCode.FromNative(string.Empty));
+        var function = new Function(scope, task);
+        function.SetReference(new Reference(FunctionKey, TestDomain, "sys-functions", TestVersion));
+
+        _componentCacheStore
+            .GetFunctionAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(Result<Function>.Ok(function));
+    }
+
+    private Instance SetupInstance()
+    {
+        var instance = Instance.Create(Guid.NewGuid(), TestFlow, TestVersion, "test-key");
+        _instanceRepository
+            .FindByIdentifierAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(instance);
+        return instance;
+    }
+
+    private void SetupFlow(bool declareFunction)
+    {
+        var workflow = Definitions.Workflow.Create();
+        workflow.SetReference(new Reference(TestFlow, TestDomain, "sys-flows", TestVersion));
+        workflow.SetType("F");
+        if (declareFunction)
+            workflow.AddFunction(new Reference(FunctionKey, TestDomain, "sys-functions", TestVersion));
+
+        _componentCacheStore
+            .GetFlowAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(Result<Definitions.Workflow>.Ok(workflow));
+    }
+}


### PR DESCRIPTION
## What

Enforces `FunctionScope` rules consistently for both function-invocation entry points (`GetFunctionByKeyAsync` and `GetFunctionByInstanceAsync`), which both funnel through `ExecuteFunctionAsync`.

| Scope | Rule |
|-------|------|
| **Domain** | Always runs — exempt from every scope restriction (even with an instance present and not declared in the flow). |
| **Instance** | Only runs when an instance exists. |
| **Flow** | Requires an instance **and** the function to be declared in that instance's flow (`workflow.Functions`). |

> Note: the domain term "Workflow scope" maps to `TaskScope.Flow` ("F").

## Why

Closes #637. Scope was only partially enforced: the inline guard in `ExecuteFunctionAsync` checked Flow membership **and only when an instance was present**. Consequences:

- `Instance`/`Flow`-scoped functions could be invoked through the domain-level endpoint (no instance) with no restriction.
- Scope failures leaked out as incidental **404s** from the cache lookup instead of an intentional response.

## Changes

- **`WorkflowErrorCodes.cs`** — new code `FunctionScopeNotSatisfied = "Function:800002"`.
- **`WorkflowErrors.cs`** — new factory `FunctionScopeNotSatisfied(functionKey, scope)` → `Error.Forbidden` (**HTTP 403**), mirroring `FunctionAccessDenied`.
- **`FunctionAppService.cs`** — replaced the partial guard with full per-scope enforcement. Domain returns early (exempt); Instance/Flow require an instance; Flow additionally verifies flow membership. Dropped the old `RuntimeSysSchemaInfo.Functions` special-case (the system-functions listing path does not go through `ExecuteFunctionAsync`).
- **`FunctionAppServiceScopeTests.cs`** — new 8-test fixture covering the full scope matrix.

## Behavior change for reviewers

Scope violations now return **403 Forbidden** (`FunctionScopeNotSatisfied`) instead of `FunctionNotInWorkflow` (400) or an incidental 404. The `FunctionNotInWorkflow` (400) factory/code is no longer emitted by this guard — left in place rather than removed.

## Test matrix

| Method | Scope | Instance | In flow | Expected |
|--------|-------|----------|---------|----------|
| `GetFunctionByKeyAsync` | Domain | – | – | OK |
| `GetFunctionByKeyAsync` | Instance | – | – | 403 |
| `GetFunctionByKeyAsync` | Flow | – | – | 403 |
| `GetFunctionByInstanceAsync` | Domain | yes | no | OK (exempt) |
| `GetFunctionByInstanceAsync` | Instance | yes | – | OK |
| `GetFunctionByInstanceAsync` | Flow | yes | yes | OK |
| `GetFunctionByInstanceAsync` | Flow | yes | no | 403 |
| `GetFunctionByInstanceAsync` | * | missing | – | `InstanceNotFound` (unchanged) |

`dotnet build` clean; all 8 new tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce function scope rules consistently for function invocation endpoints and return a dedicated 403 error when scope requirements are not met.

Enhancements:
- Apply unified FunctionScope enforcement for Domain, Instance, and Flow-scoped functions in ExecuteFunctionAsync, ensuring domain calls are exempt while instance and flow scopes require an instance and flow membership where appropriate.
- Introduce a dedicated FunctionScopeNotSatisfied workflow error code and factory that maps scope violations to HTTP 403 responses instead of reusing existing function-not-in-workflow semantics.

Tests:
- Add FunctionAppServiceScopeTests to cover the complete matrix of scope behaviors for domain-level and instance-level function invocation, including success and failure paths and instance-not-found handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened function scope validation to enforce context requirements more strictly. Domain-scoped functions operate independently, while instance and flow-scoped functions now properly verify their execution context. Functions return clearer error responses when scope requirements cannot be satisfied in the workflow context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->