### PR TITLE
fix(scripting): SoapTask mapping CS0012 + default System.Security escaping

### DIFF
--- a/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Functions/ScriptBase.cs
+++ b/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Functions/ScriptBase.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Security;
 using System.Threading.Tasks;
 using System.Xml;
 using Microsoft.Extensions.Configuration;
@@ -604,6 +605,15 @@ public abstract class ScriptBase
     /// <param name="xmlDoc">The document to serialize</param>
     /// <returns>XML string, or <c>null</c> if <paramref name="xmlDoc"/> is null</returns>
     protected static string? XmlToString(XmlDocument? xmlDoc) => xmlDoc?.OuterXml;
+
+    /// <summary>
+    /// Escapes XML-special characters (<c>&lt; &gt; &amp; " '</c>) in a value so it can be safely
+    /// embedded as text inside an XML/SOAP envelope. Pure string transform — no I/O or parsing.
+    /// Returns <c>null</c> for a null input.
+    /// </summary>
+    /// <param name="value">Raw value to escape (e.g. user-supplied input bound into a SOAP body).</param>
+    /// <returns>The XML-escaped string, or <c>null</c> if <paramref name="value"/> is null.</returns>
+    protected static string? EscapeXml(string? value) => value is null ? null : SecurityElement.Escape(value);
 
     #endregion
 

--- a/src/BBT.Workflow.Application/Scripting/ScriptEngine.cs
+++ b/src/BBT.Workflow.Application/Scripting/ScriptEngine.cs
@@ -63,29 +63,65 @@ public sealed class ScriptEngine(
     /// Includes core .NET types, collections, and workflow-specific assemblies.
     /// </summary>
     private static readonly Lazy<MetadataReference[]> DefaultReferences = new(() =>
-    [
-        MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
-        MetadataReference.CreateFromFile(typeof(IMapping).Assembly.Location),
-        MetadataReference.CreateFromFile(typeof(TimerSchedule).Assembly.Location),
-        MetadataReference.CreateFromFile(typeof(Task).Assembly.Location),
-        MetadataReference.CreateFromFile(typeof(Dictionary<,>).Assembly.Location),
-        MetadataReference.CreateFromFile(typeof(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo).Assembly.Location),
-        // System.Linq.Expressions: provides DynamicAttribute and System.Dynamic.ExpandoObject, both
-        // required for the `dynamic` keyword that mappings rely on (e.g. Handler returns dynamic,
-        // ScriptContext.Body is dynamic). Runtime-owned so it is always referenced even under the
-        // sandbox, where the curated assembly allow-list would otherwise omit it.
-        MetadataReference.CreateFromFile(typeof(System.Dynamic.ExpandoObject).Assembly.Location),
-        MetadataReference.CreateFromFile(typeof(ScriptBase).Assembly.Location),
-        // BBT.Aether.Domain: aggregate base types (AggregateRoot<>, Entity<>, audit interfaces).
-        // Domain entities exposed to mappings — e.g. ScriptContext.Instance — inherit members such as
-        // Id/CreationTime from here, so the assembly must be referenced for those inherited members to
-        // resolve. Like the others, its simple name flows into the sandbox grant automatically.
-        MetadataReference.CreateFromFile(typeof(BBT.Aether.Domain.Entities.AggregateRoot<>).Assembly.Location),
-        MetadataReference.CreateFromFile(typeof(JsonSerializableAttribute).Assembly.Location),
-        MetadataReference.CreateFromFile(typeof(System.Text.Encodings.Web.JavaScriptEncoder).Assembly.Location),
-        MetadataReference.CreateFromFile(typeof(System.Xml.XmlDocument).Assembly.Location),
-        MetadataReference.CreateFromFile(typeof(System.Xml.Linq.XDocument).Assembly.Location),
-    ]);
+    {
+        var references = new List<MetadataReference?>
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(IMapping).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(TimerSchedule).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Task).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Dictionary<,>).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo).Assembly.Location),
+            // System.Linq.Expressions: provides DynamicAttribute and System.Dynamic.ExpandoObject, both
+            // required for the `dynamic` keyword that mappings rely on (e.g. Handler returns dynamic,
+            // ScriptContext.Body is dynamic). Runtime-owned so it is always referenced even under the
+            // sandbox, where the curated assembly allow-list would otherwise omit it.
+            MetadataReference.CreateFromFile(typeof(System.Dynamic.ExpandoObject).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(ScriptBase).Assembly.Location),
+            // BBT.Aether.Domain: aggregate base types (AggregateRoot<>, Entity<>, audit interfaces).
+            // Domain entities exposed to mappings — e.g. ScriptContext.Instance — inherit members such as
+            // Id/CreationTime from here, so the assembly must be referenced for those inherited members to
+            // resolve. Like the others, its simple name flows into the sandbox grant automatically.
+            MetadataReference.CreateFromFile(typeof(BBT.Aether.Domain.Entities.AggregateRoot<>).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(JsonSerializableAttribute).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(System.Text.Encodings.Web.JavaScriptEncoder).Assembly.Location),
+            // System.Private.Xml / System.Private.Xml.Linq: the runtime *implementations* of XmlDocument
+            // and XDocument. Necessary but NOT sufficient — see the facade references below.
+            MetadataReference.CreateFromFile(typeof(System.Xml.XmlDocument).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(System.Xml.Linq.XDocument).Assembly.Location),
+            // XML facade/contract assemblies. Task definitions compiled against the .NET ref pack bind
+            // XmlDocument/XDocument to the facade identities (System.Xml.ReaderWriter / System.Xml.XDocument),
+            // not the System.Private.Xml* implementations above. Roslyn resolves type references by
+            // assembly identity, so any script that merely *touches* such a type — e.g. SoapTask, whose
+            // SetBody(XmlDocument) overload forces resolution of every member signature — fails with
+            // CS0012 unless the facade itself is referenced. The facade has no managed type of its own
+            // (it only forwards to System.Private.Xml), so it cannot be reached via typeof(...).Assembly
+            // and must be resolved by name from the trusted-platform-assembly set. Their simple names
+            // flow into the sandbox grant automatically via DefaultReferenceAssemblyNames.
+            ResolvePlatformFacade("System.Xml.ReaderWriter"),
+            ResolvePlatformFacade("System.Xml.XDocument"),
+        };
+
+        return references.Where(r => r is not null).Cast<MetadataReference>().ToArray();
+    });
+
+    /// <summary>
+    /// Resolves a platform facade/contract assembly (one that carries only <c>TypeForwardedTo</c>
+    /// entries and no managed types, so it cannot be reached through <c>typeof(...).Assembly</c>) by
+    /// its simple name from the runtime's trusted-platform-assembly list. Returns <c>null</c> when the
+    /// facade is absent on the host runtime, letting the caller degrade gracefully instead of failing
+    /// engine startup.
+    /// </summary>
+    private static MetadataReference? ResolvePlatformFacade(string simpleName)
+    {
+        var tpa = (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? string.Empty)
+            .Split(System.IO.Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
+
+        var path = Array.Find(tpa, p =>
+            string.Equals(System.IO.Path.GetFileNameWithoutExtension(p), simpleName, StringComparison.OrdinalIgnoreCase));
+
+        return path is null ? null : MetadataReference.CreateFromFile(path);
+    }
 
     /// <summary>
     /// Simple assembly names backing <see cref="DefaultReferences"/>. These are merged into the sandbox
@@ -124,7 +160,12 @@ public sealed class ScriptEngine(
         "BBT.Workflow.Scripting.Functions",
         "BBT.Workflow.Definitions.Timer",
         "System.Xml",
-        "System.Xml.Linq"
+        "System.Xml.Linq",
+        // System.Security: brings SecurityElement.Escape into scope for XML/SOAP-safe escaping of
+        // user input. The root namespace is benign (SecurityElement/SecureString/legacy CAS no-ops);
+        // a using grants no new capability — the sandbox boundary stays the reference allow-list +
+        // BannedApiAnalyzer, and dangerous sub-namespaces (Cryptography/Principal) are NOT imported.
+        "System.Security"
     };
     
     /// <summary>

--- a/test/BBT.Workflow.Application.Tests/Scripting/SandboxedScriptingTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Scripting/SandboxedScriptingTests.cs
@@ -165,6 +165,59 @@ public class SandboxedScriptingTests
         instance.Calc().ShouldBe(5);
     }
 
+    private static MetadataReference SoapTaskRef =>
+        MetadataReference.CreateFromFile(typeof(BBT.Workflow.Definitions.SoapTask).Assembly.Location);
+
+    private static MetadataReference XmlImplRef =>
+        MetadataReference.CreateFromFile(typeof(System.Xml.XmlDocument).Assembly.Location);
+
+    /// <summary>Resolves a platform facade assembly by simple name from the trusted-platform-assembly set.</summary>
+    private static MetadataReference ResolveFacade(string simpleName)
+    {
+        var tpa = (System.AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? string.Empty)
+            .Split(System.IO.Path.PathSeparator, System.StringSplitOptions.RemoveEmptyEntries);
+        var path = System.Array.Find(tpa, p =>
+            string.Equals(System.IO.Path.GetFileNameWithoutExtension(p), simpleName, System.StringComparison.OrdinalIgnoreCase));
+        path.ShouldNotBeNull($"Facade '{simpleName}' must be present in the TPA set on this runtime.");
+        return MetadataReference.CreateFromFile(path);
+    }
+
+    private const string SoapTouchingCode =
+        "public class C : ISandboxTestCalc { public int Calc() { " +
+        "var t = BBT.Workflow.Definitions.SoapTask.CreateEmpty(); t.SetBody(\"<a/>\"); return t.Body!.Length; } }";
+
+    [Fact]
+    public async Task Sandbox_Compiles_SoapTask_Mapping_With_Xml_Facade()
+    {
+        // Mirror the engine's reference contract under the sandbox: the System.Xml.ReaderWriter facade
+        // (XmlDocument's metadata identity) plus the System.Private.Xml implementation. With both,
+        // a mapping touching SoapTask compiles even when the sandbox is enabled.
+        var evaluator = new CSharpEvaluator(EnabledSandbox());
+
+        var instance = await evaluator.CompileToInstanceAsync<ISandboxTestCalc>(
+            SoapTouchingCode,
+            extraReferences: [ContractRef, SoapTaskRef, XmlImplRef, ResolveFacade("System.Xml.ReaderWriter")],
+            usingDirectives: ["BBT.Workflow.Scripting"]);
+
+        instance.Calc().ShouldBe(4);
+    }
+
+    [Fact]
+    public async Task Sandbox_Disabled_Compiles_SoapTask_Mapping_With_Xml_Facade()
+    {
+        // The reported failure (CS0012 / System.Xml.ReaderWriter) is on the Execution host where the
+        // sandbox is disabled. Supplying the facade + implementation references compiles a SoapTask
+        // mapping on that path too.
+        var evaluator = new CSharpEvaluator(new ScriptSandboxOptions { Enabled = false });
+
+        var instance = await evaluator.CompileToInstanceAsync<ISandboxTestCalc>(
+            SoapTouchingCode,
+            extraReferences: [ContractRef, SoapTaskRef, XmlImplRef, ResolveFacade("System.Xml.ReaderWriter")],
+            usingDirectives: ["BBT.Workflow.Scripting"]);
+
+        instance.Calc().ShouldBe(4);
+    }
+
     [Fact]
     public void HelperRegistry_Compiles_Set_And_Exposes_Namespaces()
     {

--- a/test/BBT.Workflow.Application.Tests/Scripting/ScriptEngineTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Scripting/ScriptEngineTests.cs
@@ -223,6 +223,186 @@ public class ScriptEngineTests : ApplicationTestBase<ApplicationEntryPoint>
         Assert.Equal("Got secret: mock_secret_value", response.Data);
     }
 
+    [Fact]
+    public async Task Compile_SoapTask_Mapping_Should_Resolve_XmlDocument_Facade()
+    {
+        // Regression: a mapping that merely touches SoapTask forces Roslyn to resolve every member
+        // signature, including SetBody(XmlDocument). XmlDocument's metadata identity binds to the
+        // System.Xml.ReaderWriter facade, which is not the System.Private.Xml implementation reachable
+        // via typeof(XmlDocument).Assembly. Without the facade reference this failed with
+        // CS0012 (System.Xml.ReaderWriter not referenced). The engine's default references must cover it
+        // WITHOUT the mapping author supplying any System.Xml reference explicitly.
+        var code = """
+                   using System.Threading.Tasks;
+                   using BBT.Workflow.Scripting;
+                   using BBT.Workflow.Definitions;
+
+                   public class SoapMapping : IMapping
+                   {
+                       public Task<ScriptResponse> InputHandler(WorkflowTask task, ScriptContext context)
+                       {
+                           var soap = (task as SoapTask)!;
+                           soap.SetUrl("https://example.com/soap");
+                           soap.SetBody("<a/>");
+                           return Task.FromResult(new ScriptResponse { Data = soap.Body, Headers = null });
+                       }
+
+                       public Task<ScriptResponse> OutputHandler(ScriptContext context)
+                           => Task.FromResult(new ScriptResponse { Data = "out", Headers = null });
+                   }
+                   """;
+
+        // Only the runtime contract assembly is supplied; the XML references come from the engine defaults.
+        var references = new List<MetadataReference>
+        {
+            MetadataReference.CreateFromFile(typeof(IMapping).Assembly.Location)
+        };
+
+        var instance = await _scriptEngine.CompileToInstanceAsync<IMapping>(code, references);
+
+        var soapTask = WorkflowTaskFactory.CreateSoapTask();
+        var response = await instance.InputHandler(
+            task: soapTask,
+            context: new ScriptContext.Builder(Mock.Of<ILogger<ScriptContext>>())
+                .SetWorkflow(WorkflowFactory.CreateDefault())
+                .SetInstance(InstanceFactory.CreateDefault())
+                .SetTransition(TransitionFactory.CreateDefault())
+                .SetRuntime(Mock.Of<IRuntimeInfoProvider>())
+                .SetDefinitions(new Dictionary<string, object>())
+                .Build());
+
+        Assert.NotNull(response);
+        Assert.Equal("<a/>", response.Data);
+        Assert.Equal("https://example.com/soap", soapTask.Url);
+        Assert.Equal("<a/>", soapTask.Body);
+    }
+
+    [Fact]
+    public async Task Compile_Mapping_Using_SecurityElement_Escape_Without_Explicit_Using_Should_Work()
+    {
+        // System.Security is a default using, so SecurityElement.Escape resolves with no explicit
+        // using in the mapping. Verifies XML/SOAP-safe escaping of user input is available by default.
+        var code = """
+                   using System.Threading.Tasks;
+                   using BBT.Workflow.Scripting;
+                   using BBT.Workflow.Definitions;
+
+                   public class EscapeMapping : IMapping
+                   {
+                       public Task<ScriptResponse> InputHandler(WorkflowTask task, ScriptContext context)
+                           => Task.FromResult(new ScriptResponse { Data = SecurityElement.Escape("<a>&'\""), Headers = null });
+
+                       public Task<ScriptResponse> OutputHandler(ScriptContext context)
+                           => Task.FromResult(new ScriptResponse { Data = "out", Headers = null });
+                   }
+                   """;
+
+        var references = new List<MetadataReference>
+        {
+            MetadataReference.CreateFromFile(typeof(IMapping).Assembly.Location)
+        };
+
+        var instance = await _scriptEngine.CompileToInstanceAsync<IMapping>(code, references);
+
+        var response = await instance.InputHandler(
+            task: WorkflowTaskFactory.CreateHttpTask(),
+            context: new ScriptContext.Builder(Mock.Of<ILogger<ScriptContext>>())
+                .SetWorkflow(WorkflowFactory.CreateDefault())
+                .SetInstance(InstanceFactory.CreateDefault())
+                .SetTransition(TransitionFactory.CreateDefault())
+                .SetRuntime(Mock.Of<IRuntimeInfoProvider>())
+                .SetDefinitions(new Dictionary<string, object>())
+                .Build());
+
+        Assert.Equal("&lt;a&gt;&amp;&apos;&quot;", response.Data?.ToString());
+    }
+
+    [Fact]
+    public async Task Compile_Mapping_Using_ScriptBase_EscapeXml_Helper_Should_Work()
+    {
+        // ScriptBase.EscapeXml wraps SecurityElement.Escape as a curated helper.
+        var code = """
+                   using System.Threading.Tasks;
+                   using BBT.Workflow.Scripting;
+                   using BBT.Workflow.Definitions;
+                   using BBT.Workflow.Scripting.Functions;
+
+                   public class EscapeHelperMapping : ScriptBase, IMapping
+                   {
+                       public Task<ScriptResponse> InputHandler(WorkflowTask task, ScriptContext context)
+                           => Task.FromResult(new ScriptResponse { Data = EscapeXml("a & b"), Headers = null });
+
+                       public Task<ScriptResponse> OutputHandler(ScriptContext context)
+                           => Task.FromResult(new ScriptResponse { Data = "out", Headers = null });
+                   }
+                   """;
+
+        var references = new List<MetadataReference>
+        {
+            MetadataReference.CreateFromFile(typeof(IMapping).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(ScriptBase).Assembly.Location)
+        };
+
+        var instance = await _scriptEngine.CompileToInstanceAsync<IMapping>(code, references);
+
+        var response = await instance.InputHandler(
+            task: WorkflowTaskFactory.CreateHttpTask(),
+            context: new ScriptContext.Builder(Mock.Of<ILogger<ScriptContext>>())
+                .SetWorkflow(WorkflowFactory.CreateDefault())
+                .SetInstance(InstanceFactory.CreateDefault())
+                .SetTransition(TransitionFactory.CreateDefault())
+                .SetRuntime(Mock.Of<IRuntimeInfoProvider>())
+                .SetDefinitions(new Dictionary<string, object>())
+                .Build());
+
+        Assert.Equal("a &amp; b", response.Data?.ToString());
+    }
+
+    [Fact]
+    public async Task Compile_Mapping_Using_ScriptBase_ParseXml_Should_Work()
+    {
+        // Locks in the general System.Xml path: ScriptBase.ParseXml returns an XmlDocument, so the
+        // facade reference is required even for mappings that never touch SoapTask.
+        var code = """
+                   using System.Threading.Tasks;
+                   using BBT.Workflow.Scripting;
+                   using BBT.Workflow.Definitions;
+                   using BBT.Workflow.Scripting.Functions;
+
+                   public class XmlMapping : ScriptBase, IMapping
+                   {
+                       public Task<ScriptResponse> InputHandler(WorkflowTask task, ScriptContext context)
+                       {
+                           var doc = ParseXml("<root><v>42</v></root>");
+                           return Task.FromResult(new ScriptResponse { Data = XmlToString(doc), Headers = null });
+                       }
+
+                       public Task<ScriptResponse> OutputHandler(ScriptContext context)
+                           => Task.FromResult(new ScriptResponse { Data = "out", Headers = null });
+                   }
+                   """;
+
+        var references = new List<MetadataReference>
+        {
+            MetadataReference.CreateFromFile(typeof(IMapping).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(ScriptBase).Assembly.Location)
+        };
+
+        var instance = await _scriptEngine.CompileToInstanceAsync<IMapping>(code, references);
+
+        var response = await instance.InputHandler(
+            task: WorkflowTaskFactory.CreateHttpTask(),
+            context: new ScriptContext.Builder(Mock.Of<ILogger<ScriptContext>>())
+                .SetWorkflow(WorkflowFactory.CreateDefault())
+                .SetInstance(InstanceFactory.CreateDefault())
+                .SetTransition(TransitionFactory.CreateDefault())
+                .SetRuntime(Mock.Of<IRuntimeInfoProvider>())
+                .SetDefinitions(new Dictionary<string, object>())
+                .Build());
+
+        Assert.NotNull(response);
+        Assert.Contains("<root>", response.Data?.ToString());
+    }
 }
 
 public interface IMyCompiledClass

--- a/test/BBT.Workflow.Domain.Tests/Factories/WorkflowTaskFactory.cs
+++ b/test/BBT.Workflow.Domain.Tests/Factories/WorkflowTaskFactory.cs
@@ -24,6 +24,23 @@ public static class WorkflowTaskFactory
         return task;
     }
 
+    public static SoapTask CreateSoapTask(string name = "mock-soap")
+    {
+        var config = """
+                      {
+                        "url": "https://example.com/soap",
+                        "soapAction": "urn:Test",
+                        "soapVersion": "1.1",
+                        "body": "<envelope/>",
+                        "timeoutSeconds": 25
+                      }
+                     """;
+
+        var task = SoapTask.Create(config.ToJsonElement());
+        task.SetReference(new Reference(name, "test", "sys-tasks", "1.0.0"));
+        return task;
+    }
+
     public static GetInstancesTask CreateGetInstancesTask(
         string name = "get-instances",
         string domain = "test-domain",


### PR DESCRIPTION
Closes #738

## What changed
**1. Fix: SoapTask mappings fail to compile with CS0012 (`System.Xml.ReaderWriter`)**
Any mapping that touches `SoapTask` forces Roslyn to resolve `SetBody(XmlDocument)`, whose `XmlDocument` metadata binds to the **facade** assembly identity `System.Xml.ReaderWriter`. The reference set only carried the **implementation** `System.Private.Xml` (via `typeof(XmlDocument).Assembly.Location`), and Roslyn matches type references by assembly identity → CS0012. SOAP integrations Fault in `sending-{operator}`.

- `ScriptEngine.DefaultReferences` now also references the XML **facade** assemblies (`System.Xml.ReaderWriter`, `System.Xml.XDocument`), resolved by name from the TPA list via a new `ResolvePlatformFacade(...)` helper (facades expose no managed type, so `typeof(...).Assembly` can't reach them; null-filtered for graceful degradation).
- Names auto-flow into the sandbox grant via `DefaultReferenceAssemblyNames`, so both Execution (sandbox off) and Orchestration (sandbox on) are covered with no appsettings changes.

**2. Enhancement: XML/SOAP-safe escaping in mappings by default**
- `ScriptEngine.DefaultUsings`: added `System.Security` so `SecurityElement.Escape(...)` resolves without an explicit `using`.
- `ScriptBase.EscapeXml(string?)`: curated, null-safe wrapper over `SecurityElement.Escape`, mirroring the existing `ParseXml`/`XmlToString` helpers.

## Why it's safe
A `using` is compile-time sugar — it grants no new capability. The sandbox boundary stays the reference allow-list + `BannedApiAnalyzer`. The `System.Security` root namespace is benign (`SecurityElement`/`SecureString`/legacy CAS no-ops), and a root `using` does **not** import dangerous sub-namespaces (`System.Security.Cryptography`/`Principal`). No analyzer change required.

## Tests
Added regression tests (Application.Tests/Scripting):
- SoapTask mapping compiles through engine defaults (no explicit XML reference).
- `ScriptBase.ParseXml` compiles/runs.
- `SecurityElement.Escape` usable with no explicit `using` (default-using path).
- `ScriptBase.EscapeXml` escapes `< > & " '` correctly.
- New `WorkflowTaskFactory.CreateSoapTask` helper.

Result: scripting suite green (1 unrelated pre-existing failure: `ScriptCodeModelTests.ScriptCode_Json_Reads_Reference_Code_For_Ref_Encoding`, confirmed failing on master without these changes).

## Reviewer notes
- **Verification gap:** the CS0012 is **not reproducible on a local .NET 10 SDK** — local Roslyn unifies the `System.Xml.ReaderWriter` TypeRef against `System.Private.Xml` and compiles fine. The failure only manifests on the stricter 0.0.61 Docker runtime. The facade fix is the correct, error-message-aligned resolution, but should be validated on a **v0.0.61-equivalent image** (or a live `sending-{operator}` SOAP flow) before relying on it.
- **Follow-up (optional):** if a stricter posture is wanted, consider banning sensitive `System.Security.*` sub-namespaces (`Cryptography`, `Principal`) in `BannedApiAnalyzer` — a pre-existing posture decision, independent of this PR.
- A stray scratch file `src/BBT.Workflow.Application/SoapTestMapping.cs` (untracked, predates this work) was intentionally **not** included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix SoapTask script compilation failures by including XML facade assemblies in default script references and add a built-in XML escaping helper for mappings.

Bug Fixes:
- Ensure SoapTask-based mappings compile by adding System.Xml facade assemblies to the script engine default references and sandbox configuration.

Enhancements:
- Expose System.Security as a default using and add a ScriptBase.EscapeXml helper to support safe XML/SOAP escaping in mappings.

Tests:
- Add regression tests covering SoapTask mappings, ScriptBase XML helpers, SecurityElement-based escaping, and sandbox behavior with XML facade references.
- Introduce a WorkflowTaskFactory helper for constructing SoapTask instances in tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added XML escaping helper for safe text embedding in XML contexts
  * Extended script engine with `System.Security` support for XML operations

* **Bug Fixes**
  * Improved handling of XML and SOAP task operations in sandboxed scripting environments

* **Tests**
  * Added comprehensive test coverage for XML escaping, SOAP task mappings, and security functionality in sandboxed scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->