### PR TITLE
feat(functions): forward output ScriptResponse headers/status in multi-task functions

### DIFF
--- a/src/BBT.Workflow.Application/Functions/FunctionAppService.cs
+++ b/src/BBT.Workflow.Application/Functions/FunctionAppService.cs
@@ -238,7 +238,9 @@ public sealed class FunctionAppService(
                     return Result<FunctionResponseOutput>.Ok(CreateRawResponse(
                         function,
                         scriptContext,
-                        scriptResponse.Data));
+                        scriptResponse.Data,
+                        (object?)scriptResponse.Headers,
+                        scriptResponse.StatusCode));
 
                 return Result<FunctionResponseOutput>.Ok(new FunctionResponseOutput
                 {
@@ -359,15 +361,19 @@ public sealed class FunctionAppService(
     internal static FunctionResponseOutput CreateRawResponse(
         Function function,
         ScriptContext scriptContext,
-        object? data)
+        object? data,
+        object? outputHeaders = null,
+        int? outputStatusCode = null)
     {
-        var (statusCode, headers) = ExtractSingleTaskHttpMetadata(function, scriptContext);
+        var (singleStatusCode, singleHeaders) = ExtractSingleTaskHttpMetadata(function, scriptContext);
 
+        // Output script may set its own headers/status (multi-task scenario); when it does,
+        // prefer them. Otherwise fall back to single-task metadata (existing behavior preserved).
         return new FunctionResponseOutput
         {
             Data = data,
-            StatusCode = statusCode,
-            Headers = headers
+            StatusCode = outputStatusCode ?? singleStatusCode,
+            Headers = NormalizeHeaders(outputHeaders) ?? singleHeaders
         };
     }
 
@@ -453,24 +459,40 @@ public sealed class FunctionAppService(
         if (response is IDictionary<string, object?> dictionary &&
             TryGetDictionaryValue(dictionary, "headers", out var value))
         {
-            try
-            {
-                return value switch
-                {
-                    Dictionary<string, string> typedHeaders => typedHeaders,
-                    IDictionary<string, object?> objectHeaders => objectHeaders
-                        .Where(header => header.Value != null)
-                        .ToDictionary(header => header.Key, header => Convert.ToString(header.Value, CultureInfo.InvariantCulture) ?? string.Empty),
-                    _ => JsonSerializer.Deserialize<Dictionary<string, string>>(JsonSerializer.Serialize(value))
-                };
-            }
-            catch
-            {
-                return null;
-            }
+            return NormalizeHeaders(value);
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Normalizes a loosely-typed headers object (e.g. <see cref="ScriptResponse.Headers"/> which is
+    /// <c>dynamic</c>) into a <see cref="Dictionary{TKey,TValue}"/> of string headers.
+    /// Accepts <see cref="Dictionary{TKey,TValue}"/>, <see cref="IDictionary{TKey,TValue}"/> of objects,
+    /// or any JSON-serializable object. Returns null when there are no usable headers.
+    /// </summary>
+    private static Dictionary<string, string>? NormalizeHeaders(object? value)
+    {
+        if (value is null)
+            return null;
+
+        try
+        {
+            var headers = value switch
+            {
+                Dictionary<string, string> typedHeaders => typedHeaders,
+                IDictionary<string, object?> objectHeaders => objectHeaders
+                    .Where(header => header.Value != null)
+                    .ToDictionary(header => header.Key, header => Convert.ToString(header.Value, CultureInfo.InvariantCulture) ?? string.Empty),
+                _ => JsonSerializer.Deserialize<Dictionary<string, string>>(JsonSerializer.Serialize(value))
+            };
+
+            return headers is { Count: > 0 } ? headers : null;
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     private static bool TryGetDictionaryValue(

--- a/src/BBT.Workflow.Domain/Scripting/Models.cs
+++ b/src/BBT.Workflow.Domain/Scripting/Models.cs
@@ -49,6 +49,14 @@ public sealed class ScriptResponse
     public dynamic? Headers { get; set; }
 
     /// <summary>
+    /// Optional HTTP status code to apply to the function response.
+    /// Allows multi-task output handlers to override the default 200 status (e.g. 400/404/410).
+    /// When null, the engine falls back to single-task metadata or the default status code.
+    /// </summary>
+    /// <value>An HTTP status code, or null to use the default behavior.</value>
+    public int? StatusCode { get; set; }
+
+    /// <summary>
     /// Route values or routing parameters associated with the response.
     /// Can be used for workflow routing decisions, URL generation, or parameter passing between workflow components.
     /// </summary>

--- a/test/BBT.Workflow.Application.Tests/Functions/FunctionOutputHandlerTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Functions/FunctionOutputHandlerTests.cs
@@ -238,10 +238,116 @@ public class FunctionOutputHandlerTests
         ((Dictionary<string, dynamic?>)response.Data).ShouldContainKey(function.Key.ToVariableName());
     }
 
+    // ─── CreateRawResponse: output headers/status (multi-task) ─────────────────
+
+    [Fact]
+    public void CreateRawResponse_UsesOutputHeadersAndStatus_WhenProvided()
+    {
+        var function = CreateMultiTaskFunction(rawResponse: true);
+        var context = CreateScriptContext();
+        var outputHeaders = new Dictionary<string, string>
+        {
+            ["X-JWS-Signature"] = "eyJ...",
+            ["X-Total-Count"] = "42"
+        };
+
+        var response = FunctionAppService.CreateRawResponse(
+            function, context, data: new { ok = true }, outputHeaders: outputHeaders, outputStatusCode: 400);
+
+        response.StatusCode.ShouldBe(400);
+        response.Headers.ShouldNotBeNull();
+        response.Headers!["X-JWS-Signature"].ShouldBe("eyJ...");
+        response.Headers!["X-Total-Count"].ShouldBe("42");
+    }
+
+    [Fact]
+    public void CreateRawResponse_OutputHeadersOverrideSingleTask()
+    {
+        var function = CreateFunction(rawResponse: true);
+        var context = CreateScriptContext();
+        var taskKey = TaskRef.Key.ToVariableName();
+        context.SetStandardResponse(new StandardTaskResponse
+        {
+            Data = new Dictionary<string, object?> { ["title"] = "from task" },
+            StatusCode = 201,
+            Headers = new Dictionary<string, string> { ["x-source"] = "single-task" }
+        }, taskKey);
+
+        var response = FunctionAppService.CreateRawResponse(
+            function, context, data: new { ok = true },
+            outputHeaders: new Dictionary<string, string> { ["x-source"] = "output" },
+            outputStatusCode: 410);
+
+        response.StatusCode.ShouldBe(410);
+        response.Headers!["x-source"].ShouldBe("output");
+    }
+
+    [Fact]
+    public void CreateRawResponse_FallsBackToSingleTask_WhenOutputHeadersNull()
+    {
+        var function = CreateFunction(rawResponse: true);
+        var context = CreateScriptContext();
+        var taskKey = TaskRef.Key.ToVariableName();
+        context.SetStandardResponse(new StandardTaskResponse
+        {
+            Data = new Dictionary<string, object?> { ["title"] = "from task" },
+            StatusCode = 201,
+            Headers = new Dictionary<string, string> { ["x-source"] = "single-task" }
+        }, taskKey);
+
+        var response = FunctionAppService.CreateRawResponse(
+            function, context, data: new { ok = true });
+
+        response.StatusCode.ShouldBe(201);
+        response.Headers!["x-source"].ShouldBe("single-task");
+    }
+
+    [Fact]
+    public void CreateRawResponse_MultiTaskWithoutOutputHeaders_HasNoHeaders()
+    {
+        var function = CreateMultiTaskFunction(rawResponse: true);
+        var context = CreateScriptContext();
+
+        var response = FunctionAppService.CreateRawResponse(function, context, data: new { ok = true });
+
+        response.StatusCode.ShouldBeNull();
+        response.Headers.ShouldBeNull();
+    }
+
+    [Fact]
+    public void CreateRawResponse_NormalizesObjectValuedOutputHeaders()
+    {
+        var function = CreateMultiTaskFunction(rawResponse: true);
+        var context = CreateScriptContext();
+        var outputHeaders = new Dictionary<string, object?>
+        {
+            ["X-Total-Count"] = 42,
+            ["X-Null"] = null
+        };
+
+        var response = FunctionAppService.CreateRawResponse(
+            function, context, data: new { ok = true }, outputHeaders: outputHeaders);
+
+        response.Headers.ShouldNotBeNull();
+        response.Headers!["X-Total-Count"].ShouldBe("42");
+        response.Headers.ShouldNotContainKey("X-Null");
+    }
+
     private static Function CreateFunction(bool rawResponse)
     {
         var function = new Function(TaskScope.Domain, CreateTask(1, TaskRef), rawResponse: rawResponse);
         function.SetReference(new Reference("send-otp", "test-domain", "sys-functions", "1.0.0"));
+        return function;
+    }
+
+    private static Function CreateMultiTaskFunction(bool rawResponse)
+    {
+        var function = new Function(
+            TaskScope.Domain,
+            CreateTask(1, TaskRef),
+            onExecutionTasks: [CreateTask(1, TaskRef), CreateTask(2, Task2Ref)],
+            rawResponse: rawResponse);
+        function.SetReference(new Reference("get-hesaplar", "test-domain", "sys-functions", "1.0.0"));
         return function;
     }
 

--- a/test/BBT.Workflow.Domain.Tests/Scripting/ScriptResponseTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Scripting/ScriptResponseTests.cs
@@ -17,9 +17,23 @@ public class ScriptResponseTests
         Assert.Null(response.Key);
         Assert.Null(response.Data);
         Assert.Null(response.Headers);
+        Assert.Null(response.StatusCode);
         Assert.Null(response.RouteValues);
         Assert.NotNull(response.Tags);
         Assert.Empty(response.Tags);
+    }
+
+    [Fact]
+    public void StatusCode_ShouldBeSettable()
+    {
+        // Arrange
+        var response = new ScriptResponse();
+
+        // Act
+        response.StatusCode = 400;
+
+        // Assert
+        Assert.Equal(400, response.StatusCode);
     }
 
     [Fact]


### PR DESCRIPTION
## What & Why

Multi-task functions (`onExecutionTasks` ≥ 2) with an `output` handler (`IOutputHandler`) could not emit custom HTTP headers or a status code — the headers/status set by the output script's `ScriptResponse` were silently discarded. The engine extracted HTTP metadata only for **single-task** functions (`GetExecuteTasks().Count == 1`).

This blocks the Open Banking HHS (TR.OHVPS) migration: the BKM contract requires every response to carry an `X-JWS-Signature` header, plus `X-Total-Count`/`Link` (RFC 5988) pagination and echo headers (`X-Request-ID`, `X-ASPSP-Code`). The data endpoints (`get-hesaplar`, `get-hesap`, `get-hesap-bakiye`, `get-bakiye-listesi`, `get-hesap-islemler`) are multi-task + output, so none of these headers reached the wire.

Closes #748

## Changes

- **`ScriptResponse`** (`Models.cs`): add optional `int? StatusCode` so output handlers can set the HTTP status (e.g. 400/404/410).
- **`BuildResponseAsync`**: forward `scriptResponse.Headers` and `StatusCode` to `CreateRawResponse` on the raw-response path.
- **`CreateRawResponse`**: accept optional `outputHeaders`/`outputStatusCode`, prefer them over single-task metadata, fall back when absent.
- **`NormalizeHeaders`**: extracted reusable helper from `ExtractHeaders` to coerce the `dynamic` `ScriptResponse.Headers` (Dictionary<string,string> / IDictionary<string,object> / JSON) into `Dictionary<string,string>`; empty → null.

Header writing and the restricted-header filter already exist in `FunctionResponseActionResultMapper` — no controller/mapper change needed.

## Scope & Compatibility

- **Backward compatible**: single-task path unchanged; new params default to null.
- `rawResponse: false` (wrapped) path intentionally **out of scope**.

## Testing

- `FunctionOutputHandlerTests`: **18/18 pass** (5 new — output-priority, override, fallback, multi-task-without-headers, object-valued header normalization).
- `ScriptResponseTests`: **15/15 pass** (StatusCode default-null + settable).
- Application project builds with 0 errors.

> Note: the live `X-JWS-Signature`/`X-Total-Count` acceptance criterion must be verified in the Open Banking domain (CSX scripts + running instance); the unit tests here prove the engine side.

## Summary by Sourcery

Allow function output handlers to forward HTTP headers and status codes from ScriptResponse in multi-task raw-response functions while preserving existing single-task behavior.

New Features:
- Enable ScriptResponse to optionally specify an HTTP status code for function responses.
- Allow multi-task functions with output handlers to emit custom HTTP headers and status codes via the raw-response path.

Enhancements:
- Introduce a reusable header normalization helper to coerce dynamic ScriptResponse headers into a string dictionary and ignore empty or invalid values.

Tests:
- Extend FunctionOutputHandlerTests to cover output header/status precedence, fallback behavior, multi-task cases without headers, and dynamic header normalization.
- Extend ScriptResponseTests to cover the new optional StatusCode property.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Scripts can now provide custom HTTP status codes and response headers. When used in multi-task output handling, these custom values override defaults.

* **Tests**
  * Added comprehensive test coverage verifying custom HTTP status codes and response headers are properly applied and normalized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->