### PR TITLE
fix: read-only /tmp body buffering and non-deterministic instance key lookup

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
     <PropertyGroup>
 
         <!-- All Prism packages -->
-        <AetherPackageVersion>1.0.25</AetherPackageVersion>
+        <AetherPackageVersion>1.0.26</AetherPackageVersion>
         <!-- Elastic Apm packages -->
         <ElasticApmPackageVersion>1.31.0</ElasticApmPackageVersion>
         <!-- Microsoft packages -->

--- a/src/BBT.Workflow.HttpApi.Shared/Middlewares/RawRequestBodyBufferingMiddleware.cs
+++ b/src/BBT.Workflow.HttpApi.Shared/Middlewares/RawRequestBodyBufferingMiddleware.cs
@@ -15,7 +15,7 @@ public sealed class RawRequestBodyBufferingMiddleware(RequestDelegate next)
     public const string RawBodyItemsKey = "__vnext.RawRequestBody";
 
     // Cap to protect memory; these JSON APIs carry small payloads.
-    private const long MaxBufferedBytes = 1024 * 1024; // 1 MB
+    private const long MaxBufferedBytes = 5 * 1024 * 1024; // 5 MB
 
     /// <summary>
     /// Captures the raw body (when applicable) and invokes the next middleware.
@@ -24,7 +24,9 @@ public sealed class RawRequestBodyBufferingMiddleware(RequestDelegate next)
     {
         if (ShouldCapture(context.Request))
         {
-            context.Request.EnableBuffering();
+            // Match the in-memory threshold to MaxBufferedBytes so captured bodies (capped at the same
+            // size by ShouldCapture) never spill to a temp file — avoids IOException on read-only /tmp.
+            context.Request.EnableBuffering(bufferThreshold: (int)MaxBufferedBytes);
 
             using var reader = new StreamReader(
                 context.Request.Body,

--- a/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceRepository.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceRepository.cs
@@ -139,10 +139,12 @@ public sealed class EfCoreInstanceRepository(
             }
         }
 
+        // Key is not unique across terminal/historical rows; OrderByDescending(CreatedAt)
+        // keeps the fallback deterministic by returning the most recent instance for the key.
         return await query
-            .FirstOrDefaultAsync(
-                p => p.Key == identifier,
-                cancellationToken);
+            .Where(p => p.Key == identifier)
+            .OrderByDescending(p => p.CreatedAt)
+            .FirstOrDefaultAsync(cancellationToken);
     }
 
     /// <inheritdoc />
@@ -181,10 +183,12 @@ public sealed class EfCoreInstanceRepository(
             }
         }
 
+        // Key is not unique across terminal/historical rows; OrderByDescending(CreatedAt)
+        // keeps the fallback deterministic by returning the most recent instance for the key.
         return await query
-            .FirstOrDefaultAsync(
-                p => p.Key == identifier,
-                cancellationToken);
+            .Where(p => p.Key == identifier)
+            .OrderByDescending(p => p.CreatedAt)
+            .FirstOrDefaultAsync(cancellationToken);
     }
 
     /// <inheritdoc />
@@ -212,10 +216,12 @@ public sealed class EfCoreInstanceRepository(
             }
         }
 
+        // Key is not unique across terminal/historical rows; OrderByDescending(CreatedAt)
+        // keeps the fallback deterministic by returning the most recent instance for the key.
         return await query
-            .FirstOrDefaultAsync(
-                p => p.Key == identifier,
-                cancellationToken);
+            .Where(p => p.Key == identifier)
+            .OrderByDescending(p => p.CreatedAt)
+            .FirstOrDefaultAsync(cancellationToken);
     }
 
     /// <inheritdoc />
@@ -240,10 +246,12 @@ public sealed class EfCoreInstanceRepository(
             }
         }
 
+        // Key is not unique across terminal/historical rows; OrderByDescending(CreatedAt)
+        // keeps the fallback deterministic by returning the most recent instance for the key.
         return await query
-            .FirstOrDefaultAsync(
-                p => p.Key == identifier,
-                cancellationToken);
+            .Where(p => p.Key == identifier)
+            .OrderByDescending(p => p.CreatedAt)
+            .FirstOrDefaultAsync(cancellationToken);
     }
 
     /// <summary>


### PR DESCRIPTION
## What changed
Three related infrastructure robustness fixes (closes #751):

1. **Aether bump 1.0.25 → 1.0.26** (`Directory.Build.props`) — consumes the upstream
   `EfCoreJobStore.SaveAsync` fix that no longer overwrites the `BackgroundJobInfo` key on
   re-enqueue with the same `jobName`. This removes the
   `"The property 'BackgroundJobInfo.Id' is part of a key and so cannot be modified"`
   exception raised during the transition pipeline's UoW commit.

2. **Request-body buffering stays in memory on read-only `/tmp`**
   (`RawRequestBodyBufferingMiddleware`) — `EnableBuffering()` defaulted to a 30 KB in-memory
   threshold, spilling larger bodies to a temp file under `/tmp` via `Path.GetTempFileName()`.
   On containers with `readOnlyRootFilesystem: true` this threw `IOException`. The threshold is
   now `MaxBufferedBytes` (raised to 5 MB), matching the `ShouldCapture` content-length cap, so
   known-length captured bodies never touch disk.

3. **Deterministic Key-fallback instance lookup** (`EfCoreInstanceRepository`) — the
   `FindByIdentifier*` methods fall back to a `Key` lookup when the identifier is not a Guid.
   The fallback used `FirstOrDefaultAsync` with no ordering, so duplicate keys (terminal /
   historical rows) returned a DB-order-dependent row. Now ordered by `CreatedAt DESC` before
   `FirstOrDefault`, matching the existing `FindActiveByKeyAsync` pattern. `Id`-based lookups
   are unchanged (unique).

## Why
All three surfaced while running the API hosts in hardened (read-only filesystem) containers
and reasoning about the background-job lifecycle / duplicate instance keys. See #751 for the
full breakdown and acceptance criteria.

## Reviewer notes
- The Aether fix itself (EfCoreJobStore + regression test) lives in the separate `aether` repo
  and is already published as 1.0.26; this PR only bumps the consumed version.
- **Remaining (tracked in #751, not in this PR):** unknown-length (chunked) request bodies can
  still exceed the 5 MB cap and spill to disk — deployments still need a writable temp dir
  (K8s `emptyDir` at `/tmp` or `TMPDIR`).
- Trade-off: the larger in-memory buffering cap increases per-request memory under concurrent
  large requests (bodies were already capped at the same size before, just on disk).

## Verification
- `dotnet build src/BBT.Workflow.HttpApi.Shared` — 0 errors.
- `dotnet build src/BBT.Workflow.Infrastructure` — 0 errors (restores Aether 1.0.26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve infrastructure robustness around instance lookup and HTTP request body buffering.

Bug Fixes:
- Make instance lookups by non-GUID identifier deterministic by returning the most recently created instance for a given key.
- Ensure raw HTTP request body buffering stays in memory for captured payloads to avoid temp-file IO errors on read-only filesystems.
- Consume updated Aether dependency version that fixes background job key overwrites during re-enqueue.

Build:
- Bump Aether package reference in Directory.Build.props to the latest patched version.