### PR TITLE
fix(init): rewrite only source-domain references during domain replacement (#729)

### DIFF
--- a/init/VNext.Init.Host/README.md
+++ b/init/VNext.Init.Host/README.md
@@ -9,7 +9,8 @@ Node.js service for downloading npm packages and publishing them to the vnext AP
 - Merges with custom components if available
 - **Automatic version generation** using extended SemVer format
 - **Opt-in domain replacement** via `replaceDomain: true` + `appDomain` (standard publish)
-- **Cross-domain exclusion** — components/references marked `crossDomain: true` are skipped during replacement
+- **Source-domain matched** — only references on the package's own (source) domain are rewritten; references on a different domain are preserved as cross-domain
+- **Cross-domain exclusion** — references marked `crossDomain: true` (and the `config` subtree) are never rewritten
 - Publishes to vnext API endpoint
 - Provides REST API for package management
 - **Two specialized endpoints** for different package types
@@ -177,12 +178,25 @@ This endpoint is for publishing any npm package with optional domain replacement
 | `appDomain` | ✅ **Required** | ⭕ Only with `replaceDomain: true` |
 | `replaceDomain` | N/A (always active) | Set `true` to enable replacement |
 | Domain Replacement | Always (when appDomain provided) | Only if `replaceDomain: true` + `appDomain` |
-| Cross-domain exclusion | ✅ Yes | ✅ Yes |
+| Source-domain matched | ✅ Yes | ✅ Yes |
+| Cross-domain references preserved | ✅ Yes | ✅ Yes |
 | Special Ordering | Yes (Workflows first, sys-flows first) | No |
 
 ---
 
 ## Domain Replacement
+
+### Core Rule — Source-Domain Match
+
+Replacement is driven by **value matching**, not by blanket rewriting:
+
+- **Source domain** = the package's own domain (`vnext.config.json` → `domain`).
+- **Target domain** = the request's `appDomain`.
+
+A `domain` field is rewritten **only when its value equals the source domain**. Any `domain`
+that points at a different domain is a genuine **cross-domain reference** and is left untouched.
+This rule is applied uniformly at every level — root, `attributes`, `data[]`, subprocess
+`process`, and any nested object.
 
 ### Standard Package (`/api/package/publish`)
 
@@ -190,25 +204,34 @@ Domain replacement is **opt-in**. It is enabled only when **both** conditions ar
 - `replaceDomain: true` is set in the request body
 - `appDomain` contains a non-empty target domain
 
-When enabled, **all** domain fields are replaced at every level:
+When enabled, each `domain` is decided by value (source domain = `core` in the table below,
+target = `my-domain`):
 
-| Field | Replaced? |
-|-------|-----------|
-| Root `domain` | ✅ Yes (unless `crossDomain: true` on root) |
-| `attributes.domain` | ✅ Yes (unless enclosing object has `crossDomain: true`) |
-| `data[].domain` | ✅ Yes (unless `crossDomain: true` on the data item) |
-| `data[].attributes.domain` | ✅ Yes (unless enclosing object has `crossDomain: true`) |
-| Any nested `domain` field | ✅ Yes (unless enclosing object has `crossDomain: true`) |
-| Any field inside `config` | ❌ Never (preserved as-is) |
-| Any field inside `process` | ❌ Never (preserved as-is) |
+| Case | Example value | Result |
+|------|---------------|--------|
+| `domain` equals source domain | `"core"` | ✅ Replaced → `"my-domain"` |
+| `domain` is a different domain | `"payments"` | ⛔ Preserved (cross-domain) |
+| `process.domain` equals source domain | `"core"` | ✅ Replaced → `"my-domain"` |
+| `process.domain` is a different domain | `"notification"` | ⛔ Preserved (cross-domain subflow) |
+| Object marked `crossDomain: true` | any value | ⛔ Preserved (explicit opt-out) |
+| Any field inside `config` | any value | ⛔ Never visited (skipped entirely) |
+
+The rule is the same for `attributes.domain`, `data[].domain`, `data[].attributes.domain`, and
+any deeply nested `domain`.
 
 ### Runtime Package (`/api/package/runtime/publish`)
 
-Domain replacement is **always active** when `appDomain` is provided (required). The same cross-domain exclusion rules apply.
+Domain replacement is **always active** when `appDomain` is provided (required). The same
+source-domain-match rules apply.
 
-### Cross-Domain Exclusion
+### Cross-Domain References
 
-Components or references that intentionally target a different domain can opt out of domain replacement by setting `crossDomain: true` on the relevant object.
+There are two ways a `domain` is preserved instead of rewritten:
+
+1. **By value (automatic)** — the `domain` differs from the source domain, so it is recognized
+   as a cross-domain reference and kept as-is. No flag required.
+2. **By flag (explicit)** — setting `crossDomain: true` on an object pins its `domain` even if
+   the value happens to equal the source domain.
 
 **Root-level exclusion** — the entire component is skipped:
 ```json
@@ -251,12 +274,39 @@ Components or references that intentionally target a different domain can opt ou
 }
 ```
 
-After replacement with `appDomain: "my-domain"`:
-- `my-workflow.domain` → `"my-domain"`
-- `local-task.domain` → `"my-domain"`
-- `cross-domain-task.domain` → `"payments"` (unchanged)
+After replacement with source domain `account` (the package's own domain) and
+`appDomain: "my-domain"`:
+- `my-workflow.domain` → `"my-domain"` (equals source)
+- `local-task.domain` → `"my-domain"` (equals source)
+- `cross-domain-task.domain` → `"payments"` (different domain → preserved; the `crossDomain: true` flag also pins it explicitly)
+
+### Subprocess (`process`) Example
+
+A SubProcess task's `process` reference follows the same source-domain match. With source
+domain `local-test-domain` and `appDomain: "real-domain"`:
+
+```json
+{
+  "key": "parent-flow",
+  "domain": "local-test-domain",
+  "flow": "sys-flows",
+  "attributes": {
+    "tasks": [
+      { "process": { "key": "start-another-flow", "domain": "local-test-domain", "flow": "sys-flows", "version": "1.0.0" } },
+      { "process": { "key": "sms-flow", "domain": "notification", "flow": "sys-flows", "version": "1.0.0" } }
+    ]
+  }
+}
+```
+
+After replacement:
+- `start-another-flow` `process.domain` → `"real-domain"` (equals source → replaced)
+- `sms-flow` `process.domain` → `"notification"` (different domain → preserved, genuine cross-domain subflow)
 
 ### Example
+
+In this example the source domain is `core` (the package's own domain), so every `domain`
+equal to `core` is rewritten to `my-domain`.
 
 **Before (`replaceDomain: true`, `appDomain: "my-domain"`):**
 ```json

--- a/init/VNext.Init.Host/package-api-server.js
+++ b/init/VNext.Init.Host/package-api-server.js
@@ -531,27 +531,25 @@ async function downloadPackage(packageName, version, registry, authOptions = {})
 }
 
 /**
- * Replace ALL domain fields in JSON object at ALL levels
+ * Replace domain fields in a JSON object at ALL levels — but only for references
+ * that belong to the package's own (source) domain.
  *
- * Replaces domain in:
+ * A `domain` is rewritten to the target domain only when it equals `sourceDomain`.
+ * Any `domain` carrying a different value is a genuine cross-domain reference and is
+ * left untouched. This rule applies uniformly to every level:
  * - Root level domain (if object has key, flow, version, domain)
  * - attributes.domain
- * - data[].domain
- * - data[].attributes.domain
- * - Any nested object's domain field
+ * - data[].domain / data[].attributes.domain
+ * - subprocess `process` references and any other nested object's domain field
  *
- * Cross-domain exclusion: if an object has `crossDomain: true`, its `domain`
- * field is preserved as-is (intentionally targets another domain).
- *
- * Subprocess references (the `process` block of a SubProcess task) are treated
- * conditionally: their `domain` is rewritten only when it equals the package's
- * own (source) domain. A `process.domain` pointing at a different domain is a
- * genuine cross-domain call and is left untouched. See replaceProcessDomainInJson.
+ * Exemptions preserved:
+ * - `crossDomain: true` — the object's `domain` is never rewritten.
+ * - `config` — the subtree is skipped entirely.
  *
  * @param {Object} obj - Object to process
  * @param {string} targetDomain - Target domain to replace with
- * @param {string} sourceDomain - Package's own domain; a `process.domain` is rewritten
- *                                only when it equals this value
+ * @param {string} sourceDomain - Package's own domain; a `domain` is rewritten only
+ *                                when it equals this value
  */
 function replaceDomainInJson(obj, targetDomain, sourceDomain) {
     if (typeof obj !== 'object' || obj === null) {
@@ -565,64 +563,20 @@ function replaceDomainInJson(obj, targetDomain, sourceDomain) {
     // Create a copy of the object
     const result = { ...obj };
 
-    // Replace domain field only if this object is not marked as cross-domain
-    if (typeof result.domain === 'string' && result.crossDomain !== true) {
-        result.domain = targetDomain;
-    }
-
-    // Recursively process all properties to find nested domain fields.
-    // "config" is always skipped. The "process" subtree is rewritten conditionally:
-    // only domains equal to the source domain are replaced (cross-domain refs kept).
-    for (const [key, value] of Object.entries(result)) {
-        if (key === 'domain' || key === 'config') {
-            continue;
-        }
-        if (key === 'process') {
-            result[key] = replaceProcessDomainInJson(value, targetDomain, sourceDomain);
-        } else {
-            result[key] = replaceDomainInJson(value, targetDomain, sourceDomain);
-        }
-    }
-
-    return result;
-}
-
-/**
- * Replace domain fields inside a subprocess `process` subtree.
- *
- * Unlike replaceDomainInJson, replacement here is conditional: a `domain` is rewritten
- * to the target domain only when it equals the source domain (the package's own domain).
- * A `domain` pointing at a different domain is a genuine cross-domain reference and is
- * preserved as-is. The `crossDomain: true` exemption and `config` skip are both honored.
- *
- * The conditional rule applies to the whole subtree, so any nested `domain` inside
- * `process` follows the same same-domain-only replacement.
- *
- * @param {Object} obj - Object to process (a `process` block or any of its descendants)
- * @param {string} targetDomain - Target domain to replace with
- * @param {string} sourceDomain - Source domain; only domains equal to this are replaced
- */
-function replaceProcessDomainInJson(obj, targetDomain, sourceDomain) {
-    if (typeof obj !== 'object' || obj === null) {
-        return obj;
-    }
-
-    if (Array.isArray(obj)) {
-        return obj.map(item => replaceProcessDomainInJson(item, targetDomain, sourceDomain));
-    }
-
-    const result = { ...obj };
-
-    // Replace domain only when it matches the source domain and is not cross-domain
+    // Replace domain only when it matches the source domain and is not cross-domain.
+    // A differing domain is a genuine cross-domain reference and is preserved as-is.
     if (typeof result.domain === 'string' && result.crossDomain !== true && result.domain === sourceDomain) {
         result.domain = targetDomain;
     }
 
+    // Recursively process all properties to find nested domain fields.
+    // "config" is always skipped; every other key (including "process") follows the
+    // same same-domain-only replacement rule.
     for (const [key, value] of Object.entries(result)) {
         if (key === 'domain' || key === 'config') {
             continue;
         }
-        result[key] = replaceProcessDomainInJson(value, targetDomain, sourceDomain);
+        result[key] = replaceDomainInJson(value, targetDomain, sourceDomain);
     }
 
     return result;
@@ -1123,8 +1077,9 @@ async function handleRuntimePublish(req, res) {
  * Processing runs in the background; poll GET /api/package/publish/status/:jobId for progress.
  *
  * Domain replacement is opt-in: set `replaceDomain: true` together with a non-empty
- * `appDomain` to replace domain fields in all components.  Components (or nested
- * references) that carry `crossDomain: true` are exempt from replacement.
+ * `appDomain` to replace domain fields. Only references whose `domain` equals the
+ * package's own (source) domain are rewritten; references on a different domain are
+ * cross-domain and preserved. Components/references with `crossDomain: true` are exempt.
  */
 async function handlePackagePublish(req, res) {
     try {
@@ -1529,7 +1484,8 @@ function startServer() {
         log.info(`Package Publish: POST http://localhost:${PORT}/api/package/publish`);
         log.detail(`  - For any npm package`);
         log.detail(`  - replaceDomain: true + appDomain to enable domain replacement`);
-        log.detail(`  - Components with crossDomain:true are exempt from replacement`);
+        log.detail(`  - Only references on the package's own (source) domain are rewritten`);
+        log.detail(`  - Cross-domain references and crossDomain:true are preserved`);
         log.info(`Job Status: GET http://localhost:${PORT}/api/package/publish/status/:jobId`);
         log.detail(`  - Poll for job progress after publish`);
         log.info(`Cancel Job: POST http://localhost:${PORT}/api/package/publish/cancel/:jobId`);
@@ -1561,4 +1517,4 @@ if (require.main === module) {
     startServer();
 }
 
-module.exports = { startServer, processPackage, downloadPackage, runAutomaticInit, replaceDomainInJson, replaceProcessDomainInJson };
+module.exports = { startServer, processPackage, downloadPackage, runAutomaticInit, replaceDomainInJson };

--- a/init/VNext.Init.Host/package-api-server.js
+++ b/init/VNext.Init.Host/package-api-server.js
@@ -333,7 +333,7 @@ function processComponentFile(jsonData, vnextConfig, shouldReplaceDomain, target
             log.detail(`Skipping domain replacement (crossDomain component)`);
         } else {
             log.detail(`Replacing domain → ${targetDomain}`);
-            processed = replaceDomainInJson(processed, targetDomain);
+            processed = replaceDomainInJson(processed, targetDomain, vnextConfig.domain);
         }
     }
     
@@ -543,16 +543,23 @@ async function downloadPackage(packageName, version, registry, authOptions = {})
  * Cross-domain exclusion: if an object has `crossDomain: true`, its `domain`
  * field is preserved as-is (intentionally targets another domain).
  *
+ * Subprocess references (the `process` block of a SubProcess task) are treated
+ * conditionally: their `domain` is rewritten only when it equals the package's
+ * own (source) domain. A `process.domain` pointing at a different domain is a
+ * genuine cross-domain call and is left untouched. See replaceProcessDomainInJson.
+ *
  * @param {Object} obj - Object to process
  * @param {string} targetDomain - Target domain to replace with
+ * @param {string} sourceDomain - Package's own domain; a `process.domain` is rewritten
+ *                                only when it equals this value
  */
-function replaceDomainInJson(obj, targetDomain) {
+function replaceDomainInJson(obj, targetDomain, sourceDomain) {
     if (typeof obj !== 'object' || obj === null) {
         return obj;
     }
 
     if (Array.isArray(obj)) {
-        return obj.map(item => replaceDomainInJson(item, targetDomain));
+        return obj.map(item => replaceDomainInJson(item, targetDomain, sourceDomain));
     }
 
     // Create a copy of the object
@@ -563,12 +570,59 @@ function replaceDomainInJson(obj, targetDomain) {
         result.domain = targetDomain;
     }
 
-    // Recursively process all properties to find nested domain fields
-    // BUT skip "config" and "process" keys - they should always remain unchanged
+    // Recursively process all properties to find nested domain fields.
+    // "config" is always skipped. The "process" subtree is rewritten conditionally:
+    // only domains equal to the source domain are replaced (cross-domain refs kept).
     for (const [key, value] of Object.entries(result)) {
-        if (key !== 'domain' && key !== 'config' && key !== "process") {
-            result[key] = replaceDomainInJson(value, targetDomain);
+        if (key === 'domain' || key === 'config') {
+            continue;
         }
+        if (key === 'process') {
+            result[key] = replaceProcessDomainInJson(value, targetDomain, sourceDomain);
+        } else {
+            result[key] = replaceDomainInJson(value, targetDomain, sourceDomain);
+        }
+    }
+
+    return result;
+}
+
+/**
+ * Replace domain fields inside a subprocess `process` subtree.
+ *
+ * Unlike replaceDomainInJson, replacement here is conditional: a `domain` is rewritten
+ * to the target domain only when it equals the source domain (the package's own domain).
+ * A `domain` pointing at a different domain is a genuine cross-domain reference and is
+ * preserved as-is. The `crossDomain: true` exemption and `config` skip are both honored.
+ *
+ * The conditional rule applies to the whole subtree, so any nested `domain` inside
+ * `process` follows the same same-domain-only replacement.
+ *
+ * @param {Object} obj - Object to process (a `process` block or any of its descendants)
+ * @param {string} targetDomain - Target domain to replace with
+ * @param {string} sourceDomain - Source domain; only domains equal to this are replaced
+ */
+function replaceProcessDomainInJson(obj, targetDomain, sourceDomain) {
+    if (typeof obj !== 'object' || obj === null) {
+        return obj;
+    }
+
+    if (Array.isArray(obj)) {
+        return obj.map(item => replaceProcessDomainInJson(item, targetDomain, sourceDomain));
+    }
+
+    const result = { ...obj };
+
+    // Replace domain only when it matches the source domain and is not cross-domain
+    if (typeof result.domain === 'string' && result.crossDomain !== true && result.domain === sourceDomain) {
+        result.domain = targetDomain;
+    }
+
+    for (const [key, value] of Object.entries(result)) {
+        if (key === 'domain' || key === 'config') {
+            continue;
+        }
+        result[key] = replaceProcessDomainInJson(value, targetDomain, sourceDomain);
     }
 
     return result;
@@ -1507,4 +1561,4 @@ if (require.main === module) {
     startServer();
 }
 
-module.exports = { startServer, processPackage, downloadPackage, runAutomaticInit };
+module.exports = { startServer, processPackage, downloadPackage, runAutomaticInit, replaceDomainInJson, replaceProcessDomainInJson };

--- a/init/VNext.Init.Host/replaceDomain.test.js
+++ b/init/VNext.Init.Host/replaceDomain.test.js
@@ -5,16 +5,17 @@
  *
  * Run with: node --test
  *
- * Covers the subprocess (`process` block) domain replacement rules from issue #729:
- * - same-domain process refs are rewritten to the target domain
- * - cross-domain process refs are preserved
- * - crossDomain:true exemption, config skipping, and non-process replacement regressions
+ * Domain replacement is source-domain matched: a `domain` is rewritten to the target
+ * domain only when it equals the package's own (source) domain. Any `domain` on a
+ * different domain is a genuine cross-domain reference and is preserved — at every level
+ * (root, attributes, data[], subprocess `process`, nested objects). `crossDomain: true`
+ * is exempt and the `config` subtree is skipped entirely.
  */
 
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
 
-const { replaceDomainInJson, replaceProcessDomainInJson } = require('./package-api-server.js');
+const { replaceDomainInJson } = require('./package-api-server.js');
 
 const SOURCE = 'local-test-domain';
 const TARGET = 'real-domain';
@@ -61,7 +62,7 @@ test('crossDomain:true is exempt at top level and inside process', () => {
     assert.equal(result.process.domain, SOURCE, 'crossDomain process ref preserved even when same domain');
 });
 
-test('No regression: non-process domain fields are still replaced unconditionally', () => {
+test('Only same-domain fields are replaced; differing domains are preserved everywhere', () => {
     const input = {
         key: 'task',
         domain: SOURCE,
@@ -75,9 +76,23 @@ test('No regression: non-process domain fields are still replaced unconditionall
     const result = replaceDomainInJson(input, TARGET, SOURCE);
 
     assert.equal(result.domain, TARGET);
-    assert.equal(result.attributes.domain, TARGET);
-    assert.equal(result.data[0].domain, TARGET);
-    assert.equal(result.data[1].domain, TARGET, 'non-process domains replaced regardless of original value');
+    assert.equal(result.attributes.domain, TARGET, 'same-domain attributes replaced');
+    assert.equal(result.data[0].domain, TARGET, 'same-domain data item replaced');
+    assert.equal(result.data[1].domain, 'some-other-domain', 'cross-domain data item preserved');
+});
+
+test('Nested non-process object with a different domain is preserved', () => {
+    const input = {
+        domain: SOURCE,
+        reference: { key: 'ext', domain: 'other-domain' },
+        attributes: { nested: { domain: 'yet-another-domain' } }
+    };
+
+    const result = replaceDomainInJson(input, TARGET, SOURCE);
+
+    assert.equal(result.domain, TARGET);
+    assert.equal(result.reference.domain, 'other-domain', 'nested cross-domain reference preserved');
+    assert.equal(result.attributes.nested.domain, 'yet-another-domain', 'deeply nested cross-domain preserved');
 });
 
 test('No regression: config subtree is left untouched', () => {
@@ -109,13 +124,4 @@ test('Nested domain inside process follows the same same-domain-only rule', () =
     assert.equal(result.process.domain, TARGET, 'process root same-domain replaced');
     assert.equal(result.process.mapping.domain, TARGET, 'nested same-domain replaced');
     assert.equal(result.process.externalRef.domain, 'notification', 'nested cross-domain preserved');
-});
-
-test('replaceProcessDomainInJson honors config skip', () => {
-    const input = { domain: SOURCE, config: { domain: SOURCE } };
-
-    const result = replaceProcessDomainInJson(input, TARGET, SOURCE);
-
-    assert.equal(result.domain, TARGET);
-    assert.equal(result.config.domain, SOURCE, 'config untouched inside process subtree');
 });

--- a/init/VNext.Init.Host/replaceDomain.test.js
+++ b/init/VNext.Init.Host/replaceDomain.test.js
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+
+/**
+ * Tests for domain replacement logic in package-api-server.js
+ *
+ * Run with: node --test
+ *
+ * Covers the subprocess (`process` block) domain replacement rules from issue #729:
+ * - same-domain process refs are rewritten to the target domain
+ * - cross-domain process refs are preserved
+ * - crossDomain:true exemption, config skipping, and non-process replacement regressions
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { replaceDomainInJson, replaceProcessDomainInJson } = require('./package-api-server.js');
+
+const SOURCE = 'local-test-domain';
+const TARGET = 'real-domain';
+
+test('Scenario 1: subprocess process.domain equal to source domain is rewritten to target', () => {
+    const input = {
+        key: 'my-subprocess-task',
+        domain: SOURCE,
+        process: { key: 'start-another-flow', domain: SOURCE, flow: 'sys-flows', version: '1.0.0' }
+    };
+
+    const result = replaceDomainInJson(input, TARGET, SOURCE);
+
+    assert.equal(result.domain, TARGET, 'top-level domain replaced');
+    assert.equal(result.process.domain, TARGET, 'same-domain subprocess ref replaced');
+    assert.equal(result.process.flow, 'sys-flows');
+    assert.equal(result.process.version, '1.0.0');
+});
+
+test('Scenario 2: subprocess process.domain on a different domain is preserved', () => {
+    const input = {
+        key: 'my-subprocess-task',
+        domain: SOURCE,
+        process: { key: 'sms-flow', domain: 'notification', flow: 'sys-flows', version: '1.0.0' }
+    };
+
+    const result = replaceDomainInJson(input, TARGET, SOURCE);
+
+    assert.equal(result.domain, TARGET, 'top-level domain replaced');
+    assert.equal(result.process.domain, 'notification', 'cross-domain subprocess ref preserved');
+});
+
+test('crossDomain:true is exempt at top level and inside process', () => {
+    const input = {
+        key: 'cross-task',
+        domain: SOURCE,
+        crossDomain: true,
+        process: { key: 'ref', domain: SOURCE, crossDomain: true, flow: 'sys-flows' }
+    };
+
+    const result = replaceDomainInJson(input, TARGET, SOURCE);
+
+    assert.equal(result.domain, SOURCE, 'crossDomain top-level domain preserved');
+    assert.equal(result.process.domain, SOURCE, 'crossDomain process ref preserved even when same domain');
+});
+
+test('No regression: non-process domain fields are still replaced unconditionally', () => {
+    const input = {
+        key: 'task',
+        domain: SOURCE,
+        attributes: { domain: SOURCE },
+        data: [
+            { key: 'd1', domain: SOURCE },
+            { key: 'd2', domain: 'some-other-domain' }
+        ]
+    };
+
+    const result = replaceDomainInJson(input, TARGET, SOURCE);
+
+    assert.equal(result.domain, TARGET);
+    assert.equal(result.attributes.domain, TARGET);
+    assert.equal(result.data[0].domain, TARGET);
+    assert.equal(result.data[1].domain, TARGET, 'non-process domains replaced regardless of original value');
+});
+
+test('No regression: config subtree is left untouched', () => {
+    const input = {
+        key: 'task',
+        domain: SOURCE,
+        config: { domain: SOURCE, nested: { domain: SOURCE } }
+    };
+
+    const result = replaceDomainInJson(input, TARGET, SOURCE);
+
+    assert.equal(result.domain, TARGET);
+    assert.equal(result.config.domain, SOURCE, 'config domain untouched');
+    assert.equal(result.config.nested.domain, SOURCE, 'nested config domain untouched');
+});
+
+test('Nested domain inside process follows the same same-domain-only rule', () => {
+    const input = {
+        domain: SOURCE,
+        process: {
+            domain: SOURCE,
+            mapping: { domain: SOURCE },
+            externalRef: { domain: 'notification' }
+        }
+    };
+
+    const result = replaceDomainInJson(input, TARGET, SOURCE);
+
+    assert.equal(result.process.domain, TARGET, 'process root same-domain replaced');
+    assert.equal(result.process.mapping.domain, TARGET, 'nested same-domain replaced');
+    assert.equal(result.process.externalRef.domain, 'notification', 'nested cross-domain preserved');
+});
+
+test('replaceProcessDomainInJson honors config skip', () => {
+    const input = { domain: SOURCE, config: { domain: SOURCE } };
+
+    const result = replaceProcessDomainInJson(input, TARGET, SOURCE);
+
+    assert.equal(result.domain, TARGET);
+    assert.equal(result.config.domain, SOURCE, 'config untouched inside process subtree');
+});


### PR DESCRIPTION
## Summary

Fixes the Init service domain replacement so it correctly handles subprocess references, then generalizes the rule so domain replacement is uniformly cross-domain-safe.

Previously `replaceDomainInJson` (`init/VNext.Init.Host/package-api-server.js`) skipped the `process` key unconditionally, so a SubProcess task's `process.domain` was never rewritten — leaving published packages pointing at the old/source domain and breaking subflow correlation after a domain rename. Non-`process` domains were rewritten unconditionally, which also clobbered genuine cross-domain references.

## Behavior

Domain replacement is now **source-domain matched** at every level (root, `attributes`, `data[]`, `process`, nested objects):

- A `domain` is rewritten to the target (`appDomain`) **only when it equals the package's own (source) domain** (`vnext.config.json` → `domain`).
- A `domain` pointing at a **different** domain is a genuine cross-domain reference and is **preserved**.
- `crossDomain: true` remains an explicit opt-out.
- The `config` subtree is still skipped entirely.

Matching the issue scenarios (source `local-test-domain` → target `real-domain`):
- `process.domain: "local-test-domain"` → `"real-domain"` (replaced)
- `process.domain: "notification"` → `"notification"` (preserved)

## Commits

1. **fix(init)** — rewrite subprocess `process.domain` when it matches the source domain (#729 core fix; added a conditional `process` helper).
2. **refactor(init)** — generalize the same-domain-only rule to every `domain` field and merge the now-redundant `process` helper back into `replaceDomainInJson`.
3. **docs(init)** — update `init/VNext.Init.Host/README.md` (decision table, cross-domain section, subprocess example) to reflect the new behavior.

## Tests / Verification

- `init/VNext.Init.Host/replaceDomain.test.js` (Node built-in `node:test`) covers same-domain → replaced, different-domain → preserved, `crossDomain: true` exemption, `config` skip, and nested `process` cases.
- `node --test` → 7 passing / 0 failing.
- `node -c package-api-server.js` → syntax OK.

## Note

This intentionally changes one of #729's original acceptance points ("non-`process` domains always replaced") because the follow-up requirement is for **all** domain structures to be cross-domain-safe via value matching.

Fixes #729

https://claude.ai/code/session_019BKWikSUn4YEkzyz7vz5vS

---
_Generated by [Claude Code](https://claude.ai/code/session_019BKWikSUn4YEkzyz7vz5vS)_

## Summary by Sourcery

Ensure domain replacement during package publishing only rewrites references on the package’s own source domain, including subprocess references, while preserving genuine cross-domain links.

Bug Fixes:
- Fix domain replacement so subprocess process.domain values matching the package’s source domain are correctly rewritten to the target domain.

Enhancements:
- Generalize domain replacement to be source-domain matched at all levels, preserving domains that point to other services as cross-domain references.
- Refine server logging and API description text to describe the new source-domain-only replacement behavior.

Documentation:
- Expand Init host README with a value-based domain replacement rule, updated decision tables, and detailed cross-domain and subprocess examples.

Tests:
- Add node:test coverage for replaceDomainInJson, including same-domain vs different-domain behavior, crossDomain:true exemptions, config subtree skipping, and subprocess/nested cases.