### PR TITLE
fix(subflow): propagate exception details into incidents

### DIFF
--- a/src/BBT.Workflow.Application/Execution/ErrorHandling/ExecutionError.cs
+++ b/src/BBT.Workflow.Application/Execution/ErrorHandling/ExecutionError.cs
@@ -30,6 +30,12 @@ public sealed record ExecutionError
     public string? ErrorMessage { get; init; }
 
     /// <summary>
+    /// Gets the original exception stack trace, when the error originated from a thrown exception.
+    /// Null for business-level (response/result) failures that carry no stack trace.
+    /// </summary>
+    public string? StackTrace { get; init; }
+
+    /// <summary>
     /// Gets the normalized error for Error Boundary policy matching.
     /// </summary>
     public required NormalizedError NormalizedError { get; init; }

--- a/src/BBT.Workflow.Application/Execution/ErrorHandling/ExecutionErrorFactory.cs
+++ b/src/BBT.Workflow.Application/Execution/ErrorHandling/ExecutionErrorFactory.cs
@@ -41,6 +41,7 @@ public sealed class ExecutionErrorFactory : IExecutionErrorFactory
             TaskType = taskType,
             StatusCode = normalized.StatusCode,
             ErrorMessage = exception.Message,
+            StackTrace = exception.StackTrace,
             NormalizedError = taskNormalizedError,
             ExecutionDurationMs = executionDurationMs,
             Metadata = new Dictionary<string, object>

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/BoundaryOutcomeHandler.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/BoundaryOutcomeHandler.cs
@@ -86,6 +86,7 @@ public static class BoundaryOutcomeHandler
             errorCode: executionError.NormalizedError.Code,
             errorLayer: executionError.NormalizedError.Layer.ToString(),
             statusCode: executionError.StatusCode,
+            stackTrace: executionError.StackTrace,
             traceId: context.TraceId);
 
         context.Instance.AddIncident(incident);
@@ -106,6 +107,7 @@ public static class BoundaryOutcomeHandler
             errorCode: error?.NormalizedError.Code ?? action?.PropagatedError?.Code ?? "Unknown",
             errorLayer: error?.NormalizedError.Layer.ToString() ?? "Pipeline",
             statusCode: error?.StatusCode,
+            stackTrace: error?.StackTrace,
             boundaryAction: action?.Action.ToString(),
             boundaryLevel: action?.ResolvedAtLevel?.ToString(),
             retryCount: action?.RetryPolicy?.MaxRetries ?? 0,

--- a/src/BBT.Workflow.Application/SubFlow/DTOs/SubFlowFaultedInput.cs
+++ b/src/BBT.Workflow.Application/SubFlow/DTOs/SubFlowFaultedInput.cs
@@ -79,6 +79,11 @@ public record SubFlowFaultedInput
     public string? IncidentErrorLayer { get; init; }
 
     /// <summary>
+    /// Exception stack trace from the SubFlow's active incident, when available.
+    /// </summary>
+    public string? IncidentStackTrace { get; init; }
+
+    /// <summary>
     /// HTTP status code from the SubFlow's active incident, when available.
     /// </summary>
     public int? IncidentStatusCode { get; init; }

--- a/src/BBT.Workflow.Application/SubFlow/Services/SubflowFaultService.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubflowFaultService.cs
@@ -106,13 +106,6 @@ public sealed class SubflowFaultService(
 
                     parentWorkflow = parentWorkflowResult.Value!;
 
-                    await outputMappingService.ApplyAsync(
-                        parentInstance,
-                        parentWorkflow,
-                        correlation.ParentState,
-                        input.InstanceData,
-                        cancellationToken);
-
                     var executionError = BuildExecutionError(input);
                     var currentState = parentWorkflow.GetState(parentInstance.GetCurrentState).Value;
                     var resolution = errorBoundaryResolver.Resolve(
@@ -127,6 +120,9 @@ public sealed class SubflowFaultService(
                         retryExecutor: null,
                         cancellationToken);
 
+                    // Record the incident on the parent BEFORE running output mapping so the
+                    // subflow fault (including stack trace) is visible to the output-mapping
+                    // script via ScriptContext.Incident, enabling error-driven routing.
                     var incident = RecordIncident(
                         parentInstance,
                         input,
@@ -141,6 +137,13 @@ public sealed class SubflowFaultService(
                     {
                         parentInstance.Fault(input.Domain);
                     }
+
+                    await outputMappingService.ApplyAsync(
+                        parentInstance,
+                        parentWorkflow,
+                        correlation.ParentState,
+                        input.InstanceData,
+                        cancellationToken);
 
                     await instanceRepository.UpdateAsync(parentInstance, true, cancellationToken);
                     await uow.CommitAsync(cancellationToken);
@@ -225,7 +228,7 @@ public sealed class SubflowFaultService(
             errorCode: $"SubFlow:Faulted:{input.IncidentErrorCode ?? "Unknown"}",
             errorLayer: "SubFlow",
             statusCode: input.IncidentStatusCode,
-            stackTrace: null,
+            stackTrace: input.IncidentStackTrace,
             boundaryAction: boundaryAction.ToString(),
             boundaryLevel: boundaryLevel?.ToString(),
             traceId: input.IncidentTraceId);

--- a/src/BBT.Workflow.Domain/Instances/Instance.cs
+++ b/src/BBT.Workflow.Domain/Instances/Instance.cs
@@ -452,6 +452,7 @@ public sealed class Instance : AggregateRoot<Guid>, ICreationAuditedObject, IMod
                     IncidentMessage = activeIncident?.Message,
                     IncidentErrorCode = activeIncident?.ErrorCode,
                     IncidentErrorLayer = activeIncident?.ErrorLayer,
+                    IncidentStackTrace = activeIncident?.StackTrace,
                     IncidentStatusCode = activeIncident?.StatusCode,
                     IncidentTraceId = activeIncident?.TraceId,
                     IncidentTaskKey = activeIncident?.Task,

--- a/src/BBT.Workflow.Events.Contracts/Instances/Events/InstanceSubFaultedEvent.cs
+++ b/src/BBT.Workflow.Events.Contracts/Instances/Events/InstanceSubFaultedEvent.cs
@@ -90,6 +90,11 @@ public class InstanceSubFaultedEvent : IDistributedEvent
     public string? IncidentErrorLayer { get; init; }
 
     /// <summary>
+    /// Exception stack trace from the SubFlow's active incident, when available.
+    /// </summary>
+    public string? IncidentStackTrace { get; init; }
+
+    /// <summary>
     /// HTTP status code from the SubFlow's active incident, when available.
     /// </summary>
     public int? IncidentStatusCode { get; init; }

--- a/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceSubFaultedEventHook.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceSubFaultedEventHook.cs
@@ -99,6 +99,7 @@ public sealed class InstanceSubFaultedEventHook(
             IncidentMessage = eventData.IncidentMessage,
             IncidentErrorCode = eventData.IncidentErrorCode,
             IncidentErrorLayer = eventData.IncidentErrorLayer,
+            IncidentStackTrace = eventData.IncidentStackTrace,
             IncidentStatusCode = eventData.IncidentStatusCode,
             IncidentTraceId = eventData.IncidentTraceId,
             IncidentTaskKey = eventData.IncidentTaskKey,

--- a/test/BBT.Workflow.Application.Tests/SubFlow/SubflowFaultServiceTests.cs
+++ b/test/BBT.Workflow.Application.Tests/SubFlow/SubflowFaultServiceTests.cs
@@ -130,6 +130,33 @@ public sealed class SubflowFaultServiceTests
             Times.Exactly(2));
     }
 
+    [Fact]
+    public async Task FaultAsync_ShouldRecordIncidentBeforeRunningOutputMapping()
+    {
+        var parentInstance = CreateParentInstance(out var subInstanceId);
+        var parentWorkflow = CreateParentWorkflow(ErrorBoundary.AbortAll);
+        var input = CreateInput(parentInstance.Id, subInstanceId, CreateJsonElement("""{"childStatus":"Faulted"}"""));
+
+        SetupParent(parentInstance, parentWorkflow);
+
+        // Capture whether the parent already carries the subflow incident at the moment
+        // output mapping runs, so the mapping script can route on the fault.
+        var incidentVisibleToMapping = false;
+        _outputMappingService
+            .Setup(x => x.ApplyAsync(
+                It.IsAny<Instance>(),
+                It.IsAny<Definitions.Workflow>(),
+                It.IsAny<string>(),
+                It.IsAny<JsonElement?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback(() => incidentVisibleToMapping = parentInstance.HasActiveIncident)
+            .Returns(Task.CompletedTask);
+
+        await CreateService().FaultAsync(input, CancellationToken.None);
+
+        incidentVisibleToMapping.ShouldBeTrue();
+    }
+
     private SubflowFaultService CreateService()
     {
         var resolver = new ErrorBoundaryResolver(Mock.Of<ILogger<ErrorBoundaryResolver>>());
@@ -208,6 +235,7 @@ public sealed class SubflowFaultServiceTests
             IncidentErrorCode = "Http.NotFound",
             IncidentErrorLayer = ErrorLayer.Task.ToString(),
             IncidentStatusCode = 404,
+            IncidentStackTrace = "at Child.CallApi() in Child.cs:line 12",
             IncidentTaskKey = "call-child-api",
             IncidentTransition = "submit"
         };

--- a/test/BBT.Workflow.Domain.Tests/Instances/InstanceTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Instances/InstanceTests.cs
@@ -858,6 +858,7 @@ public class InstanceTests : DomainTestBase<DomainEntryPoint>
             errorCode: "Task:Http:404",
             errorLayer: "Task",
             statusCode: 404,
+            stackTrace: "at Child.Task.Invoke() in Child.cs:line 42",
             boundaryAction: "Abort",
             boundaryLevel: "Global",
             traceId: "trace-1"));
@@ -879,6 +880,7 @@ public class InstanceTests : DomainTestBase<DomainEntryPoint>
         Assert.Equal(404, faultedEvent.IncidentStatusCode);
         Assert.Equal("Task:Http:404", faultedEvent.IncidentErrorCode);
         Assert.Equal("Abort", faultedEvent.IncidentBoundaryAction);
+        Assert.Equal("at Child.Task.Invoke() in Child.cs:line 42", faultedEvent.IncidentStackTrace);
         Assert.True(faultedEvent.InstanceData.HasValue);
         Assert.Equal(42, faultedEvent.InstanceData.Value.GetProperty("childValue").GetInt32());
     }

--- a/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/InstanceSubFaultedEventHandler.cs
+++ b/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/InstanceSubFaultedEventHandler.cs
@@ -63,6 +63,7 @@ internal sealed class InstanceSubFaultedEventHandler(
                 IncidentMessage = eventData.IncidentMessage,
                 IncidentErrorCode = eventData.IncidentErrorCode,
                 IncidentErrorLayer = eventData.IncidentErrorLayer,
+                IncidentStackTrace = eventData.IncidentStackTrace,
                 IncidentStatusCode = eventData.IncidentStatusCode,
                 IncidentTraceId = eventData.IncidentTraceId,
                 IncidentTaskKey = eventData.IncidentTaskKey,


### PR DESCRIPTION
## What & Why

Closes #718.

When an exception occurred during **Task execution** or **SubFlow fault propagation**, the resulting `InstanceIncident` was recorded **without the underlying stack trace**, and a faulted subflow's incident was **not visible to the parent's output-mapping script**. This made troubleshooting harder and prevented authors from routing on the error in output mapping / error boundary scripts.

The data model already supported this (`InstanceIncident.StackTrace`, `InstanceIncidentFactory.Create(stackTrace:)`, `ScriptContext.Incident`); the detail was simply being dropped at three points.

## Changes

**1. Task execution preserves the stack trace**
- Added a first-class `StackTrace` to `ExecutionError`, populated from `exception.StackTrace` in `ExecutionErrorFactory.CreateFromException`.
- Threaded it into both `InstanceIncidentFactory.Create` calls in `BoundaryOutcomeHandler` (`RecordUnhandledIncident` + `BuildIncident`).

**2. Stack trace propagates child → parent**
- Added `IncidentStackTrace` alongside the existing `Incident*` fields on `InstanceSubFaultedEvent` and `SubFlowFaultedInput`, populated from the child's active incident in `Instance.Fault`, mapped through the event hook + inbox handler, and passed to the parent incident in `SubflowFaultService` (replacing the hardcoded `stackTrace: null`).

**3. Incident visible to output mapping**
- Reordered `SubflowFaultService.FaultAsync` so the parent incident is recorded **before** `outputMappingService.ApplyAsync`. The output handler now sees the subflow fault via `ScriptContext.Incident.ActiveIncident` (message, code, statusCode, layer, **stackTrace**). Boundary resolution uses `BuildExecutionError(input)` and does not depend on output-mapping output, so the reorder is behavior-safe.

## Scope notes for reviewers

- Only the **technical fault** path (`status = Faulted` → `Instance.Fault` → `InstanceSubFaultedEvent` → `SubflowFaultService`) is in scope. A subflow that finishes in an **Error finish-state** becomes `Completed` via `Instance.Complete` → `SubflowCompletionService` (a separate, mutually-exclusive event); that path was intentionally left unchanged.
- `SubProcess` (fire-and-forget) is out of scope.

## Tests

- Domain: extended `Fault_WhenInstanceIsSubFlow_*` to assert `IncidentStackTrace` flows into `InstanceSubFaultedEvent`.
- Application: added `FaultAsync_ShouldRecordIncidentBeforeRunningOutputMapping` + a stack trace in the shared input. All 4 `SubflowFaultServiceTests` pass; solution builds clean (0 errors).

## Summary by Sourcery

Preserve and propagate exception stack traces for subflow incidents and ensure parent incidents are recorded before output mapping so scripts can route on subflow faults.

Bug Fixes:
- Include exception stack traces in execution errors and persisted incidents rather than dropping them.
- Propagate a subflow's incident stack trace from the child instance through events into the parent's recorded incident.
- Expose the parent incident (including stack trace) to output-mapping scripts by recording it before running output mapping in subflow fault handling.

Tests:
- Extend domain tests to assert incident stack traces are included in subflow fault events.
- Add an application-level test to verify incidents are recorded before output mapping in subflow fault handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exception stack traces are now captured and propagated through error handling and incident management, enabling improved diagnostics for workflow troubleshooting.
  * Stack trace information is included when faults propagate from subflows to parent instances.

* **Tests**
  * Added validation that incidents are recorded before output mapping execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->