### PR TITLE
fix(instances): remove EF compiled queries, fix key uniqueness check

### DIFF
--- a/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
@@ -111,8 +111,13 @@ public sealed class InstanceCommandAppService(
         var instanceId = input.Instance.Id;
         var instanceKey = input.Instance.Key;
 
+        // Key path: only a non-terminal (Active/Busy) row occupies the key. A plain
+        // FindByIdentifierAsync(key) uses FirstOrDefault with no status filter, so when terminal
+        // history rows share the key it can return an arbitrary (possibly completed) row and let a
+        // second active instance be created. FindActiveByKeyAsync is the deterministic check.
+        // Id path: the PK is unique, so FindByIdentifierAsync is already deterministic.
         var existingInstance = !instanceKey.IsNullOrWhiteSpace()
-            ? await instanceRepository.FindByIdentifierAsync(instanceKey, cancellationToken)
+            ? await instanceRepository.FindActiveByKeyAsync(instanceKey, cancellationToken)
             : instanceId.HasValue
                 ? await instanceRepository.FindByIdentifierAsync(instanceId.Value.ToString(), cancellationToken)
                 : null;

--- a/src/BBT.Workflow.Domain/Instances/IInstanceRepository.cs
+++ b/src/BBT.Workflow.Domain/Instances/IInstanceRepository.cs
@@ -15,6 +15,15 @@ public interface IInstanceRepository : IRepository<Instance, Guid>
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Finds the single non-terminal instance (status Active or Busy) for the given key, or null
+    /// if none exists. Terminal rows (Completed/Faulted/Passive) are ignored, so this is the
+    /// authoritative "is this key currently in use?" lookup — unlike <see cref="FindByIdentifierAsync"/>,
+    /// which matches any row regardless of status.
+    /// </summary>
+    Task<Instance?> FindActiveByKeyAsync(string key,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Loads a read-only (no-tracking) instance with the full <see cref="Instance.DataList"/>
     /// history. Dedicated to <c>GetInstanceHistoryAsync</c> where detached entities are sufficient.
     /// </summary>

--- a/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceRepository.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceRepository.cs
@@ -30,34 +30,6 @@ public sealed class EfCoreInstanceRepository(
     : EfCoreRepository<WorkflowDbContext, Instance, Guid>(dbContext, serviceProvider),
         IInstanceRepository
 {
-    #region Compiled Queries
-
-    private static readonly Func<WorkflowDbContext, string, Guid, Task<bool>>
-        AnyActiveByKeyCompiledQuery = EF.CompileAsyncQuery(
-            (WorkflowDbContext ctx, string key, Guid excludeId) =>
-                ctx.Instances.Any(
-                    i => i.Key == key
-                         && i.Id != excludeId
-                         && i.Status == InstanceStatus.Active));
-
-    private static readonly Func<WorkflowDbContext, string, string, IAsyncEnumerable<InstanceAndDataModel>>
-        FindActiveDataExactCompiledQuery = EF.CompileAsyncQuery(
-            (WorkflowDbContext ctx, string key, string version) =>
-                ctx.Instances
-                    .Where(i => i.Status == InstanceStatus.Active && i.Key == key)
-                    .Join(ctx.InstancesData,
-                        i => i.Id,
-                        d => d.InstanceId,
-                        (i, d) => new { Instance = i, Data = d })
-                    .Where(x => x.Data.Version == version)
-                    .Select(x => new InstanceAndDataModel
-                    {
-                        Instance = x.Instance,
-                        InstanceData = x.Data
-                    }));
-
-    #endregion
-
     public override async Task<IQueryable<Instance>> WithDetailsAsync()
     {
         // Loads the full InstanceData history so that Instance.AddData can perform
@@ -173,6 +145,23 @@ public sealed class EfCoreInstanceRepository(
                 cancellationToken);
     }
 
+    /// <inheritdoc />
+    public async Task<Instance?> FindActiveByKeyAsync(string key,
+        CancellationToken cancellationToken = default)
+    {
+        var query = (await WithDetailsAsync())
+            .AsSplitQuery();
+
+        // Only non-terminal instances occupy a key (Active or Busy). Terminal rows
+        // (Completed/Faulted/Passive) are ignored. OrderByDescending(CreatedAt) keeps the
+        // result deterministic even if legacy data left more than one live row for a key.
+        return await query
+            .Where(i => i.Key == key
+                        && (i.Status == InstanceStatus.Active || i.Status == InstanceStatus.Busy))
+            .OrderByDescending(i => i.CreatedAt)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
     public async Task<Instance?> FindByIdentifierAsReadOnlyAsync(string identifier,
         CancellationToken cancellationToken = default)
     {
@@ -275,15 +264,23 @@ public sealed class EfCoreInstanceRepository(
     {
         var context = await GetDbContextAsync();
 
-        // If full version → exact match via compiled query (avoids expression tree re-compilation)
+        // If full version → exact match
         if (InstanceDataVersionComparer.IsFullVersion(version))
         {
-            await foreach (var item in FindActiveDataExactCompiledQuery(context, key, version))
-            {
-                return item;
-            }
-
-            return null;
+            return await context.Instances
+                .Where(i => i.Status == InstanceStatus.Active && i.Key == key)
+                .Join(context.InstancesData,
+                    i => i.Id,
+                    d => d.InstanceId,
+                    (i, d) => new { Instance = i, Data = d })
+                .Where(x => x.Data.Version == version)
+                .Select(x => new InstanceAndDataModel
+                {
+                    Instance = x.Instance,
+                    InstanceData = x.Data
+                })
+                .AsNoTracking()
+                .FirstOrDefaultAsync(cancellationToken);
         }
 
         // For artifact or partial version → load all matching versions and use smart matching
@@ -1034,7 +1031,11 @@ public sealed class EfCoreInstanceRepository(
         CancellationToken cancellationToken = default)
     {
         var context = await GetDbContextAsync();
-        return await AnyActiveByKeyCompiledQuery(context, key, excludeInstanceId);
+        return await context.Instances.AnyAsync(
+            i => i.Key == key
+                 && i.Id != excludeInstanceId
+                 && (i.Status == InstanceStatus.Active || i.Status == InstanceStatus.Busy),
+            cancellationToken);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Summary
- Remove both `EF.CompileAsyncQuery` compiled queries from the instance repository — they cache the resolved schema on a static delegate and bind to the wrong schema / stale connection under PGBouncer transaction pooling + multi-schema. Replaced with inline async LINQ so the current schema resolves per request.
- Fix the non-deterministic instance-start duplicate-key check: the key path used `FindByIdentifierAsync(key)` -> `FirstOrDefault` with no status filter, so terminal history rows sharing a key could let a second active instance be created.
- Unify the "active" predicate as `Active || Busy` (the complement of `Instance.IsCompleted`) across the start check and both transition-side key checks.

## Changes
- `src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceRepository.cs` — drop the `Compiled Queries` region; rewrite `AnyActiveByKeyAsync` (inline `AnyAsync`, now Active+Busy) and `FindActiveDataAsync` full-version branch (inline `FirstOrDefaultAsync`); add deterministic `FindActiveByKeyAsync` (Active/Busy, ordered by `CreatedAt`).
- `src/BBT.Workflow.Domain/Instances/IInstanceRepository.cs` — add `FindActiveByKeyAsync` contract.
- `src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs` — `CheckExistingInstanceAsync` key path uses `FindActiveByKeyAsync`; id path keeps `FindByIdentifierAsync` (PK is unique).
- Transition-side checks (`CreateTransitionRecordStep`, `HandleUpdateDataPreflightStep`) already call `AnyActiveByKeyAsync` and inherit the corrected predicate — no logic change.

## Test Plan
- [ ] `dotnet build` succeeds (Infrastructure + Application verified locally).
- [ ] Grep confirms zero `EF.CompileQuery` / `EF.CompileAsyncQuery` usages repo-wide.
- [ ] Application test suite shows no new failures vs. baseline (23 pre-existing, unrelated failures confirmed identical with/without changes).
- [ ] Manual: complete an instance with key `K`, then start a new one with key `K` (should succeed); start again while one is live (should be blocked — 409 under `StrictIdempotency`, idempotent return otherwise).
- [ ] Manual: start instances across two schemas behind PGBouncer and confirm the active-by-key check resolves the correct schema.

## Notes
- Closes #715.
- No DB unique constraint on instance key exists today, so a TOCTOU race remains between the existence check and persistence. Out of scope here; could be addressed separately with a partial unique index (e.g. `WHERE status IN ('A','B')`).
- A dedicated regression test for the start key-path is not yet added (no existing coverage for it); flagged in the issue as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Remove EF Core compiled queries from the instance repository and make key-based instance lookups deterministic and schema-safe.

Bug Fixes:
- Ensure key-based instance existence checks only consider active or busy instances and return a deterministic result when multiple rows share a key.

Enhancements:
- Replace EF Core compiled queries with inline async LINQ to avoid stale schema/connection issues and to keep active-instance queries consistent across code paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved instance lookup accuracy for idempotency checks. The system now correctly identifies only active instances when validating command idempotency, preventing scenarios where completed instances could incorrectly influence conflict detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->