### PR TITLE
feat(tasks): configurable HTTP Content-Type and byte-exact body for signing

### DIFF
--- a/execution/BBT.Workflow.Execution.HttpApi.Host/Microsoft/AspNetCore/Builder/ExecutionApiApplicationBuilderExtensions.cs
+++ b/execution/BBT.Workflow.Execution.HttpApi.Host/Microsoft/AspNetCore/Builder/ExecutionApiApplicationBuilderExtensions.cs
@@ -33,6 +33,7 @@ public static class ExecutionApiApplicationBuilderExtensions
         app.UseParentInstanceIdEnrichment();
         app.UseSecurityHeaders();
         app.UseCurrentUser();
+        app.UseRawRequestBodyBuffering();
         app.UseStaticFiles();
         app.UseAetherApiVersioning(
             useSwagger: !app.Environment.IsProduction(),

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Microsoft/AspNetCore/Builder/OrchestrationApiApplicationBuilderExtensions.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Microsoft/AspNetCore/Builder/OrchestrationApiApplicationBuilderExtensions.cs
@@ -34,6 +34,7 @@ public static class OrchestrationApiApplicationBuilderExtensions
         app.UseParentInstanceIdEnrichment();
         app.UseSecurityHeaders();
         app.UseCurrentUser();
+        app.UseRawRequestBodyBuffering();
         app.UseStaticFiles();
         app.UseAetherApiVersioning(
             useSwagger: !app.Environment.IsProduction(),

--- a/src/BBT.Workflow.Application/BackgroundJobs/Handlers/TransitionJobHandler.cs
+++ b/src/BBT.Workflow.Application/BackgroundJobs/Handlers/TransitionJobHandler.cs
@@ -8,6 +8,7 @@ using BBT.Workflow.Execution;
 using BBT.Workflow.Execution.Services;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Logging;
+using BBT.Workflow.Scripting;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -58,6 +59,10 @@ public sealed class TransitionJobHandler(
 
                 try
                 {
+                    // Expose the original raw request body to mappings built inside this job (no live
+                    // HttpContext here) so background signature verification (JWS/mTLS) can run.
+                    using var rawBodyScope = RawBodyExecutionScope.Set(args.RawBody);
+
                     BackgroundJobActivityHelper.EnrichActivity(activity, args);
                     BackgroundJobActivityHelper.EnrichActivityWithTransition(activity, args.TransitionKey);
 

--- a/src/BBT.Workflow.Application/BackgroundJobs/Payloads/TransitionJobPayload.cs
+++ b/src/BBT.Workflow.Application/BackgroundJobs/Payloads/TransitionJobPayload.cs
@@ -48,6 +48,13 @@ public sealed class TransitionJobPayload : ITraceableJobPayload
     public JsonElement? Data { get; set; }
 
     /// <summary>
+    /// Gets or sets the original, unmodified request body (as a literal string) captured at accept time.
+    /// Carried so background mappings can verify signatures (JWS / mTLS) over the exact payload bytes.
+    /// A string round-trips byte-for-byte through the camelCased job payload serialization, unlike <see cref="Data"/>.
+    /// </summary>
+    public string? RawBody { get; set; }
+
+    /// <summary>
     /// Gets or sets the instance key (Optional).
     /// </summary>
     public string? InstanceKey { get; set; }

--- a/src/BBT.Workflow.Application/Execution/Transitions/Strategy/AsyncTransitionStrategy.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Strategy/AsyncTransitionStrategy.cs
@@ -14,6 +14,7 @@ using BBT.Workflow.Execution.Validation;
 using BBT.Workflow.Gateway;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Logging;
+using BBT.Workflow.Scripting;
 using Dapr.Jobs.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -51,6 +52,7 @@ public sealed class AsyncTransitionStrategy(
     IInstanceCommandGateway instanceCommandGateway,
     IDistributedEventBus eventBus,
     IOptions<WorkflowExecutionOptions> executionOptions,
+    IRequestRawBodyProvider rawBodyProvider,
     ILogger<AsyncTransitionStrategy> logger) : ITransitionStrategy
 {
     /// <summary>
@@ -232,7 +234,8 @@ public sealed class AsyncTransitionStrategy(
         // enqueue, the ChainReaper backstop recovers the pending intent. The job is keyed by
         // JobName (not the Dapr-returned id), so a generated id for the intent is sufficient —
         // mirroring the outbox path.
-        var (jobName, jobPayload, schedule, metadata) = BuildJobPayload(context, transContext, activity);
+        var (jobName, jobPayload, schedule, metadata) =
+            BuildJobPayload(context, transContext, activity, rawBodyProvider.GetRawBody());
         var jobId = Guid.NewGuid();
 
         await using (var jobUow = await uowManager.BeginAsync(
@@ -360,7 +363,8 @@ public sealed class AsyncTransitionStrategy(
     /// Pure function - no side effects.
     /// </summary>
     private static (string JobName, TransitionJobPayload Payload, string Schedule, Dictionary<string, object> Metadata)
-        BuildJobPayload(WorkflowExecutionContext context, TransitionExecutionContext transContext, Activity? activity)
+        BuildJobPayload(WorkflowExecutionContext context, TransitionExecutionContext transContext, Activity? activity,
+            string? rawBody)
     {
         var jobName = $"trans-{context.InstanceId}-{context.TransitionKey}";
 
@@ -373,6 +377,7 @@ public sealed class AsyncTransitionStrategy(
             Workflow = transContext.WorkflowKey,
             Version = transContext.Workflow.Version,
             Data = context.Data?.Attributes,
+            RawBody = rawBody,
             InstanceKey = context.Data?.Key,
             Tags = context.Data?.Tags,
             Headers = context.Headers,

--- a/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/TaskServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/TaskServiceCollectionExtensions.cs
@@ -223,6 +223,10 @@ public static class TaskServiceCollectionExtensions
     {
         services.AddSingleton<IScriptContextFactory, ScriptContextFactory>();
 
+        // Default raw-body provider resolves the original request body from the ambient job scope only.
+        // HTTP hosts replace this (via Replace) with one that also reads the live HTTP request.
+        services.TryAddSingleton<IRequestRawBodyProvider, AmbientRequestRawBodyProvider>();
+
         // Sandbox + custom-script-helpers options, bound defensively from configuration so a missing
         // section simply yields safe defaults (sandbox disabled, helpers disabled). Registered as
         // concrete singletons (not IOptions) so consumers can be constructed without an IConfiguration.

--- a/src/BBT.Workflow.Application/Tasks/Mapping/TaskBindingMapper.cs
+++ b/src/BBT.Workflow.Application/Tasks/Mapping/TaskBindingMapper.cs
@@ -195,16 +195,58 @@ public static class TaskBindingMapper
     /// <summary>
     /// Maps HttpTask to HttpTaskBinding.
     /// </summary>
-    private static HttpTaskBinding MapHttpTask(HttpTask task) => new()
+    private static HttpTaskBinding MapHttpTask(HttpTask task)
     {
-        Url = task.Url,
-        Method = task.Method,
-        Headers = task.Headers?.GetRawText(),
-        Body = task.Body?.GetRawText(),
-        TimeoutSeconds = task.TimeoutSeconds,
-        ValidateSSL = task.ValidateSSL,
-        AcceptedStatusCodes = task.AcceptedStatusCodes
-    };
+        var contentType = HttpContentType.Resolve(task.ContentType, ReadHeaderContentType(task.Headers));
+
+        return new HttpTaskBinding
+        {
+            Url = task.Url,
+            Method = task.Method,
+            Headers = task.Headers?.GetRawText(),
+            Body = task.RawBody ?? SerializeBody(task.Body, contentType),
+            ContentType = task.ContentType,
+            TimeoutSeconds = task.TimeoutSeconds,
+            ValidateSSL = task.ValidateSSL,
+            AcceptedStatusCodes = task.AcceptedStatusCodes
+        };
+    }
+
+    /// <summary>
+    /// Serializes the task body to its wire representation. JSON content types preserve the raw JSON text;
+    /// for non-JSON content types a JSON-string body is unwrapped to its raw value (e.g. form-urlencoded
+    /// "a=1&amp;b=2") so it is not transmitted with surrounding quotes.
+    /// </summary>
+    private static string? SerializeBody(JsonElement? body, string contentType)
+    {
+        if (body is not { } element)
+            return null;
+
+        if (!HttpContentType.IsJson(contentType) && element.ValueKind == JsonValueKind.String)
+            return element.GetString();
+
+        return element.GetRawText();
+    }
+
+    /// <summary>
+    /// Reads the "Content-Type" entry (case-insensitive) from the task headers JSON, if present.
+    /// </summary>
+    private static string? ReadHeaderContentType(JsonElement? headers)
+    {
+        if (headers is not { ValueKind: JsonValueKind.Object } element)
+            return null;
+
+        foreach (var property in element.EnumerateObject())
+        {
+            if (string.Equals(property.Name, "Content-Type", System.StringComparison.OrdinalIgnoreCase)
+                && property.Value.ValueKind == JsonValueKind.String)
+            {
+                return property.Value.GetString();
+            }
+        }
+
+        return null;
+    }
 
     /// <summary>
     /// Maps DaprServiceTask to DaprServiceBinding.

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/HttpTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/HttpTask.cs
@@ -40,6 +40,21 @@ public sealed class HttpTask : WorkflowTask
     public JsonElement? Body { get; private set; }
 
     /// <summary>
+    /// Explicit media type applied to the request body (e.g. "application/x-www-form-urlencoded", "text/plain").
+    /// When set, it overrides any "Content-Type" entry in <see cref="Headers"/>.
+    /// When null, the "Content-Type" header is used, falling back to "application/json".
+    /// </summary>
+    public string? ContentType { get; private set; }
+
+    /// <summary>
+    /// Verbatim request body. When set, it is transmitted byte-for-byte without any JSON re-serialization
+    /// (bypasses <see cref="Body"/> serialization and content-type unwrapping). Use this for signing
+    /// scenarios (JWS/mTLS) where the wire body must exactly match the bytes that were signed.
+    /// Takes precedence over <see cref="Body"/>.
+    /// </summary>
+    public string? RawBody { get; private set; }
+
+    /// <summary>
     /// Timeout seconds
     /// </summary>
     public int TimeoutSeconds { get; private set; } = 30;
@@ -68,6 +83,25 @@ public sealed class HttpTask : WorkflowTask
     public void SetBody(dynamic body)
     {
         Body = JsonSerializer.SerializeToElement(body);
+    }
+
+    /// <summary>
+    /// Sets the explicit content type applied to the request body. Pass null to fall back to header/default resolution.
+    /// </summary>
+    /// <param name="contentType">The media type, e.g. "application/x-www-form-urlencoded"; or null.</param>
+    public void SetContentType(string? contentType)
+    {
+        ContentType = string.IsNullOrWhiteSpace(contentType) ? null : contentType;
+    }
+
+    /// <summary>
+    /// Sets the verbatim request body that will be transmitted byte-for-byte (no JSON re-serialization).
+    /// Use for signed payloads. Pass null to clear and fall back to <see cref="Body"/>.
+    /// </summary>
+    /// <param name="raw">The exact body string to send; or null.</param>
+    public void SetRawBody(string? raw)
+    {
+        RawBody = raw;
     }
     
     public void SetHeaders(Dictionary<string, string?> headers)
@@ -105,6 +139,8 @@ public sealed class HttpTask : WorkflowTask
     /// </summary>
     internal void SetHeadersInternal(JsonElement? headers) => Headers = headers;
     internal void SetBodyInternal(JsonElement? body) => Body = body;
+    internal void SetContentTypeInternal(string? contentType) => ContentType = contentType;
+    internal void SetRawBodyInternal(string? raw) => RawBody = raw;
     internal void SetTimeoutSecondsInternal(int timeoutSeconds) => TimeoutSeconds = timeoutSeconds;
     internal void SetValidateSSLInternal(bool validateSSL) => ValidateSSL = validateSSL;
     internal void SetAcceptedStatusCodesInternal(IReadOnlyList<string>? codes) => AcceptedStatusCodes = codes;
@@ -129,6 +165,19 @@ public sealed class HttpTask : WorkflowTask
         {
             var body = bodyElement.GetRawText();
             Body = string.IsNullOrWhiteSpace(body) ? null : bodyElement;
+        }
+
+        if (config.TryGetProperty("contentType", out var contentTypeElement))
+        {
+            var contentType = contentTypeElement.GetString();
+            ContentType = string.IsNullOrWhiteSpace(contentType) ? null : contentType;
+        }
+
+        if (config.TryGetProperty("rawBody", out var rawBodyElement) &&
+            rawBodyElement.ValueKind == JsonValueKind.String)
+        {
+            var raw = rawBodyElement.GetString();
+            RawBody = string.IsNullOrEmpty(raw) ? null : raw;
         }
 
         if (config.TryGetProperty("timeoutSeconds", out var timeoutSeconds))
@@ -175,6 +224,8 @@ public sealed class HttpTask : WorkflowTask
         cloned.Method = Method;
         cloned.Headers = Headers;
         cloned.Body = Body;
+        cloned.ContentType = ContentType;
+        cloned.RawBody = RawBody;
         cloned.TimeoutSeconds = TimeoutSeconds;
         cloned.ValidateSSL = ValidateSSL;
         cloned.AcceptedStatusCodes = AcceptedStatusCodes;
@@ -193,6 +244,8 @@ public sealed class HttpTask : WorkflowTask
         Method = source.Method;
         SetHeadersInternal(source.Headers);
         SetBodyInternal(source.Body);
+        SetContentTypeInternal(source.ContentType);
+        SetRawBodyInternal(source.RawBody);
         SetTimeoutSecondsInternal(source.TimeoutSeconds);
         SetValidateSSLInternal(source.ValidateSSL);
         SetAcceptedStatusCodesInternal(source.AcceptedStatusCodes);
@@ -208,6 +261,8 @@ public sealed class HttpTask : WorkflowTask
         Method = "GET";
         Headers = null;
         Body = null;
+        ContentType = null;
+        RawBody = null;
         TimeoutSeconds = 30;
         ValidateSSL = true;
         AcceptedStatusCodes = null;

--- a/src/BBT.Workflow.Domain/Scripting/AmbientRequestRawBodyProvider.cs
+++ b/src/BBT.Workflow.Domain/Scripting/AmbientRequestRawBodyProvider.cs
@@ -1,0 +1,13 @@
+namespace BBT.Workflow.Scripting;
+
+/// <summary>
+/// Default <see cref="IRequestRawBodyProvider"/> for hosts without an HTTP request pipeline
+/// (workers, migrators). Resolves the raw body from the ambient job scope only
+/// (<see cref="RawBodyExecutionScope"/>). HTTP hosts replace this with an implementation that
+/// also reads the live request body.
+/// </summary>
+public sealed class AmbientRequestRawBodyProvider : IRequestRawBodyProvider
+{
+    /// <inheritdoc />
+    public string? GetRawBody() => RawBodyExecutionScope.Current;
+}

--- a/src/BBT.Workflow.Domain/Scripting/Factory/Contracts/IScriptContextBuilder.cs
+++ b/src/BBT.Workflow.Domain/Scripting/Factory/Contracts/IScriptContextBuilder.cs
@@ -54,6 +54,12 @@ public interface IScriptContextBuilder
     /// Sets the request body data for the ScriptContext.
     /// </summary>
     IScriptContextBuilder WithBody(object? body);
+
+    /// <summary>
+    /// Sets the original raw request body (literal string, no re-serialization) for signature verification.
+    /// When not set, the builder auto-populates it from the request/job-scoped raw body provider.
+    /// </summary>
+    IScriptContextBuilder WithRawBody(string? rawBody);
     
     /// <summary>
     /// Sets the request headers for the ScriptContext.

--- a/src/BBT.Workflow.Domain/Scripting/Factory/Services/ScriptContextBuilder.cs
+++ b/src/BBT.Workflow.Domain/Scripting/Factory/Services/ScriptContextBuilder.cs
@@ -16,13 +16,15 @@ namespace BBT.Workflow.Scripting;
 internal sealed class ScriptContextBuilder(
     IComponentCacheStore componentCacheStore,
     IInstanceRepository instanceRepository,
-    ILogger<ScriptContext> logger) : IScriptContextBuilder
+    ILogger<ScriptContext> logger,
+    IRequestRawBodyProvider? rawBodyProvider = null) : IScriptContextBuilder
 {
     private IRuntimeInfoProvider? _runtimeInfoProvider;
     private Definitions.Workflow? _workflow;
     private Instance? _instance;
     private Transition? _transition;
     private object? _body;
+    private string? _explicitRawBody;
     private Dictionary<string, string?>? _headers;
     private Dictionary<string, object?>? _routeValues;
     private Dictionary<string, object?>? _queryParameters;
@@ -120,6 +122,12 @@ internal sealed class ScriptContextBuilder(
         return this;
     }
 
+    public IScriptContextBuilder WithRawBody(string? rawBody)
+    {
+        _explicitRawBody = rawBody;
+        return this;
+    }
+
     public IScriptContextBuilder WithHeaders(Dictionary<string, string?>? headers)
     {
         _headers = headers;
@@ -212,6 +220,7 @@ internal sealed class ScriptContextBuilder(
         return builder
             .SetRuntime(_runtimeInfoProvider!)
             .SetBody(_body)
+            .SetRawBody(_explicitRawBody ?? rawBodyProvider?.GetRawBody())
             .SetHeaders(_headers)
             .SetRouteValues(_routeValues)
             .SetQueryParameters(_queryParameters)

--- a/src/BBT.Workflow.Domain/Scripting/Factory/Services/ScriptContextFactory.cs
+++ b/src/BBT.Workflow.Domain/Scripting/Factory/Services/ScriptContextFactory.cs
@@ -10,7 +10,8 @@ namespace BBT.Workflow.Scripting;
 /// </summary>
 public sealed class ScriptContextFactory(
     IComponentCacheStore componentCacheStore,
-    ILogger<ScriptContext> logger) : IScriptContextFactory
+    ILogger<ScriptContext> logger,
+    IRequestRawBodyProvider? rawBodyProvider = null) : IScriptContextFactory
 {
     /// <summary>
     /// Creates a new fluent builder for constructing ScriptContext instances.
@@ -18,6 +19,6 @@ public sealed class ScriptContextFactory(
     /// <returns>A new ScriptContextBuilder instance for fluent configuration.</returns>
     public IScriptContextBuilder NewBuilder(IInstanceRepository  instanceRepository)
     {
-        return new ScriptContextBuilder(componentCacheStore, instanceRepository, logger);
+        return new ScriptContextBuilder(componentCacheStore, instanceRepository, logger, rawBodyProvider);
     }
 }

--- a/src/BBT.Workflow.Domain/Scripting/IRequestRawBodyProvider.cs
+++ b/src/BBT.Workflow.Domain/Scripting/IRequestRawBodyProvider.cs
@@ -1,0 +1,16 @@
+namespace BBT.Workflow.Scripting;
+
+/// <summary>
+/// Provides the original, unmodified request body (as a string) for the current execution so that
+/// mappings can verify signatures (JWS / mTLS) over the exact payload bytes. Implementations resolve
+/// from the ambient job scope first (background pipeline execution via <see cref="RawBodyExecutionScope"/>),
+/// then from the live HTTP request when available.
+/// </summary>
+public interface IRequestRawBodyProvider
+{
+    /// <summary>
+    /// Returns the raw request body for the current scope, or <c>null</c> when no raw body is available
+    /// (e.g. purely internal executions with neither an HTTP request nor a job scope).
+    /// </summary>
+    string? GetRawBody();
+}

--- a/src/BBT.Workflow.Domain/Scripting/Models.cs
+++ b/src/BBT.Workflow.Domain/Scripting/Models.cs
@@ -299,6 +299,14 @@ public class ScriptContext(ILogger<ScriptContext> logger) : IDisposable, IAsyncD
     public dynamic? QueryParameters { get; private set; }
 
     /// <summary>
+    /// The original, unmodified request body exactly as received (a literal string, NOT camelCased or
+    /// re-serialized like <see cref="Body"/>). Intended for signature verification (JWS / mTLS) where the
+    /// payload must match the bytes that were signed. Null when no raw body is available for the current
+    /// execution (e.g. internal executions with neither an HTTP request nor a job scope).
+    /// </summary>
+    public string? RawBody { get; private set; }
+
+    /// <summary>
     /// The active workflow instance that is currently being processed or executed.
     /// This represents the live instance with its current state, data, and execution history.
     /// </summary>
@@ -606,6 +614,15 @@ public class ScriptContext(ILogger<ScriptContext> logger) : IDisposable, IAsyncD
         public Builder SetQueryParameters(object? queryParameters)
         {
             _context.QueryParameters = queryParameters;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the original raw request body (literal string, no re-serialization) for signature verification.
+        /// </summary>
+        public Builder SetRawBody(string? rawBody)
+        {
+            _context.RawBody = rawBody;
             return this;
         }
 

--- a/src/BBT.Workflow.Domain/Scripting/RawBodyExecutionScope.cs
+++ b/src/BBT.Workflow.Domain/Scripting/RawBodyExecutionScope.cs
@@ -1,0 +1,31 @@
+namespace BBT.Workflow.Scripting;
+
+/// <summary>
+/// Ambient holder for the original raw request body during background (non-HTTP) execution —
+/// e.g. an async transition or instance-start job, where there is no live HTTP request.
+/// A job handler sets it for the duration of its <c>HandleAsync</c> scope so that every
+/// <see cref="ScriptContext"/> built inside the job can resolve the raw body for signature verification.
+/// </summary>
+public static class RawBodyExecutionScope
+{
+    private static readonly AsyncLocal<string?> CurrentValue = new();
+
+    /// <summary>The raw body for the current async scope, or <c>null</c> when not set.</summary>
+    public static string? Current => CurrentValue.Value;
+
+    /// <summary>
+    /// Sets the raw body for the current async scope. Dispose the returned token to restore the previous value.
+    /// </summary>
+    /// <param name="rawBody">The raw request body string to expose, or null.</param>
+    public static IDisposable Set(string? rawBody)
+    {
+        var previous = CurrentValue.Value;
+        CurrentValue.Value = rawBody;
+        return new ScopeToken(previous);
+    }
+
+    private sealed class ScopeToken(string? previous) : IDisposable
+    {
+        public void Dispose() => CurrentValue.Value = previous;
+    }
+}

--- a/src/BBT.Workflow.Execution.Abstractions/Bindings/HttpContentType.cs
+++ b/src/BBT.Workflow.Execution.Abstractions/Bindings/HttpContentType.cs
@@ -1,0 +1,43 @@
+namespace BBT.Workflow.Execution.Bindings;
+
+/// <summary>
+/// Resolves the effective media type for an HTTP/SOAP-style request body and classifies it.
+/// Shared between the binding mapper (which shapes the body string) and the task invoker
+/// (which applies the content type to the request content) to keep the resolution rule in one place.
+/// </summary>
+public static class HttpContentType
+{
+    /// <summary>
+    /// The default media type used when neither an explicit content type nor a Content-Type header is supplied.
+    /// </summary>
+    public const string Default = "application/json";
+
+    /// <summary>
+    /// Determines whether the given content type denotes a JSON payload (e.g. "application/json",
+    /// "application/problem+json"). A null or empty content type is treated as JSON (the default).
+    /// </summary>
+    public static bool IsJson(string? contentType)
+    {
+        if (string.IsNullOrWhiteSpace(contentType))
+            return true;
+
+        return contentType.Contains("json", System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Resolves the effective content type using the rule:
+    /// explicit content type → "Content-Type" header → <see cref="Default"/>.
+    /// </summary>
+    /// <param name="explicitContentType">Content type set explicitly on the task, or null.</param>
+    /// <param name="headerContentType">Content type found in the request headers, or null.</param>
+    public static string Resolve(string? explicitContentType, string? headerContentType)
+    {
+        if (!string.IsNullOrWhiteSpace(explicitContentType))
+            return explicitContentType;
+
+        if (!string.IsNullOrWhiteSpace(headerContentType))
+            return headerContentType;
+
+        return Default;
+    }
+}

--- a/src/BBT.Workflow.Execution.Abstractions/Bindings/HttpTaskBinding.cs
+++ b/src/BBT.Workflow.Execution.Abstractions/Bindings/HttpTaskBinding.cs
@@ -21,9 +21,15 @@ public sealed class HttpTaskBinding
     public string? Headers { get; init; }
     
     /// <summary>
-    /// Request body as JSON string.
+    /// Request body as a string. JSON for json content types; raw text (e.g. form-urlencoded) otherwise.
     /// </summary>
     public string? Body { get; init; }
+
+    /// <summary>
+    /// Explicit media type for the request body. When set, overrides any "Content-Type" header.
+    /// When null, the "Content-Type" header is used, falling back to "application/json".
+    /// </summary>
+    public string? ContentType { get; init; }
     
     /// <summary>
     /// Request timeout in seconds.

--- a/src/BBT.Workflow.Execution/Invokers/HttpTaskInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/HttpTaskInvoker.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using BBT.Workflow.Execution.Bindings;
@@ -59,7 +60,9 @@ public sealed class HttpTaskInvoker(
                 new HttpMethod(binding.Method),
                 binding.Url);
 
-            // Add headers
+            // Add headers. Content-Type is a content header in .NET, not a request header, so it is
+            // captured here and applied to request.Content below instead of request.Headers.
+            string? headerContentType = null;
             if (!string.IsNullOrEmpty(binding.Headers))
             {
                 var headers = JsonSerializer.Deserialize<Dictionary<string, string>>(binding.Headers);
@@ -67,18 +70,23 @@ public sealed class HttpTaskInvoker(
                 {
                     foreach (var header in headers)
                     {
+                        if (string.Equals(header.Key, "Content-Type", StringComparison.OrdinalIgnoreCase))
+                        {
+                            headerContentType = header.Value;
+                            continue;
+                        }
+
                         request.Headers.TryAddWithoutValidation(header.Key, header.Value);
                     }
                 }
             }
 
-            // Add body for non-GET requests
+            // Add body for non-GET requests. Resolution: explicit ContentType → Content-Type header → json.
             if (request.Method != HttpMethod.Get && !string.IsNullOrEmpty(binding.Body))
             {
-                request.Content = new StringContent(
-                    binding.Body,
-                    Encoding.UTF8,
-                    "application/json");
+                var contentType = HttpContentType.Resolve(binding.ContentType, headerContentType);
+                request.Content = new StringContent(binding.Body, Encoding.UTF8);
+                request.Content.Headers.ContentType = MediaTypeHeaderValue.Parse(contentType);
             }
 
             var response = await httpClient.SendAsync(request, cancellationToken);

--- a/src/BBT.Workflow.HttpApi.Shared/Microsoft/AspNetCore/Builder/WorkflowApiBaseApplicationBuilderExtensions.cs
+++ b/src/BBT.Workflow.HttpApi.Shared/Microsoft/AspNetCore/Builder/WorkflowApiBaseApplicationBuilderExtensions.cs
@@ -52,6 +52,15 @@ public static class WorkflowApiBaseApplicationBuilderExtensions
     {
         return app.UseMiddleware<HttpMetricsMiddleware>();
     }
+
+    /// <summary>
+    /// Buffers the raw request body so the original payload can be exposed to mappings for signature
+    /// verification (JWS/mTLS) via <c>ScriptContext.RawBody</c>. Register before controllers/model binding.
+    /// </summary>
+    public static IApplicationBuilder UseRawRequestBodyBuffering(this IApplicationBuilder app)
+    {
+        return app.UseMiddleware<RawRequestBodyBufferingMiddleware>();
+    }
     
     public static void MigrateMessagingDbContext(this IServiceProvider services)
     {

--- a/src/BBT.Workflow.HttpApi.Shared/Microsoft/Extensions/DependencyInjection/WorkflowApiBaseServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.HttpApi.Shared/Microsoft/Extensions/DependencyInjection/WorkflowApiBaseServiceCollectionExtensions.cs
@@ -18,6 +18,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -64,6 +65,12 @@ public static class WorkflowApiBaseServiceCollectionExtensions
         services.AddEndpointsApiExplorer();
         services.AddAetherApiVersioning(apiTitle: "vNext API");
         services.AddScoped<IWorkflowContext, WorkflowContext>();
+
+        // Raw request body capture for signature verification (JWS/mTLS): expose the original payload to
+        // mappings via ScriptContext.RawBody. Replaces the ambient-only default registered in the Application layer.
+        services.AddHttpContextAccessor();
+        services.Replace(ServiceDescriptor.Singleton<BBT.Workflow.Scripting.IRequestRawBodyProvider,
+            BBT.Workflow.Middlewares.HttpContextRawBodyProvider>());
 
         services.AddControllers()
             .AddJsonOptions(options =>

--- a/src/BBT.Workflow.HttpApi.Shared/Middlewares/HttpContextRawBodyProvider.cs
+++ b/src/BBT.Workflow.HttpApi.Shared/Middlewares/HttpContextRawBodyProvider.cs
@@ -1,0 +1,30 @@
+using BBT.Workflow.Scripting;
+using Microsoft.AspNetCore.Http;
+
+namespace BBT.Workflow.Middlewares;
+
+/// <summary>
+/// HTTP-host <see cref="IRequestRawBodyProvider"/>. Resolves the raw request body from the ambient job
+/// scope first — inside a background job the surrounding HTTP request is the Dapr job-callback transport,
+/// not the original payload — then falls back to the live request body captured by
+/// <see cref="RawRequestBodyBufferingMiddleware"/>.
+/// </summary>
+public sealed class HttpContextRawBodyProvider(IHttpContextAccessor httpContextAccessor) : IRequestRawBodyProvider
+{
+    /// <inheritdoc />
+    public string? GetRawBody()
+    {
+        var ambient = RawBodyExecutionScope.Current;
+        if (ambient != null)
+            return ambient;
+
+        var items = httpContextAccessor.HttpContext?.Items;
+        if (items != null
+            && items.TryGetValue(RawRequestBodyBufferingMiddleware.RawBodyItemsKey, out var value))
+        {
+            return value as string;
+        }
+
+        return null;
+    }
+}

--- a/src/BBT.Workflow.HttpApi.Shared/Middlewares/RawRequestBodyBufferingMiddleware.cs
+++ b/src/BBT.Workflow.HttpApi.Shared/Middlewares/RawRequestBodyBufferingMiddleware.cs
@@ -1,0 +1,55 @@
+using System.Text;
+using Microsoft.AspNetCore.Http;
+
+namespace BBT.Workflow.Middlewares;
+
+/// <summary>
+/// Buffers the raw request body for body-bearing requests so the original, unmodified payload can be
+/// exposed to mappings for signature verification (JWS / mTLS). Enables buffering, reads the body once
+/// into a string stored on <see cref="HttpContext.Items"/>, then rewinds the stream so downstream
+/// <c>[FromBody]</c> model binding still works. Requests whose known content length exceeds the cap are skipped.
+/// </summary>
+public sealed class RawRequestBodyBufferingMiddleware(RequestDelegate next)
+{
+    /// <summary>The <see cref="HttpContext.Items"/> key under which the captured raw request body is stored.</summary>
+    public const string RawBodyItemsKey = "__vnext.RawRequestBody";
+
+    // Cap to protect memory; these JSON APIs carry small payloads.
+    private const long MaxBufferedBytes = 1024 * 1024; // 1 MB
+
+    /// <summary>
+    /// Captures the raw body (when applicable) and invokes the next middleware.
+    /// </summary>
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (ShouldCapture(context.Request))
+        {
+            context.Request.EnableBuffering();
+
+            using var reader = new StreamReader(
+                context.Request.Body,
+                Encoding.UTF8,
+                detectEncodingFromByteOrderMarks: false,
+                leaveOpen: true);
+
+            var raw = await reader.ReadToEndAsync();
+            context.Request.Body.Position = 0;
+            context.Items[RawBodyItemsKey] = raw;
+        }
+
+        await next(context);
+    }
+
+    private static bool ShouldCapture(HttpRequest request)
+    {
+        if (!HttpMethods.IsPost(request.Method)
+            && !HttpMethods.IsPut(request.Method)
+            && !HttpMethods.IsPatch(request.Method)
+            && !HttpMethods.IsDelete(request.Method))
+            return false;
+
+        // Skip when a known content length exceeds the cap; unknown lengths are buffered
+        // (EnableBuffering spills to disk beyond its own threshold, so memory stays bounded).
+        return request.ContentLength is null or <= MaxBufferedBytes;
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Strategy/AsyncTransitionStrategyTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Strategy/AsyncTransitionStrategyTests.cs
@@ -89,6 +89,7 @@ public class AsyncTransitionStrategyTests
             _mockInstanceCommandGateway.Object,
             _mockEventBus.Object,
             executionOptions,
+            new BBT.Workflow.Scripting.AmbientRequestRawBodyProvider(),
             _mockLogger.Object);
     }
 

--- a/test/BBT.Workflow.Application.Tests/HttpApi/RawRequestBodyBufferingMiddlewareTests.cs
+++ b/test/BBT.Workflow.Application.Tests/HttpApi/RawRequestBodyBufferingMiddlewareTests.cs
@@ -1,0 +1,62 @@
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using BBT.Workflow.Middlewares;
+using Microsoft.AspNetCore.Http;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Application.Tests.HttpApi;
+
+/// <summary>
+/// Unit tests for <see cref="RawRequestBodyBufferingMiddleware"/>: captures the raw body for
+/// body-bearing requests and rewinds the stream so downstream model binding still works.
+/// </summary>
+public class RawRequestBodyBufferingMiddlewareTests
+{
+    private const string Body = "{\n  \"Amount\":100  }"; // intentionally non-normalized
+
+    private static DefaultHttpContext BuildContext(string method, string? body)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Method = method;
+        if (body != null)
+        {
+            var bytes = Encoding.UTF8.GetBytes(body);
+            context.Request.Body = new MemoryStream(bytes);
+            context.Request.ContentLength = bytes.Length;
+        }
+
+        return context;
+    }
+
+    [Fact]
+    public async Task InvokeAsync_PostBody_CapturesRawAndRewindsStream()
+    {
+        var context = BuildContext("POST", Body);
+        string? downstreamBody = null;
+
+        var middleware = new RawRequestBodyBufferingMiddleware(async ctx =>
+        {
+            // Simulate model binding reading the (rewound) body.
+            using var reader = new StreamReader(ctx.Request.Body, Encoding.UTF8, leaveOpen: true);
+            downstreamBody = await reader.ReadToEndAsync();
+        });
+
+        await middleware.InvokeAsync(context);
+
+        context.Items[RawRequestBodyBufferingMiddleware.RawBodyItemsKey].ShouldBe(Body);
+        downstreamBody.ShouldBe(Body); // stream was rewound for downstream binding
+    }
+
+    [Fact]
+    public async Task InvokeAsync_GetRequest_DoesNotCapture()
+    {
+        var context = BuildContext("GET", null);
+
+        var middleware = new RawRequestBodyBufferingMiddleware(_ => Task.CompletedTask);
+        await middleware.InvokeAsync(context);
+
+        context.Items.ContainsKey(RawRequestBodyBufferingMiddleware.RawBodyItemsKey).ShouldBeFalse();
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/Scripting/HttpContextRawBodyProviderTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Scripting/HttpContextRawBodyProviderTests.cs
@@ -1,0 +1,55 @@
+using BBT.Workflow.Middlewares;
+using Microsoft.AspNetCore.Http;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Application.Tests.Scripting;
+
+/// <summary>
+/// Unit tests for <see cref="HttpContextRawBodyProvider"/> resolution precedence:
+/// ambient job scope first, then the live HTTP request, then null.
+/// </summary>
+public class HttpContextRawBodyProviderTests
+{
+    [Fact]
+    public void GetRawBody_ReturnsHttpContextItem_WhenPresent()
+    {
+        var context = new DefaultHttpContext();
+        context.Items[RawRequestBodyBufferingMiddleware.RawBodyItemsKey] = "LIVE";
+        var accessor = Substitute.For<IHttpContextAccessor>();
+        accessor.HttpContext.Returns(context);
+
+        var provider = new HttpContextRawBodyProvider(accessor);
+
+        provider.GetRawBody().ShouldBe("LIVE");
+    }
+
+    [Fact]
+    public void GetRawBody_PrefersAmbientScope_OverHttpContext()
+    {
+        // Inside a background job the surrounding HTTP request is the Dapr transport, not the payload.
+        var context = new DefaultHttpContext();
+        context.Items[RawRequestBodyBufferingMiddleware.RawBodyItemsKey] = "DAPR-TRANSPORT";
+        var accessor = Substitute.For<IHttpContextAccessor>();
+        accessor.HttpContext.Returns(context);
+
+        var provider = new HttpContextRawBodyProvider(accessor);
+
+        using (BBT.Workflow.Scripting.RawBodyExecutionScope.Set("ORIGINAL"))
+        {
+            provider.GetRawBody().ShouldBe("ORIGINAL");
+        }
+    }
+
+    [Fact]
+    public void GetRawBody_ReturnsNull_WhenNoHttpContextAndNoScope()
+    {
+        var accessor = Substitute.For<IHttpContextAccessor>();
+        accessor.HttpContext.Returns((HttpContext?)null);
+
+        var provider = new HttpContextRawBodyProvider(accessor);
+
+        provider.GetRawBody().ShouldBeNull();
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/Scripting/RawBodyExecutionScopeTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Scripting/RawBodyExecutionScopeTests.cs
@@ -1,0 +1,47 @@
+using System.Threading.Tasks;
+using BBT.Workflow.Scripting;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Application.Tests.Scripting;
+
+/// <summary>
+/// Unit tests for <see cref="RawBodyExecutionScope"/> ambient raw-body holder.
+/// </summary>
+public class RawBodyExecutionScopeTests
+{
+    [Fact]
+    public void Current_IsNull_WhenNotSet()
+    {
+        RawBodyExecutionScope.Current.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Set_ExposesValue_AndRestoresOnDispose()
+    {
+        RawBodyExecutionScope.Current.ShouldBeNull();
+
+        using (RawBodyExecutionScope.Set("RAW"))
+        {
+            RawBodyExecutionScope.Current.ShouldBe("RAW");
+        }
+
+        RawBodyExecutionScope.Current.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Set_FlowsToNestedAsync()
+    {
+        using (RawBodyExecutionScope.Set("RAW"))
+        {
+            await Task.Yield();
+            await NestedAsync();
+        }
+
+        static Task NestedAsync()
+        {
+            RawBodyExecutionScope.Current.ShouldBe("RAW");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/Scripting/ScriptContextRawBodyTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Scripting/ScriptContextRawBodyTests.cs
@@ -1,0 +1,50 @@
+using System.Threading.Tasks;
+using BBT.Workflow.Caching;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Runtime;
+using BBT.Workflow.Scripting;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Application.Tests.Scripting;
+
+/// <summary>
+/// Verifies the ScriptContext builder auto-populates <see cref="ScriptContext.RawBody"/> from the
+/// <see cref="IRequestRawBodyProvider"/>, and that an explicit value overrides the provider.
+/// </summary>
+public class ScriptContextRawBodyTests
+{
+    private static ScriptContextFactory CreateFactory(IRequestRawBodyProvider provider) =>
+        new(Substitute.For<IComponentCacheStore>(), NullLogger<ScriptContext>.Instance, provider);
+
+    [Fact]
+    public async Task BuildAsync_PopulatesRawBody_FromProvider()
+    {
+        var provider = Substitute.For<IRequestRawBodyProvider>();
+        provider.GetRawBody().Returns("RAW-ORIGINAL");
+
+        await using var ctx = await CreateFactory(provider)
+            .NewBuilder(Substitute.For<IInstanceRepository>())
+            .WithRuntime(Substitute.For<IRuntimeInfoProvider>())
+            .BuildAsync();
+
+        ctx.RawBody.ShouldBe("RAW-ORIGINAL");
+    }
+
+    [Fact]
+    public async Task BuildAsync_ExplicitRawBody_OverridesProvider()
+    {
+        var provider = Substitute.For<IRequestRawBodyProvider>();
+        provider.GetRawBody().Returns("FROM-PROVIDER");
+
+        await using var ctx = await CreateFactory(provider)
+            .NewBuilder(Substitute.For<IInstanceRepository>())
+            .WithRuntime(Substitute.For<IRuntimeInfoProvider>())
+            .WithRawBody("EXPLICIT")
+            .BuildAsync();
+
+        ctx.RawBody.ShouldBe("EXPLICIT");
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/Tasks/Bindings/HttpContentTypeTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Tasks/Bindings/HttpContentTypeTests.cs
@@ -1,0 +1,43 @@
+using BBT.Workflow.Execution.Bindings;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Tasks.Bindings;
+
+public sealed class HttpContentTypeTests
+{
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData("", true)]
+    [InlineData("application/json", true)]
+    [InlineData("application/problem+json", true)]
+    [InlineData("APPLICATION/JSON", true)]
+    [InlineData("application/x-www-form-urlencoded", false)]
+    [InlineData("text/plain", false)]
+    [InlineData("text/xml", false)]
+    public void IsJson_ClassifiesContentType(string? contentType, bool expected)
+    {
+        HttpContentType.IsJson(contentType).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Resolve_ExplicitContentType_Wins()
+    {
+        HttpContentType.Resolve("text/plain", "application/x-www-form-urlencoded")
+            .ShouldBe("text/plain");
+    }
+
+    [Fact]
+    public void Resolve_NoExplicit_FallsBackToHeader()
+    {
+        HttpContentType.Resolve(null, "application/x-www-form-urlencoded")
+            .ShouldBe("application/x-www-form-urlencoded");
+    }
+
+    [Fact]
+    public void Resolve_Nothing_DefaultsToApplicationJson()
+    {
+        HttpContentType.Resolve(null, null).ShouldBe("application/json");
+        HttpContentType.Resolve("  ", "  ").ShouldBe("application/json");
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/Tasks/Invokers/HttpTaskInvokerContentTypeTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Tasks/Invokers/HttpTaskInvokerContentTypeTests.cs
@@ -1,0 +1,118 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Workflow.Execution;
+using BBT.Workflow.Execution.Bindings;
+using BBT.Workflow.Execution.Invokers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Tasks.Invokers;
+
+public sealed class HttpTaskInvokerContentTypeTests
+{
+    [Fact]
+    public async Task InvokeAsync_WithoutContentType_DefaultsToApplicationJson()
+    {
+        var handler = new CapturingHttpMessageHandler();
+        var invoker = CreateInvoker(handler);
+
+        await invoker.InvokeAsync(CreateDescriptor(body: "{\"a\":1}"));
+
+        handler.CapturedContentType.ShouldBe("application/json");
+        handler.CapturedBody.ShouldBe("{\"a\":1}");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WithContentTypeHeader_AppliesToContentNotRequestHeaders()
+    {
+        var handler = new CapturingHttpMessageHandler();
+        var invoker = CreateInvoker(handler);
+
+        var descriptor = CreateDescriptor(
+            body: "grant_type=client_credentials",
+            headers: """{"Content-Type":"application/x-www-form-urlencoded","Authorization":"Bearer x"}""");
+
+        await invoker.InvokeAsync(descriptor);
+
+        handler.CapturedContentType.ShouldBe("application/x-www-form-urlencoded");
+        handler.CapturedBody.ShouldBe("grant_type=client_credentials");
+        // Content-Type must not have leaked into request headers; Authorization should still be there.
+        handler.RequestHeaderContains("Content-Type").ShouldBeFalse();
+        handler.RequestHeaderContains("Authorization").ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ExplicitContentType_OverridesHeader()
+    {
+        var handler = new CapturingHttpMessageHandler();
+        var invoker = CreateInvoker(handler);
+
+        var descriptor = CreateDescriptor(
+            body: "a=1&b=2",
+            headers: """{"Content-Type":"text/plain"}""",
+            contentType: "application/x-www-form-urlencoded");
+
+        await invoker.InvokeAsync(descriptor);
+
+        handler.CapturedContentType.ShouldBe("application/x-www-form-urlencoded");
+    }
+
+    private static HttpTaskInvoker CreateInvoker(CapturingHttpMessageHandler handler) =>
+        new(new FakeHttpClientFactory(handler), NullLogger<HttpTaskInvoker>.Instance);
+
+    private static TaskDescriptor<HttpTaskBinding> CreateDescriptor(
+        string body,
+        string? headers = null,
+        string? contentType = null) =>
+        new()
+        {
+            TaskType = TaskTypes.Http,
+            TaskKey = "http-task",
+            Binding = new HttpTaskBinding
+            {
+                Url = "https://workflow.local/endpoint",
+                Method = "POST",
+                Body = body,
+                Headers = headers,
+                ContentType = contentType
+            }
+        };
+
+    private sealed class FakeHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(handler);
+    }
+
+    private sealed class CapturingHttpMessageHandler : HttpMessageHandler
+    {
+        private HttpRequestHeaders? _requestHeaders;
+
+        public string? CapturedContentType { get; private set; }
+        public string? CapturedBody { get; private set; }
+
+        // NonValidated allows querying any header name (including content-header names) without throwing.
+        public bool RequestHeaderContains(string name) =>
+            _requestHeaders?.NonValidated.Contains(name) ?? false;
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            _requestHeaders = request.Headers;
+            if (request.Content != null)
+            {
+                CapturedContentType = request.Content.Headers.ContentType?.MediaType;
+                CapturedBody = await request.Content.ReadAsStringAsync(cancellationToken);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}")
+            };
+        }
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/Tasks/Mapping/TaskBindingMapperHttpTaskTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Tasks/Mapping/TaskBindingMapperHttpTaskTests.cs
@@ -31,4 +31,112 @@ public sealed class TaskBindingMapperHttpTaskTests
         binding.AcceptedStatusCodes.ShouldNotBeNull();
         binding.AcceptedStatusCodes.ShouldBe(["400", "4xx"]);
     }
+
+    [Fact]
+    public void CreateEnvelope_JsonContentType_PreservesObjectBody()
+    {
+        var config = """
+            {
+              "url": "https://workflow.local/endpoint",
+              "method": "POST",
+              "body": { "name": "test", "count": 1 }
+            }
+            """;
+        var task = HttpTask.Create(config.ToJsonElement());
+        task.SetReference(new Reference("http-task", "test-domain", "sys-tasks", "1.0.0"));
+
+        var binding = MapToBinding(task);
+
+        binding.ContentType.ShouldBeNull();
+        binding.Body.ShouldNotBeNull();
+        // Object body round-trips as JSON.
+        var parsed = JsonSerializer.Deserialize<JsonElement>(binding.Body!);
+        parsed.GetProperty("name").GetString().ShouldBe("test");
+        parsed.GetProperty("count").GetInt32().ShouldBe(1);
+    }
+
+    [Fact]
+    public void CreateEnvelope_NonJsonContentType_UnwrapsStringBody()
+    {
+        var config = """
+            {
+              "url": "https://workflow.local/token",
+              "method": "POST",
+              "contentType": "application/x-www-form-urlencoded",
+              "body": "grant_type=client_credentials&client_id=abc"
+            }
+            """;
+        var task = HttpTask.Create(config.ToJsonElement());
+        task.SetReference(new Reference("token-task", "test-domain", "sys-tasks", "1.0.0"));
+
+        var binding = MapToBinding(task);
+
+        binding.ContentType.ShouldBe("application/x-www-form-urlencoded");
+        // Raw, unquoted form body — no surrounding double-quotes.
+        binding.Body.ShouldBe("grant_type=client_credentials&client_id=abc");
+    }
+
+    [Fact]
+    public void CreateEnvelope_NonJsonContentTypeFromHeader_UnwrapsStringBody()
+    {
+        var config = """
+            {
+              "url": "https://workflow.local/token",
+              "method": "POST",
+              "headers": { "Content-Type": "application/x-www-form-urlencoded" },
+              "body": "a=1&b=2"
+            }
+            """;
+        var task = HttpTask.Create(config.ToJsonElement());
+        task.SetReference(new Reference("token-task", "test-domain", "sys-tasks", "1.0.0"));
+
+        var binding = MapToBinding(task);
+
+        binding.Body.ShouldBe("a=1&b=2");
+    }
+
+    [Fact]
+    public void CreateEnvelope_RawBody_SentVerbatim()
+    {
+        // Odd casing + whitespace that JSON re-serialization would normalize/alter.
+        const string signed = "{\n  \"Amount\":100,  \"Currency\" : \"TRY\"\n}";
+        var config = $$"""
+            {
+              "url": "https://workflow.local/pay",
+              "method": "POST",
+              "contentType": "application/json",
+              "rawBody": {{JsonSerializer.Serialize(signed)}}
+            }
+            """;
+        var task = HttpTask.Create(config.ToJsonElement());
+        task.SetReference(new Reference("pay-task", "test-domain", "sys-tasks", "1.0.0"));
+
+        var binding = MapToBinding(task);
+
+        binding.ContentType.ShouldBe("application/json");
+        binding.Body.ShouldBe(signed); // byte-identical to the signed bytes
+    }
+
+    [Fact]
+    public void CreateEnvelope_RawBody_TakesPrecedenceOverBody()
+    {
+        var task = HttpTask.CreateEmpty();
+        task.SetUrl("https://workflow.local/pay");
+        task.SetBody(new { amount = 1 });
+        task.SetRawBody("RAW-VERBATIM");
+        task.SetReference(new Reference("pay-task", "test-domain", "sys-tasks", "1.0.0"));
+
+        var binding = MapToBinding(task);
+
+        binding.Body.ShouldBe("RAW-VERBATIM");
+    }
+
+    private static HttpTaskBinding MapToBinding(HttpTask task)
+    {
+        var result = TaskBindingMapper.CreateEnvelope(task);
+        result.IsSuccess.ShouldBeTrue();
+        var binding = result.Value!.Binding.Deserialize<HttpTaskBinding>();
+        binding.ShouldNotBeNull();
+        return binding!;
+    }
 }

--- a/test/BBT.Workflow.Domain.Tests/Definitions/Tasks/HttpTaskRawBodyTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Definitions/Tasks/HttpTaskRawBodyTests.cs
@@ -1,0 +1,52 @@
+using Xunit;
+
+namespace BBT.Workflow.Definitions.Tasks;
+
+/// <summary>
+/// Unit tests for the verbatim <see cref="HttpTask.RawBody"/> escape hatch used in signing scenarios.
+/// </summary>
+public class HttpTaskRawBodyTests
+{
+    [Fact]
+    public void SetRawBody_StoresVerbatimString()
+    {
+        var task = HttpTask.CreateEmpty();
+        task.SetRawBody("a=1&b=2");
+        Assert.Equal("a=1&b=2", task.RawBody);
+    }
+
+    [Fact]
+    public void CloneTyped_CopiesRawBody()
+    {
+        var task = HttpTask.CreateEmpty();
+        task.SetReference(new Reference("http-task", "test-domain", "sys-tasks", "1.0.0"));
+        task.SetRawBody("SIGNED");
+
+        var clone = task.CloneTyped();
+
+        Assert.Equal("SIGNED", clone.RawBody);
+    }
+
+    [Fact]
+    public void CopyFromInternal_CopiesRawBody()
+    {
+        var source = HttpTask.CreateEmpty();
+        source.SetRawBody("SIGNED");
+        var target = HttpTask.CreateEmpty();
+
+        target.CopyFromInternal(source);
+
+        Assert.Equal("SIGNED", target.RawBody);
+    }
+
+    [Fact]
+    public void Reset_ClearsRawBody()
+    {
+        var task = HttpTask.CreateEmpty();
+        task.SetRawBody("SIGNED");
+
+        task.Reset();
+
+        Assert.Null(task.RawBody);
+    }
+}


### PR DESCRIPTION
Resolves #742.

## What changed

### Configurable Content-Type
- `HttpTask.ContentType` + `SetContentType`. Resolution: explicit `contentType` → `Content-Type` header → `application/json` default (backward compatible).
- `HttpTaskInvoker` routes `Content-Type` to `request.Content.Headers.ContentType` instead of `request.Headers` (it is a *content* header in .NET, otherwise silently dropped) and no longer hardcodes `application/json` — mirrors `SoapTaskInvoker`.
- `TaskBindingMapper` unwraps a JSON-string body for non-JSON content types, so `application/x-www-form-urlencoded` / text bodies are sent unquoted.
- New `HttpContentType` resolver helper (`IsJson` / `Resolve`) shared by mapper and invoker.

### Byte-exact body for JWS / mTLS signing
- **Outbound:** `HttpTask.RawBody` + `SetRawBody` verbatim escape hatch; mapper precedence `Body = RawBody ?? SerializeBody(...)`. The wire body is already passed verbatim, so signed bytes are preserved.
- **Inbound:** the original request body is exposed to mappings as `ScriptContext.RawBody` (literal string, **not** camelCased like `Body`). Captured once by `RawRequestBodyBufferingMiddleware` (EnableBuffering → read → rewind) and auto-populated through `IRequestRawBodyProvider` (ambient-first, then `HttpContext`), so **no changes were needed at the ~12 ScriptContext build sites**.
- **Async (`sync=false`):** the raw body rides `TransitionJobPayload.RawBody` (a string round-trips byte-for-byte through camelCased payload serialization) and is restored in `TransitionJobHandler` via `RawBodyExecutionScope.Set(...)`. Covers functions, sync transitions, async transitions, and instance start (which reuses the transition-job path).

## Why
HTTP tasks could only send `application/json`, and there was no way to preserve a body's exact bytes for signature creation/verification. See #742 for the full problem statement.

## Tests
- New unit tests: content-type resolution, body serialization, raw-body capture/provider/ambient scope, ScriptContext auto-populate, HttpTask clone/reset, capturing-handler assertions for the invoker.
- Full `vnext.sln` suite: failure counts identical to baseline (all pre-existing/environmental — InstanceData, EF Core repos, validators, RemoteInvoker/Dapr); **+16 new passing tests, zero regressions**.

## Reviewer notes
- Provider precedence is **ambient-first**: inside a background job the surrounding HTTP request is the Dapr job-callback transport, not the original payload.
- Purely internal executions (no HTTP request and no job scope) expose `RawBody = null` by design — signature verification belongs at the trigger entry mapping.
- Follow-up (separate repo, out of scope): add the new `contentType` and `rawBody` fields to the external task-config schema (`@burgan-tech/vnext-template`) and Forge Studio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add configurable HTTP content types for HTTP tasks and propagate a byte-exact raw request body through execution so signatures can be generated and verified against the original payload.

New Features:
- Allow HTTP tasks to specify an explicit request Content-Type or infer it from headers, defaulting to application/json.
- Introduce a verbatim raw body field for HTTP tasks and script context to support signing and signature verification against exact wire bytes.

Enhancements:
- Adjust HTTP task mapping and invocation to resolve Content-Type consistently and avoid re-serializing non-JSON bodies.
- Capture and expose the original HTTP request body via middleware and injectable providers across synchronous and asynchronous execution paths.

Tests:
- Add unit tests covering HTTP content-type resolution, HTTP task body serialization semantics, raw-body capture and propagation, and HttpTask cloning/reset behavior.