### PR TITLE
v0.0.61

### DIFF
--- a/.github/workflows/build-and-publish-images.yml
+++ b/.github/workflows/build-and-publish-images.yml
@@ -703,9 +703,15 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
+          # 10.0.x (latest 10.0 SDK) is installed alongside the 10.0.2xx band so
+          # the AspNetCore.App shared framework matching the runner's system
+          # runtime (e.g. 10.0.9) is present. PostSharp rolls its host forward to
+          # that runtime and requires the matching AspNetCore.App or it fails with
+          # "No compatible version of requested runtime framework Microsoft.AspNetCore.App".
           dotnet-version: |
             9.0.x
             10.0.2xx
+            10.0.x
 
       - name: Setup NETStandard.Library.Ref for PostSharp
         run: ./scripts/setup-netstandard-ref.sh
@@ -787,6 +793,9 @@ jobs:
           node-version: '24'
           always-auth: false
           cache: 'npm'
+          # setup-node runs from the repo root, but the lockfile lives in
+          # vnext-meta, so point caching at it explicitly.
+          cache-dependency-path: vnext-meta/package-lock.json
 
       - name: Set package version
         run: npm version ${{ needs.prepare.outputs.version }} --no-git-tag-version --allow-same-version

--- a/vnext-meta/package-lock.json
+++ b/vnext-meta/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "@burgan-tech/vnext-meta",
+  "version": "0.0.53",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@burgan-tech/vnext-meta",
+      "version": "0.0.53",
+      "license": "UNLICENSED"
+    }
+  }
+}

--- a/vnext-meta/version-manifest.json
+++ b/vnext-meta/version-manifest.json
@@ -1,5 +1,10 @@
 {
   "versions": {
+    "0.0.61": {
+      "schemaVersion": "0.0.46",
+      "releasedAt": "2026-06-15",
+      "releaseNotes": "https://burgan-tech.github.io/vnext-docs/blog/release-v0-0-60"
+    },
     "0.0.60": {
       "schemaVersion": "0.0.46",
       "releasedAt": "2026-06-15",


### PR DESCRIPTION
## Summary by Sourcery

Adjust build workflow dependencies for .NET and Node to ensure compatibility with PostSharp and npm caching for vnext, and update vnext metadata files.

Build:
- Configure build workflow to install both .NET 10.0.2xx and the latest 10.0.x SDK to satisfy PostSharp’s AspNetCore.App runtime requirements.
- Update Node setup caching configuration to use the vnext-meta package-lock.json for npm dependency caching.

Chores:
- Add or update vnext-meta metadata files, including the package-lock.json and version manifest.