### PR TITLE
feat(authorization): treat deny-only role grant sets as blacklists

### DIFF
--- a/src/BBT.Workflow.Application/Authorization/ITransitionAuthorizationManager.cs
+++ b/src/BBT.Workflow.Application/Authorization/ITransitionAuthorizationManager.cs
@@ -117,9 +117,20 @@ public interface ITransitionAuthorizationManager
     /// <summary>
     /// Checks whether the current user matches any predefined role ($InstanceStarter, $PreviousUser)
     /// in the given role grants. Only evaluates predefined roles; static roles are ignored.
+    /// DENY always wins. If at least one ALLOW grant exists, this is an allowlist (default deny).
+    /// A grant set with no ALLOW grant is a blacklist (default allow unless a matching DENY applies),
+    /// controlled by <paramref name="defaultAllowWhenNoAllowGrant"/>.
     /// </summary>
+    /// <param name="roleGrants">The grant set to evaluate (predefined roles only).</param>
+    /// <param name="instance">The instance used to resolve predefined roles.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="defaultAllowWhenNoAllowGrant">
+    /// When true (default), a grant set with no ALLOW grant allows callers that are not explicitly denied.
+    /// Set to false to force strict allowlist semantics (used when the blacklist decision is made over a wider grant set).
+    /// </param>
     Task<bool> IsPredefinedRoleMatchAsync(
         IReadOnlyCollection<RoleGrant> roleGrants,
         Instance instance,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default,
+        bool defaultAllowWhenNoAllowGrant = true);
 }

--- a/src/BBT.Workflow.Application/Authorization/SchemaFieldVisibilityService.cs
+++ b/src/BBT.Workflow.Application/Authorization/SchemaFieldVisibilityService.cs
@@ -33,7 +33,8 @@ public static class SchemaFieldVisibilityService
 
     /// <summary>
     /// Determines whether a property with the given role grants is visible to the caller.
-    /// Semantics: DENY wins; if no DENY match for any caller role, then any ALLOW match for any caller role → visible.
+    /// Semantics: DENY wins. If at least one ALLOW grant exists, any ALLOW match for a caller role → visible (default hidden otherwise).
+    /// A grant set with no ALLOW grant is a blacklist: visible unless a caller role is explicitly denied.
     /// </summary>
     public static bool IsPathVisibleForCaller(
         IReadOnlyList<RoleGrant> roleGrants,

--- a/src/BBT.Workflow.Application/Authorization/TransitionAuthorizationManager.cs
+++ b/src/BBT.Workflow.Application/Authorization/TransitionAuthorizationManager.cs
@@ -8,7 +8,8 @@ namespace BBT.Workflow.Authorization;
 
 /// <summary>
 /// Evaluates transition-level role grants (static + predefined + dynamic context references).
-/// DENY always wins; if no DENY match, any ALLOW match yields allowed.
+/// DENY always wins. If at least one ALLOW grant exists, the set is an allowlist (default deny unless an ALLOW matches).
+/// A grant set with no ALLOW grant is a blacklist (default allow unless a matching DENY applies).
 /// <para>
 /// Predefined actor roles ($InstanceStarter, $PreviousUser) are matched against <c>ICurrentUser.ActorUserName</c>.
 /// Predefined behalf-of roles ($InstanceBehalfOfStarter, $PreviousBehalfOfUser) are matched against <c>ICurrentUser.UserName</c>.
@@ -167,6 +168,8 @@ public sealed class TransitionAuthorizationManager(
 
     /// <summary>
     /// Evaluates role grants with resolution of predefined instance roles and dynamic context references.
+    /// DENY always wins; if at least one ALLOW grant exists, an ALLOW match is required; otherwise (deny-only set)
+    /// the caller is allowed unless explicitly denied.
     /// When role is null, only predefined/dynamic role grants are evaluated; regular role grants yield no match.
     /// </summary>
     private async Task<bool> EvaluateRolesWithPredefinedAsync(
@@ -219,6 +222,10 @@ public sealed class TransitionAuthorizationManager(
             return false;
 
         if (roleGrants.Any(g => g.IsAllow && IsMatch(g)))
+            return true;
+
+        // Blacklist (deny-only) set: no ALLOW grant defined → allow when not explicitly denied.
+        if (!roleGrants.Any(g => g.IsAllow))
             return true;
 
         return false;
@@ -414,11 +421,21 @@ public sealed class TransitionAuthorizationManager(
     }
 
     /// <summary>
-    /// Evaluates role against role grants (static only). DENY always wins; else any ALLOW match → true.
+    /// Evaluates role against role grants (static only). DENY always wins.
+    /// If at least one ALLOW grant exists, the set is an allowlist (default deny unless an ALLOW matches).
+    /// A grant set with no ALLOW grant is a blacklist (default allow unless a matching DENY applies),
+    /// controlled by <paramref name="defaultAllowWhenNoAllowGrant"/>.
     /// When role is null, no regular role grants match; only the grant count check applies (empty grants → allow).
     /// Used by transition/function authorization and by schema field-level visibility.
     /// </summary>
-    public static bool EvaluateRolesStatic(string? role, IReadOnlyCollection<RoleGrant> roleGrants)
+    /// <param name="role">The caller role to evaluate, or null.</param>
+    /// <param name="roleGrants">The grant set to evaluate against.</param>
+    /// <param name="defaultAllowWhenNoAllowGrant">
+    /// When true (default), a grant set with no ALLOW grant allows callers that are not explicitly denied.
+    /// Set to false to force strict allowlist semantics (used when the blacklist decision is made over a wider grant set).
+    /// </param>
+    public static bool EvaluateRolesStatic(string? role, IReadOnlyCollection<RoleGrant> roleGrants,
+        bool defaultAllowWhenNoAllowGrant = true)
     {
         if (roleGrants.Count == 0)
             return true; // No roles defined → allow
@@ -433,6 +450,9 @@ public sealed class TransitionAuthorizationManager(
             if (string.Equals(g.Role, normalizedRole, StringComparison.OrdinalIgnoreCase) && g.IsAllow)
                 return true;
         }
+        // Blacklist (deny-only) set: no ALLOW grant defined → allow when not explicitly denied.
+        if (defaultAllowWhenNoAllowGrant && !roleGrants.Any(g => g.IsAllow))
+            return true;
         return false;
     }
 
@@ -440,7 +460,8 @@ public sealed class TransitionAuthorizationManager(
     public async Task<bool> IsPredefinedRoleMatchAsync(
         IReadOnlyCollection<RoleGrant> roleGrants,
         Instance instance,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        bool defaultAllowWhenNoAllowGrant = true)
     {
         var predefinedGrants = roleGrants;
 
@@ -499,7 +520,10 @@ public sealed class TransitionAuthorizationManager(
                                       && string.Equals(actorUserName, previousUserCreatedBy, StringComparison.Ordinal)))
             return true;
 
-        
+        // Blacklist (deny-only) set: no ALLOW grant defined → allow when not explicitly denied.
+        if (defaultAllowWhenNoAllowGrant && !predefinedGrants.Any(g => g.IsAllow))
+            return true;
+
         return false;
     }
 }

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -1794,12 +1794,16 @@ public sealed class InstanceQueryAppService(
                     break;
                 }
 
+                // Blacklist decision is made over the WHOLE grant list, not the split subsets:
+                // when no ALLOW grant exists anywhere, both subsets evaluate as deny-only blacklists.
+                var applyBlacklistFallback = !transitionRoles.Any(g => g.IsAllow);
+
                 var staticMatch = !hasStaticRoles;
                 if (hasStaticRoles)
                 {
                     foreach (var role in userRoles)
                     {
-                        if (TransitionAuthorizationManager.EvaluateRolesStatic(role, staticRoles))
+                        if (TransitionAuthorizationManager.EvaluateRolesStatic(role, staticRoles, applyBlacklistFallback))
                         {
                             staticMatch = true;
                             break;
@@ -1811,7 +1815,7 @@ public sealed class InstanceQueryAppService(
                 if (hasPredefinedRoles)
                 {
                     predefinedMatch = await transitionAuthorizationManager.IsPredefinedRoleMatchAsync(
-                        predefinedRoles, instance, cancellationToken);
+                        predefinedRoles, instance, cancellationToken, applyBlacklistFallback);
                 }
 
                 if (staticMatch && predefinedMatch)

--- a/test/BBT.Workflow.Application.Tests/Authorization/TransitionAuthorizationManagerBlacklistTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Authorization/TransitionAuthorizationManagerBlacklistTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.Users;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Instances;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Authorization;
+
+/// <summary>
+/// Unit tests for deny-only (blacklist) grant semantics: a grant set with no ALLOW grant allows
+/// any caller that is not explicitly denied, while a set containing at least one ALLOW grant keeps
+/// strict allowlist (default-deny) behavior.
+/// </summary>
+public sealed class TransitionAuthorizationManagerBlacklistTests
+{
+    private readonly ICurrentUser _currentUser;
+    private readonly IInstanceTransitionRepository _repo;
+    private readonly TransitionAuthorizationManager _sut;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    public TransitionAuthorizationManagerBlacklistTests()
+    {
+        _currentUser = Substitute.For<ICurrentUser>();
+        _repo = Substitute.For<IInstanceTransitionRepository>();
+        _repo.GetLastCompletedManualTransitionAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+             .Returns((InstanceTransition?)null);
+        _sut = new TransitionAuthorizationManager(_currentUser, _repo);
+    }
+
+    private static List<RoleGrant> Grants(string json) =>
+        JsonSerializer.Deserialize<List<RoleGrant>>(json, JsonOptions)!;
+
+    private static Instance NewInstance() => Instance.Create(Guid.NewGuid(), "flow", "1.0.0", "key");
+
+    // ── EvaluateRolesStatic (no-instance / static path) ──────────────────────────
+
+    [Fact]
+    public void Static_DenyOnly_AllowsCallerNotDenied()
+    {
+        var grants = Grants("""[{"role":"blocked","grant":"deny"}]""");
+        TransitionAuthorizationManager.EvaluateRolesStatic("someone-else", grants).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Static_DenyOnly_DeniesMatchingCaller()
+    {
+        var grants = Grants("""[{"role":"blocked","grant":"deny"}]""");
+        TransitionAuthorizationManager.EvaluateRolesStatic("blocked", grants).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Static_Allowlist_DeniesNonMatchingCaller()
+    {
+        // At least one ALLOW grant → strict allowlist, default deny preserved.
+        var grants = Grants("""[{"role":"maker","grant":"allow"}]""");
+        TransitionAuthorizationManager.EvaluateRolesStatic("someone-else", grants).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Static_MixedAllowDeny_DenyStillWins()
+    {
+        var grants = Grants("""[{"role":"maker","grant":"allow"},{"role":"maker","grant":"deny"}]""");
+        TransitionAuthorizationManager.EvaluateRolesStatic("maker", grants).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Static_DenyOnly_StrictFlag_DeniesNonMatchingCaller()
+    {
+        // defaultAllowWhenNoAllowGrant:false forces strict allowlist — backs the whole-list gating
+        // in the query-filter path (deny-only subset must not auto-pass when the full list has an ALLOW).
+        var grants = Grants("""[{"role":"blocked","grant":"deny"}]""");
+        TransitionAuthorizationManager.EvaluateRolesStatic("someone-else", grants, defaultAllowWhenNoAllowGrant: false)
+            .ShouldBeFalse();
+    }
+
+    // ── Instance path (EvaluateRolesWithPredefinedAsync via IsRoleAllowedForGrantsAsync) ──
+
+    [Fact]
+    public async Task Instance_DenyOnly_AllowsCallerNotDenied()
+    {
+        var grants = Grants("""[{"role":"blocked","grant":"deny"}]""");
+        (await _sut.IsRoleAllowedForGrantsAsync("someone-else", grants, NewInstance())).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Instance_DenyOnly_DeniesMatchingCaller()
+    {
+        var grants = Grants("""[{"role":"blocked","grant":"deny"}]""");
+        (await _sut.IsRoleAllowedForGrantsAsync("blocked", grants, NewInstance())).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task Instance_Allowlist_DeniesNonMatchingCaller()
+    {
+        var grants = Grants("""[{"role":"maker","grant":"allow"}]""");
+        (await _sut.IsRoleAllowedForGrantsAsync("someone-else", grants, NewInstance())).ShouldBeFalse();
+    }
+
+    // ── IsPredefinedRoleMatchAsync (predefined-only path) ────────────────────────
+
+    [Fact]
+    public async Task Predefined_DenyOnly_AllowsCallerNotDenied()
+    {
+        _currentUser.ActorUserName.Returns("actor");
+        var instance = NewInstance(); // CreatedBy is not "actor" → $InstanceStarter deny does not match
+        var grants = Grants($$"""[{"role":"{{PredefinedInstanceRoles.InstanceStarter}}","grant":"deny"}]""");
+        (await _sut.IsPredefinedRoleMatchAsync(grants, instance)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Predefined_DenyOnly_StrictFlag_DeniesUnmatched()
+    {
+        _currentUser.ActorUserName.Returns("actor");
+        var instance = NewInstance();
+        var grants = Grants($$"""[{"role":"{{PredefinedInstanceRoles.InstanceStarter}}","grant":"deny"}]""");
+        (await _sut.IsPredefinedRoleMatchAsync(grants, instance, CancellationToken.None,
+            defaultAllowWhenNoAllowGrant: false)).ShouldBeFalse();
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/Steps/HandleCancelPreflightStepTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/Steps/HandleCancelPreflightStepTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using BBT.Workflow.BackgroundJobs.Options;
+using BBT.Workflow.Definitions;
 using BBT.Workflow.Execution;
 using BBT.Workflow.Execution.Pipeline.Steps;
 using BBT.Workflow.Instances;


### PR DESCRIPTION
## What & Why
Role grant evaluation was a strict **allowlist**: DENY wins → any matching ALLOW grants access → otherwise **default-deny**. A `roles` set containing **only DENY** entries (a blacklist) therefore denied *every* caller, even those not explicitly denied.

This PR makes a grant set with **no ALLOW grant** behave as a **blacklist**: callers not matched by a DENY are allowed. Sets with at least one ALLOW keep the existing strict default-deny semantics.

Closes #736

## Behavior matrix (caller = `teller`)
| Grant set | Type | Before | After |
|---|---|---|---|
| `[]` | empty | ✅ allow | ✅ allow |
| `[allow: maker]` | allowlist | ⛔ deny | ⛔ deny |
| `[allow: teller]` | allowlist | ✅ allow | ✅ allow |
| **`[deny: blocked]`** | **deny-only** | ⛔ deny | ✅ **allow** |
| `[deny: teller]` | deny-only | ⛔ deny | ⛔ deny |
| `[allow: maker, deny: teller]` | mixed | ⛔ deny | ⛔ deny (DENY wins) |

Only the deny-only / not-denied case changes.

## Whole-list gating (no leak)
The "has any ALLOW?" decision is made over the **whole** grant list, not per subset. This matters in `InstanceQueryAppService`, which splits grants into static/predefined subsets and ANDs them. If an ALLOW exists in the static subset but the predefined subset is deny-only, the deny-only subset must **not** auto-pass — otherwise instances would leak into query results. The whole-list flag (`!hasAnyAllow`) forces strict evaluation in that case.

## Scope (consistent across all grant surfaces)
- `transition.Roles` (instance & static paths)
- state / workflow `QueryRoles`
- schema field-level visibility (`SchemaFieldVisibilityService`)
- custom function `Roles`
- query-filter split path (`InstanceQueryAppService`)

## Implementation notes
Backward-compatible: optional `defaultAllowWhenNoAllowGrant = true` parameter added to `EvaluateRolesStatic` and `IsPredefinedRoleMatchAsync`; the query split path passes `!hasAnyAllow`. Doc comments updated on the class and the interface.

## Tests
New `TransitionAuthorizationManagerBlacklistTests.cs` covers the full matrix (deny-only allow/deny, allowlist regression, mixed deny-wins, strict-flag, predefined). All **63** authorization tests pass.

```
dotnet test test/BBT.Workflow.Application.Tests --filter "FullyQualifiedName~Authorization"
# Passed! Failed: 0, Passed: 63
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust role grant evaluation so deny-only grant sets act as blacklists while preserving existing allowlist behavior when any ALLOW grant is present.

New Features:
- Support blacklist-style authorization semantics where deny-only grant sets allow callers unless explicitly denied.

Enhancements:
- Extend static and predefined role evaluation to accept an optional flag controlling blacklist vs strict-allowlist behavior, enabling whole-list gating in query-based instance filtering.
- Clarify documentation comments on authorization and schema field visibility services to describe the new blacklist/allowlist semantics.

Tests:
- Add TransitionAuthorizationManagerBlacklistTests to cover deny-only blacklist behavior, allowlist regressions, mixed allow/deny precedence, and strict-flag handling across static, instance, and predefined role paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancement**
  * Authorization system updated to support configurable allow/deny semantics for transitions and instance visibility. Authorization can now operate in strict allowlist mode (default-deny unless explicitly allowed) or flexible blacklist mode (default-allow unless explicitly denied) based on grant configuration.

* **Tests**
  * Added comprehensive test coverage for blacklist-based authorization evaluation across all permission check paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->