### PR TITLE
[enhancement] Add direct Dapr-enqueue continuation mode with outbox fallback

### DIFF
--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/appsettings.json
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/appsettings.json
@@ -197,6 +197,7 @@
     "TransitionJobTimeoutSeconds": 300,
     "UseOutboxContinuations": true,
     "TransitionPerJob": true,
+    "DirectEnqueueContinuations": true,
     "StrictChainTokenGate": true,
     "EnableChainReaper": true,
     "FailurePolicy": {

--- a/src/BBT.Workflow.Application/BackgroundJobs/Options/WorkflowExecutionOptions.cs
+++ b/src/BBT.Workflow.Application/BackgroundJobs/Options/WorkflowExecutionOptions.cs
@@ -34,6 +34,21 @@ public sealed class WorkflowExecutionOptions
     public bool TransitionPerJob { get; set; }
 
     /// <summary>
+    /// Governs how <c>EnqueueContinuationStrategy</c> realizes a chained continuation.
+    /// <para>
+    /// ON (default): enqueue the Dapr job DIRECTLY (no outbox/inbox poll hop) for lower latency;
+    /// if the direct Dapr enqueue fails, fall back to publishing a <c>TransitionContinuationRequested</c>
+    /// event through the transactional outbox so durability is preserved.
+    /// </para>
+    /// <para>
+    /// OFF: always publish the continuation via the transactional outbox (legacy behavior) — fully
+    /// transactional at the cost of the outbox/inbox poll hop.
+    /// </para>
+    /// The durable <c>InstanceJob</c> intent is inserted in the ambient transition UoW in both modes.
+    /// </summary>
+    public bool DirectEnqueueContinuations { get; set; } = true;
+
+    /// <summary>
     /// When enabled, the chain-token gate rejects foreign transitions that arrive while an
     /// instance is Busy with an active chain token, unless they carry the matching token or are
     /// reserved (cancel/timeout). Provides auto-chain atomicity without a chain-spanning lock.

--- a/src/BBT.Workflow.Application/Execution/Transitions/Continuations/EnqueueContinuationStrategy.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Continuations/EnqueueContinuationStrategy.cs
@@ -1,23 +1,41 @@
+using System.Diagnostics;
 using BBT.Aether.Events;
 using BBT.Aether.Results;
+using BBT.Workflow.BackgroundJobs;
+using BBT.Workflow.BackgroundJobs.Options;
+using BBT.Workflow.BackgroundJobs.Payloads;
 using BBT.Workflow.Execution.Events;
 using BBT.Workflow.Instances;
+using BBT.Workflow.Logging;
 using BBT.Workflow.Shared;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace BBT.Workflow.Execution.Continuations;
 
 /// <summary>
 /// Realizes the auto-chain continuation as a SEPARATE background job (transition-per-job).
 /// Instead of running the next transition in-process, it persists a durable job intent
-/// (<see cref="InstanceJob"/>) and publishes a <see cref="TransitionContinuationRequested"/>
-/// event through the transactional outbox — both within the AMBIENT transition unit of work,
-/// so "this transition committed" and "next transition enqueued" are atomic. Returns Ok(null)
-/// to end the in-process loop; the Inbox handler enqueues the actual Dapr job for the next hop.
+/// (<see cref="InstanceJob"/>) within the AMBIENT transition unit of work — so "this transition
+/// committed" and "next transition tracked" are atomic — and then enqueues the next hop.
+/// <para>
+/// How the next hop is enqueued is governed by <see cref="WorkflowExecutionOptions.DirectEnqueueContinuations"/>:
+/// </para>
+/// <list type="bullet">
+/// <item>ON (default): the Dapr job is enqueued DIRECTLY (no outbox/inbox poll hop). If the direct
+/// enqueue fails, the strategy falls back to publishing a <see cref="TransitionContinuationRequested"/>
+/// event through the transactional outbox so durability is preserved.</item>
+/// <item>OFF: a <see cref="TransitionContinuationRequested"/> event is always published through the
+/// transactional outbox; the Inbox handler then performs the real Dapr enqueue.</item>
+/// </list>
+/// Returns Ok(null) to end the in-process loop; a separate job resumes the chain.
 /// </summary>
-/// <remarks>Draft (S5) — not compiled; verify ambient-UoW outbox semantics in CI.</remarks>
 public sealed class EnqueueContinuationStrategy(
     IDistributedEventBus eventBus,
-    IInstanceJobRepository jobRepository) : IContinuationStrategy
+    IInstanceJobRepository jobRepository,
+    ITransitionJobEnqueuer jobEnqueuer,
+    IOptions<WorkflowExecutionOptions> executionOptions,
+    ILogger<EnqueueContinuationStrategy> logger) : IContinuationStrategy
 {
     /// <inheritdoc />
     public ContinuationMode Mode => ContinuationMode.Enqueue;
@@ -46,13 +64,87 @@ public sealed class EnqueueContinuationStrategy(
             true,
             cancellationToken);
 
+        // Default: enqueue the Dapr job directly (no outbox/inbox poll hop). On failure, fall back
+        // to the transactional outbox so the continuation is never lost.
+        if (executionOptions.Value.DirectEnqueueContinuations)
+        {
+            var enqueueResult = await EnqueueDirectlyAsync(current, next.TransitionKey, jobName, cancellationToken);
+            if (enqueueResult.IsSuccess)
+            {
+                logger.TransitionContinuationEnqueued(current.InstanceId, next.TransitionKey, jobName);
+                return Result<WorkflowExecutionContext?>.Ok(null);
+            }
+
+            logger.TransitionContinuationFellBackToOutbox(
+                current.InstanceId, next.TransitionKey, jobName, enqueueResult.Error.Message);
+        }
+
+        await PublishViaOutboxAsync(current, next.TransitionKey, jobName, cancellationToken);
+
+        // No in-process next context — a separate job resumes the chain.
+        return Result<WorkflowExecutionContext?>.Ok(null);
+    }
+
+    /// <summary>
+    /// Enqueues the next-hop Dapr job directly via <see cref="ITransitionJobEnqueuer"/>.
+    /// Wrapped in <see cref="ResultExtensions.TryAsync{T}"/> because Dapr is an external service.
+    /// </summary>
+    private Task<Result<bool>> EnqueueDirectlyAsync(
+        TransitionExecutionContext current,
+        string transitionKey,
+        string jobName,
+        CancellationToken cancellationToken)
+    {
+        var activity = Activity.Current;
+        var payload = new TransitionJobPayload
+        {
+            JobName = jobName,
+            InstanceId = current.InstanceId,
+            TransitionKey = transitionKey,
+            Domain = current.Domain,
+            Workflow = current.WorkflowKey,
+            Version = current.Workflow.Version,
+            Data = null, // chained auto-transitions carry no new request payload
+            Headers = current.Headers.ToDictionary(kvp => kvp.Key, kvp => kvp.Value),
+            RouteValues = current.RouteValues.ToDictionary(kvp => kvp.Key, kvp => kvp.Value),
+            ExecutionActor = ExecutionActor.System,
+            CallerSync = false,
+            TraceParent = activity?.Id,
+            TraceState = activity?.TraceStateString,
+            ChainToken = current.ChainToken // propagate chain ownership (S6)
+        };
+
+        return ResultExtensions.TryAsync(
+            async ct =>
+            {
+                await jobEnqueuer.EnqueueAsync(payload, ct);
+                return true;
+            },
+            cancellationToken,
+            ex => Error.Dependency(
+                WorkflowErrorCodes.Dependency,
+                $"Failed to enqueue transition job '{jobName}': {ex.Message}",
+                "Dapr"));
+    }
+
+    /// <summary>
+    /// Publishes a <see cref="TransitionContinuationRequested"/> event through the transactional
+    /// outbox within the ambient transition UoW. Used as the legacy path and the direct-enqueue
+    /// fallback; the Inbox handler performs the real Dapr enqueue (at-least-once).
+    /// </summary>
+    private Task PublishViaOutboxAsync(
+        TransitionExecutionContext current,
+        string transitionKey,
+        string jobName,
+        CancellationToken cancellationToken)
+    {
         var continuation = new TransitionContinuationRequested
         {
             InstanceId = current.InstanceId,
             Domain = current.Domain,
             Flow = current.WorkflowKey,
             Version = current.Workflow.Version,
-            TransitionKey = next.TransitionKey,
+            TransitionKey = transitionKey,
             JobName = jobName,
             Data = null, // chained auto-transitions carry no new request payload
             Headers = current.Headers.ToDictionary(kvp => kvp.Key, kvp => kvp.Value),
@@ -62,9 +154,6 @@ public sealed class EnqueueContinuationStrategy(
             ChainDepth = current.ChainDepth + 1
         };
 
-        await eventBus.PublishAsync(continuation, subject: null, useOutbox: true, cancellationToken);
-
-        // No in-process next context — a separate job resumes the chain.
-        return Result<WorkflowExecutionContext?>.Ok(null);
+        return eventBus.PublishAsync(continuation, subject: null, useOutbox: true, cancellationToken);
     }
 }

--- a/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
@@ -116,6 +116,21 @@ public static partial class WorkflowLogs
         string reason);
 
     /// <summary>
+    /// Logs when the direct Dapr enqueue of a chained continuation fails and the strategy
+    /// falls back to publishing the continuation through the transactional outbox.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 10127,
+        Level = LogLevel.Warning,
+        Message = "Direct Dapr enqueue failed for instance {InstanceId} transition {TransitionKey} (job {JobName}); falling back to outbox: {Reason}")]
+    public static partial void TransitionContinuationFellBackToOutbox(
+        this ILogger logger,
+        Guid instanceId,
+        string transitionKey,
+        string jobName,
+        string reason);
+
+    /// <summary>
     /// Logs when a foreign transition is rejected by the chain-token gate because the instance
     /// is Busy with an active auto-chain owned by a different token.
     /// </summary>

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Continuations/EnqueueContinuationStrategyTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Continuations/EnqueueContinuationStrategyTests.cs
@@ -1,0 +1,231 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.Events;
+using BBT.Workflow.BackgroundJobs;
+using BBT.Workflow.BackgroundJobs.Options;
+using BBT.Workflow.BackgroundJobs.Payloads;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Execution;
+using BBT.Workflow.Execution.Continuations;
+using BBT.Workflow.Execution.Events;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Shared;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Application.Tests.Execution.Transitions.Continuations;
+
+/// <summary>
+/// Unit tests for <see cref="EnqueueContinuationStrategy"/> — verifies the direct Dapr-enqueue
+/// mode (default), its outbox fallback on enqueue failure, and the legacy always-outbox mode.
+/// </summary>
+public class EnqueueContinuationStrategyTests
+{
+    private readonly Mock<IDistributedEventBus> _eventBus = new();
+    private readonly Mock<IInstanceJobRepository> _jobRepository = new();
+    private readonly Mock<ITransitionJobEnqueuer> _jobEnqueuer = new();
+    private readonly Mock<ILogger<EnqueueContinuationStrategy>> _logger = new();
+
+    public EnqueueContinuationStrategyTests()
+    {
+        _jobRepository
+            .Setup(x => x.InsertAsync(It.IsAny<InstanceJob>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(It.IsAny<InstanceJob>());
+    }
+
+    private EnqueueContinuationStrategy CreateStrategy(bool directEnqueue) =>
+        new(
+            _eventBus.Object,
+            _jobRepository.Object,
+            _jobEnqueuer.Object,
+            Options.Create(new WorkflowExecutionOptions { DirectEnqueueContinuations = directEnqueue }),
+            _logger.Object);
+
+    [Fact]
+    public async Task DirectMode_WhenEnqueueSucceeds_EnqueuesDaprJobAndDoesNotWriteOutbox()
+    {
+        var strategy = CreateStrategy(directEnqueue: true);
+        var context = CreateContextWithNextTransition("approve");
+
+        var result = await strategy.DispatchAsync(context, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.ShouldBeNull(); // ends the in-process loop
+
+        _jobEnqueuer.Verify(
+            x => x.EnqueueAsync(
+                It.Is<TransitionJobPayload>(p =>
+                    p.TransitionKey == "approve"
+                    && p.InstanceId == context.InstanceId
+                    && p.ExecutionActor == ExecutionActor.System),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _eventBus.Verify(
+            x => x.PublishAsync(
+                It.IsAny<TransitionContinuationRequested>(),
+                It.IsAny<string?>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        _jobRepository.Verify(
+            x => x.InsertAsync(It.IsAny<InstanceJob>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task DirectMode_WhenEnqueueFails_FallsBackToOutbox()
+    {
+        var strategy = CreateStrategy(directEnqueue: true);
+        var context = CreateContextWithNextTransition("approve");
+
+        _jobEnqueuer
+            .Setup(x => x.EnqueueAsync(It.IsAny<TransitionJobPayload>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Dapr unavailable"));
+
+        var result = await strategy.DispatchAsync(context, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.ShouldBeNull();
+
+        _jobEnqueuer.Verify(
+            x => x.EnqueueAsync(It.IsAny<TransitionJobPayload>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _eventBus.Verify(
+            x => x.PublishAsync(
+                It.Is<TransitionContinuationRequested>(e => e.TransitionKey == "approve"),
+                It.IsAny<string?>(),
+                true,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task OutboxMode_AlwaysPublishesViaOutboxAndNeverEnqueuesDirectly()
+    {
+        var strategy = CreateStrategy(directEnqueue: false);
+        var context = CreateContextWithNextTransition("approve");
+
+        var result = await strategy.DispatchAsync(context, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.ShouldBeNull();
+
+        _jobEnqueuer.Verify(
+            x => x.EnqueueAsync(It.IsAny<TransitionJobPayload>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        _eventBus.Verify(
+            x => x.PublishAsync(
+                It.Is<TransitionContinuationRequested>(e => e.TransitionKey == "approve"),
+                It.IsAny<string?>(),
+                true,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task WhenNoNextTransition_ReturnsNullWithoutSideEffects()
+    {
+        var strategy = CreateStrategy(directEnqueue: true);
+        var context = CreateContext(); // no next transition requested
+
+        var result = await strategy.DispatchAsync(context, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.ShouldBeNull();
+
+        _jobRepository.Verify(
+            x => x.InsertAsync(It.IsAny<InstanceJob>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _jobEnqueuer.Verify(
+            x => x.EnqueueAsync(It.IsAny<TransitionJobPayload>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _eventBus.Verify(
+            x => x.PublishAsync(
+                It.IsAny<TransitionContinuationRequested>(),
+                It.IsAny<string?>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private static TransitionExecutionContext CreateContextWithNextTransition(string nextTransitionKey)
+    {
+        var context = CreateContext();
+        context.Directives.RequestNextTransition(new NextTransitionRequest(nextTransitionKey));
+        return context;
+    }
+
+    private static TransitionExecutionContext CreateContext()
+    {
+        var instanceId = Guid.NewGuid();
+        const string workflowKey = "test-workflow";
+        const string domain = "test-domain";
+
+        var workflow = CreateMockWorkflow(workflowKey, domain);
+        var instance = Instance.Create(instanceId, workflowKey, "1.0.0");
+        var state = workflow.GetState("state1").Value!;
+        var transition = Transition.Create("test-transition", null, "state1", TriggerType.Automatic, "Patch");
+
+        return new TransitionExecutionContext
+        {
+            InstanceId = instanceId,
+            Domain = domain,
+            WorkflowKey = workflowKey,
+            TransitionKey = "test-transition",
+            Trigger = TriggerType.Automatic,
+            Actor = ExecutionActor.System,
+            CorrelationId = Guid.NewGuid().ToString("N"),
+            ExecutionChainId = Guid.NewGuid().ToString("N"),
+            RequestedAt = DateTimeOffset.UtcNow,
+            Workflow = workflow,
+            Current = state,
+            Transition = transition,
+            Instance = instance,
+            Data = new { test = "data" },
+            TraceId = Guid.NewGuid().ToString("N"),
+            SpanId = Guid.NewGuid().ToString("N")[..16]
+        };
+    }
+
+    private static Definitions.Workflow CreateMockWorkflow(string key, string domain)
+    {
+        const string json = """
+        {
+            "type": "F",
+            "timeout": null,
+            "labels": [],
+            "functions": [],
+            "features": [],
+            "states": [
+                {
+                    "key": "state1",
+                    "type": "P",
+                    "transitions": []
+                }
+            ],
+            "sharedTransitions": [],
+            "extensions": [],
+            "startTransition": {"key": "start", "from": null, "target": "state1", "triggerType": "Manual", "versionStrategy": "Patch", "labels": [], "onExecutionTasks": [], "view": null}
+        }
+        """;
+
+        var options = new System.Text.Json.JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+        };
+        var workflow = System.Text.Json.JsonSerializer.Deserialize<Definitions.Workflow>(json, options)!;
+
+        workflow.SetReference(new Reference(key, domain, "sys-flows", "1.0.0"));
+        return workflow;
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new continuation realization mode to `EnqueueContinuationStrategy` that enqueues the Dapr
job **directly** (skipping the outbox→inbox poll hop) for lower latency, and **falls back to the
transactional outbox if the direct Dapr enqueue fails** so durability is preserved. The new
behavior is the **default**; when disabled, the strategy behaves exactly as before (always-outbox).

Closes #744.

## Changes

- **`WorkflowExecutionOptions.cs`** — new `DirectEnqueueContinuations` flag (default `true`).
  - ON (default): enqueue the Dapr job directly via `ITransitionJobEnqueuer`; on enqueue failure,
    fall back to publishing `TransitionContinuationRequested` through the transactional outbox.
  - OFF: legacy always-outbox behavior, unchanged.
- **`EnqueueContinuationStrategy.cs`** — branch on the new option; reuse the existing
  `ITransitionJobEnqueuer` for the direct enqueue (wrapped in `ResultExtensions.TryAsync`). The
  durable `InstanceJob` intent insert stays atomic with the transition commit (ambient UoW) in
  both modes.
- **`WorkflowLogs.cs`** — new `TransitionContinuationFellBackToOutbox` (EventId 10127, Warning);
  reuse `TransitionContinuationEnqueued` on success.
- **`appsettings.json`** (Orchestration) — explicit `"DirectEnqueueContinuations": true` in the
  `WorkflowExecution` block.
- **Tests** — `EnqueueContinuationStrategyTests` covering: direct success (no outbox publish),
  direct failure → outbox fallback, disabled mode (always outbox), and no-next-transition no-op.

## Design note / tradeoff

In direct mode the Dapr enqueue is a side-effect issued while the ambient transition UoW is still
open; a later rollback could orphan a continuation job (the same narrow window the existing
`AsyncTransitionStrategy` "direct" path accepts). Mitigated by the `AnyActiveByJobNameAsync`
duplicate guard and the `ChainReaper`. Outbox mode (`false`) remains the fully-transactional option.

## Verification

- `dotnet build` and `dotnet test test/BBT.Workflow.Application.Tests`.
  > Note: `dotnet` was not available in the authoring environment, so the build/tests were not run
  > here — please confirm in CI / locally.

## Summary by Sourcery

Introduce a configurable direct-enqueue continuation mode that prefers immediate Dapr job dispatch and falls back to the transactional outbox for durability, while preserving legacy behavior when disabled.

Enhancements:
- Add a WorkflowExecutionOptions flag to control direct vs outbox-based continuation enqueueing with a default of direct enqueue.
- Extend EnqueueContinuationStrategy to insert durable continuation intents and either enqueue Dapr jobs directly or publish outbox events as a fallback.
- Add logging for continuation enqueue fallback scenarios to aid observability of direct-enqueue failures.

Tests:
- Add EnqueueContinuationStrategy unit tests covering direct enqueue success, direct enqueue failure with outbox fallback, legacy always-outbox mode, and no-op when no next transition is requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a configurable `DirectEnqueueContinuations` option (enabled by default) that optimizes chained workflow continuations. Attempts direct job enqueue for lower latency with automatic fallback to transactional publishing on failure, balancing performance with reliability.

* **Chores**
  * Enhanced logging to track when continuations fall back to outbox publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->