### PR TITLE
feat(longpoll): declarative long-poll termination on state entry (#717)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ describe the stable mental model, boundaries, failure modes, and change-safety r
 5. Read [Task Executors and Invokers](runtime/task-executors-and-invokers.md) before adding a task type.
 6. Read [API and Service Contracts](contracts/api-and-service-contracts.md) before changing HTTP or Dapr-facing contracts.
 7. Read [JSON Validation](contracts/json-validation.md) before changing schema validation errors.
+8. Read [Long-Poll Termination on State Entry](domain/long-poll-termination.md) before changing State-function long-poll behavior or the pipeline pause/resume path.
 
 ## Documentation Rules
 

--- a/docs/domain/long-poll-termination.md
+++ b/docs/domain/long-poll-termination.md
@@ -1,0 +1,86 @@
+# Declarative Long-Poll Termination on State Entry
+
+## Why
+
+A long-polling client repeatedly issues conditional `GET /functions/state` (200/304) until the
+instance status changes. There was no declarative way for a state to tell the client *"stop polling
+now, render my screen, then let the engine continue."* Teams had to bake that into per-workflow
+client logic. This feature moves the decision into the workflow definition.
+
+## Model
+
+A state declares the behavior under a generic, extensible `interaction` container:
+
+```jsonc
+"interaction": {
+  "longPoll": {
+    "terminate": true,
+    "fallbackTimeoutSeconds": 60,        // optional, default 60
+    "roles": [ { "role": "backoffice.operator", "grant": "allow" } ]  // optional, default-allow
+  }
+  // future facets (polling, navigation, refresh) are added as siblings here
+}
+```
+
+The runtime reads only through `State` helpers (`TerminatesLongPollOnEntry`, `LongPollAckRoles`,
+`LongPollFallbackTimeoutSeconds`), so future `interaction` facets never touch the pipeline or
+State-function code.
+
+## Flow
+
+1. **Pause.** When the pipeline enters a state with `interaction.longPoll.terminate=true`, it runs
+   `ChangeState` (50) + `OnEntry` (60), then `HandleLongPollTerminationStep` (order **75**) arms a
+   durable `Instance.LongPollAckToken`, schedules a one-shot fallback resume job
+   (`fallbackTimeoutSeconds`, default 60s), and pauses by skipping the epilogue
+   (`EpilogueMode.Skip` + `MarkTerminal` + `SkipTo(Finalize)`). The instance stays **Busy** — the
+   same resting shape as a SubFlow pause.
+2. **Signal.** While `LongPollAckToken` is set, the State (long-poll) function returns **HTTP 200**
+   (no error code; ETag/304 path unchanged) with an `interaction` object — grouping client directives
+   under one key — but only for callers whose role satisfies `interaction.longPoll.roles`
+   (default-allow when none). The response still carries the entered state name + view href so the
+   client can render.
+
+   ```jsonc
+   "interaction": {
+     "terminateLongPoll": true,
+     "ack": { "href": "/api/core/workflows/account-opening/instances/{id}/longpoll/ack" }
+   }
+   ```
+
+   The `ack` href follows the same `{ "href": "…" }` shape as `data`/`view`. The `interaction` object
+   is omitted entirely when no directive applies.
+3. **Acknowledge.** The client stops polling, renders the screen, and `POST`s to
+   `…/instances/{instance}/longpoll/ack`. The endpoint role-checks, best-effort cancels the fallback
+   job, and resumes the pipeline.
+4. **Resume.** Acknowledge (or the fallback timeout) resumes via
+   `ExecMode.Resume` + `ResumeFrom = ClearBusyOnResumeStep` + `IsLongPollAckResume`. `ClearBusyOnResumeStep`
+   (79) compare-and-clears the token, clears Busy, and the epilogue runs (Schedule → Auto → Finish →
+   Finalize → ResolveAvailable) — the pipeline continues exactly where it paused.
+
+## Idempotency
+
+Acknowledge and the fallback timeout can both request a resume. The reserved `:lpack` lock
+serializes them, and `ClearBusyOnResumeStep` stops as a safe no-op when the token is already cleared
+(`!Instance.IsAwaitingLongPollAck`). The fallback handler also no-ops via the same token guard, and
+acknowledge on a non-awaiting instance returns `Ok` (no-op).
+
+## Profiles
+
+`LongPollTermination` (75) is excluded from the **ErrorBoundary** and **AutoChain** profiles —
+error-boundary and auto-chained transitions must never pause.
+
+## Key Source
+
+- `State` / `StateInteraction` / `LongPollInteraction` — `src/BBT.Workflow.Domain/Definitions/States/`
+- `Instance.LongPollAckToken` / `ArmLongPollAck` / `ClearLongPollAck` — `src/BBT.Workflow.Domain/Instances/Instance.cs`
+- `HandleLongPollTerminationStep`, `ClearBusyOnResumeStep` — `src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/`
+- `LongPollAckResumeService`, `LongPollAckTimeoutJobHandler` — `src/BBT.Workflow.Application/`
+- State signal — `InstanceQueryAppService.ResolveLongPollTerminationAsync`
+- Acknowledge — `InstanceController.AcknowledgeLongPollAsync` → `InstanceCommandAppService.AcknowledgeLongPollAsync`
+
+## Change-Safety
+
+- The pause/resume reuses the SubFlow resume plumbing (`IsInternalResume`); changes to either must
+  preserve the shared lock-key, validation-bypass, and busy-confirmation behavior.
+- The instance stays Busy during the ack window; do not re-mark Busy on long-poll resume (a redundant
+  resume must not strand an already-advanced instance).

--- a/docs/domain/long-poll-termination.md
+++ b/docs/domain/long-poll-termination.md
@@ -57,6 +57,27 @@ State-function code.
    (79) compare-and-clears the token, clears Busy, and the epilogue runs (Schedule → Auto → Finish →
    Finalize → ResolveAvailable) — the pipeline continues exactly where it paused.
 
+## SubFlow chain (nested / cross-domain)
+
+When the entered terminate state belongs to a **subflow**, the instance that pauses and arms
+`LongPollAckToken` is the deepest active subflow child — not the top instance the client polls. Both
+sides follow the chain:
+
+- **Read (State function).** `GetSubFlowTransitionsAsync` already recurses down via
+  `instanceQueryGateway.GetFunctionWithStateAsync` (routed local/remote). The child's `interaction`
+  block is bubbled up through `SubFlowStateInfo`, and each level **rewrites the ack href** to its own
+  acknowledge endpoint — so the top response always carries the top's `ack.href`. Role filtering
+  stays at the child (caller role forwarded via headers).
+- **Command (acknowledge).** `AcknowledgeLongPollAsync` descends like `MarkBusyAsync`: at each level,
+  if the instance is awaiting → resume here (leaf); else if it has an active SubFlow correlation →
+  forward via `IInstanceCommandGateway.AcknowledgeLongPollAsync` to the child (Routed → Local /
+  Remote on `IsDomainMatch`), one hop per level. The client always POSTs the top's `longpoll/ack`;
+  the chain walk reaches the paused (possibly cross-domain) instance and resumes it.
+
+Only `SubFlowType.SubFlow` correlations are followed (the same set the State function follows);
+SubProcess (fire-and-forget) is out of scope. Each level armed its own fallback job, so a failed
+descent hop is still covered by the deepest child's fallback.
+
 ## Idempotency
 
 Acknowledge and the fallback timeout can both request a resume. The reserved `:lpack` lock

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
@@ -343,6 +343,44 @@ public sealed class InstanceController(
     }
 
     /// <summary>
+    /// Acknowledges a long-poll termination signal and resumes the paused pipeline.
+    /// The client calls this after it stops long polling and renders the entered-state screen.
+    /// Idempotent: a no-op when the instance is not awaiting acknowledge (already resumed or the
+    /// fallback timeout already fired).
+    /// </summary>
+    /// <response code="200">Acknowledge accepted (pipeline resumed or already resumed)</response>
+    /// <response code="403">Acknowledge not permitted for the current roles</response>
+    /// <response code="404">Instance or workflow not found</response>
+    [HttpPost("{domain}/workflows/{workflow}/instances/{instance}/longpoll/ack")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> AcknowledgeLongPollAsync(
+        [FromRoute] string domain,
+        [FromRoute] string workflow,
+        [FromRoute] string instance,
+        [FromQuery] string? version = null,
+        [FromQuery] string? role = null,
+        CancellationToken cancellationToken = default)
+    {
+        var headers = httpContextAccessor.HttpContext?.Request.Headers
+            .ToDictionary(s => s.Key.ToLower(), s => s.Value.FirstOrDefault()?.ToString()) ?? [];
+
+        var input = new AcknowledgeLongPollInput
+        {
+            Domain = domain,
+            Workflow = workflow,
+            Instance = instance,
+            Version = version,
+            Role = role,
+            Headers = headers
+        };
+
+        var result = await commandAppService.AcknowledgeLongPollAsync(input, cancellationToken);
+        return FromResult(result);
+    }
+
+    /// <summary>
     /// Retries a faulted workflow instance by re-executing the incomplete transition.
     /// </summary>
     /// <param name="domain">The domain name.</param>

--- a/src/BBT.Workflow.Application/BackgroundJobs/Handlers/LongPollAckTimeoutJobHandler.cs
+++ b/src/BBT.Workflow.Application/BackgroundJobs/Handlers/LongPollAckTimeoutJobHandler.cs
@@ -1,0 +1,69 @@
+using System.Diagnostics;
+using BBT.Aether.BackgroundJob;
+using BBT.Aether.MultiSchema;
+using BBT.Workflow.BackgroundJobs.Payloads;
+using BBT.Workflow.Execution.LongPoll;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Logging;
+using Microsoft.Extensions.Logging;
+
+namespace BBT.Workflow.BackgroundJobs.Handlers;
+
+/// <summary>
+/// Fallback handler for declarative long-poll termination. Fires when a client did not acknowledge
+/// the long-poll termination signal within the configured window, resuming the paused pipeline so it
+/// continues past the entered state. Idempotent: if the instance already resumed (acknowledge won the
+/// race), <see cref="ILongPollAckResumeService"/> no-ops.
+/// </summary>
+public sealed class LongPollAckTimeoutJobHandler(
+    IInstanceJobRepository jobRepository,
+    ILongPollAckResumeService resumeService,
+    ICurrentSchema currentSchema,
+    ILogger<LongPollAckTimeoutJobHandler> logger) : IBackgroundJobHandler<LongPollAckTimeoutPayload>
+{
+    public const string HandlerName = "longpoll.ack.timeout";
+
+    public async Task HandleAsync(LongPollAckTimeoutPayload args, CancellationToken cancellationToken)
+    {
+        using var activity = BackgroundJobActivityHelper.StartActivityAsChildWithLink("LongPollAckTimeout.Execute", args);
+        using (currentSchema.Use(args.FlowName))
+        {
+            using (logger.BeginScope(new Dictionary<string, object>
+                   {
+                       [TelemetryConstants.TagNames.InstanceId] = args.InstanceId,
+                       [TelemetryConstants.TagNames.Flow] = args.FlowName,
+                       [TelemetryConstants.TagNames.Domain] = args.Domain,
+                       [TelemetryConstants.TagNames.FlowVersion] = args.Version,
+                       [TelemetryConstants.TagNames.JobName] = args.JobName
+                   }))
+            {
+                try
+                {
+                    BackgroundJobActivityHelper.EnrichActivity(activity, args);
+
+                    var result = await resumeService.ResumeAsync(
+                        args.Domain, args.FlowName, args.Version, args.InstanceId, cancellationToken);
+
+                    activity?.SetStatus(
+                        result.IsSuccess ? ActivityStatusCode.Ok : ActivityStatusCode.Error,
+                        result.IsSuccess ? null : result.Error.Message);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    activity?.SetStatus(ActivityStatusCode.Error, "Job cancelled");
+                    logger.JobCancelled(args.JobName, "longpoll-ack", args.InstanceId);
+                }
+                catch (Exception e)
+                {
+                    activity?.SetStatus(ActivityStatusCode.Error, e.Message);
+                    activity?.AddTag("error.type", e.GetType().Name);
+                    logger.JobFailed(e, args.JobName, args.InstanceId);
+                }
+                finally
+                {
+                    await jobRepository.MarkAsProcessedAsync(args.InstanceId, args.JobName, CancellationToken.None);
+                }
+            }
+        }
+    }
+}

--- a/src/BBT.Workflow.Application/BackgroundJobs/Payloads/LongPollAckTimeoutPayload.cs
+++ b/src/BBT.Workflow.Application/BackgroundJobs/Payloads/LongPollAckTimeoutPayload.cs
@@ -1,0 +1,34 @@
+namespace BBT.Workflow.BackgroundJobs.Payloads;
+
+/// <summary>
+/// Payload for the long-poll acknowledge fallback job. When a state pauses the pipeline for
+/// declarative long-poll termination, a delayed job carrying this payload is scheduled; if the
+/// client never acknowledges within the fallback window, the job resumes the pipeline.
+/// The <see cref="AckToken"/> guards against a stale fallback resuming an instance that was
+/// already advanced by an acknowledge.
+/// </summary>
+public sealed class LongPollAckTimeoutPayload : ITraceableJobPayload
+{
+    public string JobName { get; set; }
+
+    /// <summary>The domain context for the workflow instance.</summary>
+    public string Domain { get; set; }
+
+    /// <summary>The unique identifier of the workflow instance.</summary>
+    public Guid InstanceId { get; set; }
+
+    /// <summary>The workflow definition key.</summary>
+    public string FlowName { get; set; }
+
+    /// <summary>The workflow definition version.</summary>
+    public string Version { get; set; }
+
+    /// <summary>The acknowledge token armed when the pipeline paused; used for idempotency.</summary>
+    public Guid AckToken { get; set; }
+
+    /// <summary>W3C traceparent for distributed tracing correlation.</summary>
+    public string? TraceParent { get; set; }
+
+    /// <summary>W3C tracestate for vendor-specific trace data.</summary>
+    public string? TraceState { get; set; }
+}

--- a/src/BBT.Workflow.Application/Execution/LongPoll/ILongPollAckResumeService.cs
+++ b/src/BBT.Workflow.Application/Execution/LongPoll/ILongPollAckResumeService.cs
@@ -1,0 +1,29 @@
+using BBT.Aether.Results;
+
+namespace BBT.Workflow.Execution.LongPoll;
+
+/// <summary>
+/// Resumes a transition pipeline that was paused for declarative long-poll termination on state entry.
+/// Invoked by the acknowledge endpoint and by the fallback timeout job. Resuming continues the
+/// epilogue (Schedule → Auto → Finish → Finalize) from where the pause stopped and clears the
+/// instance's long-poll acknowledge marker. The operation is idempotent: a resume on an instance
+/// that is no longer awaiting acknowledge is a safe no-op.
+/// </summary>
+public interface ILongPollAckResumeService
+{
+    /// <summary>
+    /// Resumes the paused pipeline for the given instance.
+    /// </summary>
+    /// <param name="domain">The workflow domain.</param>
+    /// <param name="flowKey">The workflow key.</param>
+    /// <param name="flowVersion">The workflow version.</param>
+    /// <param name="instanceId">The paused instance identifier.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>Ok on success or no-op; Fail when the resume pipeline fails.</returns>
+    Task<Result> ResumeAsync(
+        string domain,
+        string flowKey,
+        string? flowVersion,
+        Guid instanceId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/BBT.Workflow.Application/Execution/LongPoll/LongPollAckResumeService.cs
+++ b/src/BBT.Workflow.Application/Execution/LongPoll/LongPollAckResumeService.cs
@@ -1,0 +1,79 @@
+using BBT.Aether.Results;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Execution.Pipeline;
+using BBT.Workflow.Execution.Services;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Logging;
+using BBT.Workflow.Shared;
+using Microsoft.Extensions.Logging;
+
+namespace BBT.Workflow.Execution.LongPoll;
+
+/// <summary>
+/// Resumes a transition pipeline paused for declarative long-poll termination on state entry.
+/// Mirrors the SubFlow-completion resume: enters the pipeline in <see cref="ExecMode.Resume"/> from
+/// <see cref="LifecycleOrder.ClearBusyOnResumeStep"/> with <see cref="ExecutionInfo.IsLongPollAckResume"/>,
+/// which clears the acknowledge marker, clears Busy, and runs the remaining epilogue steps.
+/// </summary>
+public sealed class LongPollAckResumeService(
+    IInstanceRepository instanceRepository,
+    IWorkflowExecutionService workflowExecutionService,
+    ILogger<LongPollAckResumeService> logger) : ILongPollAckResumeService
+{
+    /// <inheritdoc />
+    public async Task<Result> ResumeAsync(
+        string domain,
+        string flowKey,
+        string? flowVersion,
+        Guid instanceId,
+        CancellationToken cancellationToken = default)
+    {
+        // Cheap pre-check: skip work when the instance is no longer awaiting acknowledge
+        // (already resumed by the other trigger). The pipeline-level guard in
+        // ClearBusyOnResumeStep is the authoritative idempotency check under the reserved lock.
+        var instance = await instanceRepository.FindAsync(p => p.Id == instanceId, false, cancellationToken);
+        if (instance is null)
+        {
+            logger.InstanceNotFound(instanceId, flowKey);
+            return Result.Ok();
+        }
+
+        if (!instance.IsAwaitingLongPollAck)
+        {
+            logger.LongPollAckResumeSkipped(instanceId);
+            return Result.Ok();
+        }
+
+        var input = new WorkflowExecutionContext
+        {
+            Domain = domain,
+            WorkflowKey = flowKey,
+            WorkflowVersion = flowVersion,
+            InstanceId = instanceId.ToString(),
+            TransitionKey = string.Empty, // logging only — internal resume has no transition
+            TriggerType = TriggerType.Manual,
+            Mode = ExecMode.Resume,
+            CallerMode = ExecMode.Async,
+            Headers = new Dictionary<string, string?>(),
+            Actor = ExecutionActor.System,
+            RequestedAt = DateTimeOffset.UtcNow,
+            Execution = new ExecutionInfo
+            {
+                ExecutionChainId = Guid.NewGuid().ToString("N"),
+                ChainDepth = 0,
+                ResumeFrom = LifecycleOrder.ClearBusyOnResumeStep,
+                IsLongPollAckResume = true
+            }
+        };
+
+        var result = await workflowExecutionService.ExecuteTransitionAsync(input, cancellationToken);
+        if (!result.IsSuccess)
+        {
+            logger.LongPollAckResumeFailed(instanceId, result.Error.Message ?? result.Error.Code);
+            return Result.Fail(result.Error);
+        }
+
+        logger.LongPollAckResumed(instanceId);
+        return Result.Ok();
+    }
+}

--- a/src/BBT.Workflow.Application/Execution/Transitions/Factory/TransitionContextFactory.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Factory/TransitionContextFactory.cs
@@ -138,6 +138,9 @@ public sealed class TransitionContextFactory(
         if (input.Execution?.IsSubFlowResume == true)
             executionContext.Directives.MarkAsSubFlowResume();
 
+        if (input.Execution?.IsLongPollAckResume == true)
+            executionContext.Directives.MarkAsLongPollAckResume();
+
         if (input.Execution?.IsTimeoutTransition == true)
             executionContext.Directives.MarkAsTimeoutTransition();
 

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/ReservedTransitionResolver.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/ReservedTransitionResolver.cs
@@ -20,13 +20,15 @@ public sealed class ReservedTransitionResolver : IReservedTransitionResolver
             || context.IsUpdateDataTransition()
             || context.Directives.IsTimeoutTransition
             || context.Directives.IsSubFlowResume
+            || context.Directives.IsLongPollAckResume
             || context.IsSharedTransition();
     }
 
     /// <inheritdoc />
     public string GetOwnLockKey(TransitionExecutionContext context)
     {
-        if (context.Directives.IsSubFlowResume)     return context.LockKey + ":resume";
+        if (context.Directives.IsSubFlowResume)       return context.LockKey + ":resume";
+        if (context.Directives.IsLongPollAckResume)   return context.LockKey + ":lpack";
         if (context.IsCancelTransition())           return context.LockKey + ":cancel";
         if (context.IsExitTransition())             return context.LockKey + ":exit";
         if (context.IsUpdateDataTransition())       return context.LockKey + ":updatedata";

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ClearBusyOnResumeStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ClearBusyOnResumeStep.cs
@@ -26,10 +26,24 @@ public sealed class ClearBusyOnResumeStep() : ITransitionStep
     {
         Activity.Current?.SetDisplayName($"[{Order}] {nameof(ClearBusyOnResumeStep)}");
 
-        // Only process this step if resuming from SubFlow completion
-        if (!context.Directives.IsSubFlowResume)
+        // Only process this step on an internal resume (SubFlow completion or long-poll acknowledge)
+        if (!context.Directives.IsInternalResume)
         {
             return Task.FromResult(Result<StepOutcome>.Ok(StepOutcome.Continue()));
+        }
+
+        // Long-poll acknowledge resume: compare-and-clear the durable ack marker. Acknowledge and
+        // the fallback timeout can both request a resume; the reserved ":lpack" lock serializes
+        // them, and this guard makes the second one a no-op — if the marker is already cleared the
+        // pipeline has already advanced, so stop without re-running the epilogue.
+        if (context.Directives.IsLongPollAckResume)
+        {
+            if (!context.Instance.IsAwaitingLongPollAck)
+            {
+                return Task.FromResult(Result<StepOutcome>.Ok(StepOutcome.Stop()));
+            }
+
+            context.Instance.ClearLongPollAck();
         }
 
         // Resolve target state first, then conditionally defer status

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/HandleLongPollTerminationStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/HandleLongPollTerminationStep.cs
@@ -3,6 +3,9 @@ using BBT.Aether.Aspects;
 using BBT.Aether.BackgroundJob;
 using BBT.Aether.Guids;
 using BBT.Aether.Results;
+using BBT.Aether.Users;
+using BBT.Workflow.Authorization;
+using BBT.Workflow.CurrentUser;
 using BBT.Workflow.BackgroundJobs.Handlers;
 using BBT.Workflow.BackgroundJobs.Payloads;
 using BBT.Workflow.Execution.LongPoll;
@@ -26,6 +29,8 @@ public sealed class HandleLongPollTerminationStep(
     IInstanceJobRepository jobRepository,
     IBackgroundJobService backgroundJobService,
     IGuidGenerator guidGenerator,
+    ITransitionAuthorizationManager transitionAuthorizationManager,
+    ICurrentUser currentUser,
     ILogger<HandleLongPollTerminationStep> logger) : ITransitionStep
 {
     /// <inheritdoc />
@@ -39,6 +44,16 @@ public sealed class HandleLongPollTerminationStep(
         Activity.Current?.SetDisplayName($"[{Order}] {nameof(HandleLongPollTerminationStep)}");
 
         if (!IsApplicable(context))
+        {
+            return Result<StepOutcome>.Ok(StepOutcome.Continue());
+        }
+
+        // Role gate: the long-poll stop belongs to the role that drove the transition into this state.
+        // When the entered state scopes the stop to specific roles (interaction.longPoll.roles) and the
+        // triggering caller is not one of them, do NOT pause — that role is not an owner of the stop, so
+        // the pipeline proceeds normally (epilogue runs). The same grant is used by the State function
+        // signal and the acknowledge check, so arm → signal → ack all agree on the owning role.
+        if (!await OwnsLongPollAsync(context, cancellationToken))
         {
             return Result<StepOutcome>.Ok(StepOutcome.Continue());
         }
@@ -75,6 +90,26 @@ public sealed class HandleLongPollTerminationStep(
         => context.Target?.TerminatesLongPollOnEntry == true
            && !context.Directives.IsLongPollAckResume
            && !context.Instance.IsAwaitingLongPollAck;
+
+    /// <summary>
+    /// Returns true when the triggering caller owns the long-poll stop for the entered state.
+    /// No roles configured → applies to all (every caller owns it). Otherwise the caller's role(s)
+    /// must satisfy <c>interaction.longPoll.roles</c> (same grant used by the State function signal
+    /// and the acknowledge check; DENY-wins / allowlist semantics, predefined + dynamic roles honored).
+    /// </summary>
+    private async Task<bool> OwnsLongPollAsync(
+        TransitionExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        var roles = context.Target!.LongPollAckRoles;
+        if (roles is not { Count: > 0 })
+            return true;
+
+        var callerRoles = currentUser.ResolveCallerRoles(context.Headers);
+        var requestContext = new AuthorizationRequestContext(context.Headers, null, context.RouteValues);
+        return await transitionAuthorizationManager.IsAnyRoleAllowedForGrantsAsync(
+            callerRoles, roles, context.Instance, requestContext, cancellationToken);
+    }
 
     /// <summary>
     /// Schedules the one-shot fallback resume job and tracks it so acknowledge can cancel it.

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/HandleLongPollTerminationStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/HandleLongPollTerminationStep.cs
@@ -1,0 +1,134 @@
+using System.Diagnostics;
+using BBT.Aether.Aspects;
+using BBT.Aether.BackgroundJob;
+using BBT.Aether.Guids;
+using BBT.Aether.Results;
+using BBT.Workflow.BackgroundJobs.Handlers;
+using BBT.Workflow.BackgroundJobs.Payloads;
+using BBT.Workflow.Execution.LongPoll;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Logging;
+using Dapr.Jobs.Models;
+using Microsoft.Extensions.Logging;
+
+namespace BBT.Workflow.Execution.Pipeline.Steps;
+
+/// <summary>
+/// Pipeline step for declarative long-poll termination on state entry.
+/// When the entered state declares <c>interaction.longPoll.terminate</c>, this step arms a durable
+/// acknowledge marker, schedules a fallback resume job, and pauses the pipeline before the epilogue
+/// (Schedule/Auto) by skipping to Finalize — the instance stays Busy until the client acknowledges
+/// (or the fallback timeout fires), at which point the pipeline resumes via
+/// <see cref="ILongPollAckResumeService"/>.
+/// </summary>
+public sealed class HandleLongPollTerminationStep(
+    IInstanceRepository instanceRepository,
+    IInstanceJobRepository jobRepository,
+    IBackgroundJobService backgroundJobService,
+    IGuidGenerator guidGenerator,
+    ILogger<HandleLongPollTerminationStep> logger) : ITransitionStep
+{
+    /// <inheritdoc />
+    public int Order => LifecycleOrder.LongPollTermination;
+
+    /// <inheritdoc />
+    [Trace]
+    public async Task<Result<StepOutcome>> ExecuteAsync(TransitionExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        Activity.Current?.SetDisplayName($"[{Order}] {nameof(HandleLongPollTerminationStep)}");
+
+        if (!IsApplicable(context))
+        {
+            return Result<StepOutcome>.Ok(StepOutcome.Continue());
+        }
+
+        var token = guidGenerator.Create();
+        context.Instance.ArmLongPollAck(token);
+        await instanceRepository.UpdateAsync(context.Instance, true, cancellationToken);
+
+        await ScheduleFallbackAsync(context, token, cancellationToken);
+
+        logger.LongPollTerminationArmed(
+            context.InstanceId,
+            context.Target!.Key,
+            context.Target.LongPollFallbackTimeoutSeconds);
+
+        // Pause: skip the epilogue (Schedule/Auto) and go straight to Finalize so the transition
+        // record completes. The instance stays Busy; resume happens on acknowledge or fallback.
+        return Result<StepOutcome>.Ok(new StepOutcome
+        {
+            MutateDirectives = d =>
+            {
+                d.RequestEpilogue(EpilogueMode.Skip);
+                d.MarkTerminal();
+            },
+            SkipToOrder = LifecycleOrder.Finalize
+        });
+    }
+
+    /// <summary>
+    /// Applicable when the entered state terminates long polling and the pipeline is not itself a
+    /// long-poll resume, and the instance is not already awaiting an acknowledge (idempotent re-entry).
+    /// </summary>
+    private static bool IsApplicable(TransitionExecutionContext context)
+        => context.Target?.TerminatesLongPollOnEntry == true
+           && !context.Directives.IsLongPollAckResume
+           && !context.Instance.IsAwaitingLongPollAck;
+
+    /// <summary>
+    /// Schedules the one-shot fallback resume job and tracks it so acknowledge can cancel it.
+    /// The job name carries the well-known key suffix so the existing transition-key cancellation
+    /// path can target it.
+    /// </summary>
+    private async Task ScheduleFallbackAsync(
+        TransitionExecutionContext context,
+        Guid token,
+        CancellationToken cancellationToken)
+    {
+        var jobName = $"lpack-{context.InstanceId}-{LongPollAckConstants.JobKey}";
+        var activity = Activity.Current;
+
+        var payload = new LongPollAckTimeoutPayload
+        {
+            JobName = jobName,
+            Domain = context.Domain,
+            InstanceId = context.InstanceId,
+            FlowName = context.WorkflowKey,
+            Version = context.Workflow.Version,
+            AckToken = token,
+            TraceParent = activity?.Id,
+            TraceState = activity?.TraceStateString
+        };
+
+        var schedule = DaprJobSchedule
+            .FromDateTime(DateTime.UtcNow.AddSeconds(context.Target!.LongPollFallbackTimeoutSeconds))
+            .ExpressionValue;
+
+        var metadata = new Dictionary<string, object>
+        {
+            ["domain"] = context.Domain,
+            ["flowName"] = context.WorkflowKey,
+            ["instanceId"] = context.InstanceId.ToString()
+        };
+
+        var jobId = await backgroundJobService.EnqueueAsync(
+            LongPollAckTimeoutJobHandler.HandlerName,
+            jobName,
+            payload,
+            schedule,
+            metadata,
+            cancellationToken: cancellationToken);
+
+        await jobRepository.InsertAsync(
+            InstanceJob.Create(
+                jobId,
+                jobName,
+                jobId,
+                context.Domain,
+                context.WorkflowKey,
+                context.InstanceId),
+            true,
+            cancellationToken);
+    }
+}

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/TransitionPipeline.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/TransitionPipeline.cs
@@ -102,6 +102,9 @@ public class TransitionPipeline
             }
 
             // SubFlow Resume resumes an already-Busy instance; confirm the busy mark.
+            // (Long-poll acknowledge resume is intentionally NOT re-marked here: the paused
+            // instance is already Busy, and a redundant resume that no-ops must not strand an
+            // already-advanced instance in Busy.)
             if (context.Directives.IsSubFlowResume)
                 await _busyMarker.MarkBusyAsync(context.InstanceId, cancellationToken);
 

--- a/src/BBT.Workflow.Application/Execution/Transitions/Strategy/AsyncTransitionStrategy.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Strategy/AsyncTransitionStrategy.cs
@@ -177,7 +177,7 @@ public sealed class AsyncTransitionStrategy(
         TransitionExecutionContext ctx,
         CancellationToken cancellationToken)
     {
-        if (!ctx.Instance.IsBusy && !ctx.Instance.IsCompleted && !ctx.Directives.IsSubFlowResume)
+        if (!ctx.Instance.IsBusy && !ctx.Instance.IsCompleted && !ctx.Directives.IsInternalResume)
         {
             await using var innerUow = await uowManager.BeginAsync(
                 new UnitOfWorkOptions

--- a/src/BBT.Workflow.Application/Gateway/IInstanceCommandGateway.cs
+++ b/src/BBT.Workflow.Application/Gateway/IInstanceCommandGateway.cs
@@ -94,5 +94,18 @@ public interface IInstanceCommandGateway
     Task<Result> MarkBusyAsync(
         MarkBusyInput input,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Acknowledges a long-poll termination signal and resumes the paused pipeline, descending the
+    /// active SubFlow chain (local or cross-domain) to the instance that is actually awaiting.
+    /// Routes to local or remote execution based on target domain. Each level either resumes (if it is
+    /// the awaiting instance) or forwards to its active SubFlow child via this same method.
+    /// </summary>
+    /// <param name="input">Target domain, workflow, instance and caller context.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result indicating success or failure of the resume along the chain.</returns>
+    Task<Result> AcknowledgeLongPollAsync(
+        AcknowledgeLongPollInput input,
+        CancellationToken cancellationToken = default);
 }
 

--- a/src/BBT.Workflow.Application/Instances/DTOs/AcknowledgeLongPollInput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/AcknowledgeLongPollInput.cs
@@ -1,0 +1,37 @@
+namespace BBT.Workflow.Instances;
+
+/// <summary>
+/// Input parameters for acknowledging a long-poll termination signal and resuming the paused pipeline.
+/// </summary>
+public sealed class AcknowledgeLongPollInput
+{
+    /// <summary>
+    /// The domain/tenant identifier.
+    /// </summary>
+    public required string Domain { get; init; }
+
+    /// <summary>
+    /// The workflow key.
+    /// </summary>
+    public required string Workflow { get; init; }
+
+    /// <summary>
+    /// The instance identifier (ID or key).
+    /// </summary>
+    public required string Instance { get; init; }
+
+    /// <summary>
+    /// Optional workflow version for schema/definition resolution.
+    /// </summary>
+    public string? Version { get; init; }
+
+    /// <summary>
+    /// The caller role used for the long-poll acknowledge authorization check.
+    /// </summary>
+    public string? Role { get; init; }
+
+    /// <summary>
+    /// Request headers for context propagation.
+    /// </summary>
+    public Dictionary<string, string?> Headers { get; init; } = new();
+}

--- a/src/BBT.Workflow.Application/Instances/DTOs/GetInstanceStateOutput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/GetInstanceStateOutput.cs
@@ -43,6 +43,13 @@ public sealed class GetInstanceStateOutput
     public List<TransitionItem> Transitions { get; set; } = [];
 
     /// <summary>
+    /// Client-workflow-manager interaction directives for the current state. Present only when the
+    /// state declares an applicable directive for the caller (today: long-poll termination). A generic
+    /// container so future interaction directives are grouped under the same key.
+    /// </summary>
+    public InstanceInteractionOutput? Interaction { get; set; }
+
+    /// <summary>
     /// Representation ETag (RFC 7232 quoted) for cache validation.
     /// </summary>
     public string? ETag

--- a/src/BBT.Workflow.Application/Instances/DTOs/InstanceInteractionOutput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/InstanceInteractionOutput.cs
@@ -1,0 +1,24 @@
+using BBT.Workflow.Shared;
+
+namespace BBT.Workflow.Instances;
+
+/// <summary>
+/// Client-workflow-manager interaction directives surfaced on the State (long-poll) function response.
+/// A generic, extensible container: today it carries long-poll termination; future directives are
+/// added here as additional properties rather than at the response root.
+/// </summary>
+public sealed class InstanceInteractionOutput
+{
+    /// <summary>
+    /// When true, the client should terminate its active long-poll request, render the entered-state
+    /// screen, and acknowledge via <see cref="Ack"/>. Set when the entered state declares
+    /// <c>interaction.longPoll.terminate</c> and the caller's role is granted the signal.
+    /// </summary>
+    public bool TerminateLongPoll { get; set; }
+
+    /// <summary>
+    /// Acknowledge endpoint href. Present when <see cref="TerminateLongPoll"/> is true. POSTing to it
+    /// resumes the paused pipeline; if not called, a fallback schedule resumes it automatically.
+    /// </summary>
+    public AckHref? Ack { get; set; }
+}

--- a/src/BBT.Workflow.Application/Instances/IInstanceCommandAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/IInstanceCommandAppService.cs
@@ -15,4 +15,16 @@ public interface IInstanceCommandAppService : IApplicationService
         string transitionKey,
         TransitionInput input,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Acknowledges a long-poll termination signal for a paused instance and resumes its pipeline.
+    /// Role-checked against the entered state's <c>interaction.longPoll.roles</c>. Idempotent: a no-op
+    /// when the instance is not awaiting acknowledge (already resumed by acknowledge or fallback).
+    /// </summary>
+    /// <param name="input">The acknowledge request (domain, workflow, instance, optional version, role).</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>Ok on success or no-op; Forbidden when the caller's role is not granted; Fail on resume error.</returns>
+    Task<Result> AcknowledgeLongPollAsync(
+        AcknowledgeLongPollInput input,
+        CancellationToken cancellationToken = default);
 } 

--- a/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
@@ -4,6 +4,7 @@ using BBT.Aether;
 using BBT.Aether.Users;
 using BBT.Workflow.Authorization;
 using BBT.Workflow.Execution.LongPoll;
+using BBT.Workflow.Gateway;
 using BBT.Workflow.RepresentationEtag;
 using BBT.Aether.Application.Services;
 using BBT.Aether.BackgroundJob;
@@ -58,6 +59,7 @@ public sealed class InstanceCommandAppService(
     ITransitionAuthorizationManager transitionAuthorizationManager,
     IInstanceCancellationService cancellationService,
     ILongPollAckResumeService longPollAckResumeService,
+    IInstanceCommandGateway instanceCommandGateway,
     ICurrentUser currentUser,
     ILogger<InstanceCommandAppService> logger)
     : ApplicationService(serviceProvider), IInstanceCommandAppService
@@ -168,9 +170,28 @@ public sealed class InstanceCommandAppService(
 
         var instance = instanceResult.Value!;
 
-        // Idempotent: nothing to acknowledge (already resumed by an earlier ack or the fallback).
+        // Not the awaiting instance — descend the active SubFlow chain (local or cross-domain via the
+        // gateway) to the instance that actually paused. The State function follows the same SubFlow
+        // chain downward, so the awaiting instance is the deepest active subflow child.
         if (!instance.IsAwaitingLongPollAck)
+        {
+            var sub = instance.Subflow;
+            if (sub is not null)
+            {
+                return await instanceCommandGateway.AcknowledgeLongPollAsync(new AcknowledgeLongPollInput
+                {
+                    Domain = sub.SubFlowDomain,
+                    Workflow = sub.SubFlowName,
+                    Instance = sub.SubFlowInstanceId.ToString(),
+                    Version = sub.SubFlowVersion,
+                    Role = input.Role,
+                    Headers = input.Headers
+                }, cancellationToken);
+            }
+
+            // Idempotent: nothing awaiting anywhere in the chain (already resumed or fallback fired).
             return Result.Ok();
+        }
 
         var workflowResult = await LoadWorkflowAsync(input.Domain, input.Workflow, input.Version, cancellationToken);
         if (!workflowResult.IsSuccess)

--- a/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
@@ -1,7 +1,9 @@
 using System.Diagnostics;
 using System.Text.Json;
 using BBT.Aether;
+using BBT.Aether.Users;
 using BBT.Workflow.Authorization;
+using BBT.Workflow.Execution.LongPoll;
 using BBT.Workflow.RepresentationEtag;
 using BBT.Aether.Application.Services;
 using BBT.Aether.BackgroundJob;
@@ -53,6 +55,10 @@ public sealed class InstanceCommandAppService(
     IInstanceExtensionService instanceExtensionService,
     IScriptContextFactory scriptContextFactory,
     ITimerEvaluator timerEvaluator,
+    ITransitionAuthorizationManager transitionAuthorizationManager,
+    IInstanceCancellationService cancellationService,
+    ILongPollAckResumeService longPollAckResumeService,
+    ICurrentUser currentUser,
     ILogger<InstanceCommandAppService> logger)
     : ApplicationService(serviceProvider), IInstanceCommandAppService
 {
@@ -147,6 +153,60 @@ public sealed class InstanceCommandAppService(
             Key = existingInstance.Key,
             Status = existingInstance.Status
         });
+    }
+
+    /// <inheritdoc />
+    public async Task<Result> AcknowledgeLongPollAsync(
+        AcknowledgeLongPollInput input,
+        CancellationToken cancellationToken = default)
+    {
+        runtimeInfoProvider.Check(input.Domain);
+
+        var instanceResult = await instanceRepository.GetActiveAsync(input.Instance, cancellationToken);
+        if (!instanceResult.IsSuccess)
+            return Result.Fail(instanceResult.Error);
+
+        var instance = instanceResult.Value!;
+
+        // Idempotent: nothing to acknowledge (already resumed by an earlier ack or the fallback).
+        if (!instance.IsAwaitingLongPollAck)
+            return Result.Ok();
+
+        var workflowResult = await LoadWorkflowAsync(input.Domain, input.Workflow, input.Version, cancellationToken);
+        if (!workflowResult.IsSuccess)
+            return Result.Fail(workflowResult.Error);
+
+        var workflow = workflowResult.Value!;
+
+        // Role check against the entered state's interaction.longPoll.roles (default-allow when none).
+        var state = workflow.FindState(instance.GetCurrentState);
+        var ackRoles = state?.LongPollAckRoles;
+        if (ackRoles is { Count: > 0 })
+        {
+            var callerRoles = BuildCallerRoles(input.Role);
+            var allowed = await transitionAuthorizationManager.IsAnyRoleAllowedForGrantsAsync(
+                callerRoles, ackRoles, instance, cancellationToken: cancellationToken);
+            if (!allowed)
+                return Result.Fail(WorkflowErrors.LongPollAckAccessDenied(instance.Id));
+        }
+
+        // Best-effort cancel the fallback timeout job; the token guard in the resume path keeps the
+        // operation safe even if cancellation is missed.
+        await cancellationService.ProcessStateTransitionsCancellationAsync(
+            instance.Id, [LongPollAckConstants.JobKey], cancellationToken);
+
+        return await longPollAckResumeService.ResumeAsync(
+            workflow.Domain, workflow.Key, workflow.Version, instance.Id, cancellationToken);
+    }
+
+    private IReadOnlyCollection<string> BuildCallerRoles(string? explicitRole)
+    {
+        var roles = new List<string>();
+        if (!string.IsNullOrWhiteSpace(explicitRole))
+            roles.Add(explicitRole.Trim());
+        if (currentUser.Roles is { Length: > 0 })
+            roles.AddRange(currentUser.Roles);
+        return roles;
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -376,7 +376,9 @@ public sealed class InstanceQueryAppService(
                     SubFlowData: subFlowValue.Data,
                     SubFlowView: subFlowValue.View,
                     SubFlowActiveCorrelations: subFlowValue.ActiveCorrelations,
-                    SubFlowTransitionItems: subFlowValue.Transitions);
+                    SubFlowTransitionItems: subFlowValue.Transitions,
+                    // Bubble the (possibly deeper) subflow's long-poll termination signal up the chain.
+                    Interaction: subFlowValue.Interaction);
             }
         }
         catch (Exception ex)
@@ -1049,9 +1051,24 @@ public sealed class InstanceQueryAppService(
         // Declarative long-poll termination: when the instance is paused on a state that terminates
         // long polling and the caller's role is granted the signal, tell the client to stop polling,
         // render the entered-state screen, and acknowledge via the ack href. Role-filtered so only the
-        // intended roles are told to stop. Gated on the main-flow current state (not a subflow view).
-        var interaction = await ResolveInteractionAsync(
-            input, instance, currentStateValue, displayedState, cancellationToken);
+        // intended roles are told to stop. The awaiting instance may be THIS instance (leaf) or a
+        // nested subflow whose signal bubbled up via SubFlowStateInfo — in the subflow case the ack
+        // href is rewritten to THIS level so the client always acknowledges the instance it polls; the
+        // acknowledge endpoint then descends the chain. The two are mutually exclusive (a parent in a
+        // SubFlow state is not itself in a terminate state). Role filtering for the bubbled case was
+        // already applied at the child level (caller role forwarded via headers).
+        var interaction = subFlowStateInfo.Interaction?.TerminateLongPoll == true
+            ? new InstanceInteractionOutput
+            {
+                TerminateLongPoll = true,
+                Ack = new AckHref
+                {
+                    Href = urlTemplateBuilder.BuildLongPollAckUrl(
+                        input.Domain, input.Workflow, instance.Id.ToString())
+                }
+            }
+            : await ResolveInteractionAsync(
+                input, instance, currentStateValue, displayedState, cancellationToken);
 
         return Result<GetInstanceStateOutput>.Ok(new GetInstanceStateOutput
         {
@@ -1982,7 +1999,8 @@ public sealed class InstanceQueryAppService(
         DataHref? SubFlowData = null,
         ViewHref? SubFlowView = null,
         List<ActiveCorrelationHref>? SubFlowActiveCorrelations = null,
-        List<TransitionItem>? SubFlowTransitionItems = null);
+        List<TransitionItem>? SubFlowTransitionItems = null,
+        InstanceInteractionOutput? Interaction = null);
 
     private sealed record WizardViewSelection(
         ViewDefinition? ViewDefinition,

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -1046,6 +1046,13 @@ public sealed class InstanceQueryAppService(
                 displayedState = aliasDisplay;
         }
 
+        // Declarative long-poll termination: when the instance is paused on a state that terminates
+        // long polling and the caller's role is granted the signal, tell the client to stop polling,
+        // render the entered-state screen, and acknowledge via the ack href. Role-filtered so only the
+        // intended roles are told to stop. Gated on the main-flow current state (not a subflow view).
+        var interaction = await ResolveInteractionAsync(
+            input, instance, currentStateValue, displayedState, cancellationToken);
+
         return Result<GetInstanceStateOutput>.Ok(new GetInstanceStateOutput
         {
             Data = dataHref,
@@ -1056,8 +1063,54 @@ public sealed class InstanceQueryAppService(
                 : subFlowStateInfo.StateType!,
             Status = subFlowStateInfo.Status,
             ActiveCorrelations = allActiveCorrelations,
-            Transitions = transitionItems
+            Transitions = transitionItems,
+            Interaction = interaction
         });
+    }
+
+    /// <summary>
+    /// Resolves the client-workflow-manager interaction directives for the response, or null when none
+    /// apply. Today this is long-poll termination: emitted only on the main-flow current state, when the
+    /// instance is awaiting acknowledge, the state declares <c>interaction.longPoll.terminate</c>, and the
+    /// caller's role is granted by <c>interaction.longPoll.roles</c> (default-allow when no roles configured).
+    /// </summary>
+    private async Task<InstanceInteractionOutput?> ResolveInteractionAsync(
+        GetInstanceStateInput input,
+        Instance instance,
+        State currentStateValue,
+        string? displayedState,
+        CancellationToken cancellationToken)
+    {
+        if (!instance.IsAwaitingLongPollAck || !currentStateValue.TerminatesLongPollOnEntry)
+            return null;
+
+        // Only signal on the main-flow current state view, not a subflow terminal view.
+        if (!string.Equals(displayedState, instance.CurrentState, StringComparison.Ordinal)
+            && displayedState is not null)
+        {
+            // displayedState may be a role alias of the current state; still allow when it aliases it.
+            if (currentStateValue.Aliases.Count == 0)
+                return null;
+        }
+
+        var ackRoles = currentStateValue.LongPollAckRoles;
+        if (ackRoles is { Count: > 0 })
+        {
+            var requestContext = new AuthorizationRequestContext(input.Headers, input.QueryParams);
+            var callerRoles = input.Roles ?? (string.IsNullOrWhiteSpace(input.Role) ? [] : [input.Role]);
+            var allowed = await transitionAuthorizationManager.IsAnyRoleAllowedForGrantsAsync(
+                callerRoles, ackRoles, instance, requestContext, cancellationToken);
+            if (!allowed)
+                return null;
+        }
+
+        var ackHref = urlTemplateBuilder.BuildLongPollAckUrl(
+            input.Domain, input.Workflow, instance.Id.ToString());
+        return new InstanceInteractionOutput
+        {
+            TerminateLongPoll = true,
+            Ack = new AckHref { Href = ackHref }
+        };
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Application/Instances/Remote/IRemoteInstanceCommandAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/Remote/IRemoteInstanceCommandAppService.cs
@@ -46,4 +46,12 @@ public interface IRemoteInstanceCommandAppService
     Task<Result> MarkBusyAsync(
         MarkBusyInput input,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Acknowledges a long-poll termination signal on a remote instance, descending its SubFlow chain.
+    /// POST {baseUrl}/api/v{version}/{domain}/workflows/{workflow}/instances/{instanceId}/longpoll/ack
+    /// </summary>
+    Task<Result> AcknowledgeLongPollAsync(
+        AcknowledgeLongPollInput input,
+        CancellationToken cancellationToken = default);
 }

--- a/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/PipelineServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/PipelineServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using BBT.Workflow.Definitions.Specifications;
 using BBT.Workflow.Execution;
 using BBT.Workflow.Execution.Continuations;
 using BBT.Workflow.Execution.ErrorHandling;
+using BBT.Workflow.Execution.LongPoll;
 using BBT.Workflow.Execution.Pipeline;
 using BBT.Workflow.Execution.Pipeline.Steps;
 using BBT.Workflow.Execution.PostCommit;
@@ -80,6 +81,7 @@ public static class PipelineServiceCollectionExtensions
         services.AddScoped<ITransitionStep, ChangeStateStep>();
         services.AddScoped<ITransitionStep, RunOnEntryTasksStep>();
         services.AddScoped<ITransitionStep, HandleSubFlowStep>();
+        services.AddScoped<ITransitionStep, HandleLongPollTerminationStep>();
         services.AddScoped<ITransitionStep, ClearBusyOnResumeStep>();
         services.AddScoped<ITransitionStep, ScheduleTransitionsStep>();
         services.AddScoped<ITransitionStep, RunAutomaticTransitionsStep>();
@@ -105,6 +107,9 @@ public static class PipelineServiceCollectionExtensions
         services.AddScoped<IPostCommitHandler<StartSubflowJob>, StartSubflowJobHandler>();
         services.AddScoped<IPostCommitHandler<ForwardToSubflowJob>, ForwardToSubflowJobHandler>();
         services.AddSingleton<IPostCommitFailurePolicy, DefaultPostCommitFailurePolicy>();
+
+        // Long-poll termination resume (acknowledge endpoint + fallback timeout job)
+        services.AddScoped<ILongPollAckResumeService, LongPollAckResumeService>();
 
         return services;
     }

--- a/src/BBT.Workflow.Domain/Definitions/IUrlTemplateBuilder.cs
+++ b/src/BBT.Workflow.Domain/Definitions/IUrlTemplateBuilder.cs
@@ -108,4 +108,15 @@ public interface IUrlTemplateBuilder
     /// <param name="apiVersionPrefix">Optional API version prefix (e.g., "api/v1")</param>
     /// <returns>Generated client-facing URL</returns>
     string BuildSchemaUrl(string domain, string workflow, string instanceId, string transitionKey, string? apiVersionPrefix = null);
+
+    /// <summary>
+    /// Builds URL for the long-poll acknowledge endpoint of an instance.
+    /// </summary>
+    /// <param name="domain">The domain name</param>
+    /// <param name="workflow">The workflow name</param>
+    /// <param name="instance">The instance key or ID</param>
+    /// <param name="apiVersionPrefix">Optional API version prefix (e.g., "api/v1")</param>
+    /// <returns>Generated client-facing acknowledge URL</returns>
+    string BuildLongPollAckUrl(string domain, string workflow, string instance, string? apiVersionPrefix = null)
+        => $"{BuildInstanceUrl(domain, workflow, instance, apiVersionPrefix)}/longpoll/ack";
 }

--- a/src/BBT.Workflow.Domain/Definitions/InstanceUrlTemplates.cs
+++ b/src/BBT.Workflow.Domain/Definitions/InstanceUrlTemplates.cs
@@ -125,6 +125,12 @@ public static class InstanceUrlTemplates
     public const string MarkBusyTemplate = "/{0}/workflows/{1}/instances/{2}/busy";
 
     /// <summary>
+    /// URL template for the long-poll acknowledge endpoint.
+    /// Format: /{domain}/workflows/{workflow}/instances/{instance}/longpoll/ack
+    /// </summary>
+    public const string LongPollAckTemplate = "/{0}/workflows/{1}/instances/{2}/longpoll/ack";
+
+    /// <summary>
     /// URL template for retry instance endpoints.
     /// Format: /{domain}/workflows/{workflow}/instances/{instance}/retry
     /// </summary>
@@ -353,6 +359,9 @@ public static class InstanceUrlTemplates
     /// <returns>Generated URL</returns>
     public static string MarkBusy(string domain, string workflow, string instance, string? apiVersionPrefix = null)
         => BuildUrl(MarkBusyTemplate, apiVersionPrefix, domain, workflow, instance);
+
+    public static string LongPollAck(string domain, string workflow, string instance, string? apiVersionPrefix = null)
+        => BuildUrl(LongPollAckTemplate, apiVersionPrefix, domain, workflow, instance);
 
     /// <summary>
     /// Generates URL for retry instance endpoint.

--- a/src/BBT.Workflow.Domain/Definitions/Specifications/ResumeModeSpecification.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Specifications/ResumeModeSpecification.cs
@@ -22,7 +22,7 @@ public sealed class ResumeModeSpecification : ITransitionSpecification
     /// Applicable when execution is resuming from SubFlow completion or triggered by workflow timeout.
     /// </summary>
     public bool IsApplicable(TransitionExecutionContext context)
-        => context.Directives.IsSubFlowResume || context.Directives.IsTimeoutTransition;
+        => context.Directives.IsInternalResume || context.Directives.IsTimeoutTransition;
 
     /// <inheritdoc />
     /// <summary>

--- a/src/BBT.Workflow.Domain/Definitions/States/LongPollInteraction.cs
+++ b/src/BBT.Workflow.Domain/Definitions/States/LongPollInteraction.cs
@@ -1,0 +1,53 @@
+using System.Text.Json.Serialization;
+
+namespace BBT.Workflow.Definitions;
+
+/// <summary>
+/// Declarative long-poll interaction directive for a state.
+/// When <see cref="Terminate"/> is true, the transition pipeline pauses after the
+/// state's OnEntry tasks run and the State (long-poll) function tells the client to
+/// stop polling, render the entered-state screen, and acknowledge — at which point
+/// the pipeline resumes (Schedule → Auto → Finish → Finalize). A fallback schedule
+/// (see <see cref="FallbackTimeoutSeconds"/>) auto-resumes the pipeline if the client
+/// never acknowledges.
+/// </summary>
+public sealed class LongPollInteraction
+{
+    private LongPollInteraction()
+    {
+    }
+
+    [JsonConstructor]
+    private LongPollInteraction(
+        bool terminate,
+        int? fallbackTimeoutSeconds,
+        List<RoleGrant>? roles)
+    {
+        Terminate = terminate;
+        FallbackTimeoutSeconds = fallbackTimeoutSeconds;
+        this.roles = roles ?? [];
+    }
+
+    /// <summary>
+    /// When true, entering the state terminates the client's active long-poll request.
+    /// </summary>
+    public bool Terminate { get; private set; }
+
+    /// <summary>
+    /// Acknowledge fallback window in seconds. If the client does not acknowledge within
+    /// this window, a scheduled job resumes the pipeline. Defaults to 60 when null.
+    /// </summary>
+    public int? FallbackTimeoutSeconds { get; private set; }
+
+    [JsonInclude]
+    [JsonPropertyName("roles")]
+    private List<RoleGrant> roles = new();
+
+    /// <summary>
+    /// Role grants controlling which callers receive the long-poll termination signal.
+    /// Empty means default-allow (every caller is signalled). Evaluated with the
+    /// standard DENY-wins / allowlist semantics used elsewhere for role grants.
+    /// </summary>
+    [JsonIgnore]
+    public IReadOnlyCollection<RoleGrant> Roles => roles.AsReadOnly();
+}

--- a/src/BBT.Workflow.Domain/Definitions/States/State.cs
+++ b/src/BBT.Workflow.Domain/Definitions/States/State.cs
@@ -35,7 +35,8 @@ public sealed class State : IHasKey
         List<LanguageLabel>? labels,
         List<OnExecuteTask>? onEntries,
         List<OnExecuteTask>? onExits,
-        List<RoleGrant>? queryRoles = null)
+        List<RoleGrant>? queryRoles = null,
+        StateInteraction? interaction = null)
         : this(key, stateType, subType)
     {
         VersionStrategy = versionStrategy;
@@ -43,6 +44,7 @@ public sealed class State : IHasKey
         this.onEntries = onEntries ?? [];
         this.onExits = onExits ?? [];
         this.queryRoles = queryRoles ?? [];
+        this.interaction = interaction;
         // aliases field is populated directly by System.Text.Json via [JsonInclude] (see `transitions` pattern)
         // view property will be set by ViewDefinitionJsonConverter via JsonInclude attribute
     }
@@ -85,6 +87,9 @@ public sealed class State : IHasKey
     [JsonInclude] [JsonPropertyName("alias")]
     private List<StateAlias> aliases = new();
 
+    [JsonInclude] [JsonPropertyName("interaction")]
+    private StateInteraction? interaction;
+
     [JsonInclude] [JsonPropertyName("subFlow")]
     public SubFlow? SubFlow { get; private set; }
     
@@ -117,6 +122,33 @@ public sealed class State : IHasKey
     /// </summary>
     [JsonIgnore]
     public IReadOnlyCollection<StateAlias> Aliases => aliases.AsReadOnly();
+
+    /// <summary>
+    /// Generic client-workflow-manager interaction directives for this state
+    /// (long-poll termination today; extensible to further facets).
+    /// </summary>
+    [JsonIgnore]
+    public StateInteraction? Interaction => interaction;
+
+    /// <summary>
+    /// True when entering this state must terminate the client's active long-poll request
+    /// (pausing the pipeline until acknowledge or fallback timeout).
+    /// </summary>
+    [JsonIgnore]
+    public bool TerminatesLongPollOnEntry => interaction?.LongPoll?.Terminate == true;
+
+    /// <summary>
+    /// Role grants controlling which callers receive the long-poll termination signal.
+    /// Empty/null means default-allow.
+    /// </summary>
+    [JsonIgnore]
+    public IReadOnlyCollection<RoleGrant>? LongPollAckRoles => interaction?.LongPoll?.Roles;
+
+    /// <summary>
+    /// Acknowledge fallback window in seconds for long-poll termination (default 60).
+    /// </summary>
+    [JsonIgnore]
+    public int LongPollFallbackTimeoutSeconds => interaction?.LongPoll?.FallbackTimeoutSeconds ?? 60;
 
     /// <summary>
     /// Languages

--- a/src/BBT.Workflow.Domain/Definitions/States/StateInteraction.cs
+++ b/src/BBT.Workflow.Domain/Definitions/States/StateInteraction.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Serialization;
+
+namespace BBT.Workflow.Definitions;
+
+/// <summary>
+/// Generic, extensible container for declarative directives that steer the client-side
+/// workflow manager when an instance enters a state. Today it carries a single facet
+/// (<see cref="LongPoll"/>); future facets (e.g. polling cadence, navigation, refresh)
+/// are added as new siblings here without touching the pipeline or State-function code,
+/// which read only through the <c>State</c> helper accessors.
+/// </summary>
+public sealed class StateInteraction
+{
+    private StateInteraction()
+    {
+    }
+
+    [JsonConstructor]
+    private StateInteraction(LongPollInteraction? longPoll)
+    {
+        LongPoll = longPoll;
+    }
+
+    /// <summary>
+    /// Long-poll termination directive. Null when the state does not steer long polling.
+    /// </summary>
+    [JsonInclude]
+    [JsonPropertyName("longPoll")]
+    public LongPollInteraction? LongPoll { get; private set; }
+}

--- a/src/BBT.Workflow.Domain/Execution/LongPoll/LongPollAckConstants.cs
+++ b/src/BBT.Workflow.Domain/Execution/LongPoll/LongPollAckConstants.cs
@@ -1,0 +1,14 @@
+namespace BBT.Workflow.Execution.LongPoll;
+
+/// <summary>
+/// Constants for the declarative long-poll termination feature (long-poll acknowledge).
+/// </summary>
+public static class LongPollAckConstants
+{
+    /// <summary>
+    /// Job-name suffix key for the acknowledge fallback schedule. The fallback job is named
+    /// <c>lpack-{instanceId}-{JobKey}</c> so it can be cancelled via the existing
+    /// transition-key-suffix cancellation path on acknowledge.
+    /// </summary>
+    public const string JobKey = "longpoll-ack";
+}

--- a/src/BBT.Workflow.Domain/Execution/Transitions/Context/ExecutionInfo.cs
+++ b/src/BBT.Workflow.Domain/Execution/Transitions/Context/ExecutionInfo.cs
@@ -17,6 +17,10 @@ public sealed class ExecutionInfo
     /// <summary>Gets or sets whether this execution is resuming from a SubFlow completion.</summary>
     public bool IsSubFlowResume { get; set; }
 
+    /// <summary>Gets or sets whether this execution is resuming from a long-poll acknowledge
+    /// (client acknowledged the termination signal, or the fallback timeout fired).</summary>
+    public bool IsLongPollAckResume { get; set; }
+
     /// <summary>Gets or sets whether this execution is triggered by a workflow timeout.</summary>
     public bool IsTimeoutTransition { get; set; }
 }

--- a/src/BBT.Workflow.Domain/Execution/Transitions/Context/PipelineDirectives.cs
+++ b/src/BBT.Workflow.Domain/Execution/Transitions/Context/PipelineDirectives.cs
@@ -53,6 +53,19 @@ public sealed class PipelineDirectives
     public bool IsSubFlowResume { get; private set; }
 
     /// <summary>
+    /// Gets a value indicating whether this execution is resuming from a long-poll acknowledge
+    /// (declarative long-poll termination on state entry — client acknowledged or fallback fired).
+    /// </summary>
+    public bool IsLongPollAckResume { get; private set; }
+
+    /// <summary>
+    /// Gets a value indicating whether this is an internal, system-triggered pipeline resume of an
+    /// already-Busy instance (subflow completion or long-poll acknowledge). These share lock-key,
+    /// validation-bypass and busy-confirmation behavior.
+    /// </summary>
+    public bool IsInternalResume => IsSubFlowResume || IsLongPollAckResume;
+
+    /// <summary>
     /// Gets a value indicating whether this execution is triggered by a workflow timeout.
     /// </summary>
     public bool IsTimeoutTransition { get; private set; }
@@ -118,6 +131,11 @@ public sealed class PipelineDirectives
     /// Marks this execution as a subflow resume scenario.
     /// </summary>
     public void MarkAsSubFlowResume() => IsSubFlowResume = true;
+
+    /// <summary>
+    /// Marks this execution as a long-poll acknowledge resume scenario.
+    /// </summary>
+    public void MarkAsLongPollAckResume() => IsLongPollAckResume = true;
 
     /// <summary>
     /// Marks this execution as a workflow timeout transition.

--- a/src/BBT.Workflow.Domain/Execution/Transitions/Pipeline/LifecycleOrder.cs
+++ b/src/BBT.Workflow.Domain/Execution/Transitions/Pipeline/LifecycleOrder.cs
@@ -83,6 +83,14 @@ public static class LifecycleOrder
     /// </summary>
     public const int SubFlow = 70;
 
+    /// <summary>
+    /// Order for handling declarative long-poll termination on state entry.
+    /// Runs after OnEntry/SubFlow and before the epilogue (Schedule/Auto): when the entered
+    /// state's <c>interaction.longPoll.terminate</c> is true, the pipeline pauses here (skips the
+    /// epilogue to Finalize, instance stays Busy) and resumes on acknowledge or fallback timeout.
+    /// </summary>
+    public const int LongPollTermination = 75;
+
     public const int ClearBusyOnResumeStep = Schedule - 1;
     
     /// <summary>

--- a/src/BBT.Workflow.Domain/Instances/Instance.cs
+++ b/src/BBT.Workflow.Domain/Instances/Instance.cs
@@ -149,6 +149,16 @@ public sealed class Instance : AggregateRoot<Guid>, ICreationAuditedObject, IMod
     public int? ResumePointStepOrder { get; private set; }
 
     /// <summary>
+    /// Long-poll acknowledge token. Set when the pipeline pauses on entering a state whose
+    /// <c>interaction.longPoll.terminate</c> is true; the State (long-poll) function surfaces the
+    /// termination signal while this is non-null, and the pipeline resumes when the client
+    /// acknowledges (or the fallback schedule fires). The token guards against double-resume:
+    /// acknowledge and fallback compare-and-clear it so only one wins. Null when no long-poll
+    /// acknowledge is pending.
+    /// </summary>
+    public Guid? LongPollAckToken { get; private set; }
+
+    /// <summary>
     /// Completed at
     /// </summary>
     public DateTime? CompletedAt { get; private set; }
@@ -574,6 +584,21 @@ public sealed class Instance : AggregateRoot<Guid>, ICreationAuditedObject, IMod
     /// Clears the durable resume point (called at transition finalize so it never leaks into the next transition).
     /// </summary>
     public void ClearResumePoint() => ResumePointStepOrder = null;
+
+    /// <summary>
+    /// Arms the long-poll acknowledge marker with the supplied token (pipeline paused on state entry).
+    /// </summary>
+    public void ArmLongPollAck(Guid token) => LongPollAckToken = token;
+
+    /// <summary>
+    /// Clears the long-poll acknowledge marker (acknowledge received or fallback resumed).
+    /// </summary>
+    public void ClearLongPollAck() => LongPollAckToken = null;
+
+    /// <summary>
+    /// True while a long-poll acknowledge is pending (the pipeline is paused on state entry).
+    /// </summary>
+    public bool IsAwaitingLongPollAck => LongPollAckToken.HasValue;
 
     /// <summary>
     /// Returns whether the supplied token matches the instance's current chain ownership token.

--- a/src/BBT.Workflow.Domain/Logging/WorkflowErrors.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowErrors.cs
@@ -465,6 +465,14 @@ public static class WorkflowErrors
             $"Access to state '{stateKey}' is not permitted for the current roles.");
 
     /// <summary>
+    /// The current roles are not permitted to acknowledge long-poll termination for the instance. Maps to HTTP 403.
+    /// </summary>
+    public static Error LongPollAckAccessDenied(Guid instanceId)
+        => Error.Forbidden(
+            WorkflowErrorCodes.AuthorizationRoleDenied,
+            $"Long-poll acknowledge for instance '{instanceId}' is not permitted for the current roles.");
+
+    /// <summary>
     /// The current roles are not permitted to invoke the custom function (function-level roles). Maps to HTTP 403.
     /// </summary>
     public static Error FunctionAccessDenied(string functionKey)

--- a/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
@@ -2110,7 +2110,58 @@ public static partial class WorkflowLogs
         Guid instanceId,
         string errorCode,
         string? boundaryAction);
-  
+
+    #endregion
+
+    #region Long-Poll Termination
+
+    /// <summary>
+    /// Logs when the pipeline pauses on state entry for declarative long-poll termination.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 20300,
+        Level = LogLevel.Information,
+        Message = "Long-poll termination armed on instance {InstanceId} at state {State}; fallback in {FallbackSeconds}s")]
+    public static partial void LongPollTerminationArmed(
+        this ILogger logger,
+        Guid instanceId,
+        string state,
+        int fallbackSeconds);
+
+    /// <summary>
+    /// Logs when a paused pipeline resumes after a long-poll acknowledge (or fallback timeout).
+    /// </summary>
+    [LoggerMessage(
+        EventId = 20301,
+        Level = LogLevel.Information,
+        Message = "Long-poll acknowledge resumed pipeline for instance {InstanceId}")]
+    public static partial void LongPollAckResumed(
+        this ILogger logger,
+        Guid instanceId);
+
+    /// <summary>
+    /// Logs when a long-poll acknowledge resume is skipped because the instance is no longer awaiting acknowledge.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 20302,
+        Level = LogLevel.Debug,
+        Message = "Long-poll acknowledge resume skipped (not awaiting) for instance {InstanceId}")]
+    public static partial void LongPollAckResumeSkipped(
+        this ILogger logger,
+        Guid instanceId);
+
+    /// <summary>
+    /// Logs when a long-poll acknowledge resume fails.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 20303,
+        Level = LogLevel.Error,
+        Message = "Long-poll acknowledge resume failed for instance {InstanceId}: {Reason}")]
+    public static partial void LongPollAckResumeFailed(
+        this ILogger logger,
+        Guid instanceId,
+        string reason);
+
     #endregion
 
     #region Multi-Channel Notification

--- a/src/BBT.Workflow.Domain/Shared/HrefBase.cs
+++ b/src/BBT.Workflow.Domain/Shared/HrefBase.cs
@@ -65,6 +65,13 @@ public sealed class SchemaHref : HrefBase
 }
 
 /// <summary>
+/// Acknowledge href link (e.g. the long-poll termination acknowledge endpoint).
+/// </summary>
+public sealed class AckHref : HrefBase
+{
+}
+
+/// <summary>
 /// View href link with load data flag
 /// </summary>
 public sealed class ViewHref : HrefBase

--- a/src/BBT.Workflow.HttpApi.Shared/Microsoft/Extensions/DependencyInjection/WorkflowApiBaseServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.HttpApi.Shared/Microsoft/Extensions/DependencyInjection/WorkflowApiBaseServiceCollectionExtensions.cs
@@ -175,6 +175,7 @@ public static class WorkflowApiBaseServiceCollectionExtensions
             options.AddHandler<FlowTimeoutJobHandler>(FlowTimeoutJobHandler.HandlerName);
             options.AddHandler<TransitionJobHandler>(TransitionJobHandler.HandlerName);
             options.AddHandler<TransitionTimerJobHandler>(TransitionTimerJobHandler.HandlerName);
+            options.AddHandler<LongPollAckTimeoutJobHandler>(LongPollAckTimeoutJobHandler.HandlerName);
         });
 
         services.AddDaprJobScheduler();

--- a/src/BBT.Workflow.Infrastructure/Data/InstancesModelCreatingExtensions.cs
+++ b/src/BBT.Workflow.Infrastructure/Data/InstancesModelCreatingExtensions.cs
@@ -77,6 +77,12 @@ public static class InstancesModelCreatingExtensions
             // Durable resume point for crash-resume (S8).
             b.Property(p => p.ResumePointStepOrder);
 
+            // Long-poll acknowledge marker (declarative long-poll termination on state entry).
+            b.Property(p => p.LongPollAckToken);
+            b.HasIndex(p => p.LongPollAckToken)
+                .HasDatabaseName("IX_Instances_LongPollAckToken")
+                .HasFilter("\"LongPollAckToken\" IS NOT NULL");
+
             b.Property(p => p.Incidents)
                 .HasColumnType("jsonb")
                 .HasConversion(

--- a/src/BBT.Workflow.Infrastructure/Gateway/LocalInstanceCommandGateway.cs
+++ b/src/BBT.Workflow.Infrastructure/Gateway/LocalInstanceCommandGateway.cs
@@ -162,4 +162,17 @@ public sealed class LocalInstanceCommandGateway : IInstanceCommandGateway
                 return Result.Ok();
             }, cancellationToken);
     }
+
+    /// <inheritdoc />
+    public Task<Result> AcknowledgeLongPollAsync(
+        AcknowledgeLongPollInput input,
+        CancellationToken cancellationToken = default)
+    {
+        return _serviceScopeFactory.ExecuteWithWorkflowAsync(input.Domain, input.Workflow, input.Version ?? string.Empty,
+            async (sp, ct) =>
+            {
+                var commandService = sp.GetRequiredService<IInstanceCommandAppService>();
+                return await commandService.AcknowledgeLongPollAsync(input, ct);
+            }, cancellationToken);
+    }
 }

--- a/src/BBT.Workflow.Infrastructure/Gateway/RemoteInstanceCommandGateway.cs
+++ b/src/BBT.Workflow.Infrastructure/Gateway/RemoteInstanceCommandGateway.cs
@@ -80,5 +80,13 @@ public sealed class RemoteInstanceCommandGateway : IInstanceCommandGateway
     {
         return _remoteService.MarkBusyAsync(input, cancellationToken);
     }
+
+    /// <inheritdoc />
+    public Task<Result> AcknowledgeLongPollAsync(
+        AcknowledgeLongPollInput input,
+        CancellationToken cancellationToken = default)
+    {
+        return _remoteService.AcknowledgeLongPollAsync(input, cancellationToken);
+    }
 }
 

--- a/src/BBT.Workflow.Infrastructure/Gateway/RoutedInstanceCommandGateway.cs
+++ b/src/BBT.Workflow.Infrastructure/Gateway/RoutedInstanceCommandGateway.cs
@@ -103,5 +103,15 @@ public sealed class RoutedInstanceCommandGateway : IInstanceCommandGateway
             ? _local.MarkBusyAsync(input, cancellationToken)
             : _remote.MarkBusyAsync(input, cancellationToken);
     }
+
+    /// <inheritdoc />
+    public Task<Result> AcknowledgeLongPollAsync(
+        AcknowledgeLongPollInput input,
+        CancellationToken cancellationToken = default)
+    {
+        return _runtimeInfoProvider.IsDomainMatch(input.Domain)
+            ? _local.AcknowledgeLongPollAsync(input, cancellationToken)
+            : _remote.AcknowledgeLongPollAsync(input, cancellationToken);
+    }
 }
 

--- a/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceCommandAppService.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceCommandAppService.cs
@@ -436,6 +436,54 @@ public sealed class RemoteInstanceCommandAppService(
     }
 
     /// <summary>
+    /// Acknowledges a long-poll termination signal on a remote instance by calling the remote API.
+    /// POST {baseUrl}/api/v{version}/{domain}/workflows/{workflow}/instances/{instanceId}/longpoll/ack
+    /// </summary>
+    public async Task<Result> AcknowledgeLongPollAsync(
+        AcknowledgeLongPollInput input,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var endpointResult = await endpointResolver.GetEndpointAsync(input.Domain, EndpointKind.Url, cancellationToken);
+
+            if (!endpointResult.IsSuccess)
+                return Result.Fail(endpointResult.Error);
+
+            var endpoint = endpointResult.Value!;
+
+            var relativePath = InstanceUrlTemplates.LongPollAck(
+                input.Domain,
+                input.Workflow,
+                input.Instance,
+                ApiVersionPrefix);
+
+            var query = new List<string>();
+            if (!string.IsNullOrEmpty(input.Version))
+                query.Add($"version={Uri.EscapeDataString(input.Version)}");
+            if (!string.IsNullOrEmpty(input.Role))
+                query.Add($"role={Uri.EscapeDataString(input.Role)}");
+            if (query.Count > 0)
+                relativePath += "?" + string.Join("&", query);
+
+            var requestUri = new Uri(endpoint.BaseUrl, relativePath.TrimStart('/'));
+
+            var requestMessage = new HttpRequestMessage(HttpMethod.Post, requestUri);
+
+            var forwardHeaders = currentUser.ToForwardHeaders();
+            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, null, RemoteHttpResponseHelper.IsRestrictedHeader);
+
+            var response = await httpClient.SendAsync(requestMessage, cancellationToken);
+
+            return await HandleResponseAsync(response, cancellationToken);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or OperationCanceledException)
+        {
+            return Result.Fail(Error.Transient("remote_network_error", ex.Message));
+        }
+    }
+
+    /// <summary>
     /// Handles HTTP response by mapping status codes to appropriate Result types.
     /// Follows Railway Pattern: Status code → Result.Fail (not exceptions).
     /// </summary>

--- a/src/BBT.Workflow.Infrastructure/Migrations/20260617105558_Instance_LongPollAckToken.Designer.cs
+++ b/src/BBT.Workflow.Infrastructure/Migrations/20260617105558_Instance_LongPollAckToken.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using BBT.Workflow.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BBT.Workflow.Migrations
 {
     [DbContext(typeof(WorkflowDbContext))]
-    partial class WorkflowDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260617105558_Instance_LongPollAckToken")]
+    partial class Instance_LongPollAckToken
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/BBT.Workflow.Infrastructure/Migrations/20260617105558_Instance_LongPollAckToken.cs
+++ b/src/BBT.Workflow.Infrastructure/Migrations/20260617105558_Instance_LongPollAckToken.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BBT.Workflow.Migrations
+{
+    /// <inheritdoc />
+    public partial class Instance_LongPollAckToken : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "LongPollAckToken",
+                schema: "public",
+                table: "Instances",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Instances_LongPollAckToken",
+                schema: "public",
+                table: "Instances",
+                column: "LongPollAckToken",
+                filter: "\"LongPollAckToken\" IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Instances_LongPollAckToken",
+                schema: "public",
+                table: "Instances");
+
+            migrationBuilder.DropColumn(
+                name: "LongPollAckToken",
+                schema: "public",
+                table: "Instances");
+        }
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/Steps/ClearBusyOnResumeStepTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/Steps/ClearBusyOnResumeStepTests.cs
@@ -78,6 +78,70 @@ public class ClearBusyOnResumeStepTests
         ((ScriptContext)context.Cache["ScriptContext"]!).Instance!.CurrentState.ShouldBe("state2");
     }
 
+    [Fact]
+    public async Task ExecuteAsync_OnLongPollAckResume_WhenAwaiting_ShouldClearTokenAndContinue()
+    {
+        // Arrange: instance paused on state2 with an armed acknowledge token.
+        var instanceId = Guid.NewGuid();
+        var workflow = CreateWorkflow();
+        var instance = Instance.Create(instanceId, WorkflowKey, "1.0.0");
+        instance.ChangeState(workflow.GetState("state2").Value!);
+        instance.ArmLongPollAck(Guid.NewGuid());
+        instance.IsAwaitingLongPollAck.ShouldBeTrue();
+
+        var context = CreateContext(instanceId, workflow, instance);
+        context.Directives.MarkAsLongPollAckResume();
+
+        // Act
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        // Assert: token cleared, pipeline continues into the epilogue.
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.StopPipeline.ShouldBeFalse();
+        instance.IsAwaitingLongPollAck.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_OnLongPollAckResume_WhenNotAwaiting_ShouldStop()
+    {
+        // Arrange: a redundant resume (acknowledge already consumed the token).
+        var instanceId = Guid.NewGuid();
+        var workflow = CreateWorkflow();
+        var instance = Instance.Create(instanceId, WorkflowKey, "1.0.0");
+        instance.ChangeState(workflow.GetState("state2").Value!);
+        instance.IsAwaitingLongPollAck.ShouldBeFalse();
+
+        var context = CreateContext(instanceId, workflow, instance);
+        context.Directives.MarkAsLongPollAckResume();
+
+        // Act
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        // Assert: stops as a safe no-op; epilogue is not re-run.
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.StopPipeline.ShouldBeTrue();
+    }
+
+    private static TransitionExecutionContext CreateContext(
+        Guid instanceId, Definitions.Workflow workflow, Instance instance)
+        => new()
+        {
+            InstanceId = instanceId,
+            Domain = Domain,
+            WorkflowKey = WorkflowKey,
+            TransitionKey = "resume",
+            Trigger = TriggerType.Manual,
+            Actor = ExecutionActor.System,
+            CorrelationId = Guid.NewGuid().ToString("N"),
+            ExecutionChainId = Guid.NewGuid().ToString("N"),
+            RequestedAt = DateTimeOffset.UtcNow,
+            Workflow = workflow,
+            Current = workflow.GetState("state2").Value!,
+            Instance = instance,
+            TraceId = Guid.NewGuid().ToString("N"),
+            SpanId = Guid.NewGuid().ToString("N")[..16]
+        };
+
     private static Definitions.Workflow CreateWorkflow()
     {
         var json = """

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/Steps/HandleLongPollTerminationStepTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/Steps/HandleLongPollTerminationStepTests.cs
@@ -4,6 +4,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using BBT.Aether.BackgroundJob;
 using BBT.Aether.Guids;
+using BBT.Aether.Users;
+using BBT.Workflow.Authorization;
 using BBT.Workflow.BackgroundJobs.Payloads;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Execution;
@@ -31,6 +33,8 @@ public class HandleLongPollTerminationStepTests
     private readonly IInstanceJobRepository _jobRepository = Substitute.For<IInstanceJobRepository>();
     private readonly IBackgroundJobService _jobService = Substitute.For<IBackgroundJobService>();
     private readonly IGuidGenerator _guidGenerator = Substitute.For<IGuidGenerator>();
+    private readonly ITransitionAuthorizationManager _authManager = Substitute.For<ITransitionAuthorizationManager>();
+    private readonly ICurrentUser _currentUser = Substitute.For<ICurrentUser>();
     private readonly HandleLongPollTerminationStep _step;
 
     public HandleLongPollTerminationStepTests()
@@ -43,6 +47,7 @@ public class HandleLongPollTerminationStepTests
         _guidGenerator.Create().Returns(Guid.NewGuid());
         _step = new HandleLongPollTerminationStep(
             _instanceRepository, _jobRepository, _jobService, _guidGenerator,
+            _authManager, _currentUser,
             Substitute.For<ILogger<HandleLongPollTerminationStep>>());
     }
 
@@ -104,6 +109,43 @@ public class HandleLongPollTerminationStepTests
             default!, default!, default!, default!, default!, default);
     }
 
+    [Fact]
+    public async Task ExecuteAsync_WhenRolesConfiguredAndCallerOwns_ShouldArmAndPause()
+    {
+        var workflow = CreateWorkflow(terminate: true, withRoles: true);
+        var context = CreateContext(workflow, workflow.GetState("review").Value!);
+        _authManager.IsAnyRoleAllowedForGrantsAsync(
+                Arg.Any<IReadOnlyCollection<string>?>(), Arg.Any<IReadOnlyCollection<RoleGrant>>(),
+                Arg.Any<Instance?>(), Arg.Any<AuthorizationRequestContext?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.SkipToOrder.ShouldBe(LifecycleOrder.Finalize);
+        context.Instance.IsAwaitingLongPollAck.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenRolesConfiguredAndCallerDoesNotOwn_ShouldNotArm()
+    {
+        var workflow = CreateWorkflow(terminate: true, withRoles: true);
+        var context = CreateContext(workflow, workflow.GetState("review").Value!);
+        _authManager.IsAnyRoleAllowedForGrantsAsync(
+                Arg.Any<IReadOnlyCollection<string>?>(), Arg.Any<IReadOnlyCollection<RoleGrant>>(),
+                Arg.Any<Instance?>(), Arg.Any<AuthorizationRequestContext?>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        // Not an owning role → no pause, no arm, pipeline continues.
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.SkipToOrder.ShouldBeNull();
+        context.Instance.IsAwaitingLongPollAck.ShouldBeFalse();
+        await _jobService.DidNotReceiveWithAnyArgs().EnqueueAsync<LongPollAckTimeoutPayload>(
+            default!, default!, default!, default!, default!, default);
+    }
+
     private TransitionExecutionContext CreateContext(Definitions.Workflow workflow, State target)
     {
         var instance = Instance.Create(Guid.NewGuid(), WorkflowKey, "1.0.0");
@@ -128,10 +170,13 @@ public class HandleLongPollTerminationStepTests
         };
     }
 
-    private static Definitions.Workflow CreateWorkflow(bool terminate)
+    private static Definitions.Workflow CreateWorkflow(bool terminate, bool withRoles = false)
     {
+        var roles = withRoles
+            ? """, "roles": [ { "role": "morph-idm.core", "grant": "allow" } ]"""
+            : "";
         var interaction = terminate
-            ? """, "interaction": { "longPoll": { "terminate": true, "fallbackTimeoutSeconds": 30 } }"""
+            ? $$""", "interaction": { "longPoll": { "terminate": true, "fallbackTimeoutSeconds": 30{{roles}} } }"""
             : "";
         var json = $$"""
                    {

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/Steps/HandleLongPollTerminationStepTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/Steps/HandleLongPollTerminationStepTests.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.BackgroundJob;
+using BBT.Aether.Guids;
+using BBT.Workflow.BackgroundJobs.Payloads;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Execution;
+using BBT.Workflow.Execution.Pipeline;
+using BBT.Workflow.Execution.Pipeline.Steps;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Shared;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Application.Tests.Execution.Transitions.Pipeline.Steps;
+
+/// <summary>
+/// Unit tests for <see cref="HandleLongPollTerminationStep"/> — the declarative long-poll
+/// termination pause point.
+/// </summary>
+public class HandleLongPollTerminationStepTests
+{
+    private const string Domain = "test-domain";
+    private const string WorkflowKey = "test-workflow";
+
+    private readonly IInstanceRepository _instanceRepository = Substitute.For<IInstanceRepository>();
+    private readonly IInstanceJobRepository _jobRepository = Substitute.For<IInstanceJobRepository>();
+    private readonly IBackgroundJobService _jobService = Substitute.For<IBackgroundJobService>();
+    private readonly IGuidGenerator _guidGenerator = Substitute.For<IGuidGenerator>();
+    private readonly HandleLongPollTerminationStep _step;
+
+    public HandleLongPollTerminationStepTests()
+    {
+        _jobService.EnqueueAsync(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<LongPollAckTimeoutPayload>(),
+                Arg.Any<string>(), Arg.Any<Dictionary<string, object>>(),
+                cancellationToken: Arg.Any<CancellationToken>())
+            .Returns(Guid.NewGuid());
+        _guidGenerator.Create().Returns(Guid.NewGuid());
+        _step = new HandleLongPollTerminationStep(
+            _instanceRepository, _jobRepository, _jobService, _guidGenerator,
+            Substitute.For<ILogger<HandleLongPollTerminationStep>>());
+    }
+
+    [Fact]
+    public void Order_ShouldBeLongPollTermination()
+    {
+        _step.Order.ShouldBe(LifecycleOrder.LongPollTermination);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenStateDoesNotTerminateLongPoll_ShouldContinue()
+    {
+        var workflow = CreateWorkflow(terminate: false);
+        var context = CreateContext(workflow, workflow.GetState("review").Value!);
+
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.SkipToOrder.ShouldBeNull();
+        context.Instance.IsAwaitingLongPollAck.ShouldBeFalse();
+        await _jobService.DidNotReceiveWithAnyArgs().EnqueueAsync<LongPollAckTimeoutPayload>(
+            default!, default!, default!, default!, default!, default);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenStateTerminatesLongPoll_ShouldArmTokenScheduleFallbackAndPause()
+    {
+        var workflow = CreateWorkflow(terminate: true);
+        var context = CreateContext(workflow, workflow.GetState("review").Value!);
+
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        // Pause: skip the epilogue to Finalize.
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.SkipToOrder.ShouldBe(LifecycleOrder.Finalize);
+
+        // Token armed and persisted; fallback job scheduled and tracked.
+        context.Instance.IsAwaitingLongPollAck.ShouldBeTrue();
+        await _instanceRepository.Received(1).UpdateAsync(context.Instance, true, Arg.Any<CancellationToken>());
+        await _jobService.Received(1).EnqueueAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<LongPollAckTimeoutPayload>(),
+            Arg.Any<string>(), Arg.Any<Dictionary<string, object>>(),
+            cancellationToken: Arg.Any<CancellationToken>());
+        await _jobRepository.Received(1).InsertAsync(Arg.Any<InstanceJob>(), true, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenAlreadyAwaitingAck_ShouldNotReArm()
+    {
+        var workflow = CreateWorkflow(terminate: true);
+        var context = CreateContext(workflow, workflow.GetState("review").Value!);
+        context.Instance.ArmLongPollAck(Guid.NewGuid());
+
+        var result = await _step.ExecuteAsync(context, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.SkipToOrder.ShouldBeNull(); // not applicable → Continue
+        await _jobService.DidNotReceiveWithAnyArgs().EnqueueAsync<LongPollAckTimeoutPayload>(
+            default!, default!, default!, default!, default!, default);
+    }
+
+    private TransitionExecutionContext CreateContext(Definitions.Workflow workflow, State target)
+    {
+        var instance = Instance.Create(Guid.NewGuid(), WorkflowKey, "1.0.0");
+        instance.ChangeState(target);
+        return new TransitionExecutionContext
+        {
+            InstanceId = instance.Id,
+            Domain = Domain,
+            WorkflowKey = WorkflowKey,
+            TransitionKey = "go",
+            Trigger = TriggerType.Manual,
+            Actor = ExecutionActor.System,
+            CorrelationId = Guid.NewGuid().ToString("N"),
+            ExecutionChainId = Guid.NewGuid().ToString("N"),
+            RequestedAt = DateTimeOffset.UtcNow,
+            Workflow = workflow,
+            Current = target,
+            Target = target,
+            Instance = instance,
+            TraceId = Guid.NewGuid().ToString("N"),
+            SpanId = Guid.NewGuid().ToString("N")[..16]
+        };
+    }
+
+    private static Definitions.Workflow CreateWorkflow(bool terminate)
+    {
+        var interaction = terminate
+            ? """, "interaction": { "longPoll": { "terminate": true, "fallbackTimeoutSeconds": 30 } }"""
+            : "";
+        var json = $$"""
+                   {
+                       "type": "F",
+                       "timeout": null,
+                       "labels": [],
+                       "functions": [],
+                       "features": [],
+                       "states": [
+                           { "key": "review", "stateType": "Intermediate", "transitions": []{{interaction}} }
+                       ],
+                       "sharedTransitions": [],
+                       "extensions": [],
+                       "startTransition": {"key": "start", "from": null, "target": "review", "triggerType": "Manual", "versionStrategy": "Patch", "labels": [], "onExecutionTasks": [], "view": null}
+                   }
+                   """;
+        var options = new System.Text.Json.JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+        };
+        var workflow = System.Text.Json.JsonSerializer.Deserialize<Definitions.Workflow>(json, options)!;
+        workflow.SetReference(new Reference(WorkflowKey, Domain, "sys-flows", "1.0.0"));
+        return workflow;
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceCommandAppServiceLongPollAckTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceCommandAppServiceLongPollAckTests.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.Application.Services;
+using BBT.Aether.BackgroundJob;
+using BBT.Aether.DependencyInjection;
+using BBT.Aether.Guids;
+using BBT.Aether.Results;
+using BBT.Aether.Uow;
+using BBT.Aether.Users;
+using BBT.Workflow.Authorization;
+using BBT.Workflow.Caching;
+using BBT.Workflow.DefinitionContext;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Execution;
+using BBT.Workflow.Execution.LongPoll;
+using BBT.Workflow.Execution.Services;
+using BBT.Workflow.Execution.Transitions.Services;
+using BBT.Workflow.Execution.Validation;
+using BBT.Workflow.Extentions;
+using BBT.Workflow.Gateway;
+using BBT.Workflow.Headers;
+using BBT.Workflow.RepresentationEtag;
+using BBT.Workflow.Runtime;
+using BBT.Workflow.Scripting;
+using BBT.Workflow.Tasks.Evaluation;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Instances;
+
+/// <summary>
+/// Unit tests for <see cref="InstanceCommandAppService.AcknowledgeLongPollAsync"/> — the long-poll
+/// acknowledge that resumes a paused leaf or descends the active SubFlow chain to find it.
+/// </summary>
+public class InstanceCommandAppServiceLongPollAckTests : IDisposable
+{
+    private const string Domain = "test-domain";
+    private const string Workflow = "test-flow";
+    private const string Version = "1.0.0";
+    private const string StateKey = "review";
+
+    private readonly IInstanceRepository _instanceRepository = Substitute.For<IInstanceRepository>();
+    private readonly IComponentCacheStore _componentCacheStore = Substitute.For<IComponentCacheStore>();
+    private readonly ITransitionAuthorizationManager _authManager = Substitute.For<ITransitionAuthorizationManager>();
+    private readonly IInstanceCancellationService _cancellationService = Substitute.For<IInstanceCancellationService>();
+    private readonly ILongPollAckResumeService _resumeService = Substitute.For<ILongPollAckResumeService>();
+    private readonly IInstanceCommandGateway _gateway = Substitute.For<IInstanceCommandGateway>();
+    private readonly IWorkflowContext _workflowContext = Substitute.For<IWorkflowContext>();
+    private readonly InstanceCommandAppService _service;
+    private readonly IServiceProvider _ambient;
+    private readonly IServiceProvider? _previousAmbient;
+
+    public InstanceCommandAppServiceLongPollAckTests()
+    {
+        var mockUoWManager = Substitute.For<IUnitOfWorkManager>();
+        mockUoWManager.BeginAsync(Arg.Any<UnitOfWorkOptions>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Substitute.For<IUnitOfWork>()));
+        var services = new ServiceCollection();
+        services.AddSingleton(mockUoWManager);
+        _ambient = services.BuildServiceProvider();
+        _previousAmbient = AmbientServiceProvider.Current;
+        AmbientServiceProvider.Current = _ambient;
+
+        _resumeService.ResumeAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(),
+                Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok());
+        _gateway.AcknowledgeLongPollAsync(Arg.Any<AcknowledgeLongPollInput>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok());
+
+        _service = new InstanceCommandAppService(
+            serviceProvider: _ambient,
+            runtimeInfoProvider: Substitute.For<IRuntimeInfoProvider>(),
+            workflowExecutionService: Substitute.For<IWorkflowExecutionService>(),
+            componentCacheStore: _componentCacheStore,
+            instanceRepository: _instanceRepository,
+            instanceJobRepository: Substitute.For<IInstanceJobRepository>(),
+            backgroundJobService: Substitute.For<IBackgroundJobService>(),
+            guidGenerator: Substitute.For<IGuidGenerator>(),
+            headerService: Substitute.For<IHeaderService>(),
+            transitionDataMapper: Substitute.For<ITransitionDataMapper>(),
+            transitionValidationService: Substitute.For<ITransitionValidationService>(),
+            transitionContextFactory: Substitute.For<ITransitionContextFactory>(),
+            workflowContext: _workflowContext,
+            representationEtagService: Substitute.For<IRepresentationEtagService>(),
+            schemaFieldFilterService: Substitute.For<ISchemaFieldFilterService>(),
+            instanceExtensionService: Substitute.For<IInstanceExtensionService>(),
+            scriptContextFactory: Substitute.For<IScriptContextFactory>(),
+            timerEvaluator: Substitute.For<ITimerEvaluator>(),
+            transitionAuthorizationManager: _authManager,
+            cancellationService: _cancellationService,
+            longPollAckResumeService: _resumeService,
+            instanceCommandGateway: _gateway,
+            currentUser: Substitute.For<ICurrentUser>(),
+            logger: Substitute.For<ILogger<InstanceCommandAppService>>());
+    }
+
+    public void Dispose()
+    {
+        AmbientServiceProvider.Current = _previousAmbient;
+        (_ambient as IDisposable)?.Dispose();
+    }
+
+    [Fact]
+    public async Task AcknowledgeLongPollAsync_WhenInstanceAwaiting_ResumesLocally()
+    {
+        var instance = CreateInstance(awaiting: true, withSubflow: false);
+        _instanceRepository.GetActiveAsync(instance.Id.ToString(), Arg.Any<CancellationToken>())
+            .Returns(Result<Instance>.Ok(instance));
+        _componentCacheStore.GetFlowAsync(Domain, Workflow, Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(Result<Definitions.Workflow>.Ok(BuildWorkflow()));
+
+        var result = await _service.AcknowledgeLongPollAsync(Input(instance.Id.ToString()), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await _resumeService.Received(1).ResumeAsync(Domain, Workflow, Version, instance.Id, Arg.Any<CancellationToken>());
+        await _gateway.DidNotReceiveWithAnyArgs().AcknowledgeLongPollAsync(default!, default);
+    }
+
+    [Fact]
+    public async Task AcknowledgeLongPollAsync_WhenNotAwaitingButHasSubflow_DescendsViaGateway()
+    {
+        var instance = CreateInstance(awaiting: false, withSubflow: true);
+        _instanceRepository.GetActiveAsync(instance.Id.ToString(), Arg.Any<CancellationToken>())
+            .Returns(Result<Instance>.Ok(instance));
+
+        var result = await _service.AcknowledgeLongPollAsync(Input(instance.Id.ToString()), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await _gateway.Received(1).AcknowledgeLongPollAsync(
+            Arg.Is<AcknowledgeLongPollInput>(i =>
+                i.Domain == "sub-domain" && i.Workflow == "sub-flow" && i.Version == "1.0.0"),
+            Arg.Any<CancellationToken>());
+        await _resumeService.DidNotReceiveWithAnyArgs().ResumeAsync(default!, default!, default, default, default);
+    }
+
+    [Fact]
+    public async Task AcknowledgeLongPollAsync_WhenNotAwaitingAndNoSubflow_NoOp()
+    {
+        var instance = CreateInstance(awaiting: false, withSubflow: false);
+        _instanceRepository.GetActiveAsync(instance.Id.ToString(), Arg.Any<CancellationToken>())
+            .Returns(Result<Instance>.Ok(instance));
+
+        var result = await _service.AcknowledgeLongPollAsync(Input(instance.Id.ToString()), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await _gateway.DidNotReceiveWithAnyArgs().AcknowledgeLongPollAsync(default!, default);
+        await _resumeService.DidNotReceiveWithAnyArgs().ResumeAsync(default!, default!, default, default, default);
+    }
+
+    private static Instance CreateInstance(bool awaiting, bool withSubflow)
+    {
+        var instance = Instance.Create(Guid.NewGuid(), Workflow, Version, "test-key");
+        instance.ChangeState(State.Create(StateKey, StateType.Intermediate, StateSubType.None,
+            VersionStrategy.IncreasePatch.Code));
+        if (withSubflow)
+        {
+            instance.AddCorrelation(InstanceCorrelation.Create(
+                Guid.NewGuid(), instance.Id, StateKey, Guid.NewGuid(),
+                "S", "sub-domain", "sub-flow", "1.0.0"));
+        }
+        if (awaiting)
+            instance.ArmLongPollAck(Guid.NewGuid());
+        return instance;
+    }
+
+    private static Definitions.Workflow BuildWorkflow()
+    {
+        var workflow = Definitions.Workflow.Create();
+        workflow.SetReference(new Reference(Workflow, Domain, "sys-flows", Version));
+        workflow.SetType("F");
+        var state = State.Create(StateKey, StateType.Intermediate, StateSubType.None,
+            VersionStrategy.IncreasePatch.Code);
+        workflow.SetStartTransition(Transition.Create("start", null, StateKey, TriggerType.Manual,
+            VersionStrategy.IncreasePatch.Code));
+        workflow.AddState(state);
+        return workflow;
+    }
+
+    private static AcknowledgeLongPollInput Input(string instanceId) => new()
+    {
+        Domain = Domain,
+        Workflow = Workflow,
+        Instance = instanceId,
+        Version = Version,
+        Headers = new Dictionary<string, string?>()
+    };
+}

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceStateTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceStateTests.cs
@@ -202,6 +202,60 @@ public class InstanceQueryAppServiceStateTests : IDisposable
         result.Result.Value!.State.ShouldBe("sub-review");
     }
 
+    /// <summary>
+    /// When the active subflow signals long-poll termination, the parent bubbles the interaction up
+    /// and rewrites the ack href to the parent's own acknowledge endpoint (the instance the client polls).
+    /// </summary>
+    [Fact]
+    public async Task GetInstanceStateAsync_WhenSubFlowAwaitingLongPollAck_BubblesInteractionWithParentAckHref()
+    {
+        // Arrange — subflow is Active and signals termination with its OWN (child) ack href
+        var (instance, workflow) = CreateParentWithActiveSubFlow();
+        SetupCommonMocks(instance, workflow);
+        SetupSubFlowGateway(InstanceStatus.Active, "sub-review", new InstanceInteractionOutput
+        {
+            TerminateLongPoll = true,
+            Ack = new BBT.Workflow.Shared.AckHref { Href = "/child/longpoll/ack" }
+        });
+        _urlTemplateBuilder
+            .BuildLongPollAckUrl(TestDomain, TestWorkflow, instance.Id.ToString(), Arg.Any<string?>())
+            .Returns("/parent/longpoll/ack");
+
+        var input = CreateInput(instance.Id.ToString());
+
+        // Act
+        var result = await _service.GetInstanceStateAsync(input, CancellationToken.None);
+
+        // Assert — bubbled up, ack href rewritten to the parent's endpoint
+        result.Result.IsSuccess.ShouldBeTrue();
+        var output = result.Result.Value!;
+        output.Interaction.ShouldNotBeNull();
+        output.Interaction!.TerminateLongPoll.ShouldBeTrue();
+        output.Interaction.Ack.ShouldNotBeNull();
+        output.Interaction.Ack!.Href.ShouldBe("/parent/longpoll/ack");
+    }
+
+    /// <summary>
+    /// When the active subflow does not signal termination, the parent emits no interaction.
+    /// </summary>
+    [Fact]
+    public async Task GetInstanceStateAsync_WhenSubFlowNotAwaiting_NoInteraction()
+    {
+        // Arrange
+        var (instance, workflow) = CreateParentWithActiveSubFlow();
+        SetupCommonMocks(instance, workflow);
+        SetupSubFlowGateway(InstanceStatus.Active, "sub-review");
+
+        var input = CreateInput(instance.Id.ToString());
+
+        // Act
+        var result = await _service.GetInstanceStateAsync(input, CancellationToken.None);
+
+        // Assert
+        result.Result.IsSuccess.ShouldBeTrue();
+        result.Result.Value!.Interaction.ShouldBeNull();
+    }
+
     [Fact]
     public async Task GetInstanceStateAsync_WhenCurrentStateIsWizard_ReturnsStateTypeAsCamelCase()
     {
@@ -826,14 +880,16 @@ public class InstanceQueryAppServiceStateTests : IDisposable
             .Returns(true);
     }
 
-    private void SetupSubFlowGateway(InstanceStatus subFlowStatus, string subFlowState)
+    private void SetupSubFlowGateway(InstanceStatus subFlowStatus, string subFlowState,
+        InstanceInteractionOutput? interaction = null)
     {
         var subFlowOutput = new GetInstanceStateOutput
         {
             Status = subFlowStatus,
             State = subFlowState,
             Transitions = [],
-            ActiveCorrelations = []
+            ActiveCorrelations = [],
+            Interaction = interaction
         };
 
         _instanceQueryGateway

--- a/test/BBT.Workflow.Domain.Tests/Definitions/StateTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Definitions/StateTests.cs
@@ -575,6 +575,88 @@ public class StateTests
         Assert.Empty(state!.Aliases);
     }
 
+    [Fact]
+    public void Deserialize_ShouldPopulateInteractionLongPoll_WithRolesAndTimeout()
+    {
+        // Arrange
+        const string json = """
+        {
+            "key": "review",
+            "stateType": "Intermediate",
+            "subType": "None",
+            "versionStrategy": "Patch",
+            "interaction": {
+                "longPoll": {
+                    "terminate": true,
+                    "fallbackTimeoutSeconds": 90,
+                    "roles": [ { "role": "backoffice.operator", "grant": "allow" } ]
+                }
+            }
+        }
+        """;
+
+        // Act
+        var state = System.Text.Json.JsonSerializer.Deserialize<State>(json, EnumNamingSerializerOptions);
+
+        // Assert
+        Assert.NotNull(state);
+        Assert.True(state!.TerminatesLongPollOnEntry);
+        Assert.Equal(90, state.LongPollFallbackTimeoutSeconds);
+        Assert.NotNull(state.LongPollAckRoles);
+        Assert.Single(state.LongPollAckRoles!);
+        Assert.Equal("backoffice.operator", state.LongPollAckRoles!.First().Role);
+        Assert.True(state.LongPollAckRoles!.First().IsAllow);
+    }
+
+    [Fact]
+    public void Deserialize_ShouldDefaultLongPoll_WhenTerminateOnlySpecified()
+    {
+        // Arrange
+        const string json = """
+        {
+            "key": "review",
+            "stateType": "Intermediate",
+            "subType": "None",
+            "versionStrategy": "Patch",
+            "interaction": { "longPoll": { "terminate": true } }
+        }
+        """;
+
+        // Act
+        var state = System.Text.Json.JsonSerializer.Deserialize<State>(json, EnumNamingSerializerOptions);
+
+        // Assert
+        Assert.NotNull(state);
+        Assert.True(state!.TerminatesLongPollOnEntry);
+        Assert.Equal(60, state.LongPollFallbackTimeoutSeconds); // default
+        Assert.NotNull(state.LongPollAckRoles);
+        Assert.Empty(state.LongPollAckRoles!);
+    }
+
+    [Fact]
+    public void Deserialize_ShouldNotTerminateLongPoll_WhenInteractionOmitted()
+    {
+        // Arrange
+        const string json = """
+        {
+            "key": "review",
+            "stateType": "Intermediate",
+            "subType": "None",
+            "versionStrategy": "Patch"
+        }
+        """;
+
+        // Act
+        var state = System.Text.Json.JsonSerializer.Deserialize<State>(json, EnumNamingSerializerOptions);
+
+        // Assert
+        Assert.NotNull(state);
+        Assert.Null(state!.Interaction);
+        Assert.False(state.TerminatesLongPollOnEntry);
+        Assert.Equal(60, state.LongPollFallbackTimeoutSeconds);
+        Assert.Null(state.LongPollAckRoles);
+    }
+
     private static System.Text.Json.JsonSerializerOptions EnumNamingSerializerOptions => new()
     {
         PropertyNameCaseInsensitive = true,

--- a/vnext-meta/features.json
+++ b/vnext-meta/features.json
@@ -1,5 +1,5 @@
 {
-  "runtimeVersion": "0.0.58",
+  "runtimeVersion": "0.0.61",
   "engine": {
     "customScriptHelpers": {
       "since": "0.0.58",
@@ -13,6 +13,15 @@
         "Scripting:Sandbox:BannedNamespaces",
         "Scripting:Sandbox:PluginDirectory",
         "Scripting:Sandbox:AllowUnsafe"
+      ]
+    },
+    "longPollTermination": {
+      "since": "0.0.62",
+      "status": "stable",
+      "description": "Declarative long-poll termination on state entry. A state may declare interaction.longPoll.terminate=true (with optional interaction.longPoll.roles[] role grants and interaction.longPoll.fallbackTimeoutSeconds, default 60). When the pipeline enters such a state it runs ChangeState + OnEntry, then pauses before the epilogue (Schedule/Auto/Finish); the instance stays Busy. The State (long-poll) function returns HTTP 200 with an interaction object { terminateLongPoll: true, ack: { href } } for callers whose role is granted, telling the client to stop polling and render the entered-state screen. The client then POSTs to the acknowledge endpoint (instances/{instance}/longpoll/ack), which resumes the pipeline from where it paused; a fallback schedule auto-resumes if the client never acknowledges. The 'interaction' object is a generic, extensible container for client-workflow-manager directives.",
+      "schemaPath": "state.interaction.longPoll",
+      "apiEndpoints": [
+        "POST {domain}/workflows/{workflow}/instances/{instance}/longpoll/ack"
       ]
     }
   }


### PR DESCRIPTION
## Summary

Implements declarative long-poll termination on state entry (#717): a state can tell the client to stop its active long poll, render the entered-state screen, acknowledge, and have the pipeline resume — with role scoping and full subflow-chain (cross-domain) support.

Built in three logical commits:

1. **Declarative long-poll termination** — `interaction.longPoll` state config (generic, extensible `interaction` wrapper); `HandleLongPollTerminationStep` (order 75) arms a durable `Instance.LongPollAckToken`, schedules a fallback resume job, and pauses before the epilogue (instance stays Busy). State function returns HTTP 200 with a nested `interaction { terminateLongPoll, ack: { href } }`. New `POST .../instances/{instance}/longpoll/ack` resumes via the SubFlow-resume plumbing (`IsLongPollAckResume`, compare-and-clear idempotency). EF migration for the ack token.

2. **Follow the subflow chain on acknowledge (cross-domain)** — the paused instance is the deepest active subflow child. The child's `interaction` bubbles up through `SubFlowStateInfo` (each level rewrites the ack href to its own endpoint); `AcknowledgeLongPollAsync` descends like `MarkBusyAsync` via `IInstanceCommandGateway` (Routed → Local/Remote on `IsDomainMatch`), reusing existing gateway routing.

3. **Gate arming by the triggering caller's role** — the stop is owned by the role that drives the transition into the state. Arming now respects `interaction.longPoll.roles` using the same grant predicate as the signal and the acknowledge, so arm → signal → ack agree on the owning role; other clients proceed after ack.

## Behavior

- `longPoll.roles = [morph-idm.core: allow]`: Client (core) enters the state → long-poll engages → polls (`terminateLongPoll=true`) → acknowledges → pipeline resumes → other clients advance. A non-`core` entry flows straight through (no Busy stall).
- If the client never acknowledges, a configurable fallback schedule (default 60s) resumes the pipeline.

## Verification

- `dotnet build vnext.sln` — clean.
- `dotnet test` (Domain.Tests + Application.Tests): State deserialization, pause-step (arm + role gate), resume idempotency, interaction bubble with parent ack-href rewrite, and acknowledge descent (resume-leaf / via-gateway / no-op) — all green.
- Docs: `docs/domain/long-poll-termination.md`; `vnext-meta/features.json` capability entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add declarative long-poll termination on state entry with role-scoped acknowledge and cross-domain subflow support.

New Features:
- Allow states to declaratively request client long-poll termination via an interaction.longPoll config and expose an interaction block with terminateLongPoll and ack href from the instance state API.
- Introduce a long-poll acknowledge endpoint that resumes paused pipelines, including descending active subflow chains across domains via the command gateway.
- Provide configurable fallback scheduling to auto-resume pipelines when long-poll acknowledgements are not received within a timeout window.

Enhancements:
- Extend pipeline directives, steps, and lifecycle ordering to support internal long-poll acknowledge resumes alongside existing subflow resumes.
- Persist a durable long-poll acknowledge token on instances and index it for safe, idempotent resume handling.
- Add logging, URL helpers, and gateway wiring (local/remote) to support long-poll acknowledge flows.
- Introduce StateInteraction/LongPollInteraction models and helpers so interaction behavior is declaratively configured on states and consumed via high-level properties.

Documentation:
- Document declarative long-poll termination behavior, subflow chaining, and change-safety considerations in a new domain/long-poll-termination guide and reference it from the docs README.

Tests:
- Add unit tests covering state interaction deserialization, long-poll termination handling in the pipeline, acknowledge resume behavior, and subflow interaction bubbling with ack href rewriting.
- Extend instance query tests to verify when interaction blocks are returned or omitted for subflows and long-poll states.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added declarative long-poll termination: states can now terminate active client long-polls and require acknowledgment before resuming the pipeline.
  * New HTTP endpoint for acknowledging long-poll signals and resuming paused workflows with automatic fallback timeout handling.
  * SubFlow long-poll interactions now propagate to parent workflows with rewritten acknowledgment endpoints.

* **Documentation**
  * Added "Reading Path" guidance for long-poll termination configuration and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->