### PR TITLE
Disable production Swagger and improve function/mapping error logging

### DIFF
--- a/execution/BBT.Workflow.Execution.HttpApi.Host/Microsoft/AspNetCore/Builder/ExecutionApiApplicationBuilderExtensions.cs
+++ b/execution/BBT.Workflow.Execution.HttpApi.Host/Microsoft/AspNetCore/Builder/ExecutionApiApplicationBuilderExtensions.cs
@@ -34,7 +34,9 @@ public static class ExecutionApiApplicationBuilderExtensions
         app.UseSecurityHeaders();
         app.UseCurrentUser();
         app.UseStaticFiles();
-        app.UseAetherApiVersioning();
+        app.UseAetherApiVersioning(
+            useSwagger: !app.Environment.IsProduction(),
+            useSwaggerUi: !app.Environment.IsProduction());
         app.UseRouting();
         app.UseHttpMetrics();
         app.MapMetrics(); 

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Definitions/DefinitionController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Definitions/DefinitionController.cs
@@ -10,6 +10,7 @@ namespace BBT.Workflow.Orchestration.Controllers.Definitions;
 public sealed class DefinitionController(
     IDefinitionAppService appService) : AetherControllerBase
 {
+    [ApiExplorerSettings(IgnoreApi = true)]
     [HttpPost("publish")]
     public async Task<IActionResult> PublishAsync(
         [FromBody] PublishInput input,

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Microsoft/AspNetCore/Builder/OrchestrationApiApplicationBuilderExtensions.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Microsoft/AspNetCore/Builder/OrchestrationApiApplicationBuilderExtensions.cs
@@ -35,7 +35,9 @@ public static class OrchestrationApiApplicationBuilderExtensions
         app.UseSecurityHeaders();
         app.UseCurrentUser();
         app.UseStaticFiles();
-        app.UseAetherApiVersioning();
+        app.UseAetherApiVersioning(
+            useSwagger: !app.Environment.IsProduction(),
+            useSwaggerUi: !app.Environment.IsProduction());
         app.UseRouting();
         app.UseSchemaResolution();
         app.UseAetherUnitOfWork();

--- a/src/BBT.Workflow.Application/Functions/FunctionAppService.cs
+++ b/src/BBT.Workflow.Application/Functions/FunctionAppService.cs
@@ -13,6 +13,7 @@ using BBT.Workflow.Logging;
 using BBT.Workflow.Runtime;
 using BBT.Workflow.Scripting;
 using BBT.Workflow.Tasks.Coordinator;
+using Microsoft.Extensions.Logging;
 
 namespace BBT.Workflow.Functions;
 
@@ -165,17 +166,54 @@ public sealed class FunctionAppService(
             .WithQueryParameters(queryParameters)
             .BuildAsync(cancellationToken);
 
-        var executeResult = await taskCoordinator.ExecuteAsync(
-            function.GetExecuteTasks(),
-            null,
-            TaskTrigger.Extension,
-            scriptContext,
-            cancellationToken);
+        Result executeResult;
+        try
+        {
+            executeResult = await taskCoordinator.ExecuteAsync(
+                function.GetExecuteTasks(),
+                null,
+                TaskTrigger.Extension,
+                scriptContext,
+                cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(
+                ex,
+                "Custom function {FunctionKey} execution threw an exception. Domain={Domain}, InstanceId={InstanceId}",
+                function.Key,
+                function.Domain,
+                instance?.Id);
+
+            return Result<FunctionResponseOutput>.Fail(Error.Failure(
+                WorkflowErrorCodes.ExtensionExecutionFailed,
+                $"Function '{function.Key}' execution failed: {ex.Message}"));
+        }
 
         if (!executeResult.IsSuccess)
-            return Result<FunctionResponseOutput>.Fail(executeResult.Error);
+        {
+            Logger.LogError(
+                "Custom function {FunctionKey} execution failed. Domain={Domain}, InstanceId={InstanceId}, Error={ErrorMessage}",
+                function.Key,
+                function.Domain,
+                instance?.Id,
+                executeResult.Error.Message ?? "Unknown error");
 
-        return await BuildResponseAsync(function, scriptContext, cancellationToken);
+            return Result<FunctionResponseOutput>.Fail(executeResult.Error);
+        }
+
+        var responseResult = await BuildResponseAsync(function, scriptContext, cancellationToken);
+        if (!responseResult.IsSuccess)
+        {
+            Logger.LogError(
+                "Custom function {FunctionKey} response mapping failed. Domain={Domain}, InstanceId={InstanceId}, Error={ErrorMessage}",
+                function.Key,
+                function.Domain,
+                instance?.Id,
+                responseResult.Error.Message ?? "Unknown error");
+        }
+
+        return responseResult;
     }
 
     /// <summary>
@@ -190,20 +228,36 @@ public sealed class FunctionAppService(
     {
         if (function.Output != null)
         {
-            var handler = await scriptEngine.CompileToInstanceAsync<IOutputHandler>(
-                function.Output, flowScripts: scriptContext.Workflow?.Scripts, cancellationToken: cancellationToken);
-            var scriptResponse = await handler.OutputHandler(scriptContext);
-
-            if (function.RawResponse)
-                return Result<FunctionResponseOutput>.Ok(CreateRawResponse(
-                    function,
-                    scriptContext,
-                    scriptResponse.Data));
-
-            return Result<FunctionResponseOutput>.Ok(new FunctionResponseOutput
+            try
             {
-                Data = new Dictionary<string, dynamic?> { [function.Key.ToVariableName()] = scriptResponse.Data }
-            });
+                var handler = await scriptEngine.CompileToInstanceAsync<IOutputHandler>(
+                    function.Output, flowScripts: scriptContext.Workflow?.Scripts, cancellationToken: cancellationToken);
+                var scriptResponse = await handler.OutputHandler(scriptContext);
+
+                if (function.RawResponse)
+                    return Result<FunctionResponseOutput>.Ok(CreateRawResponse(
+                        function,
+                        scriptContext,
+                        scriptResponse.Data));
+
+                return Result<FunctionResponseOutput>.Ok(new FunctionResponseOutput
+                {
+                    Data = new Dictionary<string, dynamic?> { [function.Key.ToVariableName()] = scriptResponse.Data }
+                });
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(
+                    ex,
+                    "Custom function {FunctionKey} output ScriptMapping failed. Domain={Domain}, InstanceId={InstanceId}",
+                    function.Key,
+                    function.Domain,
+                    scriptContext.Instance?.Id);
+
+                return Result<FunctionResponseOutput>.Fail(Error.Failure(
+                    WorkflowErrorCodes.ExtensionExecutionFailed,
+                    $"Function '{function.Key}' output ScriptMapping failed: {ex.Message}"));
+            }
         }
 
         if (function.RawResponse)

--- a/src/BBT.Workflow.Application/Tasks/Coordinator/TaskExecutionEngine.cs
+++ b/src/BBT.Workflow.Application/Tasks/Coordinator/TaskExecutionEngine.cs
@@ -609,10 +609,9 @@ public sealed class TaskExecutionEngine : ITaskExecutionEngine
             if (!boundaryChain.HasAnyBoundary)
             {
                 // No ErrorBoundary - let flow continue with auto-transitions
-                _logger.LogDebug(
-                    "Task {TaskKey} failed with business error (StatusCode: {StatusCode}), " +
-                    "but no ErrorBoundary is defined. Flow will continue with auto-transitions.",
-                    task.Key, response.StatusCode);
+                _logger.LogError(
+                    "Task {TaskKey} failed with business error (StatusCode: {StatusCode}) and no ErrorBoundary is defined. Flow will continue with auto-transitions. Error: {Error}",
+                    task.Key, response.StatusCode, executionError.ErrorMessage);
 
                 // Add event only — span Status stays OK since the flow continues normally via auto-transitions
                 TaskExecutionActivityHelper.AddFailedEvent(Activity.Current, executionError.ErrorMessage, taskTypeStr, response.StatusCode);
@@ -628,10 +627,9 @@ public sealed class TaskExecutionEngine : ITaskExecutionEngine
             }
 
             // ErrorBoundary exists - return failure for retry evaluation
-            _logger.LogDebug(
-                "Task {TaskKey} failed with business error (StatusCode: {StatusCode}). " +
-                "ErrorBoundary is configured - retry policy will be evaluated.",
-                task.Key, response.StatusCode);
+            _logger.LogError(
+                "Task {TaskKey} failed with business error (StatusCode: {StatusCode}). ErrorBoundary is configured - retry policy will be evaluated. Error: {Error}",
+                task.Key, response.StatusCode, executionError.ErrorMessage);
 
             // Add event per attempt so each failure is visible in the trace timeline
             TaskExecutionActivityHelper.AddFailedEvent(Activity.Current, executionError.ErrorMessage, executionError.TaskType, response.StatusCode);

--- a/src/BBT.Workflow.Application/Tasks/Executors/Dapr/DaprBindingTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Dapr/DaprBindingTaskExecutor.cs
@@ -63,7 +63,7 @@ public sealed class DaprBindingTaskExecutor : TaskExecutorBase<DaprBindingTask>
             Logger.TaskInputHandlerFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext.Instance?.Id ?? Guid.Empty,
                 result.Error.Message ?? "Unknown error");
         }
 
@@ -82,7 +82,7 @@ public sealed class DaprBindingTaskExecutor : TaskExecutorBase<DaprBindingTask>
             Logger.TaskEnvelopeCreationFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext.Instance?.Id ?? Guid.Empty,
                 envelopeResult.Error.Message ?? "Unknown error");
             return Result<TaskInvocationResult>.Fail(envelopeResult.Error);
         }
@@ -101,7 +101,7 @@ public sealed class DaprBindingTaskExecutor : TaskExecutorBase<DaprBindingTask>
             Logger.TaskInvocationFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext.Instance?.Id ?? Guid.Empty,
                 result.Error.Message ?? "Unknown error");
         }
 
@@ -141,7 +141,7 @@ public sealed class DaprBindingTaskExecutor : TaskExecutorBase<DaprBindingTask>
             Logger.TaskOutputHandlerFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext.Instance?.Id ?? Guid.Empty,
                 result.Error.Message ?? "Unknown error");
         }
 

--- a/src/BBT.Workflow.Application/Tasks/Executors/Dapr/DaprHttpEndpointTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Dapr/DaprHttpEndpointTaskExecutor.cs
@@ -63,7 +63,7 @@ public sealed class DaprHttpEndpointTaskExecutor : TaskExecutorBase<DaprHttpEndp
             Logger.TaskInputHandlerFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext.Instance?.Id ?? Guid.Empty,
                 result.Error.Message ?? "Unknown error");
         }
 
@@ -82,7 +82,7 @@ public sealed class DaprHttpEndpointTaskExecutor : TaskExecutorBase<DaprHttpEndp
             Logger.TaskEnvelopeCreationFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext.Instance?.Id ?? Guid.Empty,
                 envelopeResult.Error.Message ?? "Unknown error");
             return Result<TaskInvocationResult>.Fail(envelopeResult.Error);
         }
@@ -101,7 +101,7 @@ public sealed class DaprHttpEndpointTaskExecutor : TaskExecutorBase<DaprHttpEndp
             Logger.TaskInvocationFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext.Instance?.Id ?? Guid.Empty,
                 result.Error.Message ?? "Unknown error");
         }
 
@@ -141,7 +141,7 @@ public sealed class DaprHttpEndpointTaskExecutor : TaskExecutorBase<DaprHttpEndp
             Logger.TaskOutputHandlerFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext.Instance?.Id ?? Guid.Empty,
                 result.Error.Message ?? "Unknown error");
         }
 

--- a/src/BBT.Workflow.Application/Tasks/Executors/Dapr/DaprPubSubTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Dapr/DaprPubSubTaskExecutor.cs
@@ -63,7 +63,7 @@ public sealed class DaprPubSubTaskExecutor : TaskExecutorBase<DaprPubSubTask>
             Logger.TaskInputHandlerFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext.Instance?.Id ?? Guid.Empty,
                 result.Error.Message ?? "Unknown error");
         }
 
@@ -82,7 +82,7 @@ public sealed class DaprPubSubTaskExecutor : TaskExecutorBase<DaprPubSubTask>
             Logger.TaskEnvelopeCreationFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext.Instance?.Id ?? Guid.Empty,
                 envelopeResult.Error.Message ?? "Unknown error");
             return Result<TaskInvocationResult>.Fail(envelopeResult.Error);
         }
@@ -101,7 +101,7 @@ public sealed class DaprPubSubTaskExecutor : TaskExecutorBase<DaprPubSubTask>
             Logger.TaskInvocationFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext.Instance?.Id ?? Guid.Empty,
                 result.Error.Message ?? "Unknown error");
         }
 
@@ -141,7 +141,7 @@ public sealed class DaprPubSubTaskExecutor : TaskExecutorBase<DaprPubSubTask>
             Logger.TaskOutputHandlerFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext.Instance?.Id ?? Guid.Empty,
                 result.Error.Message ?? "Unknown error");
         }
 

--- a/src/BBT.Workflow.Application/Tasks/Executors/Dapr/DaprServiceTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Dapr/DaprServiceTaskExecutor.cs
@@ -63,7 +63,7 @@ public sealed class DaprServiceTaskExecutor : TaskExecutorBase<DaprServiceTask>
             Logger.TaskInputHandlerFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext.Instance?.Id ?? Guid.Empty,
                 result.Error.Message ?? "Unknown error");
         }
 
@@ -82,7 +82,7 @@ public sealed class DaprServiceTaskExecutor : TaskExecutorBase<DaprServiceTask>
             Logger.TaskEnvelopeCreationFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext.Instance?.Id ?? Guid.Empty,
                 envelopeResult.Error.Message ?? "Unknown error");
             return Result<TaskInvocationResult>.Fail(envelopeResult.Error);
         }
@@ -101,7 +101,7 @@ public sealed class DaprServiceTaskExecutor : TaskExecutorBase<DaprServiceTask>
             Logger.TaskInvocationFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext.Instance?.Id ?? Guid.Empty,
                 result.Error.Message ?? "Unknown error");
         }
 
@@ -141,7 +141,7 @@ public sealed class DaprServiceTaskExecutor : TaskExecutorBase<DaprServiceTask>
             Logger.TaskOutputHandlerFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext.Instance?.Id ?? Guid.Empty,
                 result.Error.Message ?? "Unknown error");
         }
 

--- a/src/BBT.Workflow.Application/Tasks/Executors/Http/HttpTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Http/HttpTaskExecutor.cs
@@ -62,7 +62,7 @@ public sealed class HttpTaskExecutor : TaskExecutorBase<HttpTask>
             Logger.TaskInputHandlerFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext.Instance?.Id ?? Guid.Empty,
                 result.Error.Message ?? "Unknown error");
         }
 
@@ -82,7 +82,7 @@ public sealed class HttpTaskExecutor : TaskExecutorBase<HttpTask>
             Logger.TaskEnvelopeCreationFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext.Instance?.Id ?? Guid.Empty,
                 envelopeResult.Error.Message ?? "Unknown error");
             return Result<TaskInvocationResult>.Fail(envelopeResult.Error);
         }
@@ -101,7 +101,7 @@ public sealed class HttpTaskExecutor : TaskExecutorBase<HttpTask>
             Logger.TaskInvocationFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext.Instance?.Id ?? Guid.Empty,
                 result.Error.Message ?? "Unknown error");
         }
 
@@ -141,7 +141,7 @@ public sealed class HttpTaskExecutor : TaskExecutorBase<HttpTask>
             Logger.TaskOutputHandlerFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext.Instance?.Id ?? Guid.Empty,
                 result.Error.Message ?? "Unknown error");
         }
 

--- a/src/BBT.Workflow.Application/Tasks/Executors/Http/SoapTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Http/SoapTaskExecutor.cs
@@ -58,7 +58,7 @@ public sealed class SoapTaskExecutor : TaskExecutorBase<SoapTask>
             Logger.TaskInputHandlerFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext.Instance?.Id ?? Guid.Empty,
                 result.Error.Message ?? "Unknown error");
         }
 
@@ -77,7 +77,7 @@ public sealed class SoapTaskExecutor : TaskExecutorBase<SoapTask>
             Logger.TaskEnvelopeCreationFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext.Instance?.Id ?? Guid.Empty,
                 envelopeResult.Error.Message ?? "Unknown error");
             return Result<TaskInvocationResult>.Fail(envelopeResult.Error);
         }
@@ -96,7 +96,7 @@ public sealed class SoapTaskExecutor : TaskExecutorBase<SoapTask>
             Logger.TaskInvocationFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext.Instance?.Id ?? Guid.Empty,
                 result.Error.Message ?? "Unknown error");
         }
 
@@ -136,7 +136,7 @@ public sealed class SoapTaskExecutor : TaskExecutorBase<SoapTask>
             Logger.TaskOutputHandlerFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext.Instance?.Id ?? Guid.Empty,
                 result.Error.Message ?? "Unknown error");
         }
 

--- a/src/BBT.Workflow.Application/Tasks/Executors/Script/ScriptTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Script/ScriptTaskExecutor.cs
@@ -60,7 +60,7 @@ public sealed class ScriptTaskExecutor : TaskExecutorBase<ScriptTask>
             Logger.TaskInputHandlerFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext.Instance?.Id ?? Guid.Empty,
                 result.Error.Message ?? "Unknown error");
         }
 
@@ -103,7 +103,7 @@ public sealed class ScriptTaskExecutor : TaskExecutorBase<ScriptTask>
             Logger.TaskScriptCompilationFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext.Instance?.Id ?? Guid.Empty,
                 result.Error.Message ?? "Unknown error");
         }
         

--- a/src/BBT.Workflow.Application/Tasks/Executors/Trigger/SubProcessTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Trigger/SubProcessTaskExecutor.cs
@@ -407,7 +407,7 @@ public sealed class SubProcessTaskExecutor : TriggerTaskExecutorBase<SubProcessT
             Logger.TaskCorrelationFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext.Instance?.Id ?? Guid.Empty,
                 result.Error.Message ?? "Unknown error");
         }
 

--- a/src/BBT.Workflow.Application/Tasks/Executors/Trigger/TriggerTaskExecutorBase.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Trigger/TriggerTaskExecutorBase.cs
@@ -72,7 +72,7 @@ public abstract class TriggerTaskExecutorBase<TTask>(
             Logger.TaskInputHandlerFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext.Instance?.Id ?? Guid.Empty,
                 result.Error.Message ?? "Unknown error");
         }
 
@@ -113,7 +113,7 @@ public abstract class TriggerTaskExecutorBase<TTask>(
             Logger.TaskOutputHandlerFailed(
                 task.Key,
                 TaskType.ToString(),
-                context.ScriptContext.Instance.Id,
+                context.ScriptContext.Instance?.Id ?? Guid.Empty,
                 result.Error.Message ?? "Unknown error");
         }
 

--- a/workers/BBT.Workflow.Workers.Inbox/Microsoft/AspNetCore/Builder/InboxWorkerApplicationBuilderExtensions.cs
+++ b/workers/BBT.Workflow.Workers.Inbox/Microsoft/AspNetCore/Builder/InboxWorkerApplicationBuilderExtensions.cs
@@ -35,7 +35,9 @@ public static class InboxWorkerApplicationBuilderExtensions
         app.UseSecurityHeaders();
         app.UseCurrentUser();
         app.UseStaticFiles();
-        app.UseAetherApiVersioning();
+        app.UseAetherApiVersioning(
+            useSwagger: !app.Environment.IsProduction(),
+            useSwaggerUi: !app.Environment.IsProduction());
         app.UseRouting();
         app.UseSchemaResolution();
         app.UseAetherUnitOfWork();

--- a/workers/BBT.Workflow.Workers.Outbox/Microsoft/AspNetCore/Builder/OutboxWorkerApplicationBuilderExtensions.cs
+++ b/workers/BBT.Workflow.Workers.Outbox/Microsoft/AspNetCore/Builder/OutboxWorkerApplicationBuilderExtensions.cs
@@ -35,7 +35,9 @@ public static class OutboxWorkerApplicationBuilderExtensions
         app.UseSecurityHeaders();
         app.UseCurrentUser();
         app.UseStaticFiles();
-        app.UseAetherApiVersioning();
+        app.UseAetherApiVersioning(
+            useSwagger: !app.Environment.IsProduction(),
+            useSwaggerUi: !app.Environment.IsProduction());
         app.UseRouting();
         app.UseSchemaResolution();
         app.UseAetherUnitOfWork();


### PR DESCRIPTION
### Motivation

- Disable Swagger/UI in production for all Aether API hosts so the public production surface does not expose the API explorer via the pipeline helper `UseAetherApiVersioning`.
- Hide the administrative `PublishAsync` endpoint from API Explorer so publishing is not visible in Swagger UI.
- Ensure custom function execution and output/script-mapping failures are recorded as `Error` so production incidents are visible in logs and traces.
- Prevent NullReference logging when custom functions run without an instance context by making instance-id usage safe in task/script executor logs.

### Description

- Updated the `UseAetherApiVersioning` calls to pass `useSwagger: !app.Environment.IsProduction()` and `useSwaggerUi: !app.Environment.IsProduction()` in the four pipelines that call it (`Orchestration`, `Execution`, `InboxWorker`, `OutboxWorker`).
- Marked the `PublishAsync` action with `[ApiExplorerSettings(IgnoreApi = true)]` to hide it from Swagger/ApiExplorer.
- Hardened `FunctionAppService.ExecuteFunctionAsync` by catching exceptions from the task coordinator, logging execution failures at `Error` level, logging output/script-mapping failures at `Error` level, and returning a clear failure `Result` when mapping throws.
- Promoted task business-failure logs from `Debug` to `Error` inside `TaskExecutionEngine` and made executor logging robust by replacing direct `context.ScriptContext.Instance.Id` uses with `context.ScriptContext.Instance?.Id ?? Guid.Empty` across script/Dapr/HTTP/trigger executors to avoid NREs when no instance exists.

### Testing

- Ran `git diff --check` to validate whitespace and simple diff sanity and it reported no problems.
- Attempted repository build via `./scripts/setup-netstandard-ref.sh && dotnet build` but `dotnet` was not available in the environment so the build could not be executed; the setup script reported an unzip message but completed its steps.
- No unit/integration test runs were executed in this environment due to the missing `dotnet` toolchain; changes are limited to middleware wiring and logging paths and should be covered by existing tests when run in CI with .NET installed.

------
## Summary by Sourcery

Tighten API exposure in production and improve reliability and observability of custom function and task execution.

Bug Fixes:
- Avoid NullReferenceExceptions in task and trigger executors by safely handling missing instance IDs when logging.
- Ensure failures during custom function execution and output script mapping return explicit failure results instead of propagating unhandled exceptions.

Enhancements:
- Log custom function execution and response mapping failures at error level with richer context, including domain and instance identifiers.
- Promote task business-failure logging in the task execution engine from debug to error level so production issues surface more clearly in logs and traces.
- Hide the administrative definition publish endpoint from API Explorer and Swagger UI to limit visibility of operational endpoints.
- Disable Swagger and Swagger UI on orchestration, execution, inbox worker, and outbox worker hosts when running in production environments.

## Summary by Sourcery

Tighten production API exposure and improve reliability and observability of custom function and task execution.

Bug Fixes:
- Avoid NullReferenceExceptions in task and trigger executors by safely handling missing instance identifiers in logging.
- Ensure custom function execution and output script mapping failures return explicit failure results instead of propagating unhandled exceptions.

Enhancements:
- Log custom function execution failures and response mapping errors at error level with contextual metadata for easier incident diagnosis.
- Promote task business-failure logging in the task execution engine from debug to error level so operational issues surface clearly in production telemetry.
- Hide the administrative definition publish endpoint from API Explorer and Swagger UI to limit exposure of operational endpoints.
- Disable Swagger and Swagger UI for orchestration, execution, inbox worker, and outbox worker hosts when running in production environments.