### PR TITLE
feat(scripting): sandboxed, component-referenced custom C# script helpers (#710)

### DIFF
--- a/docs/custom-script-helpers.md
+++ b/docs/custom-script-helpers.md
@@ -1,0 +1,137 @@
+# Custom Script Helpers (sandboxed, component-referenced)
+
+> Status: **experimental**, available `>= 0.0.58`. Disabled by default.
+> This is a strong best-effort **compile-time** gate for same-org domain teams — **not** a hard
+> security boundary. .NET has no in-process sandbox; for a true boundary isolate at the
+> process/container level.
+
+Domain teams can ship reusable C# helper classes as **components** and reference them from a
+transition mapping. At transition time the runtime builds the referenced helper set first (sandboxed,
+cached by content hash), then compiles and runs the mapping against it with the helper namespaces
+auto-imported.
+
+## 1. Author a helper component (`sys-mappings`)
+
+A helper is a `Mapping` component published to the new system flow `sys-mappings`, just like
+flows/tasks/views. Its body is a `.csx` class library snippet.
+
+```jsonc
+// component: sys-mappings / core / tax-calculator @ 1.0.0
+{
+  "key": "tax-calculator",
+  "flow": "sys-mappings",
+  "domain": "core",
+  "version": "1.0.0",
+  "name": "Tax calculator helpers",
+  "code": "namespace Helpers { public static class TaxCalc { public static decimal Tax(decimal x) => x * 0.18m; } }",
+  "encoding": "NAT"   // NAT (native/plain) or B64 (base64)
+}
+```
+
+Publish it through the normal component pipeline (`PublishAsync` / the Publish flow). The
+`MappingComponentValidator` checks that `name`/`code` are present and the code decodes; with the
+sandbox enabled, banned APIs are rejected at compile time.
+
+## 2. Reference helpers from a transition mapping
+
+Helpers and the per-compile sandbox grant live under a `scripts` object on the mapping. `helpers[]`
+uses the **same reference shape** as every other component reference (`key`/`version`/`domain`/`flow`).
+The whole `scripts` object is **optional** — omit it and behaviour is identical to before.
+
+```jsonc
+"mapping": {
+  "location": "mappings/order-mapping.csx",
+  "code": "...",                 // the mapping body (base64 or native per "encoding")
+  "encoding": "B64",
+  "scripts": {
+    "helpers": [
+      { "key": "tax-calculator", "version": "1.0.0", "domain": "core", "flow": "sys-mappings" }
+    ],
+    "allowedAssemblies": [ "System.Security.Cryptography" ]   // per-mapping sandbox grant (optional)
+  }
+}
+```
+
+Inside the mapping you call helper types directly — their namespaces are auto-imported:
+
+```csharp
+public class Mapping : ScriptBase, ITransitionMapping
+{
+    public Task<dynamic> Handler(ScriptContext ctx)
+        => Task.FromResult<dynamic>(new { tax = TaxCalc.Tax(100m) });
+}
+```
+
+### Flow-level `scripts` (global to the workflow)
+
+A workflow definition may declare a top-level `scripts` object. It is **global to the flow** and is
+**unioned** with every mapping's `scripts` at compile time (helper references concatenated + deduped by
+`domain/flow/key/version`; allowed assemblies distinct-merged). Use it to grant a helper/assembly once
+for the whole flow instead of repeating it on each mapping.
+
+```jsonc
+// workflow definition (top level)
+"scripts": {
+  "helpers": [ { "key": "json-helper", "version": "1.0.0", "domain": "core", "flow": "sys-mappings" } ],
+  "allowedAssemblies": [ "System.Security.Cryptography" ]
+}
+```
+
+### `encoding: "REF"` — run a sys-mappings component directly
+
+When `encoding` is `REF`, the mapping `code` is **not a string** but a `Reference` to a `sys-mappings`
+component. The runtime resolves it from the component store and runs that component's body (which is
+plain `NAT`/`B64` — no REF chaining). This lets tasks reuse published mapping definitions.
+
+```jsonc
+"mapping": {
+  "code": { "key": "json-helper", "version": "1.0.0", "domain": "core", "flow": "sys-mappings" },
+  "encoding": "REF"
+}
+```
+
+## 3. Configuration
+
+```json
+"Scripting": {
+  "Helpers": { "Enabled": false },
+  "Sandbox": {
+    "Enabled": false,
+    "AllowUnsafe": false,
+    "PluginDirectory": "/app/assemblies",
+    "AllowedAssemblies": [ "System.Private.CoreLib", "System.Runtime", "System.Collections", "System.Linq", "System.Linq.Expressions", "System.Text.RegularExpressions", "Microsoft.CSharp", "netstandard" ],
+    "BannedNamespaces": []
+  }
+}
+```
+
+- **`Scripting:Helpers:Enabled`** — master switch for referencing helpers. A mapping that declares
+  `helpers[]` while this is `false` fails to compile.
+- **`Scripting:Sandbox:Enabled`** — when `true`, **all** mapping compiles use the restricted reference
+  set + banned-API analyzer. Default `false` keeps existing behaviour byte-for-byte.
+- **`AllowedAssemblies`** — global baseline of referenceable assemblies. A mapping's
+  `allowedAssemblies` is merged on top of this for that compile only.
+- **`BannedNamespaces`** — *adds* to the mandatory platform baseline; it cannot remove an entry.
+
+### Mandatory banned namespaces (non-overridable)
+
+`System.IO`, `System.Net`, `System.Net.Http`, `System.Diagnostics`, `System.Reflection`,
+`System.Runtime.InteropServices`, `Microsoft.Win32`.
+
+A mapping/helper compile may never do file IO, network/HTTP, process/diagnostics, reflection, native
+interop, or registry access. `DllImport` and `unsafe` are rejected. `System.Threading` (and
+`System.Threading.Tasks`) are **allowed** — threading/synchronization primitives and `Task`-based
+async are available to mappings.
+
+## 4. Third-party / NuGet assemblies (operator-curated only)
+
+There is **no** per-flow DLL upload or nupkg download. An operator mounts approved DLLs into
+`Scripting:Sandbox:PluginDirectory` (a Docker volume), allow-lists them in `AllowedAssemblies` (or a
+flow grants them per-mapping). The runtime loads them dynamically into the helper-set load context.
+The banned-namespace analyzer still runs on the script source.
+
+## 5. Caching & memory
+
+A helper set is compiled once per content hash (ordered key+version+code plus the per-mapping grant)
+and reused across requests. Editing a helper changes its hash → a new set is built. Each set lives in
+its own collectible `AssemblyLoadContext` and can be unloaded when superseded.

--- a/execution/BBT.Workflow.Execution.HttpApi.Host/appsettings.json
+++ b/execution/BBT.Workflow.Execution.HttpApi.Host/appsettings.json
@@ -9,6 +9,27 @@
   "OrchestrationApi": {
     "AppId": "vnext-app"
   },
+  "Scripting": {
+    "Helpers": {
+      "Enabled": false
+    },
+    "Sandbox": {
+      "Enabled": false,
+      "AllowUnsafe": false,
+      "PluginDirectory": "/app/assemblies",
+      "AllowedAssemblies": [
+        "System.Private.CoreLib",
+        "System.Runtime",
+        "System.Collections",
+        "System.Linq",
+        "System.Linq.Expressions",
+        "System.Text.RegularExpressions",
+        "Microsoft.CSharp",
+        "netstandard"
+      ],
+      "BannedNamespaces": []
+    }
+  },
   "TriggerRetry": {
     "MaxRetryAttempts": 3,
     "RetryDelayMilliseconds": 2000,

--- a/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Evaluators/CSharpEvaluator.cs
+++ b/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Evaluators/CSharpEvaluator.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using BBT.Workflow.Scripting.Functions;
+using BBT.Workflow.Scripting.Sandbox;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -20,9 +21,24 @@ namespace BBT.Workflow.Scripting.Evaluators;
 /// Memory-safe C# script evaluator with assembly sharing.
 /// Caches compiled Types so the same script code reuses the same assembly.
 /// Uses collectible AssemblyLoadContext for proper memory management.
+///
+/// When a <see cref="ScriptSandboxOptions"/> with <c>Enabled = true</c> is supplied, all compilations
+/// use the restricted reference set (<see cref="SandboxedReferenceSet"/>) instead of scanning the
+/// whole AppDomain, and the <see cref="BannedApiAnalyzer"/> runs before IL emission.
 /// </summary>
 public class CSharpEvaluator : IEvaluator
 {
+    private readonly ScriptSandboxOptions _sandbox;
+
+    /// <summary>
+    /// Creates a new evaluator. When <paramref name="sandboxOptions"/> is null or has
+    /// <c>Enabled = false</c>, the legacy (non-sandboxed) compile path is used.
+    /// </summary>
+    public CSharpEvaluator(ScriptSandboxOptions? sandboxOptions = null)
+    {
+        _sandbox = sandboxOptions ?? new ScriptSandboxOptions { Enabled = false };
+    }
+
     /// <summary>
     /// Cached compiled types indexed by code hash.
     /// Stores (LoadContext, Type) tuple so we can track the context for potential cleanup.
@@ -52,13 +68,15 @@ public class CSharpEvaluator : IEvaluator
         IScriptServices? services = null,
         IEnumerable<MetadataReference>? extraReferences = null,
         IEnumerable<string>? usingDirectives = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        AssemblyLoadContext? loadContext = null,
+        IReadOnlyList<string>? sandboxGrant = null)
     {
         if (string.IsNullOrWhiteSpace(code))
             throw new ArgumentException("Code cannot be null or empty", nameof(code));
 
-        // Generate cache key from code + target type + configuration
-        var cacheKey = GenerateCacheKey(code, typeof(T), extraReferences, usingDirectives);
+        // Generate cache key from code + target type + configuration (incl. sandbox grant).
+        var cacheKey = GenerateCacheKey(code, typeof(T), extraReferences, usingDirectives, sandboxGrant);
 
         // Try to get cached type and create instance from it
         if (_typeCache.TryGetValue(cacheKey, out var cached))
@@ -68,7 +86,45 @@ public class CSharpEvaluator : IEvaluator
         }
 
         // Compile, cache the type, and return instance
-        return CompileAndCacheAsync<T>(code, cacheKey, services, extraReferences, usingDirectives, cancellationToken);
+        return CompileAndCacheAsync<T>(
+            code, cacheKey, services, extraReferences, usingDirectives, sandboxGrant, loadContext, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public CompiledHelpers CompileHelpers(
+        IReadOnlyList<(string Path, string Code)> sources,
+        AssemblyLoadContext loadContext,
+        IEnumerable<MetadataReference>? extraReferences = null,
+        IEnumerable<string>? usingDirectives = null,
+        IReadOnlyList<string>? sandboxGrant = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (sources is null || sources.Count == 0)
+            throw new ArgumentException("At least one helper source is required.", nameof(sources));
+
+        var usingPrefix = BuildUsingPrefix(usingDirectives);
+        var trees = sources
+            .Select(s => CSharpSyntaxTree.ParseText(
+                usingPrefix + s.Code, options: ParseOptions, path: s.Path, cancellationToken: cancellationToken))
+            .ToList();
+
+        var assemblyName = $"Helpers_{Convert.ToHexString(SHA256.HashData(
+            Encoding.UTF8.GetBytes(string.Concat(sources.Select(s => s.Code)))))[..8]}";
+
+        var compilation = CreateCompilation(assemblyName, trees, extraReferences, sandboxGrant);
+        RunSandboxAnalyzer(compilation);
+
+        var image = EmitToImage(compilation, cancellationToken);
+        var assembly = loadContext.LoadFromStream(new MemoryStream(image));
+
+        var namespaces = assembly.GetExportedTypes()
+            .Select(t => t.Namespace)
+            .Where(n => !string.IsNullOrEmpty(n))
+            .Distinct()
+            .Cast<string>()
+            .ToArray();
+
+        return new CompiledHelpers(MetadataReference.CreateFromImage(image), namespaces);
     }
 
     /// <summary>
@@ -100,6 +156,8 @@ public class CSharpEvaluator : IEvaluator
         IScriptServices? services,
         IEnumerable<MetadataReference>? extraReferences,
         IEnumerable<string>? usingDirectives,
+        IReadOnlyList<string>? sandboxGrant,
+        AssemblyLoadContext? loadContext,
         CancellationToken cancellationToken)
     {
         var syntaxTree = CSharpSyntaxTree.ParseText(code, options: ParseOptions, cancellationToken: cancellationToken);
@@ -113,22 +171,96 @@ public class CSharpEvaluator : IEvaluator
             syntaxTree = syntaxTree.WithRootAndOptions(newRoot, syntaxTree.Options);
         }
 
-        // Use cached references and add any extra ones
-        var references = DefaultMetadataReferences.Value;
-        if (extraReferences != null && extraReferences.Any())
+        var assemblyName = $"Script_{cacheKey[..Math.Min(16, cacheKey.Length)]}";
+
+        var compilation = CreateCompilation(assemblyName, [syntaxTree], extraReferences, sandboxGrant);
+
+        // Layer 2 of the sandbox: semantic ban list, run before emit.
+        RunSandboxAnalyzer(compilation);
+
+        var image = EmitToImage(compilation, cancellationToken);
+
+        // Use the shared collectible context when supplied (so mappings resolve helper types),
+        // otherwise a fresh per-script collectible context (so we CAN unload, e.g. ClearCache).
+        var context = loadContext ?? new ScriptAssemblyLoadContext(assemblyName);
+        var assembly = context.LoadFromStream(new MemoryStream(image));
+
+        // Find the type that implements T
+        var types = assembly.GetTypes();
+        var matchedType = types.FirstOrDefault(t =>
+            typeof(T).IsAssignableFrom(t) && !t.IsInterface && !t.IsAbstract);
+
+        if (matchedType == null)
         {
-            references = references.Concat(extraReferences).ToList();
+            if (loadContext is null && context is ScriptAssemblyLoadContext owned)
+            {
+                owned.Unload();
+            }
+
+            var available = string.Join(", ", types.Select(t => t.FullName));
+            throw new InvalidOperationException(
+                $"No type implementing {typeof(T).FullName} found.\nAvailable types: {available}");
         }
 
-        var assemblyName = $"Script_{cacheKey[..Math.Min(16, cacheKey.Length)]}";
-        
-        var compilation = CSharpCompilation.Create(
-            assemblyName: assemblyName,
-            syntaxTrees: [syntaxTree],
-            references: references,
-            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
-                .WithOptimizationLevel(OptimizationLevel.Release));
+        // Cache the type for future reuse (same script = same assembly = same type)
+        _typeCache.TryAdd(cacheKey, (context, matchedType));
 
+        // Create instance and inject services
+        return Task.FromResult(CreateAndInjectServices<T>(matchedType, services));
+    }
+
+    /// <summary>
+    /// Builds a Roslyn compilation, selecting the sandboxed reference set when the sandbox is enabled
+    /// (baseline ∪ grant) or the full AppDomain reference set otherwise. Runtime-owned contract
+    /// references in <paramref name="extraReferences"/> are always included.
+    /// </summary>
+    private CSharpCompilation CreateCompilation(
+        string assemblyName,
+        IReadOnlyList<SyntaxTree> trees,
+        IEnumerable<MetadataReference>? extraReferences,
+        IReadOnlyList<string>? sandboxGrant)
+    {
+        IEnumerable<MetadataReference> references = _sandbox.Enabled
+            ? SandboxedReferenceSet.Build(_sandbox, sandboxGrant)
+            : DefaultMetadataReferences.Value;
+
+        if (extraReferences != null)
+        {
+            references = references.Concat(extraReferences);
+        }
+
+        return CSharpCompilation.Create(
+            assemblyName: assemblyName,
+            syntaxTrees: trees,
+            references: references.Distinct(),
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithOptimizationLevel(OptimizationLevel.Release)
+                .WithAllowUnsafe(_sandbox.AllowUnsafe));
+    }
+
+    /// <summary>
+    /// Runs the banned-API analyzer. The mandatory banned namespaces (plus <c>DllImport</c>/<c>unsafe</c>)
+    /// are enforced on EVERY compile — even when the sandbox is disabled — so mapping code can never use
+    /// IO/network/reflection/etc. Operator-configured ban additions and the restricted reference set
+    /// apply only when the sandbox is enabled. Throws <see cref="ScriptCompilationException"/> on violations.
+    /// </summary>
+    private void RunSandboxAnalyzer(Compilation compilation)
+    {
+        var violations = BannedApiAnalyzer.Analyze(
+            compilation, _sandbox, includeConfiguredBans: _sandbox.Enabled);
+
+        if (violations.Count > 0)
+        {
+            throw new ScriptCompilationException(
+                "Sandbox violations:\n  - " + string.Join("\n  - ", violations));
+        }
+    }
+
+    /// <summary>
+    /// Emits the compilation to an in-memory image, throwing on compile errors.
+    /// </summary>
+    private static byte[] EmitToImage(Compilation compilation, CancellationToken cancellationToken)
+    {
         using var ms = new MemoryStream();
         var emitResult = compilation.Emit(ms, cancellationToken: cancellationToken);
 
@@ -141,47 +273,45 @@ public class CSharpEvaluator : IEvaluator
             throw new InvalidOperationException($"Compilation failed:\n{errors}");
         }
 
-        ms.Seek(0, SeekOrigin.Begin);
+        return ms.ToArray();
+    }
 
-        // Use collectible context so we CAN unload if needed (e.g., ClearCache)
-        var loadContext = new ScriptAssemblyLoadContext(assemblyName);
-        var assembly = loadContext.LoadFromStream(ms);
-
-        // Find the type that implements T
-        var types = assembly.GetTypes();
-        var matchedType = types.FirstOrDefault(t =>
-            typeof(T).IsAssignableFrom(t) && !t.IsInterface && !t.IsAbstract);
-
-        if (matchedType == null)
-        {
-            loadContext.Unload();
-            
-            var available = string.Join(", ", types.Select(t => t.FullName));
-            throw new InvalidOperationException(
-                $"No type implementing {typeof(T).FullName} found.\nAvailable types: {available}");
-        }
-
-        // Cache the type for future reuse (same script = same assembly = same type)
-        _typeCache.TryAdd(cacheKey, (loadContext, matchedType));
-
-        // Create instance and inject services
-        return Task.FromResult(CreateAndInjectServices<T>(matchedType, services));
+    /// <summary>
+    /// Builds a leading <c>using ...;</c> prefix block from the supplied namespaces.
+    /// </summary>
+    private static string BuildUsingPrefix(IEnumerable<string>? usingDirectives)
+    {
+        return usingDirectives is null
+            ? string.Empty
+            : string.Concat(usingDirectives.Distinct().Select(u => $"using {u};\n"));
     }
 
     /// <summary>
     /// Generates a stable cache key from the code and configuration.
     /// </summary>
-    private static string GenerateCacheKey(
-        string code, 
+    private string GenerateCacheKey(
+        string code,
         Type targetType,
         IEnumerable<MetadataReference>? extraReferences,
-        IEnumerable<string>? usingDirectives)
+        IEnumerable<string>? usingDirectives,
+        IReadOnlyList<string>? sandboxGrant = null)
     {
         var sb = new StringBuilder();
         sb.Append(code);
         sb.Append('|');
         sb.Append(targetType.AssemblyQualifiedName);
-        
+
+        // Sandbox state is part of the compilation identity.
+        sb.Append("|sbx:").Append(_sandbox.Enabled ? '1' : '0');
+
+        if (sandboxGrant != null)
+        {
+            foreach (var grant in sandboxGrant.OrderBy(g => g, StringComparer.OrdinalIgnoreCase))
+            {
+                sb.Append("|@@").Append(grant);
+            }
+        }
+
         if (usingDirectives != null)
         {
             foreach (var directive in usingDirectives.OrderBy(u => u))

--- a/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Evaluators/IEvaluator.cs
+++ b/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Evaluators/IEvaluator.cs
@@ -1,10 +1,19 @@
 using System.Collections.Generic;
+using System.Runtime.Loader;
 using System.Threading;
 using System.Threading.Tasks;
 using BBT.Workflow.Scripting.Functions;
 using Microsoft.CodeAnalysis;
 
 namespace BBT.Workflow.Scripting.Evaluators;
+
+/// <summary>
+/// The compiled image of a helper set: a reference other scripts can be compiled against plus the
+/// public namespaces it exposes (auto-imported into the consuming mapping).
+/// </summary>
+/// <param name="Reference">Metadata reference to the compiled helper assembly.</param>
+/// <param name="Namespaces">Public namespaces exported by the helper assembly.</param>
+public sealed record CompiledHelpers(MetadataReference Reference, string[] Namespaces);
 
 /// <summary>
 /// Provides script compilation and instantiation capabilities.
@@ -22,11 +31,42 @@ public interface IEvaluator
     /// <param name="extraReferences">Optional additional metadata references for compilation</param>
     /// <param name="usingDirectives">Optional additional using directives to include</param>
     /// <param name="cancellationToken">Token to cancel the operation</param>
+    /// <param name="loadContext">
+    /// Optional shared collectible <see cref="AssemblyLoadContext"/> to load the compiled assembly into.
+    /// Used so a mapping resolves the helper types compiled into the same context. When <c>null</c> a
+    /// fresh per-script context is created (legacy behaviour).
+    /// </param>
+    /// <param name="sandboxGrant">
+    /// Optional per-compile assembly grant merged on top of the sandbox baseline (effective only when
+    /// the sandbox is enabled).
+    /// </param>
     /// <returns>A task containing the compiled instance of type T</returns>
     Task<T> CompileToInstanceAsync<T>(
         string code,
         IScriptServices? services = null,
         IEnumerable<MetadataReference>? extraReferences = null,
         IEnumerable<string>? usingDirectives = null,
+        CancellationToken cancellationToken = default,
+        AssemblyLoadContext? loadContext = null,
+        IReadOnlyList<string>? sandboxGrant = null);
+
+    /// <summary>
+    /// Compiles a set of helper component sources into a single assembly loaded into the supplied
+    /// collectible <see cref="AssemblyLoadContext"/>, so the helpers can reference one another and a
+    /// consuming mapping can be compiled against the result. Runs the sandbox analyzer when enabled.
+    /// </summary>
+    /// <param name="sources">The helper sources (path + code) to compile together.</param>
+    /// <param name="loadContext">The shared collectible context to load the helper assembly into.</param>
+    /// <param name="extraReferences">Runtime-owned contract references (e.g. ScriptBase) to include.</param>
+    /// <param name="usingDirectives">Optional using directives prepended to every helper source.</param>
+    /// <param name="sandboxGrant">Optional per-compile assembly grant.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    /// <returns>The compiled helper image (reference + exported namespaces).</returns>
+    CompiledHelpers CompileHelpers(
+        IReadOnlyList<(string Path, string Code)> sources,
+        AssemblyLoadContext loadContext,
+        IEnumerable<MetadataReference>? extraReferences = null,
+        IEnumerable<string>? usingDirectives = null,
+        IReadOnlyList<string>? sandboxGrant = null,
         CancellationToken cancellationToken = default);
 }

--- a/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Helpers/IScriptHelperRegistry.cs
+++ b/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Helpers/IScriptHelperRegistry.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using System.Runtime.Loader;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+
+namespace BBT.Workflow.Scripting.Helpers;
+
+/// <summary>
+/// A single helper component source to be compiled into a helper set.
+/// </summary>
+/// <param name="Key">Component key (used for cache identity).</param>
+/// <param name="Version">Component version (used for cache identity).</param>
+/// <param name="Code">Decoded C# source of the helper.</param>
+/// <param name="Path">A logical path/name used in diagnostics.</param>
+public sealed record HelperSource(string Key, string Version, string Code, string Path);
+
+/// <summary>
+/// The compiled, loadable result of a helper set.
+/// </summary>
+/// <param name="Reference">Metadata reference to the compiled helper assembly.</param>
+/// <param name="Namespaces">Public namespaces exported by the helper assembly (auto-imported into mappings).</param>
+/// <param name="LoadContext">The collectible context the helper assembly is loaded into; the consuming
+/// mapping must be compiled into the same context so helper types resolve at runtime.</param>
+/// <param name="FromCache">True when this set was served from cache rather than freshly compiled.</param>
+public sealed record HelperSet(
+    MetadataReference Reference,
+    IReadOnlyList<string> Namespaces,
+    AssemblyLoadContext LoadContext,
+    bool FromCache);
+
+/// <summary>
+/// Compiles and caches helper sets. A helper set is the expensive, process-wide artifact: it is
+/// compiled once per content hash (ordered key+version+code plus the per-mapping grant) into a shared
+/// collectible <see cref="AssemblyLoadContext"/>, then reused across requests. Implementations are
+/// registered as singletons.
+/// </summary>
+public interface IScriptHelperRegistry
+{
+    /// <summary>
+    /// Builds (or returns the cached) compiled helper set for the referenced helpers. Compiling them
+    /// together lets helpers reference one another. The grant is part of the cache key.
+    /// </summary>
+    /// <param name="helpers">Ordered helper sources to compile together.</param>
+    /// <param name="allowedAssemblies">Per-mapping sandbox grant merged on top of the baseline.</param>
+    /// <param name="contractReferences">Runtime-owned contract references (e.g. ScriptBase) to include.</param>
+    /// <param name="baseUsings">Using directives prepended to every helper source.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    HelperSet GetOrBuildHelpers(
+        IReadOnlyList<HelperSource> helpers,
+        IReadOnlyList<string>? allowedAssemblies,
+        IEnumerable<MetadataReference> contractReferences,
+        IEnumerable<string> baseUsings,
+        CancellationToken cancellationToken = default);
+}

--- a/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Helpers/ScriptHelperRegistry.cs
+++ b/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Helpers/ScriptHelperRegistry.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using BBT.Workflow.Scripting.Evaluators;
+using BBT.Workflow.Scripting.Sandbox;
+using Microsoft.CodeAnalysis;
+
+namespace BBT.Workflow.Scripting.Helpers;
+
+/// <summary>
+/// Default <see cref="IScriptHelperRegistry"/>. Each distinct (helpers + grant) content hash gets its
+/// own collectible <see cref="AssemblyLoadContext"/> into which the helper assembly — and later the
+/// consuming mapping — are loaded, so a superseded set can be unloaded independently. Operator-mounted
+/// plugin DLLs are preloaded into each set's context so helper code can resolve them at runtime even
+/// though the host does not reference them.
+/// </summary>
+public sealed class ScriptHelperRegistry(IEvaluator evaluator, ScriptSandboxOptions? sandboxOptions = null)
+    : IScriptHelperRegistry, IDisposable
+{
+    private readonly ScriptSandboxOptions _sandbox = sandboxOptions ?? new ScriptSandboxOptions { Enabled = false };
+    private readonly ConcurrentDictionary<string, Lazy<HelperSet>> _cache = new();
+
+    /// <inheritdoc />
+    public HelperSet GetOrBuildHelpers(
+        IReadOnlyList<HelperSource> helpers,
+        IReadOnlyList<string>? allowedAssemblies,
+        IEnumerable<MetadataReference> contractReferences,
+        IEnumerable<string> baseUsings,
+        CancellationToken cancellationToken = default)
+    {
+        if (helpers is null || helpers.Count == 0)
+            throw new ArgumentException("At least one helper is required.", nameof(helpers));
+
+        var key = HashOf(helpers, allowedAssemblies);
+        var fromCache = _cache.ContainsKey(key);
+
+        var lazy = _cache.GetOrAdd(key, _ => new Lazy<HelperSet>(() =>
+        {
+            var alc = new ScriptAssemblyLoadContext($"Helpers_{key[..8]}");
+            PreloadPlugins(alc);
+
+            var compiled = evaluator.CompileHelpers(
+                sources: helpers.Select(h => (h.Path, h.Code)).ToList(),
+                loadContext: alc,
+                extraReferences: contractReferences,
+                usingDirectives: baseUsings,
+                sandboxGrant: allowedAssemblies,
+                cancellationToken: cancellationToken);
+
+            return new HelperSet(compiled.Reference, compiled.Namespaces, alc, FromCache: false);
+        }));
+
+        var set = lazy.Value;
+        return fromCache ? set with { FromCache = true } : set;
+    }
+
+    /// <summary>
+    /// Loads operator-approved third-party DLLs from the plugin directory into the set's context so
+    /// compiled helpers resolve them at runtime. Failures are ignored per-DLL (best effort).
+    /// </summary>
+    private void PreloadPlugins(AssemblyLoadContext context)
+    {
+        var dir = _sandbox.ResolvePluginDirectory();
+        if (string.IsNullOrEmpty(dir) || !Directory.Exists(dir))
+            return;
+
+        foreach (var dll in Directory.EnumerateFiles(dir, "*.dll"))
+        {
+            try
+            {
+                context.LoadFromAssemblyPath(dll);
+            }
+            catch
+            {
+                // A bad/duplicate plugin DLL must not break helper compilation.
+            }
+        }
+    }
+
+    private static string HashOf(IReadOnlyList<HelperSource> helpers, IReadOnlyList<string>? allowedAssemblies)
+    {
+        var sb = new StringBuilder();
+        foreach (var h in helpers)
+            sb.Append(h.Key).Append('@').Append(h.Version).Append('|').Append(h.Code).Append(';');
+
+        if (allowedAssemblies is not null)
+            foreach (var a in allowedAssemblies.OrderBy(x => x, StringComparer.OrdinalIgnoreCase))
+                sb.Append("@@").Append(a);
+
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(sb.ToString())));
+    }
+
+    public void Dispose()
+    {
+        foreach (var entry in _cache.Values.ToList())
+        {
+            if (!entry.IsValueCreated)
+                continue;
+
+            if (entry.Value.LoadContext is ScriptAssemblyLoadContext owned)
+            {
+                try
+                {
+                    owned.Unload();
+                }
+                catch
+                {
+                    // Ignore unload failures.
+                }
+            }
+        }
+
+        _cache.Clear();
+    }
+}

--- a/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Helpers/ScriptHelpersOptions.cs
+++ b/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Helpers/ScriptHelpersOptions.cs
@@ -1,0 +1,18 @@
+namespace BBT.Workflow.Scripting.Helpers;
+
+/// <summary>
+/// Feature switch for the custom-script-helpers capability, bound from configuration
+/// (section <c>Scripting:Helpers</c>). When disabled, transition mappings that declare
+/// <c>helpers[]</c> are rejected at compile time so the feature can be opted into per environment.
+/// </summary>
+public sealed class ScriptHelpersOptions
+{
+    /// <summary>Configuration section name.</summary>
+    public const string SectionName = "Scripting:Helpers";
+
+    /// <summary>
+    /// Master switch for referencing helper components from a mapping. Defaults to <c>false</c>
+    /// so existing deployments are unaffected until explicitly opted in.
+    /// </summary>
+    public bool Enabled { get; set; }
+}

--- a/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Sandbox/BannedApiAnalyzer.cs
+++ b/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Sandbox/BannedApiAnalyzer.cs
@@ -1,0 +1,141 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace BBT.Workflow.Scripting.Sandbox;
+
+/// <summary>
+/// Semantic guard that runs after a <see cref="Compilation"/> is built but before IL is emitted.
+/// It resolves every referenced symbol and rejects any whose containing namespace falls under a
+/// banned prefix, plus <c>DllImport</c> and <c>unsafe</c>. This catches dangerous types that live
+/// in mandatory assemblies (e.g. <c>System.IO.File</c>) which reference omission alone cannot block.
+///
+/// The banned set is the <see cref="MandatoryBannedNamespaces"/> baseline (platform-owned,
+/// non-overridable) unioned with any operator additions; <see cref="MandatoryAllowedNamespaces"/>
+/// carves out sub-namespaces that must remain usable (notably <c>System.Threading.Tasks</c>, so
+/// banning thread/synchronization primitives does not break <c>Task</c>-based async).
+/// </summary>
+public static class BannedApiAnalyzer
+{
+    /// <summary>
+    /// Mandatory, non-overridable banned namespace prefixes. A mapping compile must never perform
+    /// file IO, network/HTTP, process/diagnostics, reflection, native interop, or registry access.
+    /// Config may add to this set but never remove from it.
+    /// Note: <c>System.Threading</c> is intentionally NOT banned — threading/synchronization primitives
+    /// (and <c>System.Threading.Tasks</c>) are allowed for mappings.
+    /// </summary>
+    public static readonly IReadOnlyList<string> MandatoryBannedNamespaces = new[]
+    {
+        "System.IO",
+        "System.Net",
+        "System.Net.Http",
+        "System.Diagnostics",
+        "System.Reflection",
+        "System.Runtime.InteropServices",
+        "Microsoft.Win32",
+    };
+
+    /// <summary>
+    /// Carve-outs that remain allowed even when nested under a banned prefix. Currently empty; retained
+    /// as an extension point should a future banned prefix require a usable sub-namespace.
+    /// </summary>
+    public static readonly IReadOnlyList<string> MandatoryAllowedNamespaces = System.Array.Empty<string>();
+
+    /// <summary>
+    /// Analyzes the compilation and returns the list of human-readable sandbox violations
+    /// (empty when the script is clean).
+    /// </summary>
+    /// <param name="compilation">The compilation to analyze.</param>
+    /// <param name="options">Sandbox options (used for <c>AllowUnsafe</c> and configured ban additions).</param>
+    /// <param name="includeConfiguredBans">
+    /// When <c>true</c>, operator-configured <see cref="ScriptSandboxOptions.BannedNamespaces"/> are
+    /// unioned with the mandatory baseline. When <c>false</c>, only the mandatory (non-overridable)
+    /// baseline is enforced — used when the sandbox is disabled so mapping code can still never touch
+    /// IO/network/reflection/etc. <c>DllImport</c> and <c>unsafe</c> are always enforced.
+    /// </param>
+    public static IReadOnlyList<string> Analyze(
+        Compilation compilation,
+        ScriptSandboxOptions options,
+        bool includeConfiguredBans = true)
+    {
+        var banned = MandatoryBannedNamespaces
+            .Concat(includeConfiguredBans
+                ? options.BannedNamespaces ?? Enumerable.Empty<string>()
+                : Enumerable.Empty<string>())
+            .Distinct()
+            .ToList();
+
+        var allowedCarveOuts = MandatoryAllowedNamespaces;
+
+        var violations = new List<string>();
+
+        foreach (var tree in compilation.SyntaxTrees)
+        {
+            var model = compilation.GetSemanticModel(tree);
+            var root = tree.GetRoot();
+
+            // 1. Banned namespace usage — resolve symbols on every name/expression/attribute node.
+            foreach (var node in root.DescendantNodes())
+            {
+                if (node is not (ExpressionSyntax or AttributeSyntax))
+                    continue;
+
+                var symbol = model.GetSymbolInfo(node).Symbol;
+                var ns = NamespaceOf(symbol);
+                if (ns is null)
+                    continue;
+
+                // Carve-outs win over the banned prefixes.
+                if (allowedCarveOuts.Any(a => ns == a || ns.StartsWith(a + ".", System.StringComparison.Ordinal)))
+                    continue;
+
+                var hit = banned.FirstOrDefault(b =>
+                    ns == b || ns.StartsWith(b + ".", System.StringComparison.Ordinal));
+
+                if (hit is not null)
+                {
+                    var line = node.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+                    violations.Add(
+                        $"{Path.GetFileName(tree.FilePath)}({line}): banned namespace '{hit}' via '{symbol}'");
+                }
+            }
+
+            // 2. P/Invoke.
+            foreach (var method in root.DescendantNodes().OfType<MethodDeclarationSyntax>())
+            {
+                if (method.AttributeLists.SelectMany(a => a.Attributes)
+                    .Any(a => a.Name.ToString().Contains("DllImport")))
+                {
+                    var line = method.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+                    violations.Add($"{Path.GetFileName(tree.FilePath)}({line}): P/Invoke (DllImport) is not allowed");
+                }
+            }
+
+            // 3. unsafe code.
+            if (!options.AllowUnsafe &&
+                root.DescendantTokens().Any(t => t.IsKind(SyntaxKind.UnsafeKeyword)))
+            {
+                violations.Add($"{Path.GetFileName(tree.FilePath)}: 'unsafe' code is not allowed");
+            }
+        }
+
+        return violations.Distinct().ToList();
+    }
+
+    private static string? NamespaceOf(ISymbol? symbol)
+    {
+        var type = symbol switch
+        {
+            null => null,
+            ITypeSymbol t => t,
+            _ => symbol.ContainingType,
+        };
+
+        return type?.ContainingNamespace is { IsGlobalNamespace: false } ns
+            ? ns.ToDisplayString()
+            : null;
+    }
+}

--- a/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Sandbox/SandboxedReferenceSet.cs
+++ b/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Sandbox/SandboxedReferenceSet.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.CodeAnalysis;
+
+namespace BBT.Workflow.Scripting.Sandbox;
+
+/// <summary>
+/// Builds the curated <see cref="MetadataReference"/> list for sandboxed compilation.
+/// The universe of resolvable assemblies is the runtime's Trusted Platform Assemblies (TPA)
+/// plus any DLLs in the operator-mounted plugin directory. From that universe only the effective
+/// allow-list (global baseline ∪ per-mapping grant) is kept.
+/// </summary>
+public static class SandboxedReferenceSet
+{
+    /// <summary>
+    /// Effective allow-list = global baseline ∪ the per-mapping grant. Only assemblies that are
+    /// actually available (framework TPA or mounted plugins) can resolve; banned-namespace usage
+    /// is still rejected by <see cref="BannedApiAnalyzer"/> regardless of the grant.
+    /// </summary>
+    public static IReadOnlyList<MetadataReference> Build(ScriptSandboxOptions options, IEnumerable<string>? grant = null)
+    {
+        var allowed = new HashSet<string>(options.AllowedAssemblies, StringComparer.OrdinalIgnoreCase);
+        if (grant is not null)
+            allowed.UnionWith(grant);
+
+        var available = AvailableAssemblies(options.ResolvePluginDirectory());
+
+        var refs = new List<MetadataReference>();
+        foreach (var name in allowed)
+            if (available.TryGetValue(name, out var path))
+                refs.Add(MetadataReference.CreateFromFile(path));
+
+        return refs;
+    }
+
+    /// <summary>Simple-name → path map for framework (TPA) + plugin-directory assemblies.</summary>
+    private static Dictionary<string, string> AvailableAssemblies(string pluginDirectory)
+    {
+        var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        var tpa = (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? string.Empty)
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
+        foreach (var path in tpa)
+            map[Path.GetFileNameWithoutExtension(path)] = path;
+
+        // Dynamically-loaded third-party DLLs from the plugin directory.
+        // TryAdd so framework assemblies always win over a same-named plugin.
+        if (!string.IsNullOrEmpty(pluginDirectory) && Directory.Exists(pluginDirectory))
+            foreach (var dll in Directory.EnumerateFiles(pluginDirectory, "*.dll"))
+                map.TryAdd(Path.GetFileNameWithoutExtension(dll), dll);
+
+        return map;
+    }
+}

--- a/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Sandbox/ScriptCompilationException.cs
+++ b/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Sandbox/ScriptCompilationException.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace BBT.Workflow.Scripting.Sandbox;
+
+/// <summary>
+/// Thrown when sandboxed compilation fails — either Roslyn compile errors or one or more
+/// sandbox violations detected by <see cref="BannedApiAnalyzer"/>. The message lists the offending
+/// items so a flow author can correct the script.
+/// </summary>
+public sealed class ScriptCompilationException : Exception
+{
+    public ScriptCompilationException(string message) : base(message)
+    {
+    }
+
+    public ScriptCompilationException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Sandbox/ScriptSandboxOptions.cs
+++ b/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Sandbox/ScriptSandboxOptions.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+
+namespace BBT.Workflow.Scripting.Sandbox;
+
+/// <summary>
+/// Sandbox policy for script compilation, bound from configuration (section <c>Scripting:Sandbox</c>).
+///
+/// Two independent compile-time layers gate a script:
+/// <list type="number">
+/// <item><see cref="AllowedAssemblies"/> — a reference allow-list. Anything whose assembly is not
+/// referenced will not compile (e.g. <c>System.Net.Http.HttpClient</c>).</item>
+/// <item>A banned-namespace analyzer (<see cref="Sandbox.BannedApiAnalyzer"/>) — a semantic ban for
+/// dangerous types that live inside mandatory assemblies (e.g. <c>System.IO.File</c> in
+/// <c>System.Private.CoreLib</c>) which reference omission alone cannot block.</item>
+/// </list>
+///
+/// The platform owns a mandatory, non-overridable banned-namespace baseline
+/// (<see cref="Sandbox.BannedApiAnalyzer.MandatoryBannedNamespaces"/>). <see cref="BannedNamespaces"/>
+/// only <b>adds</b> to that baseline; it can never remove an entry from it.
+/// </summary>
+public sealed class ScriptSandboxOptions
+{
+    /// <summary>Configuration section name.</summary>
+    public const string SectionName = "Scripting:Sandbox";
+
+    /// <summary>
+    /// Master switch. When <c>false</c> (default) the legacy compile path is used unchanged
+    /// (full AppDomain references, no analyzer) so existing deployments are unaffected.
+    /// When <c>true</c>, <b>all</b> script compilations use the restricted reference set and the
+    /// banned-API analyzer.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>Whether <c>unsafe</c> code is permitted in scripts. Defaults to <c>false</c>.</summary>
+    public bool AllowUnsafe { get; set; }
+
+    /// <summary>
+    /// Directory of operator-approved third-party DLLs loaded dynamically at runtime (a mounted
+    /// volume, not a host dependency). Relative paths resolve against the app base directory.
+    /// </summary>
+    public string PluginDirectory { get; set; } = "plugins";
+
+    /// <summary>
+    /// Global baseline of simple assembly names (no extension) that scripts may reference.
+    /// A per-mapping grant is merged on top of this for an individual compile.
+    /// </summary>
+    public List<string> AllowedAssemblies { get; set; } = [];
+
+    /// <summary>
+    /// Additional banned namespace prefixes, merged on top of the mandatory platform baseline.
+    /// Cannot remove entries from the mandatory baseline.
+    /// </summary>
+    public List<string> BannedNamespaces { get; set; } = [];
+
+    /// <summary>
+    /// Resolves <see cref="PluginDirectory"/> to an absolute path against the app base directory
+    /// when it is relative.
+    /// </summary>
+    public string ResolvePluginDirectory()
+    {
+        if (string.IsNullOrWhiteSpace(PluginDirectory))
+            return string.Empty;
+
+        return System.IO.Path.IsPathRooted(PluginDirectory)
+            ? PluginDirectory
+            : System.IO.Path.Combine(AppContext.BaseDirectory, PluginDirectory);
+    }
+}

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/DataFunctionHandler.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/DataFunctionHandler.cs
@@ -1,4 +1,5 @@
 using BBT.Aether.AspNetCore.Results;
+using BBT.Workflow.CurrentUser;
 using BBT.Workflow.Definitions.Functions;
 using BBT.Workflow.Domain.Shared;
 using BBT.Workflow.Instances;
@@ -28,7 +29,7 @@ public sealed class DataFunctionHandler(
             Headers = request.Headers,
             QueryParameters = request.QueryParameters,
             Version = request.QueryParameters.GetOrDefault("version"),
-            Roles = request.CurrentUser.Roles,
+            Roles = request.CurrentUser.ResolveCallerRoles(request.Headers),
         };
 
         var result = await queryAppService.GetInstanceDataAsync(input, cancellationToken);

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/SchemaFunctionHandler.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/SchemaFunctionHandler.cs
@@ -1,4 +1,5 @@
 using BBT.Aether.AspNetCore.Results;
+using BBT.Workflow.CurrentUser;
 using BBT.Workflow.Definitions.Functions;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Instances.DTOs;
@@ -25,7 +26,7 @@ public sealed class SchemaFunctionHandler(
             Version = request.Parameters.Version,
             Headers = request.Headers,
             QueryParameters = request.QueryParameters,
-            Roles = request.CurrentUser.Roles,
+            Roles = request.CurrentUser.ResolveCallerRoles(request.Headers),
         };
 
         var result = await queryAppService.GetSchemaAsync(

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/StateFunctionHandler.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/StateFunctionHandler.cs
@@ -1,4 +1,5 @@
 using BBT.Aether.AspNetCore.Results;
+using BBT.Workflow.CurrentUser;
 using BBT.Workflow.Definitions.Functions;
 using BBT.Workflow.Domain.Shared;
 using BBT.Workflow.Instances;
@@ -28,8 +29,8 @@ public sealed class StateFunctionHandler(
             Extensions = request.Parameters.Extensions,
             Headers = request.Headers,
             QueryParams = request.QueryParameters,
-            Role = request.CurrentUser.Roles?.FirstOrDefault(),
-            Roles = request.CurrentUser.Roles
+            Role = request.CurrentUser.ResolveCallerRole(request.Headers),
+            Roles = request.CurrentUser.ResolveCallerRoles(request.Headers)
         };
 
         var result = await queryAppService.GetInstanceStateAsync(input, cancellationToken);

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/ViewFunctionHandler.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/ViewFunctionHandler.cs
@@ -1,4 +1,5 @@
 using BBT.Aether.AspNetCore.Results;
+using BBT.Workflow.CurrentUser;
 using BBT.Workflow.Definitions.Functions;
 using BBT.Workflow.Instances;
 using Microsoft.AspNetCore.Mvc;
@@ -24,8 +25,8 @@ public sealed class ViewFunctionHandler(
             Version = request.Parameters.Version,
             Headers = request.Headers,
             QueryParameters = request.QueryParameters,
-            Role = request.CurrentUser.Roles?.FirstOrDefault(),
-            Roles = request.CurrentUser.Roles
+            Role = request.CurrentUser.ResolveCallerRole(request.Headers),
+            Roles = request.CurrentUser.ResolveCallerRoles(request.Headers)
         };
 
         var result = await queryAppService.GetViewAsync(

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/appsettings.json
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/appsettings.json
@@ -172,6 +172,27 @@
     "AppId": "vnext-execution-app",
     "InvocationTimeoutSeconds": 60
   },
+  "Scripting": {
+    "Helpers": {
+      "Enabled": true
+    },
+    "Sandbox": {
+      "Enabled": true,
+      "AllowUnsafe": false,
+      "PluginDirectory": "/app/assemblies",
+      "AllowedAssemblies": [
+        "System.Private.CoreLib",
+        "System.Runtime",
+        "System.Collections",
+        "System.Linq",
+        "System.Linq.Expressions",
+        "System.Text.RegularExpressions",
+        "Microsoft.CSharp",
+        "netstandard"
+      ],
+      "BannedNamespaces": []
+    }
+  },
   "WorkflowExecution": {
     "TransitionJobTimeoutSeconds": 300,
     "FailurePolicy": {

--- a/src/BBT.Workflow.Application/Caching/ComponentCacheStore.cs
+++ b/src/BBT.Workflow.Application/Caching/ComponentCacheStore.cs
@@ -58,6 +58,13 @@ public sealed class ComponentCacheStore(
     }
 
     /// <inheritdoc />
+    public async Task<Result<Mapping>> GetMappingAsync(string domain, string key, string? version,
+        CancellationToken cancellationToken = default)
+    {
+        return await cacheContext.Mappings.GetByVersionAsync(domain, key, version, cancellationToken);
+    }
+
+    /// <inheritdoc />
     public async Task<Result<IEnumerable<Extension>>> GetAllExtensionsAsync(
         string domain,
         CancellationToken cancellationToken = default)

--- a/src/BBT.Workflow.Application/Caching/DomainCacheContext.cs
+++ b/src/BBT.Workflow.Application/Caching/DomainCacheContext.cs
@@ -16,6 +16,7 @@ public class DomainCacheContext : IDomainCacheContext, IDisposable
     public ICacheSet<Function> Functions { get; }
     public ICacheSet<View> Views { get; }
     public ICacheSet<Extension> Extensions { get; }
+    public ICacheSet<Mapping> Mappings { get; }
 
     public DomainCacheContext(
         IDistributedCacheService distributedCache,
@@ -25,6 +26,7 @@ public class DomainCacheContext : IDomainCacheContext, IDisposable
         ICacheBackend<Function> functionBackend,
         ICacheBackend<View> viewBackend,
         ICacheBackend<Extension> extensionBackend,
+        ICacheBackend<Mapping> mappingBackend,
         ILoggerFactory loggerFactory)
     {
         Workflows = new CacheSet<Definitions.Workflow>(
@@ -56,6 +58,11 @@ public class DomainCacheContext : IDomainCacheContext, IDisposable
             distributedCache,
             extensionBackend,
             loggerFactory.CreateLogger<CacheSet<Extension>>());
+
+        Mappings = new CacheSet<Mapping>(
+            distributedCache,
+            mappingBackend,
+            loggerFactory.CreateLogger<CacheSet<Mapping>>());
     }
 
     public ICacheSet<T> Set<T>() where T : class, IDomainEntity, IReferenceSetter
@@ -66,6 +73,7 @@ public class DomainCacheContext : IDomainCacheContext, IDisposable
         if (typeof(T) == typeof(Function)) return (ICacheSet<T>)Functions;
         if (typeof(T) == typeof(View)) return (ICacheSet<T>)Views;
         if (typeof(T) == typeof(Extension)) return (ICacheSet<T>)Extensions;
+        if (typeof(T) == typeof(Mapping)) return (ICacheSet<T>)Mappings;
 
         throw new NotSupportedException($"Type {typeof(T).Name} is not supported in DomainCacheContext.");
     }
@@ -78,5 +86,6 @@ public class DomainCacheContext : IDomainCacheContext, IDisposable
         Functions.Dispose();
         Views.Dispose();
         Extensions.Dispose();
+        Mappings.Dispose();
     }
 }

--- a/src/BBT.Workflow.Application/Caching/IDomainCacheContext.cs
+++ b/src/BBT.Workflow.Application/Caching/IDomainCacheContext.cs
@@ -14,6 +14,7 @@ public interface IDomainCacheContext
     ICacheSet<Function> Functions { get; }
     ICacheSet<View> Views { get; }
     ICacheSet<Extension> Extensions { get; }
+    ICacheSet<Mapping> Mappings { get; }
 
     /// <summary>
     /// Gets the cache set for the specified entity type.

--- a/src/BBT.Workflow.Application/Caching/MetricsAwareComponentCacheStore.cs
+++ b/src/BBT.Workflow.Application/Caching/MetricsAwareComponentCacheStore.cs
@@ -82,6 +82,17 @@ public sealed class MetricsAwareComponentCacheStore(
             () => innerStore.GetExtensionAsync(domain, key, version, cancellationToken));
     }
 
+    public async Task<Result<Mapping>> GetMappingAsync(
+        string domain,
+        string key,
+        string? version,
+        CancellationToken cancellationToken = default)
+    {
+        return await ExecuteWithMetricsAsync(
+            "Mapping",
+            () => innerStore.GetMappingAsync(domain, key, version, cancellationToken));
+    }
+
     public async Task<Result<IEnumerable<Extension>>> GetAllExtensionsAsync(
         string domain,
         CancellationToken cancellationToken = default)

--- a/src/BBT.Workflow.Application/Definitions/CastHandlers/MappingWorkflowCastHandler.cs
+++ b/src/BBT.Workflow.Application/Definitions/CastHandlers/MappingWorkflowCastHandler.cs
@@ -1,0 +1,38 @@
+using System.Text.Json;
+using BBT.Workflow.Caching;
+using BBT.Workflow.Runtime;
+
+namespace BBT.Workflow.Definitions.CastHandlers;
+
+/// <summary>
+/// Handles workflow casting operations specifically for system mappings ("sys-mappings").
+/// This handler deserializes mapping (script-library) component data from JSON attributes and
+/// updates the mappings cache.
+/// </summary>
+/// <param name="cacheContext">The domain cache context used for storing mapping data.</param>
+public sealed class MappingWorkflowCastHandler(IDomainCacheContext cacheContext) : IWorkflowCastHandler
+{
+    /// <summary>
+    /// Determines whether this handler can process the specified workflow type.
+    /// This handler specifically processes "sys-mappings" workflows.
+    /// </summary>
+    /// <param name="workflow">The workflow type identifier to check.</param>
+    /// <returns>True if the workflow type is "sys-mappings"; otherwise, false.</returns>
+    public bool CanHandle(string workflow) => workflow == RuntimeSysSchemaInfo.Mappings;
+
+    /// <summary>
+    /// Asynchronously processes mapping workflow data by deserializing JSON attributes
+    /// and storing the mapping component in the cache context.
+    /// </summary>
+    /// <param name="reference">The reference object containing mapping metadata.</param>
+    /// <param name="attributes">The JSON element containing the mapping attributes to be deserialized.</param>
+    /// <param name="cancellationToken">The cancellation token to observe during the asynchronous operation.</param>
+    /// <returns>A task that represents the asynchronous handling operation.</returns>
+    /// <exception cref="JsonException">Thrown when JSON deserialization of mapping data fails.</exception>
+    public async Task HandleAsync(IReference reference, JsonElement attributes, CancellationToken cancellationToken)
+    {
+        var item = attributes.Deserialize<Mapping>(JsonSerializerConstants.JsonOptions);
+        item!.SetReference(reference);
+        await cacheContext.Mappings.SetAsync(item!, cancellationToken);
+    }
+}

--- a/src/BBT.Workflow.Application/Definitions/Validators/MappingComponentValidator.cs
+++ b/src/BBT.Workflow.Application/Definitions/Validators/MappingComponentValidator.cs
@@ -1,0 +1,69 @@
+using System.Text.Json;
+using BBT.Workflow.Runtime;
+
+namespace BBT.Workflow.Definitions.Validators;
+
+/// <summary>
+/// Validates mapping (script-library) components (sys-mappings).
+/// Ensures the component carries a name and decodable script code.
+/// </summary>
+public sealed class MappingComponentValidator : IComponentValidator
+{
+    /// <inheritdoc />
+    public bool CanHandle(string componentType) => componentType == RuntimeSysSchemaInfo.Mappings;
+
+    /// <inheritdoc />
+    public ComponentValidationResult Validate(JsonElement attributes)
+    {
+        var result = new ComponentValidationResult();
+
+        try
+        {
+            var mapping = attributes.Deserialize<Mapping>(JsonSerializerConstants.JsonOptions);
+            if (mapping == null)
+            {
+                result.AddError("Failed to deserialize mapping from attributes.", nameof(Mapping));
+                return result;
+            }
+
+            if (string.IsNullOrWhiteSpace(mapping.Name))
+            {
+                result.AddError("Mapping name is required.", $"{nameof(Mapping)}.{nameof(Mapping.Name)}");
+            }
+
+            if (string.IsNullOrWhiteSpace(mapping.Code))
+            {
+                result.AddError("Mapping code is required.", $"{nameof(Mapping)}.{nameof(Mapping.Code)}");
+                return result;
+            }
+
+            // A sys-mappings component is the resolution target of a REF mapping; it must itself be
+            // plain code (Native/Base64) — REF chaining is not supported.
+            if (mapping.Encoding.Equals(CodeEncoding.Reference))
+            {
+                result.AddError(
+                    "Mapping component encoding cannot be REF (a referenced component must be plain Native/Base64 code).",
+                    $"{nameof(Mapping)}.{nameof(Mapping.Encoding)}");
+                return result;
+            }
+
+            // Ensure the code is decodable under its declared encoding so a broken helper
+            // fails at publish time rather than at transition time.
+            try
+            {
+                _ = mapping.DecodedCode;
+            }
+            catch (InvalidOperationException ex)
+            {
+                result.AddError(ex.Message, $"{nameof(Mapping)}.{nameof(Mapping.Code)}");
+            }
+
+            return result;
+        }
+        catch (JsonException ex)
+        {
+            result.AddError($"Invalid JSON format for mapping: {ex.Message}", nameof(Mapping));
+            return result;
+        }
+    }
+}

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ResourceLockStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ResourceLockStep.cs
@@ -62,7 +62,8 @@ public sealed class ResourceLockStep(
         try
         {
             var mapping = await scriptEngine.CompileToInstanceAsync<ITransitionMapping>(
-                lockDef.KeyExpression.DecodedCode,
+                lockDef.KeyExpression,
+                flowScripts: context.Workflow.Scripts,
                 cancellationToken: cancellationToken);
 
             var scriptContext = await BuildScriptContextAsync(context, cancellationToken);

--- a/src/BBT.Workflow.Application/Execution/Transitions/Services/TransitionDataMapper.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Services/TransitionDataMapper.cs
@@ -55,7 +55,7 @@ public sealed class TransitionDataMapper(
         var result = await ResultExtensions.TryAsync(
             async ct =>
             {
-                var mappingInstance = await CompileMappingScriptAsync(transition, ct);
+                var mappingInstance = await CompileMappingScriptAsync(transition, workflow.Scripts, ct);
                 var scriptContext = await BuildScriptContextAsync(
                     payload, transition, workflow, instance, runtimeInfoProvider, headers, ct);
 
@@ -75,10 +75,12 @@ public sealed class TransitionDataMapper(
     /// </summary>
     private Task<ITransitionMapping> CompileMappingScriptAsync(
         Transition transition,
+        ScriptSettings? flowScripts,
         CancellationToken cancellationToken)
     {
         return scriptEngine.CompileToInstanceAsync<ITransitionMapping>(
-            transition.Mapping!.DecodedCode,
+            transition.Mapping!,
+            flowScripts: flowScripts,
             cancellationToken: cancellationToken);
     }
 

--- a/src/BBT.Workflow.Application/Functions/FunctionAppService.cs
+++ b/src/BBT.Workflow.Application/Functions/FunctionAppService.cs
@@ -191,7 +191,7 @@ public sealed class FunctionAppService(
         if (function.Output != null)
         {
             var handler = await scriptEngine.CompileToInstanceAsync<IOutputHandler>(
-                function.Output.DecodedCode, cancellationToken: cancellationToken);
+                function.Output, flowScripts: scriptContext.Workflow?.Scripts, cancellationToken: cancellationToken);
             var scriptResponse = await handler.OutputHandler(scriptContext);
 
             if (function.RawResponse)

--- a/src/BBT.Workflow.Application/Instances/DTOs/GetFunctionWithInstanceInput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/GetFunctionWithInstanceInput.cs
@@ -42,5 +42,11 @@ public sealed class GetFunctionWithInstanceInput : IHasDomain
     /// Caller role for state function (e.g. to filter available transitions by transition role grants when calling SubFlow state).
     /// </summary>
     public string? Role { get; set; }
+
+    /// <summary>
+    /// Caller roles forwarded to the locally-routed function for authorization (e.g. instance query
+    /// access checks). Mirrors the single <see cref="Role"/> but carries the full role list.
+    /// </summary>
+    public IReadOnlyList<string>? Roles { get; set; }
 }
 

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -20,6 +20,7 @@ using BBT.Workflow.RepresentationEtag;
 using BBT.Workflow.Tasks.Coordinator;
 using BBT.Aether.MultiSchema;
 using BBT.Aether.Users;
+using BBT.Workflow.CurrentUser;
 using BBT.Workflow.Definitions.Schemas;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -343,7 +344,8 @@ public sealed class InstanceQueryAppService(
                 Extensions = extensions,
                 Headers = headers,
                 QueryParams = queryParams,
-                Role = role
+                Role = currentUser.ResolveCallerRole(headers),
+                Roles = currentUser.ResolveCallerRoles(headers)
             };
 
             var subFlowResult = await instanceQueryGateway.GetFunctionWithStateAsync(
@@ -1259,7 +1261,9 @@ public sealed class InstanceQueryAppService(
             Workflow = subflow.SubFlowName,
             Version = subflow.SubFlowVersion,
             Instance = subflow.SubFlowInstanceId.ToString(),
-            Extensions = extensions
+            Extensions = extensions,
+            Role = currentUser.ResolveCallerRole(null),
+            Roles = currentUser.ResolveCallerRoles(null)
         };
 
         return await instanceQueryGateway.GetFunctionWithExtensionsAsync(
@@ -1342,7 +1346,9 @@ public sealed class InstanceQueryAppService(
             Domain = subflow.SubFlowDomain,
             Workflow = subflow.SubFlowName,
             Version = subflow.SubFlowVersion,
-            Instance = subflow.SubFlowInstanceId.ToString()
+            Instance = subflow.SubFlowInstanceId.ToString(),
+            Role = currentUser.ResolveCallerRole(null),
+            Roles = currentUser.ResolveCallerRoles(null)
         };
 
         return await instanceQueryGateway.GetFunctionWithSchemaAsync(
@@ -1514,7 +1520,8 @@ public sealed class InstanceQueryAppService(
                 Version = instance.Subflow!.SubFlowVersion,
                 Headers = headers ?? new Dictionary<string, string?>(),
                 QueryParams = queryParams ?? new Dictionary<string, string?>(),
-                Role = role
+                Role = currentUser.ResolveCallerRole(headers),
+                Roles = currentUser.ResolveCallerRoles(headers)
             },
             transitionKey,
             cancellationToken);

--- a/src/BBT.Workflow.Application/Instances/InstanceRetryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceRetryAppService.cs
@@ -1,7 +1,9 @@
 using BBT.Aether.Application.Services;
 using BBT.Aether.Results;
 using BBT.Aether.Uow;
+using BBT.Aether.Users;
 using BBT.Workflow.Caching;
+using BBT.Workflow.CurrentUser;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Execution;
 using BBT.Workflow.Execution.Services;
@@ -28,6 +30,7 @@ public sealed class InstanceRetryAppService(
     IInstanceRetryGateway instanceRetryGateway,
     IComponentCacheStore componentCacheStore,
     IWorkflowExecutionService workflowExecutionService,
+    ICurrentUser currentUser,
     ILogger<InstanceRetryAppService> logger)
     : ApplicationService(serviceProvider), IInstanceRetryAppService
 {
@@ -87,7 +90,9 @@ public sealed class InstanceRetryAppService(
             Version = subflowCorrelation.SubFlowVersion,
             Instance = subflowCorrelation.SubFlowInstanceId.ToString(),
             Headers = input.Headers,
-            QueryParams = input.RouteValues
+            QueryParams = input.RouteValues,
+            Role = currentUser.ResolveCallerRole(input.Headers),
+            Roles = currentUser.ResolveCallerRoles(input.Headers)
         };
 
         var subflowStateResult = await instanceQueryGateway.GetFunctionWithStateAsync(

--- a/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/TaskServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/TaskServiceCollectionExtensions.cs
@@ -4,6 +4,9 @@ using BBT.Workflow.Execution.ErrorHandling;
 using BBT.Workflow.Scripting;
 using BBT.Workflow.Scripting.Evaluators;
 using BBT.Workflow.Scripting.Functions;
+using BBT.Workflow.Scripting.Helpers;
+using BBT.Workflow.Scripting.Sandbox;
+using Microsoft.Extensions.Configuration;
 using BBT.Workflow.Tasks.Coordinator;
 using BBT.Workflow.Tasks.Evaluation;
 using BBT.Workflow.Tasks.Evaluators;
@@ -219,8 +222,22 @@ public static class TaskServiceCollectionExtensions
     {
         services.AddSingleton<IScriptContextFactory, ScriptContextFactory>();
 
-        // Evaluator is stateless - singleton for efficiency (caches MetadataReferences only)
-        services.TryAddSingleton<IEvaluator, CSharpEvaluator>();
+        // Sandbox + custom-script-helpers options, bound defensively from configuration so a missing
+        // section simply yields safe defaults (sandbox disabled, helpers disabled). Registered as
+        // concrete singletons (not IOptions) so consumers can be constructed without an IConfiguration.
+        services.TryAddSingleton(sp => BindSection<ScriptSandboxOptions>(sp, ScriptSandboxOptions.SectionName));
+        services.TryAddSingleton(sp => BindSection<ScriptHelpersOptions>(sp, ScriptHelpersOptions.SectionName));
+
+        // Evaluator is stateless - singleton for efficiency (caches MetadataReferences only).
+        // Built via factory so it receives the (singleton) sandbox options.
+        services.TryAddSingleton<IEvaluator>(sp =>
+            new CSharpEvaluator(sp.GetRequiredService<ScriptSandboxOptions>()));
+
+        // Helper-set registry is a process-wide singleton (shared collectible ALCs, content-hash cache).
+        services.TryAddSingleton<IScriptHelperRegistry>(sp =>
+            new ScriptHelperRegistry(
+                sp.GetRequiredService<IEvaluator>(),
+                sp.GetRequiredService<ScriptSandboxOptions>()));
 
         // Script services - scoped for per-request isolation (requires DaprClient to be registered)
         services.TryAddScoped<IScriptServices, ScriptServices>();
@@ -228,6 +245,18 @@ public static class TaskServiceCollectionExtensions
         services.TryAddScoped<IScriptEngine, ScriptEngine>();
 
         return services;
+    }
+
+    /// <summary>
+    /// Binds a configuration section into a fresh options instance, tolerating an absent
+    /// <see cref="IConfiguration"/> or section (returns defaults) so consumers stay test-friendly.
+    /// </summary>
+    private static T BindSection<T>(IServiceProvider sp, string sectionName) where T : class, new()
+    {
+        var options = new T();
+        var configuration = sp.GetService<IConfiguration>();
+        configuration?.GetSection(sectionName)?.Bind(options);
+        return options;
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
@@ -101,6 +101,7 @@ public static class WorkflowApplicationModuleServiceCollectionExtensions
         services.AddSingleton<ICacheBackend<Function>, RuntimeCacheBackend<Function>>();
         services.AddSingleton<ICacheBackend<View>, RuntimeCacheBackend<View>>();
         services.AddSingleton<ICacheBackend<Extension>, RuntimeCacheBackend<Extension>>();
+        services.AddSingleton<ICacheBackend<Mapping>, RuntimeCacheBackend<Mapping>>();
 
         // Domain Cache Context
         services.AddSingleton<DomainCacheContext>();
@@ -118,6 +119,7 @@ public static class WorkflowApplicationModuleServiceCollectionExtensions
         services.AddSingleton<IWorkflowCastHandler, ViewWorkflowCastHandler>();
         services.AddSingleton<IWorkflowCastHandler, SchemaWorkflowCastHandler>();
         services.AddSingleton<IWorkflowCastHandler, ExtensionWorkflowCastHandler>();
+        services.AddSingleton<IWorkflowCastHandler, MappingWorkflowCastHandler>();
         services.AddSingleton<WorkflowCastProcessor>();
     }
 
@@ -132,6 +134,7 @@ public static class WorkflowApplicationModuleServiceCollectionExtensions
         services.AddSingleton<IComponentValidator, FunctionComponentValidator>();
         services.AddSingleton<IComponentValidator, SchemaComponentValidator>();
         services.AddSingleton<IComponentValidator, ExtensionComponentValidator>();
+        services.AddSingleton<IComponentValidator, MappingComponentValidator>();
         services.AddSingleton<ComponentValidatorProcessor>();
     }
 

--- a/src/BBT.Workflow.Application/Scripting/ScriptEngine.cs
+++ b/src/BBT.Workflow.Application/Scripting/ScriptEngine.cs
@@ -1,9 +1,18 @@
+using BBT.Aether.MultiSchema;
+using BBT.Workflow.Caching;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Logging;
 using BBT.Workflow.Monitoring;
+using BBT.Workflow.Runtime;
 using BBT.Workflow.Scripting.Evaluators;
 using BBT.Workflow.Scripting.Functions;
+using BBT.Workflow.Scripting.Helpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Scripting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using System.Diagnostics;
+using System.Runtime.Loader;
 using System.Text.Json.Serialization;
 using BBT.Workflow.Definitions.Timer;
 
@@ -18,10 +27,19 @@ namespace BBT.Workflow.Scripting;
 /// <param name="evaluator">The underlying C# evaluator responsible for script compilation and execution (injected as singleton for shared caching)</param>
 /// <param name="scriptServices">The script services to inject into compiled script instances</param>
 /// <param name="workflowMetrics">The workflow metrics service for recording script engine metrics</param>
+/// <param name="helperRegistry">Registry that compiles and caches referenced helper sets</param>
+/// <param name="helpersOptions">Feature switch for the custom-script-helpers capability</param>
+/// <param name="serviceProvider">Used to lazily resolve helper-only dependencies (component store, schema)
+/// so non-helper compiles never construct the cache graph</param>
+/// <param name="logger">Logger for helper/sandbox diagnostics</param>
 public sealed class ScriptEngine(
     IEvaluator evaluator,
     IScriptServices scriptServices,
-    IWorkflowMetrics workflowMetrics) : IScriptEngine
+    IWorkflowMetrics workflowMetrics,
+    IScriptHelperRegistry helperRegistry,
+    ScriptHelpersOptions helpersOptions,
+    IServiceProvider serviceProvider,
+    ILogger<ScriptEngine> logger) : IScriptEngine
 {
     /// <summary>
     /// The underlying C# evaluator responsible for script compilation and execution.
@@ -35,6 +53,11 @@ public sealed class ScriptEngine(
     /// </summary>
     private readonly IScriptServices _scriptServices = scriptServices;
 
+    private readonly IScriptHelperRegistry _helperRegistry = helperRegistry;
+    private readonly ScriptHelpersOptions _helpersOptions = helpersOptions;
+    private readonly IServiceProvider _serviceProvider = serviceProvider;
+    private readonly ILogger<ScriptEngine> _logger = logger;
+
     /// <summary>
     /// Lazily-initialized default metadata references used for script compilation.
     /// Includes core .NET types, collections, and workflow-specific assemblies.
@@ -47,6 +70,11 @@ public sealed class ScriptEngine(
         MetadataReference.CreateFromFile(typeof(Task).Assembly.Location),
         MetadataReference.CreateFromFile(typeof(Dictionary<,>).Assembly.Location),
         MetadataReference.CreateFromFile(typeof(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo).Assembly.Location),
+        // System.Linq.Expressions: provides DynamicAttribute and System.Dynamic.ExpandoObject, both
+        // required for the `dynamic` keyword that mappings rely on (e.g. Handler returns dynamic,
+        // ScriptContext.Body is dynamic). Runtime-owned so it is always referenced even under the
+        // sandbox, where the curated assembly allow-list would otherwise omit it.
+        MetadataReference.CreateFromFile(typeof(System.Dynamic.ExpandoObject).Assembly.Location),
         MetadataReference.CreateFromFile(typeof(ScriptBase).Assembly.Location),
         MetadataReference.CreateFromFile(typeof(JsonSerializableAttribute).Assembly.Location),
         MetadataReference.CreateFromFile(typeof(System.Text.Encodings.Web.JavaScriptEncoder).Assembly.Location),
@@ -55,13 +83,25 @@ public sealed class ScriptEngine(
     ]);
 
     /// <summary>
+    /// Simple assembly names backing <see cref="DefaultReferences"/>. These are merged into the sandbox
+    /// grant on every compile so the engine's own default references are always part of the effective
+    /// allow-list when the sandbox is enabled — existing mappings keep compiling without operators
+    /// having to restate them in <c>Scripting:Sandbox:AllowedAssemblies</c>.
+    /// </summary>
+    private static readonly Lazy<string[]> DefaultReferenceAssemblyNames = new(() =>
+        DefaultReferences.Value
+            .Select(r => System.IO.Path.GetFileNameWithoutExtension(r.Display) ?? string.Empty)
+            .Where(n => !string.IsNullOrEmpty(n))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray());
+
+    /// <summary>
     /// Default using directives automatically included in all scripts.
     /// Provides access to common .NET namespaces and workflow-specific types.
     /// </summary>
     private static readonly string[] DefaultUsings =
     {
         "System",
-        "System.IO",
         "System.Linq",
         "System.Collections.Generic",
         "System.Threading",
@@ -97,11 +137,167 @@ public sealed class ScriptEngine(
     /// <exception cref="CompilationErrorException">Thrown when the code contains compilation errors</exception>
     /// <exception cref="InvalidOperationException">Thrown when the code cannot be compiled to the target type</exception>
     /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled</exception>
-    public async Task<T> CompileToInstanceAsync<T>(
+    public Task<T> CompileToInstanceAsync<T>(
         string code,
         IEnumerable<MetadataReference>? extraReferences = null,
         IEnumerable<string>? usingDirectives = null,
         CancellationToken cancellationToken = default)
+    {
+        return CompileCoreAsync<T>(code, extraReferences, usingDirectives, null, null, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<T> CompileToInstanceAsync<T>(
+        ScriptCode scriptCode,
+        ScriptSettings? flowScripts = null,
+        IEnumerable<MetadataReference>? extraReferences = null,
+        IEnumerable<string>? usingDirectives = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(scriptCode);
+
+        // Flow-level scripts are global to the workflow; union them with the task/mapping-level scripts.
+        var effective = ScriptSettings.Union(flowScripts, scriptCode.Scripts);
+        var grant = effective?.AllowedAssemblies?.ToArray();
+
+        // Resolve the mapping body: for REF encoding, fetch it from the sys-mappings component store;
+        // otherwise use the inline (Native/Base64) code.
+        var body = scriptCode.IsReference
+            ? await ResolveReferencedCodeAsync(scriptCode.CodeReference!, cancellationToken)
+            : scriptCode.DecodedCode;
+
+        // No helpers declared → straight compile (effective sandbox grant still applies).
+        if (effective?.HasHelpers != true)
+        {
+            return await CompileCoreAsync<T>(
+                body, extraReferences, usingDirectives, null, grant, cancellationToken);
+        }
+
+        if (!_helpersOptions.Enabled)
+        {
+            _logger.ScriptHelpersDisabled();
+            throw new InvalidOperationException(
+                "Mapping references helpers but the custom-script-helpers feature is disabled " +
+                "(Scripting:Helpers:Enabled=false).");
+        }
+
+        var helperSources = await ResolveHelperSourcesAsync(effective.Helpers!, cancellationToken);
+
+        // Build the referenced helper set first (sandboxed, cached by content hash), referencing the
+        // runtime-owned contract assemblies and importing the default namespaces.
+        var helperSet = _helperRegistry.GetOrBuildHelpers(
+            helperSources,
+            MergeDefaultGrant(grant),
+            DefaultReferences.Value,
+            DefaultUsings,
+            cancellationToken);
+
+        var helperKeys = string.Join(", ", effective.Helpers!.Select(h => $"{h.Key}@{h.Version}"));
+        if (helperSet.FromCache)
+        {
+            _logger.ScriptHelperSetCacheHit(helperSources.Count, helperKeys);
+        }
+        else
+        {
+            _logger.ScriptHelperSetBuilt(helperSources.Count, helperKeys, string.Join(", ", helperSet.Namespaces));
+        }
+
+        // Reference the helper assembly + auto-import its namespaces, and compile the mapping into the
+        // helper set's load context so helper types resolve at runtime.
+        var refs = (extraReferences ?? []).Append(helperSet.Reference);
+        var usings = (usingDirectives ?? []).Concat(helperSet.Namespaces);
+
+        return await CompileCoreAsync<T>(
+            body, refs, usings, helperSet.LoadContext, grant, cancellationToken);
+    }
+
+    /// <summary>
+    /// Resolves a <c>REF</c>-encoded mapping body from the sys-mappings component store. The referenced
+    /// component is plain (Native/Base64) — no REF chaining.
+    /// </summary>
+    private async Task<string> ResolveReferencedCodeAsync(Reference reference, CancellationToken cancellationToken)
+    {
+        var componentCacheStore = _serviceProvider.GetRequiredService<IComponentCacheStore>();
+        var currentSchema = _serviceProvider.GetRequiredService<ICurrentSchema>();
+
+        using (currentSchema.Use(RuntimeSysSchemaInfo.Mappings))
+        {
+            var result = await componentCacheStore.GetMappingAsync(
+                reference.Domain, reference.Key, reference.Version, cancellationToken);
+
+            if (!result.IsSuccess || result.Value is null)
+            {
+                _logger.ScriptHelperReferenceUnresolved(reference.Domain, reference.Flow, reference.Key, reference.Version);
+                throw new InvalidOperationException(
+                    $"Referenced mapping component could not be resolved: {reference}");
+            }
+
+            return result.Value.DecodedCode;
+        }
+    }
+
+    /// <summary>
+    /// Resolves the referenced helper components from the component store (under the sys-mappings schema)
+    /// into compilable sources, ordered as declared.
+    /// </summary>
+    private async Task<IReadOnlyList<HelperSource>> ResolveHelperSourcesAsync(
+        IReadOnlyList<Reference> helpers,
+        CancellationToken cancellationToken)
+    {
+        var sources = new List<HelperSource>(helpers.Count);
+
+        // Resolve helper-only dependencies lazily so non-helper compiles never touch the cache graph.
+        var componentCacheStore = _serviceProvider.GetRequiredService<IComponentCacheStore>();
+        var currentSchema = _serviceProvider.GetRequiredService<ICurrentSchema>();
+
+        using (currentSchema.Use(RuntimeSysSchemaInfo.Mappings))
+        {
+            foreach (var helper in helpers)
+            {
+                var result = await componentCacheStore.GetMappingAsync(
+                    helper.Domain, helper.Key, helper.Version, cancellationToken);
+
+                if (!result.IsSuccess || result.Value is null)
+                {
+                    _logger.ScriptHelperReferenceUnresolved(helper.Domain, helper.Flow, helper.Key, helper.Version);
+                    throw new InvalidOperationException(
+                        $"Helper component could not be resolved: {helper.Domain}/{helper.Flow}/{helper.Key}/{helper.Version}");
+                }
+
+                var mapping = result.Value;
+                sources.Add(new HelperSource(
+                    mapping.Key,
+                    mapping.Version,
+                    mapping.DecodedCode,
+                    $"{mapping.Key}.csx"));
+            }
+        }
+
+        return sources;
+    }
+
+    /// <summary>
+    /// Merges the engine's default reference assembly names into the per-compile sandbox grant so the
+    /// runtime's own references are always part of the effective allow-list under the sandbox.
+    /// </summary>
+    private static IReadOnlyList<string> MergeDefaultGrant(IReadOnlyList<string>? grant)
+    {
+        if (grant is null || grant.Count == 0)
+            return DefaultReferenceAssemblyNames.Value;
+
+        return grant
+            .Concat(DefaultReferenceAssemblyNames.Value)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private async Task<T> CompileCoreAsync<T>(
+        string code,
+        IEnumerable<MetadataReference>? extraReferences,
+        IEnumerable<string>? usingDirectives,
+        AssemblyLoadContext? loadContext,
+        IReadOnlyList<string>? sandboxGrant,
+        CancellationToken cancellationToken)
     {
         var stopwatch = Stopwatch.StartNew();
         const string scriptType = "compilation";
@@ -121,11 +317,13 @@ public sealed class ScriptEngine(
 
             // Pass script services to the evaluator for injection into ScriptBase instances
             var result = await _evaluator.CompileToInstanceAsync<T>(
-                code, 
+                code,
                 _scriptServices,
-                mergedReferences, 
-                mergedUsings, 
-                cancellationToken);
+                mergedReferences,
+                mergedUsings,
+                cancellationToken,
+                loadContext,
+                MergeDefaultGrant(sandboxGrant));
 
             stopwatch.Stop();
             var durationSeconds = stopwatch.Elapsed.TotalSeconds;

--- a/src/BBT.Workflow.Application/SubFlow/Services/SubflowOutputMappingService.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubflowOutputMappingService.cs
@@ -33,7 +33,7 @@ public sealed class SubflowOutputMappingService(
 
         var parentState = parentStateResult.Value!;
         var subFlowConfig = parentState.SubFlow;
-        if (subFlowConfig?.Mapping == null || string.IsNullOrWhiteSpace(subFlowConfig.Mapping.DecodedCode))
+        if (subFlowConfig?.Mapping is null || !subFlowConfig.Mapping.HasMappingCode)
             return;
 
         try
@@ -48,7 +48,8 @@ public sealed class SubflowOutputMappingService(
                 .BuildAsync(cancellationToken);
 
             var mappingInstance = await scriptEngine.CompileToInstanceAsync<object>(
-                subFlowConfig.Mapping.DecodedCode,
+                subFlowConfig.Mapping,
+                flowScripts: parentWorkflow.Scripts,
                 cancellationToken: cancellationToken);
 
             ScriptResponse? outputMappingResult = null;

--- a/src/BBT.Workflow.Application/SubFlow/Services/SubflowStarter.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubflowStarter.cs
@@ -50,6 +50,7 @@ public sealed class SubflowStarter(
             {
                 return Result.Fail(mappingResult.Error);
             }
+
             inputMappingResult = mappingResult.Value;
         }
 
@@ -67,7 +68,7 @@ public sealed class SubflowStarter(
             mode,
             cancellationToken);
     }
-    
+
     /// <summary>
     /// Internal method that contains the common logic for starting SubFlow/SubProcess workflows.
     /// </summary>
@@ -86,7 +87,8 @@ public sealed class SubflowStarter(
         ExecMode mode,
         CancellationToken cancellationToken)
     {
-        using var activity = SubFlowActivityHelper.StartActivity($"SubFlow.Start/{subFlowReference.Domain}/{subFlowReference.Key}");
+        using var activity =
+            SubFlowActivityHelper.StartActivity($"SubFlow.Start/{subFlowReference.Domain}/{subFlowReference.Key}");
         SubFlowActivityHelper.EnrichWithStart(
             activity,
             parentInstance.Id,
@@ -98,14 +100,14 @@ public sealed class SubflowStarter(
         activity?.SetTag("vnext.subflow.parent.transition", transitionKey);
 
         using (logger.BeginScope(new Dictionary<string, object>
-        {
-            [TelemetryConstants.TagNames.Domain] = workflow.Domain,
-            [TelemetryConstants.TagNames.Flow] = workflow.Key,
-            [TelemetryConstants.TagNames.FlowVersion] = workflow.Version,
-            [TelemetryConstants.TagNames.InstanceId] = parentInstance.Id,
-            [TelemetryConstants.TagNames.InstanceKey] = parentInstance.Key ?? "N/A",
-            [TelemetryConstants.TagNames.SubflowInstanceId] = correlation.SubFlowInstanceId
-        }))
+               {
+                   [TelemetryConstants.TagNames.Domain] = workflow.Domain,
+                   [TelemetryConstants.TagNames.Flow] = workflow.Key,
+                   [TelemetryConstants.TagNames.FlowVersion] = workflow.Version,
+                   [TelemetryConstants.TagNames.InstanceId] = parentInstance.Id,
+                   [TelemetryConstants.TagNames.InstanceKey] = parentInstance.Key ?? "N/A",
+                   [TelemetryConstants.TagNames.SubflowInstanceId] = correlation.SubFlowInstanceId
+               }))
         {
             // Prepare instance creation input
             var createInstanceInput = new CreateInstanceInput
@@ -149,6 +151,7 @@ public sealed class SubflowStarter(
                 createInstanceInput.ExtraProperties[DomainConsts.MetaDataKeys.TransitionRoleOverrides] =
                     JsonSerializer.Serialize(overrides.Transitions);
             }
+
             if (overrides?.States is { Count: > 0 })
             {
                 createInstanceInput.ExtraProperties[DomainConsts.MetaDataKeys.StateRoleOverrides] =
@@ -177,6 +180,7 @@ public sealed class SubflowStarter(
                 foreach (var kv in fromMapping)
                     headers[kv.Key] = kv.Value;
             }
+
             headers[TelemetryConstants.HeaderNames.ParentInstanceId] = parentInstance.Id.ToString();
 
             var subFlowStartInput = new StartInstanceInput(
@@ -227,8 +231,6 @@ public sealed class SubflowStarter(
         ScriptContext context,
         CancellationToken cancellationToken = default)
     {
-        var mappingCode = subFlowConfig.Mapping.DecodedCode;
-
         // Determine the appropriate mapping interface based on SubFlow type
         var mappingInterfaceType = subFlowConfig.Type.Code == "S"
             ? typeof(ISubFlowMapping)
@@ -238,7 +240,7 @@ public sealed class SubflowStarter(
         {
             // Compile the mapping script to the appropriate interface
             var mappingInstance = await scriptEngine.CompileToInstanceAsync<object>(
-                mappingCode,
+                subFlowConfig.Mapping,
                 cancellationToken: ct);
 
             // Cast to the appropriate mapping interface and execute InputHandler

--- a/src/BBT.Workflow.Application/Tasks/Evaluators/ScriptConditionEvaluator.cs
+++ b/src/BBT.Workflow.Application/Tasks/Evaluators/ScriptConditionEvaluator.cs
@@ -39,7 +39,8 @@ public sealed class ScriptConditionEvaluator : IConditionEvaluator
         return await ResultExtensions.TryAsync(async ct =>
             {
                 var scriptRunner = await _scriptEngine.CompileToInstanceAsync<IConditionMapping>(
-                    script.DecodedCode,
+                    script,
+                    flowScripts: context.Workflow?.Scripts,
                     cancellationToken: ct);
             
                 var result = await scriptRunner.Handler(context);

--- a/src/BBT.Workflow.Application/Tasks/Evaluators/ScriptTimerEvaluator.cs
+++ b/src/BBT.Workflow.Application/Tasks/Evaluators/ScriptTimerEvaluator.cs
@@ -40,7 +40,8 @@ public sealed class ScriptTimerEvaluator : ITimerEvaluator
         return await ResultExtensions.TryAsync(async ct =>
             {
                 var scriptRunner = await _scriptEngine.CompileToInstanceAsync<ITimerMapping>(
-                    script.DecodedCode,
+                    script,
+                    flowScripts: context.Workflow?.Scripts,
                     cancellationToken: ct);
             
                 // ITimerMapping.Handler directly returns TimerSchedule

--- a/src/BBT.Workflow.Application/Tasks/Executors/Dapr/DaprBindingTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Dapr/DaprBindingTaskExecutor.cs
@@ -41,7 +41,7 @@ public sealed class DaprBindingTaskExecutor : TaskExecutorBase<DaprBindingTask>
         CancellationToken cancellationToken)
     {
         var mapping = context.OnExecuteTask.Mapping;
-        if (mapping == null || string.IsNullOrEmpty(mapping.DecodedCode))
+        if (mapping is null || !mapping.HasMappingCode)
         {
             return Result<ScriptResponse?>.Ok(null);
         }
@@ -49,7 +49,8 @@ public sealed class DaprBindingTaskExecutor : TaskExecutorBase<DaprBindingTask>
         var result = await ResultExtensions.TryAsync<ScriptResponse?>(async ct =>
         {
             var scriptRunner = await _scriptEngine.CompileToInstanceAsync<IMapping>(
-                mapping.DecodedCode,
+                mapping,
+                flowScripts: context.ScriptContext.Workflow?.Scripts,
                 cancellationToken: ct);
 
             return await scriptRunner.InputHandler(task, context.ScriptContext);
@@ -115,7 +116,7 @@ public sealed class DaprBindingTaskExecutor : TaskExecutorBase<DaprBindingTask>
         CancellationToken cancellationToken)
     {
         var mapping = context.OnExecuteTask.Mapping;
-        if (mapping == null || string.IsNullOrEmpty(mapping.DecodedCode))
+        if (mapping is null || !mapping.HasMappingCode)
         {
             return Result<object?>.Ok(invocationResult.Data);
         }
@@ -125,7 +126,8 @@ public sealed class DaprBindingTaskExecutor : TaskExecutorBase<DaprBindingTask>
         var result = await ResultExtensions.TryAsync<object?>(async ct =>
         {
             var scriptRunner = await _scriptEngine.CompileToInstanceAsync<IMapping>(
-                mapping.DecodedCode,
+                mapping,
+                flowScripts: context.ScriptContext.Workflow?.Scripts,
                 cancellationToken: ct);
 
             var outputResponse = await scriptRunner.OutputHandler(context.ScriptContext);

--- a/src/BBT.Workflow.Application/Tasks/Executors/Dapr/DaprHttpEndpointTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Dapr/DaprHttpEndpointTaskExecutor.cs
@@ -41,7 +41,7 @@ public sealed class DaprHttpEndpointTaskExecutor : TaskExecutorBase<DaprHttpEndp
         CancellationToken cancellationToken)
     {
         var mapping = context.OnExecuteTask.Mapping;
-        if (mapping == null || string.IsNullOrEmpty(mapping.DecodedCode))
+        if (mapping is null || !mapping.HasMappingCode)
         {
             return Result<ScriptResponse?>.Ok(null);
         }
@@ -49,7 +49,8 @@ public sealed class DaprHttpEndpointTaskExecutor : TaskExecutorBase<DaprHttpEndp
         var result = await ResultExtensions.TryAsync<ScriptResponse?>(async ct =>
         {
             var scriptRunner = await _scriptEngine.CompileToInstanceAsync<IMapping>(
-                mapping.DecodedCode,
+                mapping,
+                flowScripts: context.ScriptContext.Workflow?.Scripts,
                 cancellationToken: ct);
 
             return await scriptRunner.InputHandler(task, context.ScriptContext);
@@ -115,7 +116,7 @@ public sealed class DaprHttpEndpointTaskExecutor : TaskExecutorBase<DaprHttpEndp
         CancellationToken cancellationToken)
     {
         var mapping = context.OnExecuteTask.Mapping;
-        if (mapping == null || string.IsNullOrEmpty(mapping.DecodedCode))
+        if (mapping is null || !mapping.HasMappingCode)
         {
             return Result<object?>.Ok(invocationResult.Data);
         }
@@ -125,7 +126,8 @@ public sealed class DaprHttpEndpointTaskExecutor : TaskExecutorBase<DaprHttpEndp
         var result = await ResultExtensions.TryAsync<object?>(async ct =>
         {
             var scriptRunner = await _scriptEngine.CompileToInstanceAsync<IMapping>(
-                mapping.DecodedCode,
+                mapping,
+                flowScripts: context.ScriptContext.Workflow?.Scripts,
                 cancellationToken: ct);
 
             var outputResponse = await scriptRunner.OutputHandler(context.ScriptContext);

--- a/src/BBT.Workflow.Application/Tasks/Executors/Dapr/DaprPubSubTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Dapr/DaprPubSubTaskExecutor.cs
@@ -41,7 +41,7 @@ public sealed class DaprPubSubTaskExecutor : TaskExecutorBase<DaprPubSubTask>
         CancellationToken cancellationToken)
     {
         var mapping = context.OnExecuteTask.Mapping;
-        if (mapping == null || string.IsNullOrEmpty(mapping.DecodedCode))
+        if (mapping is null || !mapping.HasMappingCode)
         {
             return Result<ScriptResponse?>.Ok(null);
         }
@@ -49,7 +49,8 @@ public sealed class DaprPubSubTaskExecutor : TaskExecutorBase<DaprPubSubTask>
         var result = await ResultExtensions.TryAsync<ScriptResponse?>(async ct =>
         {
             var scriptRunner = await _scriptEngine.CompileToInstanceAsync<IMapping>(
-                mapping.DecodedCode,
+                mapping,
+                flowScripts: context.ScriptContext.Workflow?.Scripts,
                 cancellationToken: ct);
 
             return await scriptRunner.InputHandler(task, context.ScriptContext);
@@ -115,7 +116,7 @@ public sealed class DaprPubSubTaskExecutor : TaskExecutorBase<DaprPubSubTask>
         CancellationToken cancellationToken)
     {
         var mapping = context.OnExecuteTask.Mapping;
-        if (mapping == null || string.IsNullOrEmpty(mapping.DecodedCode))
+        if (mapping is null || !mapping.HasMappingCode)
         {
             return Result<object?>.Ok(invocationResult.Data);
         }
@@ -125,7 +126,8 @@ public sealed class DaprPubSubTaskExecutor : TaskExecutorBase<DaprPubSubTask>
         var result = await ResultExtensions.TryAsync<object?>(async ct =>
         {
             var scriptRunner = await _scriptEngine.CompileToInstanceAsync<IMapping>(
-                mapping.DecodedCode,
+                mapping,
+                flowScripts: context.ScriptContext.Workflow?.Scripts,
                 cancellationToken: ct);
 
             var outputResponse = await scriptRunner.OutputHandler(context.ScriptContext);

--- a/src/BBT.Workflow.Application/Tasks/Executors/Dapr/DaprServiceTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Dapr/DaprServiceTaskExecutor.cs
@@ -41,7 +41,7 @@ public sealed class DaprServiceTaskExecutor : TaskExecutorBase<DaprServiceTask>
         CancellationToken cancellationToken)
     {
         var mapping = context.OnExecuteTask.Mapping;
-        if (mapping == null || string.IsNullOrEmpty(mapping.DecodedCode))
+        if (mapping is null || !mapping.HasMappingCode)
         {
             return Result<ScriptResponse?>.Ok(null);
         }
@@ -49,7 +49,8 @@ public sealed class DaprServiceTaskExecutor : TaskExecutorBase<DaprServiceTask>
         var result = await ResultExtensions.TryAsync<ScriptResponse?>(async ct =>
         {
             var scriptRunner = await _scriptEngine.CompileToInstanceAsync<IMapping>(
-                mapping.DecodedCode,
+                mapping,
+                flowScripts: context.ScriptContext.Workflow?.Scripts,
                 cancellationToken: ct);
 
             return await scriptRunner.InputHandler(task, context.ScriptContext);
@@ -115,7 +116,7 @@ public sealed class DaprServiceTaskExecutor : TaskExecutorBase<DaprServiceTask>
         CancellationToken cancellationToken)
     {
         var mapping = context.OnExecuteTask.Mapping;
-        if (mapping == null || string.IsNullOrEmpty(mapping.DecodedCode))
+        if (mapping is null || !mapping.HasMappingCode)
         {
             return Result<object?>.Ok(invocationResult.Data);
         }
@@ -125,7 +126,8 @@ public sealed class DaprServiceTaskExecutor : TaskExecutorBase<DaprServiceTask>
         var result = await ResultExtensions.TryAsync<object?>(async ct =>
         {
             var scriptRunner = await _scriptEngine.CompileToInstanceAsync<IMapping>(
-                mapping.DecodedCode,
+                mapping,
+                flowScripts: context.ScriptContext.Workflow?.Scripts,
                 cancellationToken: ct);
 
             var outputResponse = await scriptRunner.OutputHandler(context.ScriptContext);

--- a/src/BBT.Workflow.Application/Tasks/Executors/Http/HttpTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Http/HttpTaskExecutor.cs
@@ -40,7 +40,7 @@ public sealed class HttpTaskExecutor : TaskExecutorBase<HttpTask>
         CancellationToken cancellationToken)
     {
         var mapping = context.OnExecuteTask.Mapping;
-        if (mapping == null || string.IsNullOrEmpty(mapping.DecodedCode))
+        if (mapping is null || !mapping.HasMappingCode)
         {
             return Result<ScriptResponse?>.Ok(null);
         }
@@ -48,7 +48,8 @@ public sealed class HttpTaskExecutor : TaskExecutorBase<HttpTask>
         var result = await ResultExtensions.TryAsync<ScriptResponse?>(async ct =>
         {
             var scriptRunner = await _scriptEngine.CompileToInstanceAsync<IMapping>(
-                mapping.DecodedCode,
+                mapping,
+                flowScripts: context.ScriptContext.Workflow?.Scripts,
                 cancellationToken: ct);
 
             return await scriptRunner.InputHandler(task, context.ScriptContext);
@@ -117,7 +118,7 @@ public sealed class HttpTaskExecutor : TaskExecutorBase<HttpTask>
         UpdateScriptContextWithResponse(task.Key, invocationResult, context.ScriptContext);
 
         var mapping = context.OnExecuteTask.Mapping;
-        if (mapping == null || string.IsNullOrEmpty(mapping.DecodedCode))
+        if (mapping is null || !mapping.HasMappingCode)
         {
             return Result<object?>.Ok(invocationResult.Data);
         }
@@ -125,7 +126,8 @@ public sealed class HttpTaskExecutor : TaskExecutorBase<HttpTask>
         var result = await ResultExtensions.TryAsync<object?>(async ct =>
         {
             var scriptRunner = await _scriptEngine.CompileToInstanceAsync<IMapping>(
-                mapping.DecodedCode,
+                mapping,
+                flowScripts: context.ScriptContext.Workflow?.Scripts,
                 cancellationToken: ct);
 
             var outputResponse = await scriptRunner.OutputHandler(context.ScriptContext);

--- a/src/BBT.Workflow.Application/Tasks/Executors/Http/SoapTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Http/SoapTaskExecutor.cs
@@ -36,7 +36,7 @@ public sealed class SoapTaskExecutor : TaskExecutorBase<SoapTask>
         CancellationToken cancellationToken)
     {
         var mapping = context.OnExecuteTask.Mapping;
-        if (mapping == null || string.IsNullOrEmpty(mapping.DecodedCode))
+        if (mapping is null || !mapping.HasMappingCode)
         {
             return Result<ScriptResponse?>.Ok(null);
         }
@@ -44,7 +44,8 @@ public sealed class SoapTaskExecutor : TaskExecutorBase<SoapTask>
         var result = await ResultExtensions.TryAsync<ScriptResponse?>(async ct =>
         {
             var scriptRunner = await _scriptEngine.CompileToInstanceAsync<IMapping>(
-                mapping.DecodedCode,
+                mapping,
+                flowScripts: context.ScriptContext.Workflow?.Scripts,
                 cancellationToken: ct);
 
             return await scriptRunner.InputHandler(task, context.ScriptContext);
@@ -110,7 +111,7 @@ public sealed class SoapTaskExecutor : TaskExecutorBase<SoapTask>
         CancellationToken cancellationToken)
     {
         var mapping = context.OnExecuteTask.Mapping;
-        if (mapping == null || string.IsNullOrEmpty(mapping.DecodedCode))
+        if (mapping is null || !mapping.HasMappingCode)
         {
             return Result<object?>.Ok(invocationResult.Data);
         }
@@ -120,7 +121,8 @@ public sealed class SoapTaskExecutor : TaskExecutorBase<SoapTask>
         var result = await ResultExtensions.TryAsync<object?>(async ct =>
         {
             var scriptRunner = await _scriptEngine.CompileToInstanceAsync<IMapping>(
-                mapping.DecodedCode,
+                mapping,
+                flowScripts: context.ScriptContext.Workflow?.Scripts,
                 cancellationToken: ct);
 
             var outputResponse = await scriptRunner.OutputHandler(context.ScriptContext);

--- a/src/BBT.Workflow.Application/Tasks/Executors/Notification/NotificationTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Notification/NotificationTaskExecutor.cs
@@ -46,21 +46,23 @@ public sealed class NotificationTaskExecutor(
                 taskType: TaskType.ToString()));
         }
 
-        var mappingCode = context.OnExecuteTask.Mapping?.DecodedCode;
+        var mappingScript = context.OnExecuteTask.Mapping;
         INotificationMapping? mapping = null;
         IStateNotificationMapping? stateMapping = null;
 
         var hasStateChannel = channels.Any(c => string.Equals(c, StateChannel, StringComparison.OrdinalIgnoreCase));
         var hasNonStateChannels = channels.Any(c => !string.Equals(c, StateChannel, StringComparison.OrdinalIgnoreCase));
 
-        if (!string.IsNullOrEmpty(mappingCode))
+        var flowScripts = context.ScriptContext.Workflow?.Scripts;
+
+        if (mappingScript is not null && mappingScript.HasMappingCode)
         {
             if (hasNonStateChannels)
                 mapping = await scriptEngine.CompileToInstanceAsync<INotificationMapping>(
-                    mappingCode, cancellationToken: cancellationToken);
+                    mappingScript, flowScripts: flowScripts, cancellationToken: cancellationToken);
 
             if (hasStateChannel)
-                stateMapping = await TryCompileStateMappingAsync(mappingCode, cancellationToken);
+                stateMapping = await TryCompileStateMappingAsync(mappingScript, flowScripts, cancellationToken);
         }
 
         var dispatched = new List<string>();
@@ -103,12 +105,13 @@ public sealed class NotificationTaskExecutor(
     }
 
     private async Task<IStateNotificationMapping?> TryCompileStateMappingAsync(
-        string code, CancellationToken cancellationToken)
+        ScriptCode code, ScriptSettings? flowScripts, CancellationToken cancellationToken)
     {
         try
         {
             return await scriptEngine.CompileToInstanceAsync<IStateNotificationMapping>(
                 code,
+                flowScripts: flowScripts,
                 cancellationToken: cancellationToken);
         }
         catch (InvalidOperationException)

--- a/src/BBT.Workflow.Application/Tasks/Executors/Notification/StateChannelMessageBuilder.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Notification/StateChannelMessageBuilder.cs
@@ -1,6 +1,7 @@
 using System.Dynamic;
 using BBT.Aether.Results;
 using BBT.Aether.Users;
+using BBT.Workflow.CurrentUser;
 using BBT.Workflow.Gateway;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Scripting;
@@ -26,8 +27,8 @@ internal sealed class StateChannelMessageBuilder(
             ? instance!.Key
             : instance?.Id.ToString() ?? string.Empty;
 
-        var headers = DynamicToDictionary(context.ScriptContext.Headers);
-        var queryParams = DynamicToDictionary(context.ScriptContext.QueryParameters);
+        Dictionary<string, string?> headers = DynamicToDictionary(context.ScriptContext.Headers);
+        Dictionary<string, string?> queryParams = DynamicToDictionary(context.ScriptContext.QueryParameters);
 
         var input = new GetFunctionWithInstanceInput
         {
@@ -38,7 +39,8 @@ internal sealed class StateChannelMessageBuilder(
             Extensions = null,
             Headers = headers,
             QueryParams = queryParams,
-            Role = currentUser.Roles is { Length: > 0 } ? currentUser.Roles[0] : null
+            Role = currentUser.ResolveCallerRole(headers),
+            Roles = currentUser.ResolveCallerRoles(headers)
         };
 
         var stateResult = await instanceQueryGateway.GetFunctionWithStateAsync(input, cancellationToken);

--- a/src/BBT.Workflow.Application/Tasks/Executors/Script/ScriptTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Script/ScriptTaskExecutor.cs
@@ -38,7 +38,7 @@ public sealed class ScriptTaskExecutor : TaskExecutorBase<ScriptTask>
     {
         // Compile and run input handler
         var mapping = context.OnExecuteTask.Mapping;
-        if (mapping == null || string.IsNullOrEmpty(mapping.DecodedCode))
+        if (mapping is null || !mapping.HasMappingCode)
         {
             return Result<ScriptResponse?>.Ok(null);
         }
@@ -46,7 +46,8 @@ public sealed class ScriptTaskExecutor : TaskExecutorBase<ScriptTask>
         var result = await ResultExtensions.TryAsync<ScriptResponse?>(async ct =>
         {
             var scriptRunner = await _scriptEngine.CompileToInstanceAsync<IMapping>(
-                mapping.DecodedCode,
+                mapping,
+                flowScripts: context.ScriptContext.Workflow?.Scripts,
                 cancellationToken: ct);
 
             return await scriptRunner.InputHandler(task, context.ScriptContext);
@@ -74,7 +75,7 @@ public sealed class ScriptTaskExecutor : TaskExecutorBase<ScriptTask>
     {
         // Run output handler to get the result
         var mapping = context.OnExecuteTask.Mapping;
-        if (mapping == null || string.IsNullOrEmpty(mapping.DecodedCode))
+        if (mapping is null || !mapping.HasMappingCode)
         {
             return Result<TaskInvocationResult>.Ok(TaskInvocationResult.Success(
                 data: null,
@@ -84,7 +85,8 @@ public sealed class ScriptTaskExecutor : TaskExecutorBase<ScriptTask>
         var result = await ResultExtensions.TryAsync<TaskInvocationResult>(async ct =>
         {
             var scriptRunner = await _scriptEngine.CompileToInstanceAsync<IMapping>(
-                mapping.DecodedCode,
+                mapping,
+                flowScripts: context.ScriptContext.Workflow?.Scripts,
                 cancellationToken: ct);
 
             var outputResponse = await scriptRunner.OutputHandler(context.ScriptContext);

--- a/src/BBT.Workflow.Application/Tasks/Executors/Trigger/TriggerTaskExecutorBase.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Trigger/TriggerTaskExecutorBase.cs
@@ -50,7 +50,7 @@ public abstract class TriggerTaskExecutorBase<TTask>(
         CancellationToken cancellationToken)
     {
         var mapping = context.OnExecuteTask.Mapping;
-        if (mapping == null || string.IsNullOrEmpty(mapping.DecodedCode))
+        if (mapping is null || !mapping.HasMappingCode)
         {
             return Result<ScriptResponse?>.Ok(null);
         }
@@ -58,7 +58,8 @@ public abstract class TriggerTaskExecutorBase<TTask>(
         var result = await ResultExtensions.TryAsync<ScriptResponse?>(async ct =>
         {
             var scriptRunner = await ScriptEngine.CompileToInstanceAsync<IMapping>(
-                mapping.DecodedCode,
+                mapping,
+                flowScripts: context.ScriptContext.Workflow?.Scripts,
                 cancellationToken: ct);
 
             return await scriptRunner.InputHandler(task, context.ScriptContext);
@@ -89,7 +90,7 @@ public abstract class TriggerTaskExecutorBase<TTask>(
         UpdateScriptContextWithResponse(task.Key, invocationResult, context.ScriptContext);
 
         var mapping = context.OnExecuteTask.Mapping;
-        if (mapping == null || string.IsNullOrEmpty(mapping.DecodedCode))
+        if (mapping is null || !mapping.HasMappingCode)
         {
             return Result<object?>.Ok(invocationResult.Data);
         }
@@ -97,7 +98,8 @@ public abstract class TriggerTaskExecutorBase<TTask>(
         var result = await ResultExtensions.TryAsync<object?>(async ct =>
         {
             var scriptRunner = await ScriptEngine.CompileToInstanceAsync<IMapping>(
-                mapping.DecodedCode,
+                mapping,
+                flowScripts: context.ScriptContext.Workflow?.Scripts,
                 cancellationToken: ct);
 
             var outputResponse = await scriptRunner.OutputHandler(context.ScriptContext);

--- a/src/BBT.Workflow.Domain/Caching/IComponentCacheStore.cs
+++ b/src/BBT.Workflow.Domain/Caching/IComponentCacheStore.cs
@@ -134,6 +134,23 @@ public interface IComponentCacheStore
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Retrieves a mapping (script-library) component definition (<c>sys-mappings</c>) from the cache.
+    /// </summary>
+    /// <param name="domain">The domain identifier where the mapping belongs.</param>
+    /// <param name="key">The unique key/name identifier of the mapping component.</param>
+    /// <param name="version">The specific version of the mapping. If null, returns the latest version.</param>
+    /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> whose result contains a <see cref="Result{T}"/> with the
+    /// <see cref="Mapping"/> if found, or <see cref="Error.NotFound"/> otherwise.
+    /// </returns>
+    Task<Result<Mapping>> GetMappingAsync(
+        string domain,
+        string key,
+        string? version,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Stores an entity in the cache.
     /// </summary>
     /// <typeparam name="T">The type of entity to store. Must implement <see cref="IDomainEntity"/>.</typeparam>

--- a/src/BBT.Workflow.Domain/CurrentUser/CurrentUserHeaderExtensions.cs
+++ b/src/BBT.Workflow.Domain/CurrentUser/CurrentUserHeaderExtensions.cs
@@ -89,6 +89,43 @@ public static class CurrentUserHeaderExtensions
     }
 
     /// <summary>
+    /// Resolves the single caller role used when locally routing the state function. Prefers the first
+    /// role on the current user; when the user carries no roles, falls back to the first role parsed from
+    /// the request <c>role</c> header; returns <c>null</c> when neither is present.
+    /// </summary>
+    /// <param name="currentUser">The current user.</param>
+    /// <param name="headers">Request headers to read the <c>role</c> value from when the user has none.</param>
+    public static string? ResolveCallerRole(
+        this ICurrentUser currentUser,
+        IReadOnlyDictionary<string, string?>? headers)
+    {
+        if (currentUser.Roles is { Length: > 0 } roles)
+            return roles[0];
+
+        var headerRole = headers is null ? null : GetHeader(headers, CurrentUserHeaderKeys.Role);
+        var parsed = ParseRolesFromHeader(headerRole);
+        return parsed is { Length: > 0 } ? parsed[0] : null;
+    }
+
+    /// <summary>
+    /// Resolves the caller role list used when locally routing a function. Prefers all roles on the
+    /// current user; when the user carries no roles, falls back to the roles parsed from the request
+    /// <c>role</c> header; returns <c>null</c> when neither is present.
+    /// </summary>
+    /// <param name="currentUser">The current user.</param>
+    /// <param name="headers">Request headers to read the <c>role</c> value from when the user has none.</param>
+    public static string[]? ResolveCallerRoles(
+        this ICurrentUser currentUser,
+        IReadOnlyDictionary<string, string?>? headers)
+    {
+        if (currentUser.Roles is { Length: > 0 } roles)
+            return roles;
+
+        var headerRole = headers is null ? null : GetHeader(headers, CurrentUserHeaderKeys.Role);
+        return ParseRolesFromHeader(headerRole);
+    }
+
+    /// <summary>
     /// Parses the role header value into an array of role strings.
     /// Supports multiple roles separated by comma or space (e.g. "role1, role2" or "role1 role2").
     /// </summary>

--- a/src/BBT.Workflow.Domain/Definitions/CodeEncoding.cs
+++ b/src/BBT.Workflow.Domain/Definitions/CodeEncoding.cs
@@ -19,6 +19,13 @@ public sealed class CodeEncoding : IEquatable<CodeEncoding>
     public static readonly CodeEncoding Native = new("NAT", "Native");
 
     /// <summary>
+    /// Code is a reference to a <c>sys-mappings</c> component; the actual body is resolved from the
+    /// component store (its own <c>Name/Code/Encoding</c>). The <c>code</c> field holds a
+    /// <see cref="Reference"/> object instead of a string.
+    /// </summary>
+    public static readonly CodeEncoding Reference = new("REF", "Reference");
+
+    /// <summary>
     /// Short code identifier for the encoding type.
     /// </summary>
     public string Code { get; }
@@ -51,6 +58,7 @@ public sealed class CodeEncoding : IEquatable<CodeEncoding>
         {
             "B64" => Base64,
             "NAT" => Native,
+            "REF" => Reference,
             _ => Base64
         };
     }

--- a/src/BBT.Workflow.Domain/Definitions/Mappings/IMappingReference.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Mappings/IMappingReference.cs
@@ -1,0 +1,8 @@
+namespace BBT.Workflow.Definitions;
+
+/// <summary>
+/// Marker reference contract for a mapping (script-library) component (<c>sys-mappings</c>).
+/// </summary>
+public interface IMappingReference : IReference
+{
+}

--- a/src/BBT.Workflow.Domain/Definitions/Mappings/Mapping.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Mappings/Mapping.cs
@@ -1,0 +1,134 @@
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using BBT.Aether;
+using BBT.Workflow.Runtime;
+
+namespace BBT.Workflow.Definitions;
+
+/// <summary>
+/// A mapping component (<c>sys-mappings</c>): a reusable, versioned C# script distributed with the
+/// domain like flows/tasks/views. A mapping component is typically authored as a helper class body
+/// (a <c>.csx</c> snippet) that transition mappings reference via <c>mapping.helpers[]</c>.
+/// The referenced set is compiled (sandboxed, cached by content hash) before the mapping that uses it.
+/// </summary>
+public sealed class Mapping : IDomainEntity, IMappingReference, IReferenceSetter
+{
+    private Mapping()
+    {
+        Flow = RuntimeSysSchemaInfo.Mappings;
+        Name = string.Empty;
+        Code = string.Empty;
+        Encoding = CodeEncoding.Base64;
+    }
+
+    [JsonConstructor]
+    public Mapping(
+        string name,
+        string code,
+        CodeEncoding? encoding = null) : this()
+    {
+        Name = name ?? string.Empty;
+        Code = code ?? string.Empty;
+        Encoding = encoding ?? CodeEncoding.Base64;
+    }
+
+    /// <summary>
+    /// If present, it is the more readable key value of the record.
+    /// </summary>
+    public string Key { get; private set; }
+
+    /// <summary>
+    /// It is the information on which stream the record is located.
+    /// </summary>
+    public string Flow { get; init; }
+
+    /// <summary>
+    /// Information about which domain the flow is working on and which domain it belongs to.
+    /// </summary>
+    public string Domain { get; private set; }
+
+    /// <summary>
+    /// This is the version information at the time the record is assigned.
+    /// </summary>
+    public string Version { get; private set; }
+
+    /// <summary>
+    /// Human-readable name of the mapping component.
+    /// </summary>
+    public string Name { get; private set; }
+
+    /// <summary>
+    /// The script code content. Can be Base64 encoded or native (plain text) based on <see cref="Encoding"/>.
+    /// </summary>
+    public string Code { get; private set; }
+
+    /// <summary>
+    /// The encoding of <see cref="Code"/>. Base64 (default, backward compatible) or Native (plain text).
+    /// </summary>
+    public CodeEncoding Encoding { get; private set; }
+
+    /// <summary>
+    /// Semantic Version
+    /// </summary>
+    public string SemanticVersion => Regex.Match(Version, @"^([^+]+)").Groups[1].Value;
+
+    /// <summary>
+    /// The decoded, compilable C# source. For Native encoding, returns the code as-is;
+    /// for Base64, decodes the content.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when Base64 decoding fails.</exception>
+    public string DecodedCode
+    {
+        get
+        {
+            if (Encoding.Equals(CodeEncoding.Native))
+            {
+                return Code;
+            }
+
+            try
+            {
+                var bytes = Convert.FromBase64String(Code);
+                return System.Text.Encoding.UTF8.GetString(bytes);
+            }
+            catch (FormatException ex)
+            {
+                throw new InvalidOperationException("Invalid Base64 string in Mapping code.", ex);
+            }
+        }
+    }
+
+    public static string ComponentTypeKey => RuntimeSysSchemaInfo.Mappings;
+    public string ComponentKey => ComponentTypeKey;
+
+    public static string GenerateCacheKey(
+        string domain,
+        string flow,
+        string key,
+        string version)
+    {
+        return $"{nameof(Mapping)}:{domain}:{flow}:{key}:{version}";
+    }
+
+    private void SetKey(string key)
+    {
+        Key = Check.NotNullOrWhiteSpace(key, nameof(Key), MappingConstants.MaxKeyLength);
+    }
+
+    private void SetDomain(string domain)
+    {
+        Domain = Check.NotNullOrWhiteSpace(domain, nameof(Domain), WorkflowConstants.MaxDomainLength);
+    }
+
+    private void SetVersion(string version)
+    {
+        Version = Check.NotNullOrWhiteSpace(version, nameof(Version), WorkflowConstants.MaxVersionLength);
+    }
+
+    public void SetReference(IReference reference)
+    {
+        SetKey(reference.Key);
+        SetDomain(reference.Domain);
+        SetVersion(reference.Version);
+    }
+}

--- a/src/BBT.Workflow.Domain/Definitions/ScriptCode.cs
+++ b/src/BBT.Workflow.Domain/Definitions/ScriptCode.cs
@@ -4,7 +4,12 @@ using BBT.Aether.Domain.Values;
 namespace BBT.Workflow.Definitions;
 
 /// <summary>
-/// Represents a script code value object with support for both Base64 encoded and native (plain text) code content.
+/// Represents a script code value object. The body may be plain text (<see cref="CodeEncoding.Native"/>),
+/// Base64 (<see cref="CodeEncoding.Base64"/>), or a reference to a reusable <c>sys-mappings</c> component
+/// (<see cref="CodeEncoding.Reference"/>, in which case <see cref="CodeReference"/> is populated and the
+/// body is resolved from the component store at compile time).
+/// Helper references and the per-compile sandbox grant live under <see cref="Scripts"/>.
+/// Deserialized via <see cref="ScriptCodeJsonConverter"/> because the <c>code</c> field is polymorphic.
 /// </summary>
 public sealed class ScriptCode : ValueObject
 {
@@ -20,9 +25,16 @@ public sealed class ScriptCode : ValueObject
     public string Location { get; private set; }
 
     /// <summary>
-    /// The script code content. Can be Base64 encoded or native (plain text) based on <see cref="Encoding"/>.
+    /// The script code content (string) for <see cref="CodeEncoding.Native"/> / <see cref="CodeEncoding.Base64"/>.
+    /// Empty when <see cref="Encoding"/> is <see cref="CodeEncoding.Reference"/> (see <see cref="CodeReference"/>).
     /// </summary>
     public string Code { get; private set; }
+
+    /// <summary>
+    /// Reference to a <c>sys-mappings</c> component supplying the body. Populated only when
+    /// <see cref="Encoding"/> is <see cref="CodeEncoding.Reference"/>.
+    /// </summary>
+    public Reference? CodeReference { get; private set; }
 
     /// <summary>
     /// The mapping type for script code execution (Global or Local).
@@ -30,9 +42,15 @@ public sealed class ScriptCode : ValueObject
     public MappingType Type { get; private set; }
 
     /// <summary>
-    /// The encoding type of the code content. Base64 for backward compatibility, Native for plain text.
+    /// The encoding of the code content: Base64 (default), Native (plain text), or Reference (sys-mappings).
     /// </summary>
     public CodeEncoding Encoding { get; private set; }
+
+    /// <summary>
+    /// Optional script settings (helper references + per-compile sandbox grant). Unioned with the
+    /// flow-level <c>scripts</c> at compile time.
+    /// </summary>
+    public ScriptSettings? Scripts { get; private set; }
 
     private ScriptCode()
     {
@@ -46,29 +64,70 @@ public sealed class ScriptCode : ValueObject
     /// Creates a new ScriptCode instance.
     /// </summary>
     /// <param name="location">The location/path identifier. Defaults to "inline" if null or empty.</param>
-    /// <param name="code">The script code content.</param>
+    /// <param name="code">The script code content (for Native/Base64). Ignored for Reference encoding.</param>
     /// <param name="type">The mapping type (Global or Local). Defaults to Local.</param>
-    /// <param name="encoding">The code encoding (Base64 or Native). Defaults to Base64 for backward compatibility.</param>
-    [JsonConstructor]
-    public ScriptCode(string? location, string? code, MappingType? type = null, CodeEncoding? encoding = null)
+    /// <param name="encoding">The code encoding. Defaults to Base64 for backward compatibility.</param>
+    /// <param name="scripts">Optional script settings (helpers + sandbox grant).</param>
+    /// <param name="codeReference">Reference to a sys-mappings component (only for Reference encoding).</param>
+    public ScriptCode(
+        string? location,
+        string? code,
+        MappingType? type = null,
+        CodeEncoding? encoding = null,
+        ScriptSettings? scripts = null,
+        Reference? codeReference = null)
     {
         Location = string.IsNullOrWhiteSpace(location) ? DefaultLocation : location;
         Code = code ?? string.Empty;
         Type = type ?? MappingType.Local;
         Encoding = encoding ?? CodeEncoding.Base64;
+        Scripts = scripts;
+        CodeReference = Encoding.Equals(CodeEncoding.Reference) ? codeReference : null;
     }
 
     /// <summary>
-    /// Gets the decoded/usable script code content.
+    /// True when this script references one or more helper components and therefore requires
+    /// the sandboxed helper-set compile path.
+    /// </summary>
+    [JsonIgnore]
+    public bool HasHelpers => Scripts?.HasHelpers == true;
+
+    /// <summary>
+    /// True when this script encoding is a reference to a sys-mappings component.
+    /// </summary>
+    [JsonIgnore]
+    public bool IsReference => Encoding.Equals(CodeEncoding.Reference);
+
+    /// <summary>
+    /// True when there is an actual mapping body to compile and run. Used by executors to decide
+    /// whether to invoke the script engine. For Reference encoding this is true when a
+    /// <see cref="CodeReference"/> is set; otherwise when the inline <see cref="Code"/> is non-empty.
+    /// Always false for the Global mapping type.
+    /// </summary>
+    [JsonIgnore]
+    public bool HasMappingCode =>
+        !Type.Equals(MappingType.Global)
+        && (IsReference ? CodeReference is not null : !string.IsNullOrWhiteSpace(Code));
+
+    /// <summary>
+    /// Gets the decoded/usable inline script code content.
     /// For Base64 encoding, decodes the content. For Native encoding, returns the code as-is.
     /// Returns empty string for Global mapping type.
     /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown when Base64 decoding fails.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when Base64 decoding fails, or when the encoding is Reference (the body must be resolved
+    /// from the component store by the script engine, not read inline).
+    /// </exception>
     public string DecodedCode
     {
         get
         {
             if (Type.Equals(MappingType.Global))
+            {
+                return string.Empty;
+            }
+
+            if (IsReference)
             {
                 return string.Empty;
             }
@@ -93,10 +152,6 @@ public sealed class ScriptCode : ValueObject
     /// <summary>
     /// Creates a ScriptCode instance with native (plain text) encoding.
     /// </summary>
-    /// <param name="code">The plain text script code.</param>
-    /// <param name="location">Optional location identifier.</param>
-    /// <param name="type">Optional mapping type.</param>
-    /// <returns>A new ScriptCode instance with Native encoding.</returns>
     public static ScriptCode FromNative(string code, string? location = null, MappingType? type = null)
     {
         return new ScriptCode(location, code, type, CodeEncoding.Native);
@@ -105,13 +160,17 @@ public sealed class ScriptCode : ValueObject
     /// <summary>
     /// Creates a ScriptCode instance with Base64 encoded content.
     /// </summary>
-    /// <param name="base64Code">The Base64 encoded script code.</param>
-    /// <param name="location">Optional location identifier.</param>
-    /// <param name="type">Optional mapping type.</param>
-    /// <returns>A new ScriptCode instance with Base64 encoding.</returns>
     public static ScriptCode FromBase64(string base64Code, string? location = null, MappingType? type = null)
     {
         return new ScriptCode(location, base64Code, type, CodeEncoding.Base64);
+    }
+
+    /// <summary>
+    /// Creates a ScriptCode instance that references a sys-mappings component for its body.
+    /// </summary>
+    public static ScriptCode FromReference(Reference codeReference, string? location = null, MappingType? type = null)
+    {
+        return new ScriptCode(location, code: null, type, CodeEncoding.Reference, scripts: null, codeReference);
     }
 
     protected override IEnumerable<object> GetAtomicValues()
@@ -120,5 +179,15 @@ public sealed class ScriptCode : ValueObject
         yield return Code;
         yield return Type;
         yield return Encoding;
+
+        if (CodeReference is not null)
+        {
+            yield return CodeReference.ToString();
+        }
+
+        if (Scripts is not null)
+        {
+            yield return Scripts;
+        }
     }
 }

--- a/src/BBT.Workflow.Domain/Definitions/ScriptCodeJsonConverter.cs
+++ b/src/BBT.Workflow.Domain/Definitions/ScriptCodeJsonConverter.cs
@@ -1,0 +1,114 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace BBT.Workflow.Definitions;
+
+/// <summary>
+/// Custom converter for <see cref="ScriptCode"/>. The <c>code</c> field is polymorphic: a string for
+/// <see cref="CodeEncoding.Native"/>/<see cref="CodeEncoding.Base64"/>, or a <see cref="Reference"/>
+/// object for <see cref="CodeEncoding.Reference"/> (REF). Helper references + sandbox grant are read
+/// from the nested <c>scripts</c> object.
+/// </summary>
+public sealed class ScriptCodeJsonConverter : JsonConverter<ScriptCode>
+{
+    public override ScriptCode? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Null)
+        {
+            return null;
+        }
+
+        using var doc = JsonDocument.ParseValue(ref reader);
+        var root = doc.RootElement;
+
+        var location = TryGet(root, "location") is { ValueKind: JsonValueKind.String } locEl
+            ? locEl.GetString()
+            : null;
+
+        var type = Deserialize<MappingType>(root, "type", options);
+        var encoding = Deserialize<CodeEncoding>(root, "encoding", options) ?? CodeEncoding.Base64;
+        var scripts = Deserialize<ScriptSettings>(root, "scripts", options);
+
+        string? code = null;
+        Reference? codeReference = null;
+
+        if (TryGet(root, "code") is { } codeEl && codeEl.ValueKind != JsonValueKind.Null)
+        {
+            if (encoding.Equals(CodeEncoding.Reference))
+            {
+                // REF: code is a Reference object. Tolerate a string that is not meaningful here.
+                if (codeEl.ValueKind == JsonValueKind.Object)
+                {
+                    codeReference = codeEl.Deserialize<Reference>(options);
+                }
+            }
+            else if (codeEl.ValueKind == JsonValueKind.String)
+            {
+                code = codeEl.GetString();
+            }
+        }
+
+        return new ScriptCode(location, code, type, encoding, scripts, codeReference);
+    }
+
+    public override void Write(Utf8JsonWriter writer, ScriptCode value, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+
+        writer.WriteString("location", value.Location);
+
+        writer.WritePropertyName("code");
+        if (value.IsReference)
+        {
+            JsonSerializer.Serialize(writer, value.CodeReference, options);
+        }
+        else
+        {
+            writer.WriteStringValue(value.Code);
+        }
+
+        writer.WritePropertyName("type");
+        JsonSerializer.Serialize(writer, value.Type, options);
+
+        writer.WritePropertyName("encoding");
+        JsonSerializer.Serialize(writer, value.Encoding, options);
+
+        if (value.Scripts is not null)
+        {
+            writer.WritePropertyName("scripts");
+            JsonSerializer.Serialize(writer, value.Scripts, options);
+        }
+
+        writer.WriteEndObject();
+    }
+
+    /// <summary>Case-insensitive property lookup (JSON is camelCase but stays robust).</summary>
+    private static JsonElement? TryGet(JsonElement root, string name)
+    {
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        foreach (var property in root.EnumerateObject())
+        {
+            if (string.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase))
+            {
+                return property.Value;
+            }
+        }
+
+        return null;
+    }
+
+    private static T? Deserialize<T>(JsonElement root, string name, JsonSerializerOptions options)
+    {
+        var element = TryGet(root, name);
+        if (element is null || element.Value.ValueKind == JsonValueKind.Null)
+        {
+            return default;
+        }
+
+        return element.Value.Deserialize<T>(options);
+    }
+}

--- a/src/BBT.Workflow.Domain/Definitions/ScriptSettings.cs
+++ b/src/BBT.Workflow.Domain/Definitions/ScriptSettings.cs
@@ -1,0 +1,102 @@
+using System.Text.Json.Serialization;
+using BBT.Aether.Domain.Values;
+
+namespace BBT.Workflow.Definitions;
+
+/// <summary>
+/// Script-level settings shared by a mapping (<c>mapping.scripts</c>) and a workflow definition
+/// (flow-level <c>scripts</c>). Declares the helper components a script may call and the per-compile
+/// sandbox assembly grant. Flow-level and task/mapping-level settings are unioned at compile time
+/// (see <see cref="Union"/>).
+/// </summary>
+public sealed class ScriptSettings : ValueObject
+{
+    /// <summary>
+    /// References to mapping (script-library) components (<c>sys-mappings</c>) whose public types the
+    /// script may call. The referenced set is compiled (sandboxed, cached) before the script, its
+    /// assembly referenced, and its public namespaces auto-imported.
+    /// </summary>
+    public IReadOnlyList<Reference>? Helpers { get; private set; }
+
+    /// <summary>
+    /// Per-compile sandbox grant: assembly simple names merged on top of the global baseline
+    /// (<c>Scripting:Sandbox:AllowedAssemblies</c>). Resolves only against assemblies actually available
+    /// (framework TPA + operator-mounted plugins); the mandatory banned-namespace baseline always applies.
+    /// </summary>
+    public IReadOnlyList<string>? AllowedAssemblies { get; private set; }
+
+    private ScriptSettings()
+    {
+    }
+
+    [JsonConstructor]
+    public ScriptSettings(
+        IReadOnlyList<Reference>? helpers = null,
+        IReadOnlyList<string>? allowedAssemblies = null)
+    {
+        Helpers = helpers is { Count: > 0 } ? helpers : null;
+        AllowedAssemblies = allowedAssemblies is { Count: > 0 } ? allowedAssemblies : null;
+    }
+
+    /// <summary>
+    /// True when at least one helper reference is declared.
+    /// </summary>
+    [JsonIgnore]
+    public bool HasHelpers => Helpers is { Count: > 0 };
+
+    /// <summary>
+    /// Unions a flow-level and a task/mapping-level settings object: helper references are concatenated
+    /// and de-duplicated by <c>domain/flow/key/version</c>; allowed assemblies are distinct-merged
+    /// (case-insensitive). Returns <c>null</c> when both inputs are null/empty.
+    /// </summary>
+    public static ScriptSettings? Union(ScriptSettings? flow, ScriptSettings? task)
+    {
+        if (flow is null)
+        {
+            return task;
+        }
+
+        if (task is null)
+        {
+            return flow;
+        }
+
+        var helpers = new List<Reference>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var reference in (flow.Helpers ?? []).Concat(task.Helpers ?? []))
+        {
+            if (seen.Add(reference.ToString()))
+            {
+                helpers.Add(reference);
+            }
+        }
+
+        var assemblies = (flow.AllowedAssemblies ?? [])
+            .Concat(task.AllowedAssemblies ?? [])
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        return new ScriptSettings(
+            helpers.Count > 0 ? helpers : null,
+            assemblies.Length > 0 ? assemblies : null);
+    }
+
+    protected override IEnumerable<object> GetAtomicValues()
+    {
+        if (Helpers is { Count: > 0 })
+        {
+            foreach (var helper in Helpers)
+            {
+                yield return helper.ToString();
+            }
+        }
+
+        if (AllowedAssemblies is { Count: > 0 })
+        {
+            foreach (var assembly in AllowedAssemblies)
+            {
+                yield return assembly;
+            }
+        }
+    }
+}

--- a/src/BBT.Workflow.Domain/Definitions/Workflow.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Workflow.cs
@@ -156,8 +156,16 @@ public sealed class Workflow : IDomainEntity, IReference, IReferenceSetter, IHas
     [JsonInclude] [JsonPropertyName("queryRoles")]
     private List<RoleGrant> queryRoles = new();
 
-    [JsonInclude] [JsonPropertyName("schema")] 
+    [JsonInclude] [JsonPropertyName("schema")]
     public Reference? Schema { get; private set; }
+
+    /// <summary>
+    /// Flow-level script settings (helper references + sandbox grant) that apply globally to every
+    /// mapping in this workflow. At compile time these are unioned with the task/mapping-level
+    /// <c>scripts</c> (see <see cref="ScriptSettings.Union"/>).
+    /// </summary>
+    [JsonInclude] [JsonPropertyName("scripts")]
+    public ScriptSettings? Scripts { get; private set; }
 
     /// <summary>
     /// Root-level query roles for state-based visibility. When a state has no queryRoles, this is used.

--- a/src/BBT.Workflow.Domain/Definitions/WorkflowConstants.cs
+++ b/src/BBT.Workflow.Domain/Definitions/WorkflowConstants.cs
@@ -52,3 +52,9 @@ public class SchemaConstants
 {
     public const int MaxKeyLength = WorkflowConstants.MaxKeyLength;
 }
+
+public class MappingConstants
+{
+    public const int MaxKeyLength = WorkflowConstants.MaxKeyLength;
+    public const int MaxNameLength = 180;
+}

--- a/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
@@ -2082,4 +2082,68 @@ public static partial class WorkflowLogs
         int maxRequestHeaderCount);
 
     #endregion
+
+    #region Scripting Helpers (sandbox)
+
+    /// <summary>
+    /// Logs that a referenced helper set was compiled and loaded for a mapping.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 60010,
+        Level = LogLevel.Information,
+        Message = "Helper set built for mapping: {HelperCount} helper(s) [{HelperKeys}], namespaces=[{Namespaces}]")]
+    public static partial void ScriptHelperSetBuilt(
+        this ILogger logger,
+        int helperCount,
+        string helperKeys,
+        string namespaces);
+
+    /// <summary>
+    /// Logs that a referenced helper set was served from the registry cache (no recompile).
+    /// </summary>
+    [LoggerMessage(
+        EventId = 60011,
+        Level = LogLevel.Debug,
+        Message = "Helper set served from cache: {HelperCount} helper(s) [{HelperKeys}]")]
+    public static partial void ScriptHelperSetCacheHit(
+        this ILogger logger,
+        int helperCount,
+        string helperKeys);
+
+    /// <summary>
+    /// Logs that a mapping referenced a helper component that could not be resolved from the store.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 60012,
+        Level = LogLevel.Error,
+        Message = "Helper component could not be resolved: domain={Domain}, flow={Flow}, key={Key}, version={Version}")]
+    public static partial void ScriptHelperReferenceUnresolved(
+        this ILogger logger,
+        string domain,
+        string flow,
+        string key,
+        string version);
+
+    /// <summary>
+    /// Logs that a mapping referenced helpers while the custom-script-helpers feature is disabled.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 60013,
+        Level = LogLevel.Error,
+        Message = "Mapping references helpers but the custom-script-helpers feature is disabled (Scripting:Helpers:Enabled=false)")]
+    public static partial void ScriptHelpersDisabled(
+        this ILogger logger);
+
+    /// <summary>
+    /// Logs that a script failed the sandbox / compilation gate.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 60014,
+        Level = LogLevel.Error,
+        Message = "Script compilation rejected by sandbox: {Reason}")]
+    public static partial void ScriptSandboxViolation(
+        this ILogger logger,
+        string reason);
+
+    #endregion
 }

--- a/src/BBT.Workflow.Domain/Microsoft/Extensions/DependencyInjection/WorkflowDomainModuleServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Domain/Microsoft/Extensions/DependencyInjection/WorkflowDomainModuleServiceCollectionExtensions.cs
@@ -30,6 +30,7 @@ public static class WorkflowDomainModuleServiceCollectionExtensions
             opt.Schemas.Add(RuntimeSysSchemaInfo.Tasks, "sys_tasks", typeof(WorkflowTask));
             opt.Schemas.Add(RuntimeSysSchemaInfo.Views, "sys_views", typeof(View));
             opt.Schemas.Add(RuntimeSysSchemaInfo.Extensions, "sys_extensions", typeof(Extension));
+            opt.Schemas.Add(RuntimeSysSchemaInfo.Mappings, "sys_mappings", typeof(Mapping));
         });
 
         services.AddSingleton<IRuntimeInfoProvider, RuntimeInfoProvider>();

--- a/src/BBT.Workflow.Domain/Runtime/RuntimeOptions.cs
+++ b/src/BBT.Workflow.Domain/Runtime/RuntimeOptions.cs
@@ -127,6 +127,13 @@ public class RuntimeSysSchemaInfo(string name, string schema, Type type)
     /// Constant representing the system extensions schema identifier.
     /// </summary>
     public const string Extensions = "sys-extensions";
+
+    /// <summary>
+    /// Constant representing the system mappings schema identifier.
+    /// A mapping component (<see cref="BBT.Workflow.Definitions.Mapping"/>) is a reusable, versioned
+    /// C# script (e.g. a helper class library) that transition mappings can reference.
+    /// </summary>
+    public const string Mappings = "sys-mappings";
 }
 
 /// <summary>

--- a/src/BBT.Workflow.Domain/Scripting/Contracts/IScriptEngine.cs
+++ b/src/BBT.Workflow.Domain/Scripting/Contracts/IScriptEngine.cs
@@ -1,3 +1,4 @@
+using BBT.Workflow.Definitions;
 using BBT.Workflow.Scripting.Functions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Scripting;
@@ -33,6 +34,28 @@ public interface IScriptCompiler
     /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled</exception>
     Task<T> CompileToInstanceAsync<T>(
         string code,
+        IEnumerable<MetadataReference>? extraReferences = null,
+        IEnumerable<string>? usingDirectives = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Compiles a mapping <see cref="ScriptCode"/> into an instance of the specified type.
+    /// When the script declares helper references (<see cref="ScriptCode.Helpers"/>), the referenced
+    /// helper set is built first (sandboxed, cached by content hash), its assembly referenced and its
+    /// public namespaces auto-imported, and the mapping is compiled into the helper set's load context.
+    /// When no helpers are declared this is equivalent to the string overload.
+    /// </summary>
+    /// <typeparam name="T">The target type to compile the code into.</typeparam>
+    /// <param name="scriptCode">The mapping script (code/encoding, optional <c>scripts</c> settings).</param>
+    /// <param name="flowScripts">Optional flow-level (workflow) script settings, unioned with the
+    /// mapping-level <c>scripts</c> (helpers concatenated/deduped, allowed assemblies merged).</param>
+    /// <param name="extraReferences">Optional additional metadata references for compilation.</param>
+    /// <param name="usingDirectives">Optional additional using directives to include.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    /// <returns>A task containing the compiled instance of type T.</returns>
+    Task<T> CompileToInstanceAsync<T>(
+        ScriptCode scriptCode,
+        ScriptSettings? flowScripts = null,
         IEnumerable<MetadataReference>? extraReferences = null,
         IEnumerable<string>? usingDirectives = null,
         CancellationToken cancellationToken = default);

--- a/src/BBT.Workflow.Domain/Shared/JsonSerializerConstants.cs
+++ b/src/BBT.Workflow.Domain/Shared/JsonSerializerConstants.cs
@@ -33,5 +33,6 @@ public static class JsonSerializerConstants
         // Add converters for proper serialization of enums and dynamic objects
         JsonOptions.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
         JsonOptions.Converters.Add(new ExpandoObjectJsonConverter());
+        JsonOptions.Converters.Add(new BBT.Workflow.Definitions.ScriptCodeJsonConverter());
     }
 }

--- a/src/BBT.Workflow.Infrastructure/Gateway/LocalInstanceQueryGateway.cs
+++ b/src/BBT.Workflow.Infrastructure/Gateway/LocalInstanceQueryGateway.cs
@@ -95,6 +95,7 @@ public sealed class LocalInstanceQueryGateway : IInstanceQueryGateway
                     Headers = input.Headers,
                     QueryParams = input.QueryParams,
                     Role = input.Role,
+                    Roles = input.Roles,
                     IfNoneMatch = input.IfNoneMatch
                 };
                 return await queryService.GetInstanceStateAsync(stateInput, ct);
@@ -119,7 +120,8 @@ public sealed class LocalInstanceQueryGateway : IInstanceQueryGateway
                     Instance = input.Instance,
                     Headers = input.Headers,
                     QueryParameters = input.QueryParams,
-                    Role = input.Role
+                    Role = input.Role,
+                    Roles = input.Roles
                 };
                 return await queryService.GetViewAsync(viewInput, transitionKey, ct);
             }, cancellationToken);
@@ -140,7 +142,8 @@ public sealed class LocalInstanceQueryGateway : IInstanceQueryGateway
                     Domain = input.Domain,
                     Workflow = input.Workflow,
                     Version = input.Version,
-                    Instance = input.Instance
+                    Instance = input.Instance,
+                    Roles = input.Roles
                 };
                 return await queryService.GetSchemaAsync(schemaInput, transitionKey, ct);
             }, cancellationToken);

--- a/src/BBT.Workflow.Infrastructure/Security/SchemaValidator.cs
+++ b/src/BBT.Workflow.Infrastructure/Security/SchemaValidator.cs
@@ -36,7 +36,8 @@ public class SchemaValidator : ISchemaValidator
         "sys_functions",
         "sys_schemas",
         "sys_tasks",
-        "sys_views"
+        "sys_views",
+        "sys_mappings"
     };
 
     // Valid table names whitelist

--- a/test/BBT.Workflow.Application.Tests/CurrentUser/CurrentUserHeaderExtensionsTests.cs
+++ b/test/BBT.Workflow.Application.Tests/CurrentUser/CurrentUserHeaderExtensionsTests.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using BBT.Aether.Users;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.CurrentUser;
+
+/// <summary>
+/// Tests for the caller role/roles resolution helpers used when locally routing function services:
+/// prefer the current user's roles, fall back to the request <c>role</c> header, else null.
+/// </summary>
+public class CurrentUserHeaderExtensionsTests
+{
+    private static ICurrentUser UserWithRoles(params string[]? roles)
+    {
+        var user = Substitute.For<ICurrentUser>();
+        user.Roles.Returns(roles);
+        return user;
+    }
+
+    [Fact]
+    public void ResolveCallerRole_PrefersFirstUserRole()
+    {
+        var user = UserWithRoles("admin", "ops");
+        user.ResolveCallerRole(new Dictionary<string, string?> { ["role"] = "ignored" }).ShouldBe("admin");
+    }
+
+    [Fact]
+    public void ResolveCallerRole_FallsBackToHeader_WhenUserHasNoRoles()
+    {
+        var user = UserWithRoles();
+        var headers = new Dictionary<string, string?> { ["role"] = "approver, auditor" };
+        user.ResolveCallerRole(headers).ShouldBe("approver");
+    }
+
+    [Fact]
+    public void ResolveCallerRole_Null_WhenNeitherPresent()
+    {
+        UserWithRoles().ResolveCallerRole(null).ShouldBeNull();
+        UserWithRoles().ResolveCallerRole(new Dictionary<string, string?>()).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ResolveCallerRoles_ReturnsAllUserRoles()
+    {
+        var user = UserWithRoles("admin", "ops");
+        user.ResolveCallerRoles(new Dictionary<string, string?> { ["role"] = "ignored" })
+            .ShouldBe(new[] { "admin", "ops" });
+    }
+
+    [Fact]
+    public void ResolveCallerRoles_FallsBackToParsedHeader_WhenUserHasNoRoles()
+    {
+        var user = UserWithRoles();
+        var headers = new Dictionary<string, string?> { ["role"] = "approver auditor" };
+        user.ResolveCallerRoles(headers).ShouldBe(new[] { "approver", "auditor" });
+    }
+
+    [Fact]
+    public void ResolveCallerRoles_Null_WhenNeitherPresent()
+    {
+        UserWithRoles().ResolveCallerRoles(null).ShouldBeNull();
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/Steps/ResourceLockStepTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/Steps/ResourceLockStepTests.cs
@@ -181,7 +181,7 @@ public class ResourceLockStepTests
             .ReturnsForAnyArgs<Task<dynamic>>(_ => throw new InvalidOperationException("script error"));
 
         _scriptEngine
-            .CompileToInstanceAsync<ITransitionMapping>(Arg.Any<string>())
+            .CompileToInstanceAsync<ITransitionMapping>(Arg.Any<ScriptCode>())
             .ReturnsForAnyArgs(Task.FromResult(mapping));
 
         SetupScriptContextFactory();
@@ -201,7 +201,7 @@ public class ResourceLockStepTests
             .ReturnsForAnyArgs(Task.FromResult<dynamic>(keyResult));
 
         _scriptEngine
-            .CompileToInstanceAsync<ITransitionMapping>(Arg.Any<string>())
+            .CompileToInstanceAsync<ITransitionMapping>(Arg.Any<ScriptCode>())
             .ReturnsForAnyArgs(Task.FromResult(mapping));
 
         SetupScriptContextFactory();

--- a/test/BBT.Workflow.Application.Tests/Scripting/SandboxedScriptingTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Scripting/SandboxedScriptingTests.cs
@@ -1,0 +1,230 @@
+using System.Linq;
+using System.Threading.Tasks;
+using BBT.Workflow.Scripting.Evaluators;
+using BBT.Workflow.Scripting.Helpers;
+using BBT.Workflow.Scripting.Sandbox;
+using Microsoft.CodeAnalysis;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Scripting;
+
+/// <summary>
+/// Public test contract referenced by sandboxed scripts (passed as an explicit metadata reference,
+/// independent of the assembly allow-list).
+/// </summary>
+public interface ISandboxTestCalc
+{
+    int Calc();
+}
+
+/// <summary>
+/// Unit tests for the sandboxed compile path (<see cref="CSharpEvaluator"/> + <see cref="BannedApiAnalyzer"/>)
+/// and the helper registry (<see cref="ScriptHelperRegistry"/>). These exercise the core acceptance
+/// criteria without any database or DI container.
+/// </summary>
+public class SandboxedScriptingTests
+{
+    private static ScriptSandboxOptions EnabledSandbox() => new()
+    {
+        Enabled = true,
+        AllowUnsafe = false,
+        AllowedAssemblies =
+        {
+            "System.Private.CoreLib",
+            "System.Runtime",
+            "System.Collections",
+            "System.Linq",
+            "netstandard"
+        },
+        BannedNamespaces = [] // mandatory baseline still applies
+    };
+
+    private static MetadataReference ContractRef =>
+        MetadataReference.CreateFromFile(typeof(ISandboxTestCalc).Assembly.Location);
+
+    [Fact]
+    public async Task Sandbox_Blocks_Banned_Namespace()
+    {
+        var evaluator = new CSharpEvaluator(EnabledSandbox());
+        const string code = "public class C : ISandboxTestCalc { public int Calc() { var s = new System.IO.MemoryStream(); return (int)s.Length; } }";
+
+        var ex = await Should.ThrowAsync<ScriptCompilationException>(async () =>
+            await evaluator.CompileToInstanceAsync<ISandboxTestCalc>(code, extraReferences: [ContractRef]));
+
+        ex.Message.ShouldContain("System.IO");
+    }
+
+    [Fact]
+    public async Task MandatoryBan_Cannot_Be_Removed_By_Config()
+    {
+        // Even with an empty configured ban list, the mandatory baseline still blocks System.IO.
+        var options = EnabledSandbox();
+        options.BannedNamespaces = [];
+        var evaluator = new CSharpEvaluator(options);
+        const string code = "public class C : ISandboxTestCalc { public int Calc() { var s = new System.IO.MemoryStream(); return (int)s.Length; } }";
+
+        await Should.ThrowAsync<ScriptCompilationException>(async () =>
+            await evaluator.CompileToInstanceAsync<ISandboxTestCalc>(code, extraReferences: [ContractRef]));
+    }
+
+    [Fact]
+    public async Task Sandbox_Blocks_Net_Http_Even_When_Assembly_Granted()
+    {
+        // Granting the assembly widens the reference allow-list but must NOT bypass the mandatory
+        // banned-namespace analyzer: System.Net / System.Net.Http stay blocked.
+        var options = EnabledSandbox();
+        options.AllowedAssemblies.Add("System.Net.Http");
+        var evaluator = new CSharpEvaluator(options);
+
+        const string code =
+            "public class C : ISandboxTestCalc { public int Calc() { var h = new System.Net.Http.HttpClient(); return 0; } }";
+
+        var ex = await Should.ThrowAsync<ScriptCompilationException>(async () =>
+            await evaluator.CompileToInstanceAsync<ISandboxTestCalc>(
+                code, extraReferences: [ContractRef], usingDirectives: ["BBT.Workflow.Scripting"]));
+
+        ex.Message.ShouldContain("System.Net");
+    }
+
+    [Fact]
+    public async Task Sandbox_Blocks_DllImport()
+    {
+        var evaluator = new CSharpEvaluator(EnabledSandbox());
+        const string code =
+            "public class C : ISandboxTestCalc { [System.Runtime.InteropServices.DllImport(\"x\")] static extern int Native(); public int Calc() => 1; }";
+
+        var ex = await Should.ThrowAsync<ScriptCompilationException>(async () =>
+            await evaluator.CompileToInstanceAsync<ISandboxTestCalc>(code, extraReferences: [ContractRef]));
+
+        ex.Message.ShouldContain("DllImport");
+    }
+
+    [Fact]
+    public async Task Sandbox_Allows_Threading_And_Tasks()
+    {
+        // System.Threading (and System.Threading.Tasks) are intentionally allowed under the sandbox.
+        var evaluator = new CSharpEvaluator(EnabledSandbox());
+        const string code =
+            "public class C : ISandboxTestCalc { public int Calc() { int n = 6; System.Threading.Interlocked.Increment(ref n); var t = System.Threading.Tasks.Task.FromResult(n); return t.Result; } }";
+
+        var instance = await evaluator.CompileToInstanceAsync<ISandboxTestCalc>(
+            code, extraReferences: [ContractRef], usingDirectives: ["BBT.Workflow.Scripting"]);
+
+        instance.Calc().ShouldBe(7);
+    }
+
+    [Fact]
+    public async Task Sandbox_Disabled_Still_Blocks_Mandatory_Namespace()
+    {
+        // Even with the sandbox disabled, the mandatory bans are always enforced so mapping code can
+        // never use IO/network/reflection/etc.
+        var evaluator = new CSharpEvaluator(new ScriptSandboxOptions { Enabled = false });
+        const string code = "public class C : ISandboxTestCalc { public int Calc() { var s = new System.IO.MemoryStream(); return 42; } }";
+
+        var ex = await Should.ThrowAsync<ScriptCompilationException>(async () =>
+            await evaluator.CompileToInstanceAsync<ISandboxTestCalc>(
+                code, extraReferences: [ContractRef], usingDirectives: ["BBT.Workflow.Scripting"]));
+
+        ex.Message.ShouldContain("System.IO");
+    }
+
+    [Fact]
+    public async Task Sandbox_Disabled_Compiles_Benign_Mapping()
+    {
+        // A mapping that touches no banned namespace compiles normally when the sandbox is disabled.
+        var evaluator = new CSharpEvaluator(new ScriptSandboxOptions { Enabled = false });
+        const string code = "public class C : ISandboxTestCalc { public int Calc() { var list = new System.Collections.Generic.List<int> { 21 }; return list[0] * 2; } }";
+
+        var instance = await evaluator.CompileToInstanceAsync<ISandboxTestCalc>(
+            code, extraReferences: [ContractRef], usingDirectives: ["BBT.Workflow.Scripting"]);
+
+        instance.Calc().ShouldBe(42);
+    }
+
+    [Fact]
+    public async Task Sandbox_Allows_Dynamic_And_ExpandoObject_When_Expressions_Referenced()
+    {
+        // Regression: `dynamic` needs DynamicAttribute and System.Dynamic.ExpandoObject (both in
+        // System.Linq.Expressions) + the Microsoft.CSharp runtime binder. These are runtime-owned
+        // references that must always be present even under the sandbox.
+        var evaluator = new CSharpEvaluator(EnabledSandbox());
+        const string code =
+            "public class C : ISandboxTestCalc { public int Calc() { dynamic o = new System.Dynamic.ExpandoObject(); o.x = 5; return (int)o.x; } }";
+
+        var refs = new[]
+        {
+            ContractRef,
+            MetadataReference.CreateFromFile(typeof(System.Dynamic.ExpandoObject).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo).Assembly.Location)
+        };
+
+        var instance = await evaluator.CompileToInstanceAsync<ISandboxTestCalc>(
+            code, extraReferences: refs, usingDirectives: ["BBT.Workflow.Scripting"]);
+
+        instance.Calc().ShouldBe(5);
+    }
+
+    [Fact]
+    public void HelperRegistry_Compiles_Set_And_Exposes_Namespaces()
+    {
+        var sandbox = EnabledSandbox();
+        var registry = new ScriptHelperRegistry(new CSharpEvaluator(sandbox), sandbox);
+
+        var helper = new HelperSource(
+            "tax-calculator", "1.0.0",
+            "namespace MyHelpers { public static class TaxCalc { public static int Tax(int x) => x / 10; } }",
+            "tax-calculator.csx");
+
+        var set = registry.GetOrBuildHelpers([helper], null, [], ["System"]);
+
+        set.Namespaces.ShouldContain("MyHelpers");
+        set.FromCache.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void HelperRegistry_Caches_By_Content_Hash()
+    {
+        var sandbox = EnabledSandbox();
+        var registry = new ScriptHelperRegistry(new CSharpEvaluator(sandbox), sandbox);
+
+        var helper = new HelperSource(
+            "tax-calculator", "1.0.0",
+            "namespace MyHelpers { public static class TaxCalc { public static int Tax(int x) => x / 10; } }",
+            "tax-calculator.csx");
+
+        var first = registry.GetOrBuildHelpers([helper], null, [], ["System"]);
+        var second = registry.GetOrBuildHelpers([helper], null, [], ["System"]);
+
+        first.FromCache.ShouldBeFalse();
+        second.FromCache.ShouldBeTrue();
+        second.LoadContext.ShouldBeSameAs(first.LoadContext);
+    }
+
+    [Fact]
+    public async Task Mapping_Can_Call_Referenced_Helper()
+    {
+        var sandbox = EnabledSandbox();
+        var evaluator = new CSharpEvaluator(sandbox);
+        var registry = new ScriptHelperRegistry(evaluator, sandbox);
+
+        var helper = new HelperSource(
+            "tax-calculator", "1.0.0",
+            "namespace MyHelpers { public static class TaxCalc { public static int Tax(int x) => x / 10; } }",
+            "tax-calculator.csx");
+
+        var set = registry.GetOrBuildHelpers([helper], null, [], ["System"]);
+
+        // Mapping references the helper assembly + auto-imports its namespace, compiled into the
+        // helper set's load context so the call resolves at runtime.
+        const string mapping = "public class C : ISandboxTestCalc { public int Calc() => MyHelpers.TaxCalc.Tax(100); }";
+
+        var instance = await evaluator.CompileToInstanceAsync<ISandboxTestCalc>(
+            mapping,
+            extraReferences: new[] { ContractRef, set.Reference },
+            usingDirectives: set.Namespaces.Append("BBT.Workflow.Scripting"),
+            loadContext: set.LoadContext);
+
+        instance.Calc().ShouldBe(10);
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/Scripting/ScriptCodeModelTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Scripting/ScriptCodeModelTests.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Linq;
+using System.Text.Json;
+using BBT.Workflow.Definitions;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Scripting;
+
+/// <summary>
+/// Tests for the Extension-2 model changes: the <c>scripts</c> object, <see cref="ScriptSettings.Union"/>,
+/// and the polymorphic <c>code</c> field (string vs <see cref="Reference"/> for <c>REF</c> encoding) via
+/// <see cref="ScriptCodeJsonConverter"/>.
+/// </summary>
+public class ScriptCodeModelTests
+{
+    private static readonly JsonSerializerOptions Options = JsonSerializerConstants.JsonOptions;
+
+    [Fact]
+    public void ScriptSettings_Union_Dedupes_Helpers_And_Merges_Grants()
+    {
+        var flow = new ScriptSettings(
+            new[] { new Reference("rsa-crypto", "core", "sys-mappings", "1.0.0") },
+            new[] { "System.Security.Cryptography" });
+
+        var task = new ScriptSettings(
+            new[]
+            {
+                new Reference("rsa-crypto", "core", "sys-mappings", "1.0.0"), // duplicate of flow's
+                new Reference("json-helper", "core", "sys-mappings", "1.0.0")
+            },
+            new[] { "System.Text.Json", "system.security.cryptography" }); // last is a case-variant dup
+
+        var union = ScriptSettings.Union(flow, task);
+
+        union.ShouldNotBeNull();
+        union!.Helpers!.Count.ShouldBe(2); // rsa-crypto (deduped) + json-helper
+        union.Helpers!.Select(h => h.Key).ShouldBe(new[] { "rsa-crypto", "json-helper" });
+        union.AllowedAssemblies!.Count.ShouldBe(2); // crypto (deduped, case-insensitive) + json
+    }
+
+    [Fact]
+    public void ScriptSettings_Union_Returns_NonNull_Side_When_Other_Null()
+    {
+        var task = new ScriptSettings(new[] { new Reference("h", "core", "sys-mappings", "1.0.0") }, null);
+
+        ScriptSettings.Union(null, task).ShouldBeSameAs(task);
+        ScriptSettings.Union(task, null).ShouldBeSameAs(task);
+        ScriptSettings.Union(null, null).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ScriptCode_Json_Reads_Scripts_Object_For_Native_Code()
+    {
+        const string json = """
+        {
+          "location": "./src/UserSessionMapping.csx",
+          "code": "public class M {}",
+          "encoding": "NAT",
+          "scripts": {
+            "helpers": [ { "key": "rsa-crypto", "version": "1.0.0", "domain": "core", "flow": "sys-mappings" } ],
+            "allowedAssemblies": [ "System.Security.Cryptography" ]
+          }
+        }
+        """;
+
+        var sc = JsonSerializer.Deserialize<ScriptCode>(json, Options);
+
+        sc.ShouldNotBeNull();
+        sc!.Encoding.ShouldBe(CodeEncoding.Native);
+        sc.IsReference.ShouldBeFalse();
+        sc.DecodedCode.ShouldBe("public class M {}");
+        sc.HasMappingCode.ShouldBeTrue();
+        sc.HasHelpers.ShouldBeTrue();
+        sc.Scripts!.Helpers!.Single().Key.ShouldBe("rsa-crypto");
+        sc.Scripts.AllowedAssemblies!.ShouldContain("System.Security.Cryptography");
+    }
+
+    [Fact]
+    public void ScriptCode_Json_Reads_Reference_Code_For_Ref_Encoding()
+    {
+        const string json = """
+        {
+          "code": { "key": "json-helper", "version": "1.0.0", "domain": "core", "flow": "sys-mappings" },
+          "encoding": "REF"
+        }
+        """;
+
+        var sc = JsonSerializer.Deserialize<ScriptCode>(json, Options);
+
+        sc.ShouldNotBeNull();
+        sc!.IsReference.ShouldBeTrue();
+        sc.CodeReference.ShouldNotBeNull();
+        sc.CodeReference!.Key.ShouldBe("json-helper");
+        sc.CodeReference.Flow.ShouldBe("sys-mappings");
+        sc.HasMappingCode.ShouldBeTrue();
+        Should.Throw<InvalidOperationException>(() => _ = sc.DecodedCode);
+    }
+
+    [Fact]
+    public void ScriptCode_Json_RoundTrips_Ref_Encoding()
+    {
+        var original = ScriptCode.FromReference(new Reference("json-helper", "core", "sys-mappings", "1.0.0"));
+
+        var json = JsonSerializer.Serialize(original, Options);
+        var clone = JsonSerializer.Deserialize<ScriptCode>(json, Options);
+
+        clone.ShouldNotBeNull();
+        clone!.IsReference.ShouldBeTrue();
+        clone.CodeReference!.ToString().ShouldBe("core/sys-mappings/json-helper/1.0.0");
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/Tasks/Executors/NotificationTaskExecutorTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Tasks/Executors/NotificationTaskExecutorTests.cs
@@ -128,7 +128,7 @@ public sealed class NotificationTaskExecutorTests
     {
         var engine = Substitute.For<IScriptEngine>();
         engine.CompileToInstanceAsync<INotificationMapping>(
-                Arg.Any<string>(),
+                Arg.Any<ScriptCode>(), Arg.Any<ScriptSettings>(),
                 Arg.Any<IEnumerable<Microsoft.CodeAnalysis.MetadataReference>?>(),
                 Arg.Any<IEnumerable<string>?>(),
                 Arg.Any<CancellationToken>())
@@ -137,7 +137,7 @@ public sealed class NotificationTaskExecutorTests
         if (stateMapping is not null)
         {
             engine.CompileToInstanceAsync<IStateNotificationMapping>(
-                    Arg.Any<string>(),
+                    Arg.Any<ScriptCode>(), Arg.Any<ScriptSettings>(),
                     Arg.Any<IEnumerable<Microsoft.CodeAnalysis.MetadataReference>?>(),
                     Arg.Any<IEnumerable<string>?>(),
                     Arg.Any<CancellationToken>())
@@ -146,7 +146,7 @@ public sealed class NotificationTaskExecutorTests
         else
         {
             engine.CompileToInstanceAsync<IStateNotificationMapping>(
-                    Arg.Any<string>(),
+                    Arg.Any<ScriptCode>(), Arg.Any<ScriptSettings>(),
                     Arg.Any<IEnumerable<Microsoft.CodeAnalysis.MetadataReference>?>(),
                     Arg.Any<IEnumerable<string>?>(),
                     Arg.Any<CancellationToken>())
@@ -431,7 +431,7 @@ public sealed class NotificationTaskExecutorTests
     {
         var scriptEngine = Substitute.For<IScriptEngine>();
         scriptEngine.CompileToInstanceAsync<IStateNotificationMapping>(
-                Arg.Any<string>(),
+                Arg.Any<ScriptCode>(), Arg.Any<ScriptSettings>(),
                 Arg.Any<IEnumerable<Microsoft.CodeAnalysis.MetadataReference>?>(),
                 Arg.Any<IEnumerable<string>?>(),
                 Arg.Any<CancellationToken>())
@@ -446,7 +446,7 @@ public sealed class NotificationTaskExecutorTests
 
         result.IsSuccess.ShouldBeTrue();
         await scriptEngine.DidNotReceive().CompileToInstanceAsync<INotificationMapping>(
-            Arg.Any<string>(),
+            Arg.Any<ScriptCode>(), Arg.Any<ScriptSettings>(),
             Arg.Any<IEnumerable<Microsoft.CodeAnalysis.MetadataReference>?>(),
             Arg.Any<IEnumerable<string>?>(),
             Arg.Any<CancellationToken>());
@@ -458,7 +458,7 @@ public sealed class NotificationTaskExecutorTests
         var mapping = CreateMapping();
         var scriptEngine = Substitute.For<IScriptEngine>();
         scriptEngine.CompileToInstanceAsync<INotificationMapping>(
-                Arg.Any<string>(),
+                Arg.Any<ScriptCode>(), Arg.Any<ScriptSettings>(),
                 Arg.Any<IEnumerable<Microsoft.CodeAnalysis.MetadataReference>?>(),
                 Arg.Any<IEnumerable<string>?>(),
                 Arg.Any<CancellationToken>())
@@ -472,7 +472,7 @@ public sealed class NotificationTaskExecutorTests
 
         result.IsSuccess.ShouldBeTrue();
         await scriptEngine.DidNotReceive().CompileToInstanceAsync<IStateNotificationMapping>(
-            Arg.Any<string>(),
+            Arg.Any<ScriptCode>(), Arg.Any<ScriptSettings>(),
             Arg.Any<IEnumerable<Microsoft.CodeAnalysis.MetadataReference>?>(),
             Arg.Any<IEnumerable<string>?>(),
             Arg.Any<CancellationToken>());

--- a/vnext-meta/features.json
+++ b/vnext-meta/features.json
@@ -1,3 +1,19 @@
 {
-
+  "runtimeVersion": "0.0.58",
+  "engine": {
+    "customScriptHelpers": {
+      "since": "0.0.58",
+      "status": "experimental",
+      "configFlag": "Scripting:Helpers:Enabled",
+      "description": "Reference reusable C# helper components (sys-mappings) from a mapping via mapping.scripts.helpers[] (Reference: key/version/domain/flow), with a per-mapping mapping.scripts.allowedAssemblies grant. A workflow may also declare a flow-level scripts object that is unioned with each mapping's scripts (helpers deduped, assemblies merged). The referenced helper set is compiled first under a best-effort compile-time sandbox (reference allow-list + mandatory banned-namespace analyzer), cached by content hash, then the mapping is compiled against it with helper namespaces auto-imported. A mapping may set encoding=REF to run a sys-mappings component directly (code is a Reference, resolved from the component store; single level, no REF chaining). Grants merge on top of the Scripting:Sandbox:AllowedAssemblies baseline. Disabled by default; not a hard security boundary.",
+      "relatedConfig": [
+        "Scripting:Helpers:Enabled",
+        "Scripting:Sandbox:Enabled",
+        "Scripting:Sandbox:AllowedAssemblies",
+        "Scripting:Sandbox:BannedNamespaces",
+        "Scripting:Sandbox:PluginDirectory",
+        "Scripting:Sandbox:AllowUnsafe"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
Closes #710.

## What & why

Lets domain teams ship reusable C# helpers as versioned **`sys-mappings`** components and reference them from a mapping. At transition time the runtime builds the referenced helper set first (sandboxed, cached by content hash), then compiles and runs the mapping against it — without base-image rebuilds or startup folders. Helpers travel with the domain like every other component.

> Best-effort **compile-time** gate for same-org teams — **not** a hard security boundary. .NET has no in-process sandbox; for a true boundary isolate at the process/container level.

## Core feature

- **`sys-mappings` system component** (`Mapping` entity) integrated like other `sys-*` components: `RuntimeSysSchemaInfo.Mappings`, schema registration (DbMigrator auto-provisions `sys_mappings`), `DomainCacheContext`/`IComponentCacheStore.GetMappingAsync`, `MappingWorkflowCastHandler`, `MappingComponentValidator`, `SchemaValidator` allow-list.
- **Scripting sandbox module** (`modules/.../Scripting/{Sandbox,Helpers}`): `ScriptSandboxOptions`/`ScriptHelpersOptions`, `SandboxedReferenceSet`, `BannedApiAnalyzer`, `IScriptHelperRegistry`/`ScriptHelperRegistry` (content-hash cache + collectible ALC, operator plugin preload). `IEvaluator`/`CSharpEvaluator` extended for a sandboxed multi-source compile path.
- **`ScriptEngine`** resolves referenced helpers, builds the set first, then compiles the mapping into the same ALC with helper namespaces auto-imported. All `IScriptEngine` consumers migrated to the `ScriptCode` overload.

## `scripts` object, flow-level scripts, `REF` encoding (architecture committee)

- `helpers` + `allowedAssemblies` now live under **`mapping.scripts`** (`ScriptSettings`).
- A workflow may declare a **flow-level `scripts`** object, **unioned** with each mapping's scripts (helpers deduped, allowed assemblies merged).
- **`encoding: "REF"`** — `code` is a `Reference` to a `sys-mappings` component, resolved from the component store (single level, no chaining). Polymorphic `code` handled by a custom `ScriptCodeJsonConverter`.

## Sandbox hardening

- **Mandatory banned namespaces** — `System.IO`, `System.Net`, `System.Net.Http`, `System.Diagnostics`, `System.Reflection`, `System.Runtime.InteropServices`, `Microsoft.Win32` — enforced on **every** compile, even when the sandbox is disabled. Config may only *add*, never remove. `DllImport`/`unsafe` rejected. `System.Threading` (+ `Tasks`) intentionally allowed. `System.Linq.Expressions` is runtime-owned so `dynamic`/`ExpandoObject` always work.
- `Sandbox.Enabled` only gates the curated reference allow-list + operator-added bans (default `false`).

## Caller Role/Roles propagation

- `ResolveCallerRole`/`ResolveCallerRoles` (currentUser → header `role` → null).
- `GetFunctionWithInstanceInput` gains `Roles`; both `Role` and `Roles` are populated and forwarded across the local route (gateway) and the State/View/Data/Schema HTTP handlers.

## Config

`Scripting:Helpers:Enabled` and `Scripting:Sandbox:Enabled` are independent switches (defaults `false` in committed appsettings; the orchestration host currently has them enabled for local testing — reviewers may want to confirm the intended default before release). Helpers work without the sandbox; the sandbox is the stricter compile-time gate.

## Tests

New unit coverage under `test/BBT.Workflow.Application.Tests/`:
- `Scripting/SandboxedScriptingTests` — banned namespace / mandatory-ban-not-removable / DllImport / Net.Http-blocked-even-when-granted / threading allowed / dynamic+ExpandoObject / disabled-still-blocks-mandatory / helper compile + namespaces / content-hash caching / mapping-calls-helper.
- `Scripting/ScriptCodeModelTests` — `ScriptSettings.Union`, `scripts.helpers` JSON, `REF` `code` → `CodeReference` round-trip.
- `CurrentUser/CurrentUserHeaderExtensionsTests` — role/roles resolution incl. header fallback.

`dotnet build` 0 errors. Affected suites (Scripting / Notification / ResourceLock / Function / SubFlow / CurrentUser) green. Pre-existing, unrelated failures remain in `RemoteInvokerServiceTests` and `InstanceQueryAppServiceHistory/Version` (Dapr timeout / data-path; not touched here).

## Docs / meta

`docs/custom-script-helpers.md` (authoring, `scripts`, flow-level, `REF`, config, plugin DLLs) and `vnext-meta/features.json` (`custom-script-helpers`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Custom script helpers system with configurable sandbox compilation and security controls
  * Mapping components for reusable script definitions
  * Enhanced role-resolution capabilities in workflow function and SubFlow execution paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->