### PR TITLE
fix(pipeline): release chain ownership when resting in Busy-subtype state

### DIFF
--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ClearBusyOnResumeStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ClearBusyOnResumeStep.cs
@@ -64,9 +64,15 @@ public sealed class ClearBusyOnResumeStep() : ITransitionStep
     /// </summary>
     private static void ClearBusyIfNeeded(TransitionExecutionContext context)
     {
-        // If target state is Busy subtype, ChangeState will handle status
+        // If target state is Busy subtype, ChangeState will handle status. The chain has come
+        // to rest in a Busy-subtype state, so release the durable chain-ownership token (the
+        // instance stays Busy) — otherwise the chain-token gate would reject legitimate foreign
+        // transitions and the ChainReaper would treat the resting instance as stuck.
         if (context.Target?.SubType == StateSubType.Busy)
+        {
+            context.Directives.RequestEndChain();
             return;
+        }
 
         // Defer status update to after post-commit jobs complete
         if (context.Instance is { IsActive: false, IsCompleted: false })

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ResolveAvailableStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ResolveAvailableStep.cs
@@ -102,6 +102,14 @@ public sealed class ResolveAvailableStep(
                 "Instance {InstanceId} has Busy subtype in state {TargetState}, skipping ResolveAvailableStep",
                 context.InstanceId,
                 context.Target.Key);
+
+            // The instance comes to rest in a Busy-subtype state with no in-flight chain
+            // (earlier guards guarantee NextTransition == null and !TerminalReached here),
+            // so the auto-chain has finished. Release the durable chain-ownership token while
+            // keeping the Busy status: leaving the token set would make the chain-token gate
+            // reject legitimate foreign transitions (e.g. a child sub-process signalling its
+            // initiator) and would make the ChainReaper treat this resting instance as stuck.
+            context.Directives.RequestEndChain();
             return false;
         }
 

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/TransitionPipeline.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/TransitionPipeline.cs
@@ -190,8 +190,10 @@ public class TransitionPipeline
             if (continuationResult.Value is null)
             {
                 // No further in-process work (chain complete or continuation enqueued) —
-                // apply deferred status (inside lock, no re-acquire needed).
+                // apply deferred status and release chain ownership if requested
+                // (inside lock, no re-acquire needed).
                 await ApplyResolvedStatusAsync(context, cancellationToken);
+                await ApplyChainOwnershipAsync(context, cancellationToken);
                 return Result<TransitionExecutionContext>.Ok(context);
             }
 
@@ -320,6 +322,31 @@ public class TransitionPipeline
 
         _logger.LogDebug(
             "Instance {InstanceId} resolved to Active after chain completion",
+            context.InstanceId);
+    }
+
+    /// <summary>
+    /// Releases the durable chain-ownership token when the pipeline has come to rest while the
+    /// instance stays Busy (e.g. a Busy-subtype state). The auto-chain has finished, so the token
+    /// must be cleared — otherwise the chain-token gate would reject legitimate foreign transitions
+    /// and the ChainReaper would treat the resting instance as stuck. The instance status is left
+    /// unchanged (still Busy). Already within lock scope — no re-acquisition needed.
+    /// </summary>
+    private async Task ApplyChainOwnershipAsync(
+        TransitionExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        if (!context.Directives.ConsumeEndChain())
+            return;
+
+        if (context.Instance.IsCompleted || !context.Instance.ChainToken.HasValue)
+            return;
+
+        context.Instance.EndChain();
+        await _instanceRepository.UpdateAsync(context.Instance, true, cancellationToken);
+
+        _logger.LogDebug(
+            "Instance {InstanceId} released chain ownership at rest (stays Busy)",
             context.InstanceId);
     }
 }

--- a/src/BBT.Workflow.Domain/Execution/Transitions/Context/PipelineDirectives.cs
+++ b/src/BBT.Workflow.Domain/Execution/Transitions/Context/PipelineDirectives.cs
@@ -171,6 +171,34 @@ public sealed class PipelineDirectives
     }
 
     /// <summary>
+    /// Gets a value indicating whether the auto-chain ownership token should be released
+    /// after all pipeline work completes, while the instance stays Busy.
+    /// Set when the pipeline comes to rest in a Busy-subtype state with no in-flight chain
+    /// (no next transition, not terminal): the chain is finished, so the durable
+    /// <see cref="Instances.Instance.ChainToken"/> must be cleared so that legitimate foreign
+    /// transitions (e.g. a child sub-process signalling its initiator) are not rejected by the
+    /// chain-token gate, and the ChainReaper does not treat the resting instance as stuck.
+    /// </summary>
+    public bool EndChainRequested { get; private set; }
+
+    /// <summary>
+    /// Requests the auto-chain ownership token to be released at rest (instance stays Busy).
+    /// </summary>
+    public void RequestEndChain() => EndChainRequested = true;
+
+    /// <summary>
+    /// Consumes and clears the end-chain request.
+    /// Called by the pipeline after post-commit jobs complete.
+    /// </summary>
+    /// <returns><c>true</c> if a chain-ownership release was requested; otherwise <c>false</c>.</returns>
+    public bool ConsumeEndChain()
+    {
+        var v = EndChainRequested;
+        EndChainRequested = false;
+        return v;
+    }
+
+    /// <summary>
     /// Enqueues a post-commit job to be executed after the distributed lock is released.
     /// Post-commit jobs are used for side effects like remote calls that shouldn't block the lock.
     /// For idempotent jobs, duplicate enqueueing within the same transition is prevented.

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/Steps/HandleCancelPreflightStepTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/Steps/HandleCancelPreflightStepTests.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Workflow.BackgroundJobs.Options;
+using BBT.Workflow.Execution;
+using BBT.Workflow.Execution.Pipeline.Steps;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Shared;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Application.Tests.Execution.Transitions.Pipeline.Steps;
+
+/// <summary>
+/// Unit tests for the chain-token gate in <see cref="HandleCancelPreflightStep"/>.
+/// Characterizes the #725 gate behaviour the Busy-subtype chain-ownership fix relies on:
+/// once a resting Busy instance has its ChainToken released, a legitimate foreign transition
+/// (e.g. a child sub-process triggering the initiator's "Ready") is no longer rejected.
+/// </summary>
+public class HandleCancelPreflightStepTests
+{
+    private readonly HandleCancelPreflightStep _step;
+
+    public HandleCancelPreflightStepTests()
+    {
+        var options = Options.Create(new WorkflowExecutionOptions { StrictChainTokenGate = true });
+        _step = new HandleCancelPreflightStep(
+            new ReservedTransitionResolver(),
+            options,
+            Substitute.For<ILogger<HandleCancelPreflightStep>>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenBusyWithForeignChainToken_ShouldRejectWithLockConflict()
+    {
+        // Busy + chain token set, incoming transition carries no matching token → foreign → rejected.
+        var context = CreateContext();
+        context.Instance.BeginChain(Guid.NewGuid());
+
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenBusyButChainTokenReleased_ShouldNotReject()
+    {
+        // The fix releases the ChainToken when an instance rests in a Busy-subtype state.
+        // The gate keys on ChainToken presence, so a foreign transition is now accepted.
+        var context = CreateContext();
+        context.Instance.Busy(); // Busy, but no chain token
+
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.StopPipeline.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenBusyWithMatchingChainToken_ShouldNotReject()
+    {
+        // The chain's own continuation carries the matching token → accepted (gate preserved).
+        var context = CreateContext();
+        var token = Guid.NewGuid();
+        context.Instance.BeginChain(token);
+        context.ChainToken = token;
+
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.StopPipeline.ShouldBeFalse();
+    }
+
+    private static TransitionExecutionContext CreateContext()
+    {
+        var instanceId = Guid.NewGuid();
+        const string workflowKey = "test-workflow";
+        const string domain = "test-domain";
+
+        var workflow = CreateMockWorkflow(workflowKey, domain);
+        var instance = Instance.Create(instanceId, workflowKey, "1.0.0");
+        var state = workflow.GetState("state1").Value!;
+        var transition = Transition.Create("Ready", "state1", "state2", TriggerType.Manual, "Patch");
+
+        return new TransitionExecutionContext
+        {
+            InstanceId = instanceId,
+            Domain = domain,
+            WorkflowKey = workflowKey,
+            TransitionKey = "Ready",
+            Trigger = TriggerType.Manual,
+            Actor = ExecutionActor.User,
+            CorrelationId = Guid.NewGuid().ToString("N"),
+            ExecutionChainId = Guid.NewGuid().ToString("N"),
+            RequestedAt = DateTimeOffset.UtcNow,
+            Workflow = workflow,
+            Current = state,
+            Target = workflow.GetState("state2").Value!,
+            Transition = transition,
+            Instance = instance,
+            TraceId = Guid.NewGuid().ToString("N"),
+            SpanId = Guid.NewGuid().ToString("N")[..16]
+        };
+    }
+
+    private static Definitions.Workflow CreateMockWorkflow(string key, string domain)
+    {
+        var json = """
+        {
+            "type": "F",
+            "timeout": null,
+            "labels": [],
+            "functions": [],
+            "features": [],
+            "states": [
+                {
+                    "key": "state1",
+                    "stateType": "Initial",
+                    "transitions": [{"key": "Ready", "from": "state1", "target": "state2", "triggerType": "Manual", "versionStrategy": "Patch"}]
+                },
+                {
+                    "key": "state2",
+                    "stateType": "Intermediate",
+                    "transitions": []
+                }
+            ],
+            "sharedTransitions": [],
+            "extensions": [],
+            "startTransition": {"key": "start", "from": null, "target": "state1", "triggerType": "Manual", "versionStrategy": "Patch", "labels": [], "onExecutionTasks": [], "view": null}
+        }
+        """;
+
+        var options = new System.Text.Json.JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+        };
+        var workflow = System.Text.Json.JsonSerializer.Deserialize<Definitions.Workflow>(json, options)!;
+
+        workflow.SetReference(new Reference(key, domain, "sys-flows", "1.0.0"));
+        return workflow;
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/Steps/ResolveAvailableStepTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/Steps/ResolveAvailableStepTests.cs
@@ -136,6 +136,40 @@ public class ResolveAvailableStepTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_WhenTargetIsBusySubType_ShouldRequestEndChainAndNotDeferStatus()
+    {
+        // Regression (#725 chain-token gate): an instance that comes to rest in a Busy-subtype
+        // state stays Busy but the auto-chain is finished. The chain-ownership token must be
+        // released so legitimate foreign transitions (e.g. a child sub-process triggering the
+        // initiator's "Ready") are not rejected by the chain-token gate.
+        var context = CreateTransitionExecutionContextWithBusySubTypeState();
+        context.Instance.BeginChain(Guid.NewGuid()); // Busy + chain token, as a real start sets
+
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        context.Instance.IsBusy.ShouldBeTrue();              // stays Busy
+        context.Directives.ResolvedStatus.ShouldBeNull();    // not resolved to Active
+        context.Directives.EndChainRequested.ShouldBeTrue(); // but chain ownership released
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenBusySubTypeButNextTransitionPending_ShouldNotRequestEndChain()
+    {
+        // An in-flight auto-chain (NextTransition set) must keep its token — the NextTransition
+        // guard short-circuits before the Busy-subtype branch, so no release is requested.
+        var context = CreateTransitionExecutionContextWithBusySubTypeState();
+        context.Instance.BeginChain(Guid.NewGuid());
+        context.Directives.RequestNextTransition(new NextTransitionRequest("auto-transition", "auto"));
+
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        context.Directives.EndChainRequested.ShouldBeFalse();
+        context.Directives.ResolvedStatus.ShouldBeNull();
+    }
+
+    [Fact]
     public async Task ExecuteAsync_WhenTargetIsFinishState_ShouldNotDeferStatus()
     {
         // Arrange
@@ -448,6 +482,79 @@ public class ResolveAvailableStepTests
             "sharedTransitions": [],
             "extensions": [],
             "startTransition": {"key": "start", "from": null, "target": "state1", "triggerType": "Manual", "versionStrategy": "Patch", "labels": [], "onExecutionTasks": [], "view": null}
+        }
+        """;
+
+        var options = new System.Text.Json.JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+        };
+        var workflow = System.Text.Json.JsonSerializer.Deserialize<Definitions.Workflow>(json, options)!;
+
+        workflow.SetReference(new Reference(key, domain, "sys-flows", "1.0.0"));
+        return workflow;
+    }
+
+    private TransitionExecutionContext CreateTransitionExecutionContextWithBusySubTypeState()
+    {
+        var instanceId = Guid.NewGuid();
+        var workflowKey = "test-workflow";
+        var domain = "test-domain";
+
+        var workflow = CreateMockWorkflowWithBusySubTypeState(workflowKey, domain);
+        var instance = Instance.Create(instanceId, workflowKey, "1.0.0");
+        var busyState = workflow.GetState("busy-state").Value!;
+        var transition = Transition.Create("start", null, "busy-state", TriggerType.Manual, "Patch");
+
+        return new TransitionExecutionContext
+        {
+            InstanceId = instanceId,
+            Domain = domain,
+            WorkflowKey = workflowKey,
+            TransitionKey = "start",
+            Trigger = TriggerType.Manual,
+            Actor = ExecutionActor.User,
+            CorrelationId = Guid.NewGuid().ToString("N"),
+            ExecutionChainId = Guid.NewGuid().ToString("N"),
+            RequestedAt = DateTimeOffset.UtcNow,
+            Workflow = workflow,
+            Current = busyState,
+            Target = busyState,
+            Transition = transition,
+            Instance = instance,
+            TraceId = Guid.NewGuid().ToString("N"),
+            SpanId = Guid.NewGuid().ToString("N")[..16]
+        };
+    }
+
+    private Definitions.Workflow CreateMockWorkflowWithBusySubTypeState(string key, string domain)
+    {
+        // "busy-state" has only a manual "Ready" transition (no auto transitions) and a Busy
+        // subtype — the resting state in the regression scenario.
+        var json = """
+        {
+            "type": "F",
+            "timeout": null,
+            "labels": [],
+            "functions": [],
+            "features": [],
+            "states": [
+                {
+                    "key": "busy-state",
+                    "stateType": "Initial",
+                    "subType": "Busy",
+                    "transitions": [{"key": "Ready", "from": "busy-state", "target": "state2", "triggerType": "Manual", "versionStrategy": "Patch"}]
+                },
+                {
+                    "key": "state2",
+                    "stateType": "Intermediate",
+                    "transitions": []
+                }
+            ],
+            "sharedTransitions": [],
+            "extensions": [],
+            "startTransition": {"key": "start", "from": null, "target": "busy-state", "triggerType": "Manual", "versionStrategy": "Patch", "labels": [], "onExecutionTasks": [], "view": null}
         }
         """;
 


### PR DESCRIPTION
## Summary

Fixes the regression where a child sub-process (flow B) triggering a `Ready` transition on its initiator (flow A) — which rests in a **Busy-subtype** state — is rejected with `InstanceLockConflict` (lock-like 409). Worked in 0.0.59, broke in 0.0.61.

Closes #730.

## Root cause

- `SetBusyStep` mints a durable `ChainToken` via `Instance.BeginChain(token)`.
- When the instance rests in a Busy-subtype state, `ResolveAvailableStep` and `TransitionPipeline.ApplyResolvedStatusAsync` skip resolving to `Active` (Busy-subtype guard). Since `Instance.Active()` is the only path that clears `ChainToken`, the token **leaks** even though the auto-chain has finished.
- With `StrictChainTokenGate` enabled (#725), `HandleCancelPreflightStep` then rejects any non-reserved foreign transition while the instance is `Busy` with a `ChainToken` that the incoming request doesn't match. The cross-flow `Ready` is not reserved and cannot carry A's internal token → persistent rejection. The `ChainReaper` can also falsely fault the resting instance.

The "Busy subtype … skipping ResolveAvailableStep" log predates #725 (#517); it is a symptom marker. The actual regression is the durable gate turning a leaked token into a persistent rejection.

## Change

Release the chain-ownership token when the pipeline comes to rest in a Busy-subtype state (no in-flight chain: `NextTransition == null`, not terminal), while keeping the `Busy` status:

- `PipelineDirectives` — new deferred directive `EndChainRequested` / `RequestEndChain()` / `ConsumeEndChain()` (mirrors the existing `ResolvedStatus` pattern).
- `ResolveAvailableStep` — Busy-subtype branch now calls `RequestEndChain()`.
- `ClearBusyOnResumeStep` — same on the subflow-resume path.
- `TransitionPipeline` — new `ApplyChainOwnershipAsync` (post-commit, inside lock) calls `Instance.EndChain()` + persist when requested.

In-flight auto-chain protection and the subflow-entry token (TerminalReached) are intentionally left untouched.

## Tests

- `ResolveAvailableStepTests` — Busy-subtype at rest requests end-chain; in-flight chain (NextTransition set) does not.
- `HandleCancelPreflightStepTests` (new) — gate characterization: released token → accepted; foreign token → rejected; matching token → accepted.

## Verification note

No .NET SDK is available in the execution environment, so `dotnet build` / `dotnet test` could not be run here. Please run the build and tests in CI. End-to-end verification (Main → A sub-process → B sub-process → B triggers A's `Ready`) should confirm the `Ready` is processed instead of returning 409.


---

## Summary by Sourcery

Adjust chain-ownership handling for Busy-subtype workflow states to prevent leaked chain tokens from blocking legitimate transitions and to ensure resting Busy instances are not treated as stuck.

Bug Fixes:
- Release leaked chain-ownership tokens when a pipeline comes to rest in a Busy-subtype state while keeping the instance Busy, avoiding InstanceLockConflict errors for valid foreign transitions and false-positive stuck detection.

Enhancements:
- Introduce deferred end-chain directives and pipeline handling to coordinate safe release of chain-ownership tokens after pipeline completion.

Tests:
- Add and extend unit tests to cover Busy-subtype end-chain behavior and to characterize the strict chain-token gate behavior relied on by the fix.