### PR TITLE
v0.0.63

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
     <PropertyGroup>
 
         <!-- All Prism packages -->
-        <AetherPackageVersion>1.0.25</AetherPackageVersion>
+        <AetherPackageVersion>1.0.26</AetherPackageVersion>
         <!-- Elastic Apm packages -->
         <ElasticApmPackageVersion>1.31.0</ElasticApmPackageVersion>
         <!-- Microsoft packages -->

--- a/src/BBT.Workflow.HttpApi.Shared/Middlewares/RawRequestBodyBufferingMiddleware.cs
+++ b/src/BBT.Workflow.HttpApi.Shared/Middlewares/RawRequestBodyBufferingMiddleware.cs
@@ -15,7 +15,7 @@ public sealed class RawRequestBodyBufferingMiddleware(RequestDelegate next)
     public const string RawBodyItemsKey = "__vnext.RawRequestBody";
 
     // Cap to protect memory; these JSON APIs carry small payloads.
-    private const long MaxBufferedBytes = 1024 * 1024; // 1 MB
+    private const long MaxBufferedBytes = 5 * 1024 * 1024; // 5 MB
 
     /// <summary>
     /// Captures the raw body (when applicable) and invokes the next middleware.
@@ -24,7 +24,9 @@ public sealed class RawRequestBodyBufferingMiddleware(RequestDelegate next)
     {
         if (ShouldCapture(context.Request))
         {
-            context.Request.EnableBuffering();
+            // Match the in-memory threshold to MaxBufferedBytes so captured bodies (capped at the same
+            // size by ShouldCapture) never spill to a temp file — avoids IOException on read-only /tmp.
+            context.Request.EnableBuffering(bufferThreshold: (int)MaxBufferedBytes);
 
             using var reader = new StreamReader(
                 context.Request.Body,

--- a/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceRepository.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceRepository.cs
@@ -139,10 +139,12 @@ public sealed class EfCoreInstanceRepository(
             }
         }
 
+        // Key is not unique across terminal/historical rows; OrderByDescending(CreatedAt)
+        // keeps the fallback deterministic by returning the most recent instance for the key.
         return await query
-            .FirstOrDefaultAsync(
-                p => p.Key == identifier,
-                cancellationToken);
+            .Where(p => p.Key == identifier)
+            .OrderByDescending(p => p.CreatedAt)
+            .FirstOrDefaultAsync(cancellationToken);
     }
 
     /// <inheritdoc />
@@ -181,10 +183,12 @@ public sealed class EfCoreInstanceRepository(
             }
         }
 
+        // Key is not unique across terminal/historical rows; OrderByDescending(CreatedAt)
+        // keeps the fallback deterministic by returning the most recent instance for the key.
         return await query
-            .FirstOrDefaultAsync(
-                p => p.Key == identifier,
-                cancellationToken);
+            .Where(p => p.Key == identifier)
+            .OrderByDescending(p => p.CreatedAt)
+            .FirstOrDefaultAsync(cancellationToken);
     }
 
     /// <inheritdoc />
@@ -212,10 +216,12 @@ public sealed class EfCoreInstanceRepository(
             }
         }
 
+        // Key is not unique across terminal/historical rows; OrderByDescending(CreatedAt)
+        // keeps the fallback deterministic by returning the most recent instance for the key.
         return await query
-            .FirstOrDefaultAsync(
-                p => p.Key == identifier,
-                cancellationToken);
+            .Where(p => p.Key == identifier)
+            .OrderByDescending(p => p.CreatedAt)
+            .FirstOrDefaultAsync(cancellationToken);
     }
 
     /// <inheritdoc />
@@ -240,10 +246,12 @@ public sealed class EfCoreInstanceRepository(
             }
         }
 
+        // Key is not unique across terminal/historical rows; OrderByDescending(CreatedAt)
+        // keeps the fallback deterministic by returning the most recent instance for the key.
         return await query
-            .FirstOrDefaultAsync(
-                p => p.Key == identifier,
-                cancellationToken);
+            .Where(p => p.Key == identifier)
+            .OrderByDescending(p => p.CreatedAt)
+            .FirstOrDefaultAsync(cancellationToken);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary by Sourcery

Make instance lookup by key deterministic and increase raw HTTP body buffering threshold while avoiding temp file spills.

Bug Fixes:
- Ensure instance queries using a non-unique key return the most recently created matching instance to keep behavior deterministic.
- Prevent raw request body buffering from spilling to temporary files on read-only file systems by aligning the in-memory buffer threshold with the maximum buffered size.

Enhancements:
- Increase maximum raw HTTP request body size captured by middleware from 1 MB to 5 MB.