### PR TITLE
feat(jobs): per-transition Dapr job handoff with reliable cancellation-by-id

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
     <PropertyGroup>
 
         <!-- All Prism packages -->
-        <AetherPackageVersion>1.0.26</AetherPackageVersion>
+        <AetherPackageVersion>1.0.27</AetherPackageVersion>
         <!-- Elastic Apm packages -->
         <ElasticApmPackageVersion>1.31.0</ElasticApmPackageVersion>
         <!-- Microsoft packages -->

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
@@ -291,7 +291,7 @@ public sealed class InstanceController(
             ChainToken = continuation.ChainToken
         };
 
-        await transitionJobEnqueuer.EnqueueAsync(payload, cancellationToken);
+        await transitionJobEnqueuer.EnqueueAsync(payload, continuation.JobId, cancellationToken);
         return Ok();
     }
 

--- a/src/BBT.Workflow.Application/BackgroundJobs/ITransitionJobEnqueuer.cs
+++ b/src/BBT.Workflow.Application/BackgroundJobs/ITransitionJobEnqueuer.cs
@@ -13,7 +13,9 @@ public interface ITransitionJobEnqueuer
 {
     /// <summary>
     /// Enqueues the transition job. The caller owns any durable <c>InstanceJob</c> intent (written
-    /// in its unit of work); this method performs only the Dapr enqueue.
+    /// in its unit of work) and supplies <paramref name="jobId"/> — the same id is used as the
+    /// underlying <c>BackgroundJobInfo.Id</c>, so the tracking <c>InstanceJob.JobId</c> stays in sync
+    /// (no placeholder) and cancellation-by-id remains reliable.
     /// </summary>
-    Task EnqueueAsync(TransitionJobPayload payload, CancellationToken cancellationToken = default);
+    Task EnqueueAsync(TransitionJobPayload payload, Guid jobId, CancellationToken cancellationToken = default);
 }

--- a/src/BBT.Workflow.Application/BackgroundJobs/TransitionJobEnqueuer.cs
+++ b/src/BBT.Workflow.Application/BackgroundJobs/TransitionJobEnqueuer.cs
@@ -9,13 +9,17 @@ namespace BBT.Workflow.BackgroundJobs;
 
 /// <summary>
 /// Default <see cref="ITransitionJobEnqueuer"/> over the Aether background-job service / Dapr Jobs.
+/// Enqueues with <c>useAmbientUnitOfWork: true</c> so the durable job row joins the transition
+/// pipeline's ambient unit of work (committing atomically with the transition) and the Dapr schedule
+/// is deferred to post-commit — avoiding the nested-UoW / shared-DbContext collision
+/// ("A second operation was started on this context instance").
 /// </summary>
 public sealed class TransitionJobEnqueuer(
     IBackgroundJobService backgroundJobService,
     IOptions<WorkflowExecutionOptions> executionOptions) : ITransitionJobEnqueuer
 {
     /// <inheritdoc />
-    public Task EnqueueAsync(TransitionJobPayload payload, CancellationToken cancellationToken = default)
+    public Task EnqueueAsync(TransitionJobPayload payload, Guid jobId, CancellationToken cancellationToken = default)
     {
         var fp = executionOptions.Value.FailurePolicy;
         var failurePolicy = JobScheduleFailurePolicy.Constant(
@@ -38,6 +42,8 @@ public sealed class TransitionJobEnqueuer(
             schedule,
             metadata,
             failurePolicy,
+            useAmbientUnitOfWork: true,
+            jobId: jobId,
             cancellationToken);
     }
 }

--- a/src/BBT.Workflow.Application/Execution/PostCommit/PostCommitExecutor.cs
+++ b/src/BBT.Workflow.Application/Execution/PostCommit/PostCommitExecutor.cs
@@ -146,7 +146,8 @@ public sealed class PostCommitExecutor(
                     {
                         return PostCommitResult.Fail(
                             execResult.Error,
-                            new PostCommitFaultRequest(decision.FaultErrorCode, decision.FaultErrorMessage));
+                            new PostCommitFaultRequest(
+                                decision.FaultErrorCode, decision.FaultErrorMessage, execResult.Error.Detail));
                     }
 
                     if (!decision.ShouldContinue)
@@ -184,7 +185,7 @@ public sealed class PostCommitExecutor(
         {
             return PostCommitResult.Fail(
                 error,
-                new PostCommitFaultRequest(decision.FaultErrorCode, decision.FaultErrorMessage));
+                new PostCommitFaultRequest(decision.FaultErrorCode, decision.FaultErrorMessage, error.Detail));
         }
 
         return PostCommitResult.Fail(error);

--- a/src/BBT.Workflow.Application/Execution/Transitions/Continuations/EnqueueContinuationStrategy.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Continuations/EnqueueContinuationStrategy.cs
@@ -52,13 +52,18 @@ public sealed class EnqueueContinuationStrategy(
         var jobName = JobName.ForAsyncTransition(current.InstanceId, next.TransitionKey);
         var jobNameValue = jobName.Value;
 
+        // Single caller-generated id, reused for the durable InstanceJob.JobId AND the underlying
+        // BackgroundJobInfo.Id (direct + outbox paths). Keeps the two in sync so cancellation-by-id
+        // works — no placeholder.
+        var jobId = Guid.NewGuid();
+
         // Durable intent for the active-job guard / reaper — atomic with the transition commit
         // because we run inside the pipeline's ambient UoW (TransitionRunner).
         await jobRepository.InsertAsync(
             InstanceJob.Create(
-                Guid.NewGuid(),
+                jobId,
                 jobName,
-                Guid.NewGuid(),
+                jobId,
                 current.Domain,
                 current.WorkflowKey,
                 current.InstanceId),
@@ -69,7 +74,7 @@ public sealed class EnqueueContinuationStrategy(
         // to the transactional outbox so the continuation is never lost.
         if (executionOptions.Value.DirectEnqueueContinuations)
         {
-            var enqueueResult = await EnqueueDirectlyAsync(current, next.TransitionKey, jobNameValue, cancellationToken);
+            var enqueueResult = await EnqueueDirectlyAsync(current, next.TransitionKey, jobNameValue, jobId, cancellationToken);
             if (enqueueResult.IsSuccess)
             {
                 logger.TransitionContinuationEnqueued(current.InstanceId, next.TransitionKey, jobNameValue);
@@ -80,7 +85,7 @@ public sealed class EnqueueContinuationStrategy(
                 current.InstanceId, next.TransitionKey, jobNameValue, enqueueResult.Error.Message);
         }
 
-        await PublishViaOutboxAsync(current, next.TransitionKey, jobNameValue, cancellationToken);
+        await PublishViaOutboxAsync(current, next.TransitionKey, jobNameValue, jobId, cancellationToken);
 
         // No in-process next context — a separate job resumes the chain.
         return Result<WorkflowExecutionContext?>.Ok(null);
@@ -88,12 +93,20 @@ public sealed class EnqueueContinuationStrategy(
 
     /// <summary>
     /// Enqueues the next-hop Dapr job directly via <see cref="ITransitionJobEnqueuer"/>.
-    /// Wrapped in <see cref="ResultExtensions.TryAsync{T}"/> because Dapr is an external service.
+    /// <para>
+    /// The enqueuer joins the ambient transition unit of work (transactional enqueue): the durable
+    /// job row commits atomically with the transition and the actual Dapr schedule is deferred to
+    /// post-commit. Consequently the <see cref="ResultExtensions.TryAsync{T}"/> wrapper here only
+    /// catches SYNCHRONOUS failures (intent persistence / scheduler registration); a Dapr scheduling
+    /// failure that happens after commit is recovered by the ChainReaper backstop, not by the
+    /// outbox fallback below.
+    /// </para>
     /// </summary>
     private Task<Result<bool>> EnqueueDirectlyAsync(
         TransitionExecutionContext current,
         string transitionKey,
         string jobName,
+        Guid jobId,
         CancellationToken cancellationToken)
     {
         var activity = Activity.Current;
@@ -118,7 +131,7 @@ public sealed class EnqueueContinuationStrategy(
         return ResultExtensions.TryAsync(
             async ct =>
             {
-                await jobEnqueuer.EnqueueAsync(payload, ct);
+                await jobEnqueuer.EnqueueAsync(payload, jobId, ct);
                 return true;
             },
             cancellationToken,
@@ -137,6 +150,7 @@ public sealed class EnqueueContinuationStrategy(
         TransitionExecutionContext current,
         string transitionKey,
         string jobName,
+        Guid jobId,
         CancellationToken cancellationToken)
     {
         var continuation = new TransitionContinuationRequested
@@ -147,6 +161,7 @@ public sealed class EnqueueContinuationStrategy(
             Version = current.Workflow.Version,
             TransitionKey = transitionKey,
             JobName = jobName,
+            JobId = jobId,
             Data = null, // chained auto-transitions carry no new request payload
             Headers = current.Headers.ToDictionary(kvp => kvp.Key, kvp => kvp.Value),
             RouteValues = current.RouteValues.ToDictionary(kvp => kvp.Key, kvp => kvp.Value),

--- a/src/BBT.Workflow.Application/Execution/Transitions/Continuations/EnqueueContinuationStrategy.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Continuations/EnqueueContinuationStrategy.cs
@@ -49,7 +49,8 @@ public sealed class EnqueueContinuationStrategy(
         if (next is null)
             return Result<WorkflowExecutionContext?>.Ok(null);
 
-        var jobName = $"trans-{current.InstanceId}-{next.TransitionKey}";
+        var jobName = JobName.ForAsyncTransition(current.InstanceId, next.TransitionKey);
+        var jobNameValue = jobName.Value;
 
         // Durable intent for the active-job guard / reaper — atomic with the transition commit
         // because we run inside the pipeline's ambient UoW (TransitionRunner).
@@ -68,18 +69,18 @@ public sealed class EnqueueContinuationStrategy(
         // to the transactional outbox so the continuation is never lost.
         if (executionOptions.Value.DirectEnqueueContinuations)
         {
-            var enqueueResult = await EnqueueDirectlyAsync(current, next.TransitionKey, jobName, cancellationToken);
+            var enqueueResult = await EnqueueDirectlyAsync(current, next.TransitionKey, jobNameValue, cancellationToken);
             if (enqueueResult.IsSuccess)
             {
-                logger.TransitionContinuationEnqueued(current.InstanceId, next.TransitionKey, jobName);
+                logger.TransitionContinuationEnqueued(current.InstanceId, next.TransitionKey, jobNameValue);
                 return Result<WorkflowExecutionContext?>.Ok(null);
             }
 
             logger.TransitionContinuationFellBackToOutbox(
-                current.InstanceId, next.TransitionKey, jobName, enqueueResult.Error.Message);
+                current.InstanceId, next.TransitionKey, jobNameValue, enqueueResult.Error.Message);
         }
 
-        await PublishViaOutboxAsync(current, next.TransitionKey, jobName, cancellationToken);
+        await PublishViaOutboxAsync(current, next.TransitionKey, jobNameValue, cancellationToken);
 
         // No in-process next context — a separate job resumes the chain.
         return Result<WorkflowExecutionContext?>.Ok(null);

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/HandleLongPollTerminationStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/HandleLongPollTerminationStep.cs
@@ -153,6 +153,7 @@ public sealed class HandleLongPollTerminationStep(
             payload,
             schedule,
             metadata,
+            useAmbientUnitOfWork: true,
             cancellationToken: cancellationToken);
 
         await jobRepository.InsertAsync(

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/HandleLongPollTerminationStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/HandleLongPollTerminationStep.cs
@@ -121,12 +121,12 @@ public sealed class HandleLongPollTerminationStep(
         Guid token,
         CancellationToken cancellationToken)
     {
-        var jobName = $"lpack-{context.InstanceId}-{LongPollAckConstants.JobKey}";
+        var jobName = JobName.ForLongPollAck(context.InstanceId);
         var activity = Activity.Current;
 
         var payload = new LongPollAckTimeoutPayload
         {
-            JobName = jobName,
+            JobName = jobName.Value,
             Domain = context.Domain,
             InstanceId = context.InstanceId,
             FlowName = context.WorkflowKey,
@@ -149,7 +149,7 @@ public sealed class HandleLongPollTerminationStep(
 
         var jobId = await backgroundJobService.EnqueueAsync(
             LongPollAckTimeoutJobHandler.HandlerName,
-            jobName,
+            jobName.Value,
             payload,
             schedule,
             metadata,

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ScheduleTransitionsStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ScheduleTransitionsStep.cs
@@ -8,7 +8,6 @@ using BBT.Workflow.Definitions;
 using BBT.Workflow.Definitions.Timer;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Scripting;
-using BBT.Workflow.Tasks;
 using BBT.Workflow.Logging;
 using BBT.Workflow.Runtime;
 using BBT.Workflow.Tasks.Coordinator;
@@ -172,6 +171,7 @@ public sealed class ScheduleTransitionsStep(
             info.Payload,
             info.ScheduleExpression,
             metadata: info.Metadata,
+            useAmbientUnitOfWork: true,
             cancellationToken: cancellationToken);
 
         await jobRepository.InsertAsync(

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ScheduleTransitionsStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ScheduleTransitionsStep.cs
@@ -129,12 +129,12 @@ public sealed class ScheduleTransitionsStep(
         Transition scheduledTransition,
         TimerSchedule timerSchedule)
     {
-        var jobName = $"trans-{context.InstanceId}-{scheduledTransition.Key}";
+        var jobName = JobName.ForScheduledTransition(context.InstanceId, scheduledTransition.Key);
         var activity = Activity.Current;
-        
+
         var payload = new TransitionTimerPayload
         {
-            JobName = jobName,
+            JobName = jobName.Value,
             Domain = context.Domain,
             FlowName = context.WorkflowKey,
             Version = context.Workflow.Version,
@@ -168,7 +168,7 @@ public sealed class ScheduleTransitionsStep(
     {
         var jobId = await backgroundJobService.EnqueueAsync(
             TransitionTimerJobHandler.HandlerName,
-            info.JobName,
+            info.JobName.Value,
             info.Payload,
             info.ScheduleExpression,
             metadata: info.Metadata,
@@ -193,7 +193,7 @@ public sealed class ScheduleTransitionsStep(
     /// </summary>
     private sealed record TransitionSchedulingInfo(
         TransitionExecutionContext Context,
-        string JobName,
+        JobName JobName,
         TransitionTimerPayload Payload,
         string ScheduleExpression,
         Dictionary<string, object> Metadata);

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/TransitionPipeline.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/TransitionPipeline.cs
@@ -289,6 +289,21 @@ public class TransitionPipeline
             "Marking instance {InstanceId} as faulted due to post-commit failure: {ErrorCode} - {ErrorMessage}",
             context.InstanceId, faultRequest.ErrorCode, faultRequest.ErrorMessage);
 
+        if (!context.Instance.HasActiveIncident)
+        {
+            var incident = InstanceIncidentFactory.Create(
+                state: context.Instance.GetCurrentState,
+                transition: context.TransitionKey,
+                taskKey: null,
+                message: faultRequest.ErrorMessage ?? "Post-commit execution failed",
+                errorCode: faultRequest.ErrorCode,
+                errorLayer: "PostCommit",
+                stackTrace: faultRequest.StackTrace,
+                traceId: context.TraceId);
+
+            context.Instance.AddIncident(incident);
+        }
+
         context.Instance.Fault(context.Domain);
         context.ExtractAndDeferInstanceEvents();
         await _instanceRepository.UpdateAsync(context.Instance, true, cancellationToken);

--- a/src/BBT.Workflow.Application/Execution/Transitions/Strategy/AsyncTransitionStrategy.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Strategy/AsyncTransitionStrategy.cs
@@ -113,7 +113,8 @@ public sealed class AsyncTransitionStrategy(
         Activity? activity,
         CancellationToken cancellationToken)
     {
-        var jobName = JobName.ForAsyncTransition(context.InstanceId, context.TransitionKey).Value;
+        var jobName = JobName.ForAsyncTransition(
+            Guid.Parse(context.InstanceId), context.TransitionKey).Value;
         EnrichTelemetry(activity, ctx, jobName);
 
         Result<TransitionExecutionContext> lockScopeResult =
@@ -246,7 +247,7 @@ public sealed class AsyncTransitionStrategy(
         }
 
         // Side-effect AFTER the intent is durable. Dapr is external → TryAsync.
-        var enqueueResult = await EnqueueToDaprAsync(jobName.Value, jobPayload, schedule, metadata, cancellationToken);
+        var enqueueResult = await EnqueueToDaprAsync(jobName.Value, jobPayload, schedule, metadata, jobId, cancellationToken);
         if (!enqueueResult.IsSuccess)
             return Result<string>.Fail(enqueueResult.Error);
 
@@ -267,8 +268,9 @@ public sealed class AsyncTransitionStrategy(
     {
         var jobName = JobName.ForAsyncTransition(transContext.InstanceId, transContext.TransitionKey);
 
-        // The active-job guard keys on JobName, so a generated job id is sufficient here;
-        // the real Dapr job id is produced later by the Inbox handler's enqueue.
+        // Single caller-generated id, reused for the InstanceJob.JobId intent AND threaded on the
+        // event so the downstream enqueue sets BackgroundJobInfo.Id to the same value — keeping them
+        // in sync for cancellation-by-id.
         var jobId = Guid.NewGuid();
 
         var continuation = new TransitionContinuationRequested
@@ -279,6 +281,7 @@ public sealed class AsyncTransitionStrategy(
             Version = transContext.Workflow.Version,
             TransitionKey = transContext.TransitionKey,
             JobName = jobName.Value,
+            JobId = jobId,
             Data = context.Data?.Attributes,
             InstanceKey = context.Data?.Key,
             Tags = context.Data?.Tags,
@@ -312,6 +315,7 @@ public sealed class AsyncTransitionStrategy(
         TransitionJobPayload jobPayload,
         string schedule,
         Dictionary<string, object> metadata,
+        Guid jobId,
         CancellationToken cancellationToken)
     {
         var fp = executionOptions.Value.FailurePolicy;
@@ -320,6 +324,10 @@ public sealed class AsyncTransitionStrategy(
             (uint)fp.MaxRetries);
 
         return ResultExtensions.TryAsync(
+            // Non-ambient (default useAmbientUnitOfWork:false): this enqueue runs AFTER the durable
+            // intent UoW has already committed (intent-first ordering), so there is no ambient
+            // transition UoW to join — keep the self-contained RequiresNew path. The caller-supplied
+            // jobId is reused as BackgroundJobInfo.Id so it matches the InstanceJob.JobId intent.
             async ct => await backgroundJobService.EnqueueAsync(
                 TransitionJobHandler.HandlerName,
                 jobName,
@@ -327,7 +335,8 @@ public sealed class AsyncTransitionStrategy(
                 schedule,
                 metadata,
                 failurePolicy,
-                ct),
+                jobId: jobId,
+                cancellationToken: ct),
             cancellationToken,
             ex => Error.Dependency(
                 WorkflowErrorCodes.Dependency,

--- a/src/BBT.Workflow.Application/Execution/Transitions/Strategy/AsyncTransitionStrategy.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Strategy/AsyncTransitionStrategy.cs
@@ -113,7 +113,7 @@ public sealed class AsyncTransitionStrategy(
         Activity? activity,
         CancellationToken cancellationToken)
     {
-        var jobName = $"trans-{context.InstanceId}-{context.TransitionKey}";
+        var jobName = JobName.ForAsyncTransition(context.InstanceId, context.TransitionKey).Value;
         EnrichTelemetry(activity, ctx, jobName);
 
         Result<TransitionExecutionContext> lockScopeResult =
@@ -246,11 +246,11 @@ public sealed class AsyncTransitionStrategy(
         }
 
         // Side-effect AFTER the intent is durable. Dapr is external → TryAsync.
-        var enqueueResult = await EnqueueToDaprAsync(jobName, jobPayload, schedule, metadata, cancellationToken);
+        var enqueueResult = await EnqueueToDaprAsync(jobName.Value, jobPayload, schedule, metadata, cancellationToken);
         if (!enqueueResult.IsSuccess)
             return Result<string>.Fail(enqueueResult.Error);
 
-        return Result<string>.Ok(jobName);
+        return Result<string>.Ok(jobName.Value);
     }
 
     /// <summary>
@@ -265,7 +265,7 @@ public sealed class AsyncTransitionStrategy(
         Activity? activity,
         CancellationToken cancellationToken)
     {
-        var jobName = $"trans-{context.InstanceId}-{context.TransitionKey}";
+        var jobName = JobName.ForAsyncTransition(transContext.InstanceId, transContext.TransitionKey);
 
         // The active-job guard keys on JobName, so a generated job id is sufficient here;
         // the real Dapr job id is produced later by the Inbox handler's enqueue.
@@ -278,7 +278,7 @@ public sealed class AsyncTransitionStrategy(
             Flow = transContext.WorkflowKey,
             Version = transContext.Workflow.Version,
             TransitionKey = transContext.TransitionKey,
-            JobName = jobName,
+            JobName = jobName.Value,
             Data = context.Data?.Attributes,
             InstanceKey = context.Data?.Key,
             Tags = context.Data?.Tags,
@@ -300,7 +300,7 @@ public sealed class AsyncTransitionStrategy(
 
         await uow.CommitAsync(cancellationToken);
 
-        return Result<string>.Ok(jobName);
+        return Result<string>.Ok(jobName.Value);
     }
 
     /// <summary>
@@ -342,7 +342,7 @@ public sealed class AsyncTransitionStrategy(
     private Task SaveJobRecordAsync(
         WorkflowExecutionContext context,
         TransitionExecutionContext transContext,
-        string jobName,
+        JobName jobName,
         Guid jobId,
         CancellationToken cancellationToken)
     {
@@ -362,15 +362,15 @@ public sealed class AsyncTransitionStrategy(
     /// Builds the job payload, schedule, and metadata.
     /// Pure function - no side effects.
     /// </summary>
-    private static (string JobName, TransitionJobPayload Payload, string Schedule, Dictionary<string, object> Metadata)
+    private static (JobName JobName, TransitionJobPayload Payload, string Schedule, Dictionary<string, object> Metadata)
         BuildJobPayload(WorkflowExecutionContext context, TransitionExecutionContext transContext, Activity? activity,
             string? rawBody)
     {
-        var jobName = $"trans-{context.InstanceId}-{context.TransitionKey}";
+        var jobName = JobName.ForAsyncTransition(transContext.InstanceId, transContext.TransitionKey);
 
         var jobPayload = new TransitionJobPayload
         {
-            JobName = jobName,
+            JobName = jobName.Value,
             InstanceId = transContext.InstanceId,
             TransitionKey = transContext.TransitionKey,
             Domain = transContext.Domain,

--- a/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
@@ -417,11 +417,11 @@ public sealed class InstanceCommandAppService(
 
         try
         {
-            var jobName = $"timeout-{instance.Id}";
+            var jobName = JobName.ForTimeout(instance.Id);
             var activity = Activity.Current;
             var payload = new WorkflowTimeoutPayload
             {
-                JobName = jobName,
+                JobName = jobName.Value,
                 Domain = workflow.Domain,
                 InstanceId = instance.Id,
                 FlowName = workflow.Key,
@@ -452,7 +452,7 @@ public sealed class InstanceCommandAppService(
             // Enqueue the timeout job
             var jobId = await backgroundJobService.EnqueueAsync(
                 FlowTimeoutJobHandler.HandlerName,
-                jobName,
+                jobName.Value,
                 payload,
                 schedule,
                 metadata,

--- a/src/BBT.Workflow.Application/Instances/Managers/InstanceCancellationService.cs
+++ b/src/BBT.Workflow.Application/Instances/Managers/InstanceCancellationService.cs
@@ -20,13 +20,6 @@ public sealed class InstanceCancellationService(
     ILogger<InstanceCancellationService> logger)
     :  IInstanceCancellationService
 {
-    /// <summary>
-    /// Job types eligible for state-scoped cancellation: timer-based scheduled transitions and the
-    /// long-poll acknowledge fallback (whose well-known key is passed as a pseudo transition key).
-    /// </summary>
-    private static readonly JobType[] StateCancellationJobTypes =
-        [JobType.ScheduledTransition, JobType.LongPollAck];
-
     /// <inheritdoc />
     public async Task<Result> ProcessCancellationAsync(
         Guid instanceId,
@@ -97,20 +90,18 @@ public sealed class InstanceCancellationService(
                 return Result.Fail(WorkflowErrors.InstanceNotFound(instanceId.ToString()));
             }
 
-            // Structured (DB-side) match: scheduled-transition and long-poll-ack jobs whose
-            // targeted key is in the requested set. Async-transition (tx) jobs are intentionally
-            // NOT cancelled here — they guard themselves via the instance lock. Legacy rows
-            // (JobType.Unknown) are also returned for the transitional suffix-based fallback.
-            var candidates = await instanceJobRepository.GetActiveForStateCancellationAsync(
-                instance.Id,
-                StateCancellationJobTypes,
-                transitionKeys,
-                cancellationToken);
+            // The caller (e.g. CancelScheduledJobsStep) already resolved which transitions must be
+            // cancelled, so we simply match this instance's active jobs by their targeted key —
+            // no extra job-type conditioning. Matching uses the structured TransitionKey column
+            // instead of the previous fragile JobName suffix parse.
+            var allJobs = await instanceJobRepository.GetListActiveAsync(instance.Id, cancellationToken);
 
-            var jobsToCancel = candidates
-                .Where(job => job.JobType != JobType.Unknown
-                    // Transitional fallback for pre-rollout rows: old "-{key}" suffix match.
-                    || transitionKeys.Any(key => job.JobName.EndsWith($"-{key}", StringComparison.Ordinal)))
+            var jobsToCancel = allJobs
+                .Where(job => (job.TransitionKey != null && transitionKeys.Contains(job.TransitionKey))
+                    // Transitional fallback for pre-rollout rows (no structured columns):
+                    // old "-{key}" suffix match. Removable once no legacy rows remain.
+                    || (job.JobType == JobType.Unknown
+                        && transitionKeys.Any(key => job.JobName.EndsWith($"-{key}", StringComparison.Ordinal))))
                 .ToList();
 
             if (!jobsToCancel.Any())

--- a/src/BBT.Workflow.Application/Instances/Managers/InstanceCancellationService.cs
+++ b/src/BBT.Workflow.Application/Instances/Managers/InstanceCancellationService.cs
@@ -20,6 +20,13 @@ public sealed class InstanceCancellationService(
     ILogger<InstanceCancellationService> logger)
     :  IInstanceCancellationService
 {
+    /// <summary>
+    /// Job types eligible for state-scoped cancellation: timer-based scheduled transitions and the
+    /// long-poll acknowledge fallback (whose well-known key is passed as a pseudo transition key).
+    /// </summary>
+    private static readonly JobType[] StateCancellationJobTypes =
+        [JobType.ScheduledTransition, JobType.LongPollAck];
+
     /// <inheritdoc />
     public async Task<Result> ProcessCancellationAsync(
         Guid instanceId,
@@ -90,14 +97,22 @@ public sealed class InstanceCancellationService(
                 return Result.Fail(WorkflowErrors.InstanceNotFound(instanceId.ToString()));
             }
 
-            // Get all active jobs for this instance
-            var allJobs = await instanceJobRepository.GetListActiveAsync(instance.Id, cancellationToken);
-            
-            // Filter jobs by transition keys
-            // Job name format: trans-{instanceId}-{transitionKey}
-            var jobsToCancel = allJobs.Where(job => 
-                transitionKeys.Any(key => job.JobName.EndsWith($"-{key}"))).ToList();
-            
+            // Structured (DB-side) match: scheduled-transition and long-poll-ack jobs whose
+            // targeted key is in the requested set. Async-transition (tx) jobs are intentionally
+            // NOT cancelled here — they guard themselves via the instance lock. Legacy rows
+            // (JobType.Unknown) are also returned for the transitional suffix-based fallback.
+            var candidates = await instanceJobRepository.GetActiveForStateCancellationAsync(
+                instance.Id,
+                StateCancellationJobTypes,
+                transitionKeys,
+                cancellationToken);
+
+            var jobsToCancel = candidates
+                .Where(job => job.JobType != JobType.Unknown
+                    // Transitional fallback for pre-rollout rows: old "-{key}" suffix match.
+                    || transitionKeys.Any(key => job.JobName.EndsWith($"-{key}", StringComparison.Ordinal)))
+                .ToList();
+
             if (!jobsToCancel.Any())
             {
                 return Result.Ok();

--- a/src/BBT.Workflow.Application/SubFlow/Services/SubflowStarter.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubflowStarter.cs
@@ -238,25 +238,27 @@ public sealed class SubflowStarter(
 
         return await ResultExtensions.TryAsync<ScriptResponse?>(async ct =>
         {
-            // Compile the mapping script to the appropriate interface
-            var mappingInstance = await scriptEngine.CompileToInstanceAsync<object>(
-                subFlowConfig.Mapping,
-                cancellationToken: ct);
-
             // Cast to the appropriate mapping interface and execute InputHandler
-            if (subFlowConfig.Type.Code == "S" && mappingInstance is ISubFlowMapping subFlowMapping)
+            if (subFlowConfig.Type.Code == "S")
             {
+                var subFlowMapping = await scriptEngine.CompileToInstanceAsync<ISubFlowMapping>(
+                    subFlowConfig.Mapping,
+                    cancellationToken: ct);
                 return await subFlowMapping.InputHandler(context);
             }
 
-            if (subFlowConfig.Type.Code == "P" && mappingInstance is ISubProcessMapping subProcessMapping)
+            if (subFlowConfig.Type.Code == "P")
             {
+                var subProcessMapping = await scriptEngine.CompileToInstanceAsync<ISubProcessMapping>(
+                    subFlowConfig.Mapping,
+                    cancellationToken: ct);
                 return await subProcessMapping.InputHandler(context);
             }
 
             // If we reach here, casting failed
             throw new InvalidOperationException(
                 $"Failed to cast mapping instance to {mappingInterfaceType.Name} for SubFlow type '{subFlowConfig.Type.Code}'");
-        }, cancellationToken, ex => WorkflowErrors.SubFlowInputMappingFailed(subFlowConfig.Process.Key, ex.Message));
+        }, cancellationToken, ex => WorkflowErrors.SubFlowInputMappingFailed(
+            subFlowConfig.Process.Key, ex.Message, ex.StackTrace));
     }
 }

--- a/src/BBT.Workflow.Domain/Execution/LongPoll/LongPollAckConstants.cs
+++ b/src/BBT.Workflow.Domain/Execution/LongPoll/LongPollAckConstants.cs
@@ -6,9 +6,10 @@ namespace BBT.Workflow.Execution.LongPoll;
 public static class LongPollAckConstants
 {
     /// <summary>
-    /// Job-name suffix key for the acknowledge fallback schedule. The fallback job is named
-    /// <c>lpack-{instanceId}-{JobKey}</c> so it can be cancelled via the existing
-    /// transition-key-suffix cancellation path on acknowledge.
+    /// Well-known segment key for the acknowledge fallback schedule. The fallback job is built via
+    /// <see cref="BBT.Workflow.Instances.JobName.ForLongPollAck"/> (type <c>la</c>) carrying this
+    /// key as its segment, so it can be cancelled via the structured state-transition cancellation
+    /// path on acknowledge (matched by job type + this key).
     /// </summary>
     public const string JobKey = "longpoll-ack";
 }

--- a/src/BBT.Workflow.Domain/Execution/PostCommit/PostCommitResult.cs
+++ b/src/BBT.Workflow.Domain/Execution/PostCommit/PostCommitResult.cs
@@ -8,7 +8,11 @@ namespace BBT.Workflow.Execution.PostCommit;
 /// </summary>
 /// <param name="ErrorCode">The error code that caused the fault.</param>
 /// <param name="ErrorMessage">The error message describing the fault.</param>
-public sealed record PostCommitFaultRequest(string ErrorCode, string? ErrorMessage);
+/// <param name="StackTrace">
+/// Optional exception stack trace (sourced from the originating error's detail) so the
+/// pipeline can record it on the instance incident.
+/// </param>
+public sealed record PostCommitFaultRequest(string ErrorCode, string? ErrorMessage, string? StackTrace = null);
 
 /// <summary>
 /// Result of post-commit job execution.

--- a/src/BBT.Workflow.Domain/Instances/IInstanceJobRepository.cs
+++ b/src/BBT.Workflow.Domain/Instances/IInstanceJobRepository.cs
@@ -5,6 +5,19 @@ namespace BBT.Workflow.Instances;
 public interface IInstanceJobRepository : IRepository<InstanceJob, Guid>
 {
     Task<List<InstanceJob>> GetListActiveAsync(Guid instanceId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the active jobs that are candidates for state-scoped cancellation: structured rows
+    /// whose <see cref="InstanceJob.JobType"/> is one of <paramref name="matchTypes"/> and whose
+    /// <see cref="InstanceJob.TransitionKey"/> is in <paramref name="transitionKeys"/>, plus any
+    /// legacy rows (<see cref="JobType.Unknown"/>) for the transitional suffix-based fallback.
+    /// </summary>
+    Task<List<InstanceJob>> GetActiveForStateCancellationAsync(
+        Guid instanceId,
+        IReadOnlyCollection<JobType> matchTypes,
+        IReadOnlyCollection<string> transitionKeys,
+        CancellationToken cancellationToken = default);
+
     Task MarkAsProcessedAsync(Guid instanceId, string jobName, CancellationToken cancellationToken = default);
     Task<InstanceJob?> FindByJobIdAsReadOnlyAsync(Guid jobId, CancellationToken cancellationToken = default);
     Task<bool> AnyActiveByJobNameAsync(Guid instanceId, string jobName, CancellationToken cancellationToken = default);

--- a/src/BBT.Workflow.Domain/Instances/IInstanceJobRepository.cs
+++ b/src/BBT.Workflow.Domain/Instances/IInstanceJobRepository.cs
@@ -5,19 +5,6 @@ namespace BBT.Workflow.Instances;
 public interface IInstanceJobRepository : IRepository<InstanceJob, Guid>
 {
     Task<List<InstanceJob>> GetListActiveAsync(Guid instanceId, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Returns the active jobs that are candidates for state-scoped cancellation: structured rows
-    /// whose <see cref="InstanceJob.JobType"/> is one of <paramref name="matchTypes"/> and whose
-    /// <see cref="InstanceJob.TransitionKey"/> is in <paramref name="transitionKeys"/>, plus any
-    /// legacy rows (<see cref="JobType.Unknown"/>) for the transitional suffix-based fallback.
-    /// </summary>
-    Task<List<InstanceJob>> GetActiveForStateCancellationAsync(
-        Guid instanceId,
-        IReadOnlyCollection<JobType> matchTypes,
-        IReadOnlyCollection<string> transitionKeys,
-        CancellationToken cancellationToken = default);
-
     Task MarkAsProcessedAsync(Guid instanceId, string jobName, CancellationToken cancellationToken = default);
     Task<InstanceJob?> FindByJobIdAsReadOnlyAsync(Guid jobId, CancellationToken cancellationToken = default);
     Task<bool> AnyActiveByJobNameAsync(Guid instanceId, string jobName, CancellationToken cancellationToken = default);

--- a/src/BBT.Workflow.Domain/Instances/InstanceJob.cs
+++ b/src/BBT.Workflow.Domain/Instances/InstanceJob.cs
@@ -13,13 +13,16 @@ public class InstanceJob : Entity<Guid>, IHasCreatedAt, IHasModifyTime
 
     internal InstanceJob(
         Guid id,
-        string jobName,
+        JobName jobName,
         Guid jobId,
         string domain,
         string flowName,
         Guid instanceId) : base(id)
     {
-        JobName = Check.NotNullOrWhiteSpace(jobName, nameof(JobName), InstanceJobConstants.MaxJobNameLength);
+        ArgumentNullException.ThrowIfNull(jobName);
+        JobName = Check.NotNullOrWhiteSpace(jobName.Value, nameof(JobName), InstanceJobConstants.MaxJobNameLength);
+        JobType = jobName.Type;
+        TransitionKey = jobName.Segment;
         JobId = jobId;
         Domain = Check.NotNullOrWhiteSpace(domain, nameof(Domain), WorkflowConstants.MaxDomainLength);
         FlowName = Check.NotNullOrWhiteSpace(flowName, nameof(FlowName), WorkflowConstants.MaxFlowLength);
@@ -29,6 +32,16 @@ public class InstanceJob : Entity<Guid>, IHasCreatedAt, IHasModifyTime
     }
 
     public string JobName { get; private set; }
+
+    /// <summary>The job kind, projected from the structured <see cref="Instances.JobName"/> for queryable resolution.</summary>
+    public JobType JobType { get; private set; }
+
+    /// <summary>
+    /// The transition key (or well-known job key) this job targets, projected from the job name.
+    /// <c>null</c> for jobs without a targeted key (e.g. timeout) and for legacy rows.
+    /// </summary>
+    public string? TransitionKey { get; private set; }
+
     public Guid JobId { get; private set; }
     public string FlowName { get; private set; }
     public string Domain { get; private set; }
@@ -45,7 +58,7 @@ public class InstanceJob : Entity<Guid>, IHasCreatedAt, IHasModifyTime
 
     public static InstanceJob Create(
         Guid id,
-        string jobName,
+        JobName jobName,
         Guid jobId,
         string domain,
         string flowName,

--- a/src/BBT.Workflow.Domain/Instances/JobName.cs
+++ b/src/BBT.Workflow.Domain/Instances/JobName.cs
@@ -84,7 +84,7 @@ public sealed record JobName
             return false;
         }
 
-        const string expectedPrefix = Prefix + Delimiter; // "vnext.job.v1."
+        string expectedPrefix = Prefix + Delimiter; // "vnext.job.v1."
         if (!value.StartsWith(expectedPrefix, StringComparison.Ordinal))
         {
             return false;

--- a/src/BBT.Workflow.Domain/Instances/JobName.cs
+++ b/src/BBT.Workflow.Domain/Instances/JobName.cs
@@ -1,0 +1,211 @@
+using System.Text;
+using BBT.Workflow.Execution.LongPoll;
+
+namespace BBT.Workflow.Instances;
+
+/// <summary>
+/// Structured, resolvable identity for a Dapr background job.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Wire format: <c>vnext.job.v1.{type}.{instanceId}[.{segment}]</c>
+/// </para>
+/// <list type="bullet">
+///   <item>Delimiter is <c>.</c> — unreserved in URL path segments (RFC 3986), so it survives
+///   Dapr's scheduler / etcd-backed store unmodified. The classic URN <c>:</c> delimiter is
+///   intentionally avoided because Dapr job names are used in URL paths.</item>
+///   <item><c>vnext.job.v1</c> is a fixed namespace + format version so the parser can reject
+///   foreign / legacy names deterministically and the scheme can evolve.</item>
+///   <item><c>{type}</c> is a short controlled-vocabulary code (never free text) — see
+///   <see cref="JobType"/>. This is what distinguishes async vs scheduled transitions, which
+///   shared an identical name before this scheme.</item>
+///   <item><c>{instanceId}</c> is a GUID in "N" format (32 hex, no dashes).</item>
+///   <item><c>{segment}</c> is the optional, type-specific final segment (the transition key for
+///   transition jobs, the well-known key for long-poll-ack, absent for timeout). As the reserved
+///   final segment it is the only part allowed to carry arbitrary user input; it is Base64Url
+///   encoded (with a <c>~</c> marker) whenever it contains a character outside
+///   <c>[A-Za-z0-9_-]</c>, guaranteeing collision-free, reversible round-trips.</item>
+/// </list>
+/// </remarks>
+public sealed record JobName
+{
+    private const string Prefix = "vnext.job.v1";
+    private const char Delimiter = '.';
+    private const char EncodedMarker = '~';
+
+    private JobName(JobType type, Guid instanceId, string? segment, string value)
+    {
+        Type = type;
+        InstanceId = instanceId;
+        Segment = segment;
+        Value = value;
+    }
+
+    /// <summary>The job kind decoded from the name.</summary>
+    public JobType Type { get; }
+
+    /// <summary>The owning workflow instance id.</summary>
+    public Guid InstanceId { get; }
+
+    /// <summary>
+    /// The decoded final segment: the transition key for transition jobs, the well-known job key
+    /// for long-poll-ack, or <c>null</c> for timeout jobs.
+    /// </summary>
+    public string? Segment { get; }
+
+    /// <summary>The encoded wire string persisted as the Dapr job name and on the instance-job row.</summary>
+    public string Value { get; }
+
+    /// <summary>Builds the name of an async transition continuation job.</summary>
+    public static JobName ForAsyncTransition(Guid instanceId, string transitionKey)
+        => Build(JobType.AsyncTransition, instanceId, transitionKey);
+
+    /// <summary>Builds the name of a timer-based scheduled transition job.</summary>
+    public static JobName ForScheduledTransition(Guid instanceId, string transitionKey)
+        => Build(JobType.ScheduledTransition, instanceId, transitionKey);
+
+    /// <summary>Builds the name of a workflow timeout job.</summary>
+    public static JobName ForTimeout(Guid instanceId)
+        => Build(JobType.Timeout, instanceId, segment: null);
+
+    /// <summary>Builds the name of a long-poll acknowledge fallback job.</summary>
+    public static JobName ForLongPollAck(Guid instanceId)
+        => Build(JobType.LongPollAck, instanceId, LongPollAckConstants.JobKey);
+
+    /// <summary>
+    /// Attempts to parse a structured job name. Returns <c>false</c> for any value that does not
+    /// match the <c>vnext.job.v1</c> scheme (e.g. legacy names written before the rollout).
+    /// </summary>
+    public static bool TryParse(string? value, out JobName result)
+    {
+        result = null!;
+        if (string.IsNullOrEmpty(value))
+        {
+            return false;
+        }
+
+        const string expectedPrefix = Prefix + Delimiter; // "vnext.job.v1."
+        if (!value.StartsWith(expectedPrefix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        // Remaining: {type}.{instanceId}[.{segment}] — segment never contains the delimiter on
+        // the wire (it is encoded when it would), but split with a bound for defensiveness.
+        var parts = value[expectedPrefix.Length..].Split(Delimiter, 3);
+        if (parts.Length < 2)
+        {
+            return false;
+        }
+
+        var type = FromWireCode(parts[0]);
+        if (type == JobType.Unknown)
+        {
+            return false;
+        }
+
+        if (!Guid.TryParseExact(parts[1], "N", out var instanceId))
+        {
+            return false;
+        }
+
+        var segment = parts.Length == 3 ? Decode(parts[2]) : null;
+        result = new JobName(type, instanceId, segment, value);
+        return true;
+    }
+
+    /// <summary>Parses a structured job name or throws when the format is invalid.</summary>
+    public static JobName Parse(string value)
+        => TryParse(value, out var result)
+            ? result
+            : throw new FormatException($"Invalid job name format: '{value}'.");
+
+    /// <inheritdoc />
+    public override string ToString() => Value;
+
+    private static JobName Build(JobType type, Guid instanceId, string? segment)
+    {
+        var builder = new StringBuilder(Prefix)
+            .Append(Delimiter).Append(ToWireCode(type))
+            .Append(Delimiter).Append(instanceId.ToString("N"));
+
+        var decodedSegment = string.IsNullOrEmpty(segment) ? null : segment;
+        if (decodedSegment is not null)
+        {
+            builder.Append(Delimiter).Append(Encode(decodedSegment));
+        }
+
+        var value = builder.ToString();
+        if (value.Length > InstanceJobConstants.MaxJobNameLength)
+        {
+            throw new ArgumentException(
+                $"Job name length {value.Length} exceeds the maximum of {InstanceJobConstants.MaxJobNameLength}.",
+                nameof(segment));
+        }
+
+        return new JobName(type, instanceId, decodedSegment, value);
+    }
+
+    private static string ToWireCode(JobType type) => type switch
+    {
+        JobType.AsyncTransition => "tx",
+        JobType.ScheduledTransition => "sx",
+        JobType.Timeout => "to",
+        JobType.LongPollAck => "la",
+        _ => throw new ArgumentOutOfRangeException(nameof(type), type, "Unsupported job type.")
+    };
+
+    private static JobType FromWireCode(string code) => code switch
+    {
+        "tx" => JobType.AsyncTransition,
+        "sx" => JobType.ScheduledTransition,
+        "to" => JobType.Timeout,
+        "la" => JobType.LongPollAck,
+        _ => JobType.Unknown
+    };
+
+    private static string Encode(string raw)
+    {
+        if (IsUrlSafe(raw))
+        {
+            return raw;
+        }
+
+        var base64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(raw))
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+        return EncodedMarker + base64;
+    }
+
+    private static string Decode(string segment)
+    {
+        if (segment.Length == 0 || segment[0] != EncodedMarker)
+        {
+            return segment;
+        }
+
+        var base64 = segment[1..].Replace('-', '+').Replace('_', '/');
+        base64 += (base64.Length % 4) switch
+        {
+            2 => "==",
+            3 => "=",
+            _ => string.Empty
+        };
+        return Encoding.UTF8.GetString(Convert.FromBase64String(base64));
+    }
+
+    private static bool IsUrlSafe(string value)
+    {
+        foreach (var c in value)
+        {
+            var ok = c is (>= 'A' and <= 'Z') or (>= 'a' and <= 'z') or (>= '0' and <= '9') or '_' or '-';
+            if (!ok)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/BBT.Workflow.Domain/Instances/JobType.cs
+++ b/src/BBT.Workflow.Domain/Instances/JobType.cs
@@ -1,0 +1,25 @@
+namespace BBT.Workflow.Instances;
+
+/// <summary>
+/// Discriminates the kind of Dapr background job tracked by an <see cref="InstanceJob"/>.
+/// The value is persisted on the instance-job row and is also encoded (as a short, stable
+/// wire code) into the structured <see cref="JobName"/> so a job's purpose is resolvable
+/// from its name alone.
+/// </summary>
+public enum JobType
+{
+    /// <summary>Unrecognized / legacy job name written before the structured-name rollout.</summary>
+    Unknown = 0,
+
+    /// <summary>Async transition continuation (handler <c>flow.transition</c>).</summary>
+    AsyncTransition = 1,
+
+    /// <summary>Timer-based scheduled transition (handler <c>flow.transition.schedule</c>).</summary>
+    ScheduledTransition = 2,
+
+    /// <summary>Workflow timeout (handler <c>flow.timeout</c>).</summary>
+    Timeout = 3,
+
+    /// <summary>Long-poll acknowledge fallback (handler <c>longpoll.ack.timeout</c>).</summary>
+    LongPollAck = 4
+}

--- a/src/BBT.Workflow.Domain/Logging/WorkflowErrors.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowErrors.cs
@@ -362,11 +362,16 @@ public static class WorkflowErrors
     /// </summary>
     /// <param name="subFlowKey">The key of the SubFlow.</param>
     /// <param name="reason">The reason for the mapping failure.</param>
-    public static Error SubFlowInputMappingFailed(string subFlowKey, string reason)
+    /// <param name="stackTrace">
+    /// Optional exception stack trace carried in <see cref="Error.Detail"/> so the
+    /// post-commit fault path can record it on the instance incident. The SubFlow key
+    /// is already part of the message, so no diagnostic context is lost.
+    /// </param>
+    public static Error SubFlowInputMappingFailed(string subFlowKey, string reason, string? stackTrace = null)
         => Error.Failure(
             WorkflowErrorCodes.SubflowStartFailed,
             $"SubFlow '{subFlowKey}' input mapping failed: {reason}",
-            detail: subFlowKey);
+            detail: stackTrace ?? subFlowKey);
 
     /// <summary>
     /// Correlation not found for SubFlow start.

--- a/src/BBT.Workflow.Events.Contracts/Execution/Events/TransitionContinuationRequested.cs
+++ b/src/BBT.Workflow.Events.Contracts/Execution/Events/TransitionContinuationRequested.cs
@@ -38,6 +38,13 @@ public sealed class TransitionContinuationRequested : IDistributedEvent
     /// <summary>The deterministic job name (used for the active-job idempotency guard).</summary>
     public required string JobName { get; init; }
 
+    /// <summary>
+    /// The caller-generated job id. Threaded so the downstream enqueue uses the SAME id for
+    /// <c>BackgroundJobInfo.Id</c> as the upstream <c>InstanceJob.JobId</c> — keeping the two in sync
+    /// (no placeholder) so cancellation-by-id works across the outbox path.
+    /// </summary>
+    public required Guid JobId { get; init; }
+
     /// <summary>The transition payload data (JSON), if any.</summary>
     public JsonElement? Data { get; init; }
 

--- a/src/BBT.Workflow.Infrastructure/Data/InstancesModelCreatingExtensions.cs
+++ b/src/BBT.Workflow.Infrastructure/Data/InstancesModelCreatingExtensions.cs
@@ -428,6 +428,13 @@ public static class InstancesModelCreatingExtensions
                 .IsRequired()
                 .HasMaxLength(InstanceJobConstants.MaxJobNameLength);
 
+            b.Property(p => p.JobType)
+                .IsRequired()
+                .HasConversion<int>();
+
+            b.Property(p => p.TransitionKey)
+                .HasMaxLength(InstanceConstants.MaxKeyLength);
+
             b.Property(p => p.JobId)
                 .IsRequired();
 
@@ -450,6 +457,12 @@ public static class InstancesModelCreatingExtensions
             b.HasIndex(i => new { i.InstanceId, i.JobName })
                 .HasFilter("\"IsActive\" = true")
                 .HasDatabaseName("IX_InstanceJobs_Active_Instance_JobName");
+
+            // Supports GetActiveForStateCancellationAsync: filter active jobs by
+            // (InstanceId, JobType, TransitionKey). Partial on active rows to stay compact.
+            b.HasIndex(i => new { i.InstanceId, i.JobType, i.TransitionKey })
+                .HasFilter("\"IsActive\" = true")
+                .HasDatabaseName("IX_InstanceJobs_Active_Instance_Type_Key");
         });
     }
 }

--- a/src/BBT.Workflow.Infrastructure/Data/InstancesModelCreatingExtensions.cs
+++ b/src/BBT.Workflow.Infrastructure/Data/InstancesModelCreatingExtensions.cs
@@ -457,12 +457,6 @@ public static class InstancesModelCreatingExtensions
             b.HasIndex(i => new { i.InstanceId, i.JobName })
                 .HasFilter("\"IsActive\" = true")
                 .HasDatabaseName("IX_InstanceJobs_Active_Instance_JobName");
-
-            // Supports GetActiveForStateCancellationAsync: filter active jobs by
-            // (InstanceId, JobType, TransitionKey). Partial on active rows to stay compact.
-            b.HasIndex(i => new { i.InstanceId, i.JobType, i.TransitionKey })
-                .HasFilter("\"IsActive\" = true")
-                .HasDatabaseName("IX_InstanceJobs_Active_Instance_Type_Key");
         });
     }
 }

--- a/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceJobRepository.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceJobRepository.cs
@@ -18,6 +18,23 @@ public sealed class EfCoreInstanceJobRepository(
             .ToListAsync(cancellationToken);
     }
 
+    public async Task<List<InstanceJob>> GetActiveForStateCancellationAsync(
+        Guid instanceId,
+        IReadOnlyCollection<JobType> matchTypes,
+        IReadOnlyCollection<string> transitionKeys,
+        CancellationToken cancellationToken = default)
+    {
+        return await (await GetQueryableAsync())
+            .Where(j => j.InstanceId == instanceId && j.IsActive == true
+                && ((matchTypes.Contains(j.JobType)
+                        && j.TransitionKey != null
+                        && transitionKeys.Contains(j.TransitionKey))
+                    // Transitional fallback: legacy rows carry no structured columns; the service
+                    // matches them by the old "-{key}" suffix until none remain.
+                    || j.JobType == JobType.Unknown))
+            .ToListAsync(cancellationToken);
+    }
+
     public async Task MarkAsProcessedAsync(Guid instanceId, string jobName,
         CancellationToken cancellationToken = default)
     {

--- a/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceJobRepository.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceJobRepository.cs
@@ -18,23 +18,6 @@ public sealed class EfCoreInstanceJobRepository(
             .ToListAsync(cancellationToken);
     }
 
-    public async Task<List<InstanceJob>> GetActiveForStateCancellationAsync(
-        Guid instanceId,
-        IReadOnlyCollection<JobType> matchTypes,
-        IReadOnlyCollection<string> transitionKeys,
-        CancellationToken cancellationToken = default)
-    {
-        return await (await GetQueryableAsync())
-            .Where(j => j.InstanceId == instanceId && j.IsActive == true
-                && ((matchTypes.Contains(j.JobType)
-                        && j.TransitionKey != null
-                        && transitionKeys.Contains(j.TransitionKey))
-                    // Transitional fallback: legacy rows carry no structured columns; the service
-                    // matches them by the old "-{key}" suffix until none remain.
-                    || j.JobType == JobType.Unknown))
-            .ToListAsync(cancellationToken);
-    }
-
     public async Task MarkAsProcessedAsync(Guid instanceId, string jobName,
         CancellationToken cancellationToken = default)
     {

--- a/src/BBT.Workflow.Infrastructure/Migrations/20260618120000_AddInstanceJobStructuredColumns.Designer.cs
+++ b/src/BBT.Workflow.Infrastructure/Migrations/20260618120000_AddInstanceJobStructuredColumns.Designer.cs
@@ -518,10 +518,6 @@ namespace BBT.Workflow.Migrations
                         .HasDatabaseName("IX_InstanceJobs_Active_Instance_JobName")
                         .HasFilter("\"IsActive\" = true");
 
-                    b.HasIndex("InstanceId", "JobType", "TransitionKey")
-                        .HasDatabaseName("IX_InstanceJobs_Active_Instance_Type_Key")
-                        .HasFilter("\"IsActive\" = true");
-
                     b.ToTable("InstanceJobs", "public");
                 });
 

--- a/src/BBT.Workflow.Infrastructure/Migrations/20260618120000_AddInstanceJobStructuredColumns.Designer.cs
+++ b/src/BBT.Workflow.Infrastructure/Migrations/20260618120000_AddInstanceJobStructuredColumns.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using BBT.Workflow.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BBT.Workflow.Migrations
 {
     [DbContext(typeof(WorkflowDbContext))]
-    partial class WorkflowDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260618120000_AddInstanceJobStructuredColumns")]
+    partial class AddInstanceJobStructuredColumns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/BBT.Workflow.Infrastructure/Migrations/20260618120000_AddInstanceJobStructuredColumns.cs
+++ b/src/BBT.Workflow.Infrastructure/Migrations/20260618120000_AddInstanceJobStructuredColumns.cs
@@ -6,8 +6,7 @@ namespace BBT.Workflow.Migrations
 {
     /// <summary>
     /// Adds the structured projection columns <c>JobType</c> and <c>TransitionKey</c> to
-    /// <c>InstanceJobs</c>, plus a partial composite index supporting state-scoped job
-    /// cancellation (filter active jobs by <c>InstanceId</c> + <c>JobType</c> + <c>TransitionKey</c>).
+    /// <c>InstanceJobs</c>.
     ///
     /// <para>
     /// These columns project the structured <c>JobName</c> (URN-style: <c>vnext.job.v1.{type}.{instanceId}[.{segment}]</c>)
@@ -36,23 +35,11 @@ namespace BBT.Workflow.Migrations
                 type: "character varying(100)",
                 maxLength: 100,
                 nullable: true);
-
-            migrationBuilder.CreateIndex(
-                name: "IX_InstanceJobs_Active_Instance_Type_Key",
-                schema: "public",
-                table: "InstanceJobs",
-                columns: new[] { "InstanceId", "JobType", "TransitionKey" },
-                filter: "\"IsActive\" = true");
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropIndex(
-                name: "IX_InstanceJobs_Active_Instance_Type_Key",
-                schema: "public",
-                table: "InstanceJobs");
-
             migrationBuilder.DropColumn(
                 name: "JobType",
                 schema: "public",

--- a/src/BBT.Workflow.Infrastructure/Migrations/20260618120000_AddInstanceJobStructuredColumns.cs
+++ b/src/BBT.Workflow.Infrastructure/Migrations/20260618120000_AddInstanceJobStructuredColumns.cs
@@ -1,0 +1,67 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BBT.Workflow.Migrations
+{
+    /// <summary>
+    /// Adds the structured projection columns <c>JobType</c> and <c>TransitionKey</c> to
+    /// <c>InstanceJobs</c>, plus a partial composite index supporting state-scoped job
+    /// cancellation (filter active jobs by <c>InstanceId</c> + <c>JobType</c> + <c>TransitionKey</c>).
+    ///
+    /// <para>
+    /// These columns project the structured <c>JobName</c> (URN-style: <c>vnext.job.v1.{type}.{instanceId}[.{segment}]</c>)
+    /// so cancellation/resolution no longer depends on fragile job-name suffix parsing.
+    /// Existing rows are backfilled with <c>JobType = 0</c> (Unknown) and a null transition key;
+    /// the cancellation service keeps a transitional suffix-based fallback for those legacy rows.
+    /// </para>
+    /// </summary>
+    public partial class AddInstanceJobStructuredColumns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "JobType",
+                schema: "public",
+                table: "InstanceJobs",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "TransitionKey",
+                schema: "public",
+                table: "InstanceJobs",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InstanceJobs_Active_Instance_Type_Key",
+                schema: "public",
+                table: "InstanceJobs",
+                columns: new[] { "InstanceId", "JobType", "TransitionKey" },
+                filter: "\"IsActive\" = true");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_InstanceJobs_Active_Instance_Type_Key",
+                schema: "public",
+                table: "InstanceJobs");
+
+            migrationBuilder.DropColumn(
+                name: "JobType",
+                schema: "public",
+                table: "InstanceJobs");
+
+            migrationBuilder.DropColumn(
+                name: "TransitionKey",
+                schema: "public",
+                table: "InstanceJobs");
+        }
+    }
+}

--- a/src/BBT.Workflow.Infrastructure/Migrations/WorkflowDbContextModelSnapshot.cs
+++ b/src/BBT.Workflow.Infrastructure/Migrations/WorkflowDbContextModelSnapshot.cs
@@ -515,10 +515,6 @@ namespace BBT.Workflow.Migrations
                         .HasDatabaseName("IX_InstanceJobs_Active_Instance_JobName")
                         .HasFilter("\"IsActive\" = true");
 
-                    b.HasIndex("InstanceId", "JobType", "TransitionKey")
-                        .HasDatabaseName("IX_InstanceJobs_Active_Instance_Type_Key")
-                        .HasFilter("\"IsActive\" = true");
-
                     b.ToTable("InstanceJobs", "public");
                 });
 

--- a/test/BBT.Workflow.Application.Tests/Execution/PostCommit/PostCommitExecutorTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/PostCommit/PostCommitExecutorTests.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.Results;
+using BBT.Workflow.Execution;
+using BBT.Workflow.Execution.PostCommit;
+using BBT.Workflow.Instances;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Application.Tests.Execution.PostCommit;
+
+/// <summary>
+/// Unit tests for PostCommitExecutor.
+/// Focuses on how handler failures are surfaced as fault requests, including the
+/// propagation of the originating error's detail (stack trace) into the fault request.
+/// </summary>
+public class PostCommitExecutorTests
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IPostCommitIdempotencyStore _idempotencyStore;
+    private readonly PostCommitExecutor _executor;
+
+    public PostCommitExecutorTests()
+    {
+        _serviceProvider = Substitute.For<IServiceProvider>();
+        var scope = Substitute.For<IServiceScope>();
+        scope.ServiceProvider.Returns(_serviceProvider);
+        _scopeFactory = Substitute.For<IServiceScopeFactory>();
+        _scopeFactory.CreateScope().Returns(scope);
+
+        _idempotencyStore = Substitute.For<IPostCommitIdempotencyStore>();
+
+        _executor = new PostCommitExecutor(
+            _scopeFactory,
+            new DefaultPostCommitFailurePolicy(),
+            _idempotencyStore,
+            Substitute.For<ILogger<PostCommitExecutor>>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenHandlerFaultsWithStackTraceDetail_ShouldPropagateStackTraceToFaultRequest()
+    {
+        // Arrange — a system error (faulting) whose Detail carries the exception stack trace,
+        // mirroring SubFlowInputMappingFailed capturing ex.StackTrace in Error.Detail.
+        const string stackTrace = "   at SubFlowMapping.InputHandler(ScriptContext ctx)";
+        var error = Error.Failure(
+            "Instance:100023",
+            "SubFlow 'credit-bureau-inquiry' input mapping failed: " +
+            "'System.Dynamic.ExpandoObject' does not contain a definition for 'application'",
+            detail: stackTrace);
+
+        var handler = Substitute.For<IPostCommitHandler<TestJob>>();
+        handler.HandleAsync(Arg.Any<TestJob>(), Arg.Any<TransitionExecutionContext>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Fail(error));
+        _serviceProvider.GetService(typeof(IPostCommitHandler<TestJob>)).Returns(handler);
+
+        var context = CreateContext();
+
+        // Act
+        var result = await _executor.ExecuteAsync(new IPostCommitJob[] { new TestJob() }, context, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeFalse();
+        result.FaultRequest.ShouldNotBeNull();
+        result.FaultRequest!.ErrorCode.ShouldBe("Instance:100023");
+        result.FaultRequest.StackTrace.ShouldBe(stackTrace);
+    }
+
+    private static TransitionExecutionContext CreateContext()
+    {
+        var instanceId = Guid.NewGuid();
+        var instance = Instance.Create(instanceId, "test-workflow", "1.0.0", "test-key");
+
+        return new TransitionExecutionContext
+        {
+            InstanceId = instanceId,
+            Instance = instance,
+            Workflow = CreateMockWorkflow("test-workflow", "test-domain"),
+            Domain = "test-domain",
+            WorkflowKey = "test-workflow",
+            TransitionKey = "test-transition"
+        };
+    }
+
+    private static Definitions.Workflow CreateMockWorkflow(string key, string domain)
+    {
+        var json = """
+        {
+            "type": "F",
+            "timeout": null,
+            "labels": [],
+            "functions": [],
+            "features": [],
+            "states": [
+                {
+                    "key": "state1",
+                    "type": "P",
+                    "transitions": []
+                }
+            ],
+            "sharedTransitions": [],
+            "extensions": [],
+            "startTransition": {"key": "start", "from": null, "target": "state1", "triggerType": "Manual", "versionStrategy": "Patch", "labels": [], "onExecutionTasks": [], "view": null}
+        }
+        """;
+
+        var options = new System.Text.Json.JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+        };
+        var workflow = System.Text.Json.JsonSerializer.Deserialize<Definitions.Workflow>(json, options)!;
+
+        workflow.SetReference(new Reference(key, domain, "sys-flows", "1.0.0"));
+        return workflow;
+    }
+
+    /// <summary>
+    /// Minimal non-idempotent post-commit job used to drive the executor without
+    /// touching the idempotency store.
+    /// </summary>
+    public sealed record TestJob : IPostCommitJob;
+}

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Continuations/EnqueueContinuationStrategyTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Continuations/EnqueueContinuationStrategyTests.cs
@@ -52,6 +52,19 @@ public class EnqueueContinuationStrategyTests
         var strategy = CreateStrategy(directEnqueue: true);
         var context = CreateContextWithNextTransition("approve");
 
+        // Capture the InstanceJob intent and the jobId passed to the enqueuer to prove they match.
+        InstanceJob? insertedJob = null;
+        _jobRepository
+            .Setup(x => x.InsertAsync(It.IsAny<InstanceJob>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .Callback<InstanceJob, bool, CancellationToken>((j, _, _) => insertedJob = j)
+            .ReturnsAsync((InstanceJob j, bool _, CancellationToken _) => j);
+
+        Guid enqueuedJobId = Guid.Empty;
+        _jobEnqueuer
+            .Setup(x => x.EnqueueAsync(It.IsAny<TransitionJobPayload>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Callback<TransitionJobPayload, Guid, CancellationToken>((_, id, _) => enqueuedJobId = id)
+            .Returns(Task.CompletedTask);
+
         var result = await strategy.DispatchAsync(context, CancellationToken.None);
 
         result.IsSuccess.ShouldBeTrue();
@@ -63,8 +76,16 @@ public class EnqueueContinuationStrategyTests
                     p.TransitionKey == "approve"
                     && p.InstanceId == context.InstanceId
                     && p.ExecutionActor == ExecutionActor.System),
+                It.IsAny<Guid>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
+
+        // JobId consistency: the InstanceJob intent carries the SAME id passed to the enqueuer
+        // (no placeholder), so cancellation-by-id resolves the BackgroundJobInfo.
+        insertedJob.ShouldNotBeNull();
+        enqueuedJobId.ShouldNotBe(Guid.Empty);
+        insertedJob!.JobId.ShouldBe(enqueuedJobId);
+        insertedJob.Id.ShouldBe(enqueuedJobId);
 
         _eventBus.Verify(
             x => x.PublishAsync(
@@ -86,7 +107,7 @@ public class EnqueueContinuationStrategyTests
         var context = CreateContextWithNextTransition("approve");
 
         _jobEnqueuer
-            .Setup(x => x.EnqueueAsync(It.IsAny<TransitionJobPayload>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.EnqueueAsync(It.IsAny<TransitionJobPayload>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("Dapr unavailable"));
 
         var result = await strategy.DispatchAsync(context, CancellationToken.None);
@@ -95,7 +116,7 @@ public class EnqueueContinuationStrategyTests
         result.Value.ShouldBeNull();
 
         _jobEnqueuer.Verify(
-            x => x.EnqueueAsync(It.IsAny<TransitionJobPayload>(), It.IsAny<CancellationToken>()),
+            x => x.EnqueueAsync(It.IsAny<TransitionJobPayload>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         _eventBus.Verify(
@@ -119,7 +140,7 @@ public class EnqueueContinuationStrategyTests
         result.Value.ShouldBeNull();
 
         _jobEnqueuer.Verify(
-            x => x.EnqueueAsync(It.IsAny<TransitionJobPayload>(), It.IsAny<CancellationToken>()),
+            x => x.EnqueueAsync(It.IsAny<TransitionJobPayload>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
             Times.Never);
 
         _eventBus.Verify(
@@ -146,7 +167,7 @@ public class EnqueueContinuationStrategyTests
             x => x.InsertAsync(It.IsAny<InstanceJob>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
             Times.Never);
         _jobEnqueuer.Verify(
-            x => x.EnqueueAsync(It.IsAny<TransitionJobPayload>(), It.IsAny<CancellationToken>()),
+            x => x.EnqueueAsync(It.IsAny<TransitionJobPayload>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
             Times.Never);
         _eventBus.Verify(
             x => x.PublishAsync(

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/Steps/HandleLongPollTerminationStepTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/Steps/HandleLongPollTerminationStepTests.cs
@@ -42,6 +42,7 @@ public class HandleLongPollTerminationStepTests
         _jobService.EnqueueAsync(
                 Arg.Any<string>(), Arg.Any<string>(), Arg.Any<LongPollAckTimeoutPayload>(),
                 Arg.Any<string>(), Arg.Any<Dictionary<string, object>>(),
+                useAmbientUnitOfWork: Arg.Any<bool>(),
                 cancellationToken: Arg.Any<CancellationToken>())
             .Returns(Guid.NewGuid());
         _guidGenerator.Create().Returns(Guid.NewGuid());
@@ -90,6 +91,7 @@ public class HandleLongPollTerminationStepTests
         await _jobService.Received(1).EnqueueAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<LongPollAckTimeoutPayload>(),
             Arg.Any<string>(), Arg.Any<Dictionary<string, object>>(),
+            useAmbientUnitOfWork: true,
             cancellationToken: Arg.Any<CancellationToken>());
         await _jobRepository.Received(1).InsertAsync(Arg.Any<InstanceJob>(), true, Arg.Any<CancellationToken>());
     }

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/TransitionPipelineTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/TransitionPipelineTests.cs
@@ -483,6 +483,47 @@ public class TransitionPipelineTests
     }
 
     [Fact]
+    public async Task RunAsync_WhenPostCommitFaults_ShouldRecordIncidentAndFaultInstance()
+    {
+        // Arrange
+        var context = CreateTransitionExecutionContext();
+        var workflowContext = CreateWorkflowExecutionContext(context);
+
+        SetupContextFactory(context);
+        SetupStepsToSucceed();
+
+        // Queue a post-commit job so the executor is invoked.
+        context.Directives.EnqueuePostCommit(Substitute.For<IPostCommitJob>());
+
+        // Simulate a subflow input-mapping failure that the failure policy classifies
+        // as a system error (Instance:* prefix) -> ShouldMarkInstanceFaulted.
+        var error = Error.Failure(
+            "Instance:100023",
+            "SubFlow 'credit-bureau-inquiry' input mapping failed: " +
+            "'System.Dynamic.ExpandoObject' does not contain a definition for 'application'");
+
+        _mockPostCommitExecutor.ExecuteAsync(
+            Arg.Any<IReadOnlyList<IPostCommitJob>>(),
+            Arg.Any<TransitionExecutionContext>(),
+            Arg.Any<CancellationToken>())
+            .Returns(PostCommitResult.Fail(
+                error,
+                new PostCommitFaultRequest(error.Code, error.Message, "   at SubFlowMapping.InputHandler()")));
+
+        // Act
+        var result = await _pipeline.RunAsync(workflowContext, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        context.Instance.HasActiveIncident.ShouldBeTrue();
+        await _mockInstanceRepository.Received(1)
+            .UpdateAsync(
+                Arg.Is<Instance>(x => x.Status.Equals(InstanceStatus.Faulted) && x.HasActiveIncident),
+                true,
+                Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task RunAsync_WhenStepReturnsStop_ShouldStopPipeline()
     {
         // Arrange

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Strategy/AsyncTransitionStrategyTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Strategy/AsyncTransitionStrategyTests.cs
@@ -114,7 +114,7 @@ public class AsyncTransitionStrategyTests
         _mockBackgroundJobService.Verify(
             x => x.EnqueueAsync(
                 TransitionJobHandler.HandlerName,
-                It.Is<string>(id => id.StartsWith($"trans-{workflowContext.InstanceId}")),
+                It.Is<string>(id => id.StartsWith($"vnext.job.v1.tx.{workflowContext.InstanceId:N}")),
                 It.IsAny<TransitionJobPayload>(),
                 It.IsAny<string>(),
                 It.IsAny<Dictionary<string, object>>(),

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Strategy/AsyncTransitionStrategyTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Strategy/AsyncTransitionStrategyTests.cs
@@ -119,6 +119,8 @@ public class AsyncTransitionStrategyTests
                 It.IsAny<string>(),
                 It.IsAny<Dictionary<string, object>>(),
                 It.IsAny<JobScheduleFailurePolicy?>(),
+                It.IsAny<bool>(),
+                It.IsAny<Guid?>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -141,9 +143,11 @@ public class AsyncTransitionStrategyTests
                 It.IsAny<string>(),
                 It.IsAny<Dictionary<string, object>>(),
                 It.IsAny<JobScheduleFailurePolicy?>(),
+                It.IsAny<bool>(),
+                It.IsAny<Guid?>(),
                 It.IsAny<CancellationToken>()))
-            .Callback<string, string, TransitionJobPayload, string, Dictionary<string, object>, JobScheduleFailurePolicy?, CancellationToken>(
-                (_, _, payload, _, _, _, _) => capturedPayload = payload)
+            .Callback<string, string, TransitionJobPayload, string, Dictionary<string, object>, JobScheduleFailurePolicy?, bool, Guid?, CancellationToken>(
+                (_, _, payload, _, _, _, _, _, _) => capturedPayload = payload)
             .ReturnsAsync(It.IsAny<Guid>());
 
         // Act
@@ -177,9 +181,11 @@ public class AsyncTransitionStrategyTests
                 It.IsAny<string>(),
                 It.IsAny<Dictionary<string, object>>(),
                 It.IsAny<JobScheduleFailurePolicy?>(),
+                It.IsAny<bool>(),
+                It.IsAny<Guid?>(),
                 It.IsAny<CancellationToken>()))
-            .Callback<string, string, TransitionJobPayload, string, Dictionary<string, object>, JobScheduleFailurePolicy?, CancellationToken>(
-                (_, _, _, _, metadata, _, _) => capturedMetadata = metadata)
+            .Callback<string, string, TransitionJobPayload, string, Dictionary<string, object>, JobScheduleFailurePolicy?, bool, Guid?, CancellationToken>(
+                (_, _, _, _, metadata, _, _, _, _) => capturedMetadata = metadata)
             .ReturnsAsync(It.IsAny<Guid>());
 
         // Act
@@ -213,9 +219,11 @@ public class AsyncTransitionStrategyTests
                 It.IsAny<string>(),
                 It.IsAny<Dictionary<string, object>>(),
                 It.IsAny<JobScheduleFailurePolicy?>(),
+                It.IsAny<bool>(),
+                It.IsAny<Guid?>(),
                 It.IsAny<CancellationToken>()))
-            .Callback<string, string, TransitionJobPayload, string, Dictionary<string, object>, JobScheduleFailurePolicy?, CancellationToken>(
-                (_, jobId, _, _, _, _, _) => jobIds.Add(jobId))
+            .Callback<string, string, TransitionJobPayload, string, Dictionary<string, object>, JobScheduleFailurePolicy?, bool, Guid?, CancellationToken>(
+                (_, jobId, _, _, _, _, _, _, _) => jobIds.Add(jobId))
             .ReturnsAsync(It.IsAny<Guid>());
 
         await _strategy.ExecuteAsync(workflowContextOne, CancellationToken.None);
@@ -251,6 +259,8 @@ public class AsyncTransitionStrategyTests
                 It.IsAny<string>(),
                 It.IsAny<Dictionary<string, object>>(),
                 It.IsAny<JobScheduleFailurePolicy?>(),
+                It.IsAny<bool>(),
+                It.IsAny<Guid?>(),
                 It.IsAny<CancellationToken>()),
             Times.Never);
     }
@@ -274,6 +284,8 @@ public class AsyncTransitionStrategyTests
                 It.IsAny<string>(),
                 It.IsAny<Dictionary<string, object>>(),
                 It.IsAny<JobScheduleFailurePolicy?>(),
+                It.IsAny<bool>(),
+                It.IsAny<Guid?>(),
                 It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("Job service unavailable"));
 
@@ -303,9 +315,11 @@ public class AsyncTransitionStrategyTests
                 It.IsAny<string>(),
                 It.IsAny<Dictionary<string, object>>(),
                 It.IsAny<JobScheduleFailurePolicy?>(),
+                It.IsAny<bool>(),
+                It.IsAny<Guid?>(),
                 It.IsAny<CancellationToken>()))
-            .Callback<string, string, TransitionJobPayload, string, Dictionary<string, object>, JobScheduleFailurePolicy?, CancellationToken>(
-                (_, _, _, schedule, _, _, _) => capturedSchedule = schedule)
+            .Callback<string, string, TransitionJobPayload, string, Dictionary<string, object>, JobScheduleFailurePolicy?, bool, Guid?, CancellationToken>(
+                (_, _, _, schedule, _, _, _, _, _) => capturedSchedule = schedule)
             .ReturnsAsync(It.IsAny<Guid>());
 
         // Act
@@ -335,6 +349,8 @@ public class AsyncTransitionStrategyTests
                 It.IsAny<string>(),
                 It.IsAny<Dictionary<string, object>>(),
                 It.IsAny<JobScheduleFailurePolicy?>(),
+                It.IsAny<bool>(),
+                It.IsAny<Guid?>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -381,9 +397,11 @@ public class AsyncTransitionStrategyTests
                 It.IsAny<string>(),
                 It.IsAny<Dictionary<string, object>>(),
                 It.IsAny<JobScheduleFailurePolicy?>(),
+                It.IsAny<bool>(),
+                It.IsAny<Guid?>(),
                 It.IsAny<CancellationToken>()))
-            .Callback<string, string, TransitionJobPayload, string, Dictionary<string, object>, JobScheduleFailurePolicy?, CancellationToken>(
-                (_, _, payload, _, _, _, _) => capturedPayload = payload)
+            .Callback<string, string, TransitionJobPayload, string, Dictionary<string, object>, JobScheduleFailurePolicy?, bool, Guid?, CancellationToken>(
+                (_, _, payload, _, _, _, _, _, _) => capturedPayload = payload)
             .ReturnsAsync(It.IsAny<Guid>());
 
         // Act
@@ -486,6 +504,8 @@ public class AsyncTransitionStrategyTests
                 It.IsAny<string>(),
                 It.IsAny<Dictionary<string, object>>(),
                 It.IsAny<JobScheduleFailurePolicy?>(),
+                It.IsAny<bool>(),
+                It.IsAny<Guid?>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -569,6 +589,8 @@ public class AsyncTransitionStrategyTests
                 It.IsAny<string>(),
                 It.IsAny<Dictionary<string, object>>(),
                 It.IsAny<JobScheduleFailurePolicy?>(),
+                It.IsAny<bool>(),
+                It.IsAny<Guid?>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(It.IsAny<Guid>());
 
@@ -628,6 +650,8 @@ public class AsyncTransitionStrategyTests
                 It.IsAny<string>(),
                 It.IsAny<Dictionary<string, object>>(),
                 It.IsAny<JobScheduleFailurePolicy?>(),
+                It.IsAny<bool>(),
+                It.IsAny<Guid?>(),
                 It.IsAny<CancellationToken>()),
             Times.Never);
 

--- a/test/BBT.Workflow.Domain.Tests/Instances/JobNameTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Instances/JobNameTests.cs
@@ -1,0 +1,118 @@
+using System;
+using BBT.Workflow.Execution.LongPoll;
+using Xunit;
+
+namespace BBT.Workflow.Instances;
+
+/// <summary>
+/// Unit tests for the structured <see cref="JobName"/> value object: builder/parser round-trips,
+/// segment encoding collision cases, job-type distinctness, and legacy-name rejection.
+/// </summary>
+public class JobNameTests
+{
+    private static readonly Guid Instance = Guid.Parse("550e8400-e29b-41d4-a716-446655440000");
+
+    [Fact]
+    public void ForAsyncTransition_ShouldRoundTrip()
+    {
+        var jobName = JobName.ForAsyncTransition(Instance, "approve");
+
+        Assert.Equal("vnext.job.v1.tx.550e8400e29b41d4a716446655440000.approve", jobName.Value);
+
+        Assert.True(JobName.TryParse(jobName.Value, out var parsed));
+        Assert.Equal(JobType.AsyncTransition, parsed.Type);
+        Assert.Equal(Instance, parsed.InstanceId);
+        Assert.Equal("approve", parsed.Segment);
+    }
+
+    [Fact]
+    public void ForScheduledTransition_ShouldUseDistinctTypeCode()
+    {
+        var jobName = JobName.ForScheduledTransition(Instance, "approve");
+
+        Assert.StartsWith("vnext.job.v1.sx.", jobName.Value);
+        Assert.Equal(JobType.ScheduledTransition, JobName.Parse(jobName.Value).Type);
+    }
+
+    [Fact]
+    public void Async_And_Scheduled_ForSameInstanceAndKey_ShouldDiffer()
+    {
+        var async = JobName.ForAsyncTransition(Instance, "approve");
+        var scheduled = JobName.ForScheduledTransition(Instance, "approve");
+
+        Assert.NotEqual(async.Value, scheduled.Value);
+        Assert.NotEqual(JobName.Parse(async.Value).Type, JobName.Parse(scheduled.Value).Type);
+    }
+
+    [Fact]
+    public void ForTimeout_ShouldHaveNoSegment()
+    {
+        var jobName = JobName.ForTimeout(Instance);
+
+        Assert.Equal("vnext.job.v1.to.550e8400e29b41d4a716446655440000", jobName.Value);
+
+        Assert.True(JobName.TryParse(jobName.Value, out var parsed));
+        Assert.Equal(JobType.Timeout, parsed.Type);
+        Assert.Null(parsed.Segment);
+    }
+
+    [Fact]
+    public void ForLongPollAck_ShouldCarryWellKnownKey()
+    {
+        var jobName = JobName.ForLongPollAck(Instance);
+
+        Assert.True(JobName.TryParse(jobName.Value, out var parsed));
+        Assert.Equal(JobType.LongPollAck, parsed.Type);
+        Assert.Equal(LongPollAckConstants.JobKey, parsed.Segment);
+    }
+
+    [Theory]
+    [InlineData("approve")]
+    [InlineData("go-back")]               // hyphen — the original suffix-match bug case
+    [InlineData("step_1")]
+    [InlineData("a.b.c")]                 // dots — would collide with the delimiter if not encoded
+    [InlineData("with:colon")]
+    [InlineData("with space")]
+    [InlineData("son-aşama")]             // non-ascii
+    [InlineData("emoji-🚀-key")]
+    [InlineData("-leading")]
+    [InlineData("trailing-")]
+    public void Segment_ShouldRoundTripForArbitraryKeys(string key)
+    {
+        var jobName = JobName.ForAsyncTransition(Instance, key);
+
+        Assert.True(JobName.TryParse(jobName.Value, out var parsed));
+        Assert.Equal(key, parsed.Segment);
+        Assert.Equal(JobType.AsyncTransition, parsed.Type);
+        Assert.Equal(Instance, parsed.InstanceId);
+    }
+
+    [Fact]
+    public void Build_ShouldStayWithinMaxLength_ForMaxKey()
+    {
+        var key = new string('x', 100); // WorkflowConstants.MaxKeyLength
+        var jobName = JobName.ForScheduledTransition(Instance, key);
+
+        Assert.True(jobName.Value.Length <= InstanceJobConstants.MaxJobNameLength);
+    }
+
+    [Theory]
+    [InlineData("trans-550e8400-e29b-41d4-a716-446655440000-approve")]
+    [InlineData("timeout-550e8400-e29b-41d4-a716-446655440000")]
+    [InlineData("lpack-550e8400-e29b-41d4-a716-446655440000-longpoll-ack")]
+    [InlineData("")]
+    [InlineData(null)]
+    [InlineData("vnext.job.v1.zz.550e8400e29b41d4a716446655440000")]   // unknown type code
+    [InlineData("vnext.job.v1.tx.not-a-guid.approve")]                 // bad instance id
+    [InlineData("garbage")]
+    public void TryParse_ShouldRejectLegacyAndInvalidNames(string? value)
+    {
+        Assert.False(JobName.TryParse(value, out _));
+    }
+
+    [Fact]
+    public void Parse_ShouldThrow_OnInvalidName()
+    {
+        Assert.Throws<FormatException>(() => JobName.Parse("trans-abc-go"));
+    }
+}


### PR DESCRIPTION
## Summary
- Redesign async-transition execution onto a per-transition Dapr job model with structured, URN-style job names (`vnext.job.v1.…`) that resolve type/key, so scheduled transitions and cancellations target a single deterministic job.
- Persist structured `InstanceJob` columns (job id/type/key) and reuse one caller-generated job id end-to-end so `BackgroundJobInfo.Id` matches the durable `InstanceJob.JobId` intent — making cancellation-by-id reliable across the outbox path.
- Fix: record an instance incident (with the mapping exception stack trace) when a post-commit subflow/subprocess start fails, instead of faulting silently.

## Changes
- **Job model**: `JobName`, `JobType`, `InstanceJob` structured columns + EF migration `AddInstanceJobStructuredColumns`; `ITransitionJobEnqueuer`/`TransitionJobEnqueuer`, `AsyncTransitionStrategy`, `EnqueueContinuationStrategy`, `TransitionContinuationRequested.JobId`.
- **Cancellation**: `InstanceCancellationService`, `ScheduleTransitionsStep`, long-poll termination handling.
- **Subflow incident**: `TransitionPipeline.MarkInstanceFaultedFromPostCommitAsync`, `PostCommitExecutor`, `PostCommitResult.PostCommitFaultRequest`, `SubflowStarter`, `WorkflowErrors.SubFlowInputMappingFailed`.
- **Deps**: Aether `1.0.26` → `1.0.27`.
- **Tests**: `JobNameTests`, `PostCommitExecutorTests`, plus updates to `AsyncTransitionStrategyTests`, `EnqueueContinuationStrategyTests`, `TransitionPipelineTests`, `HandleLongPollTerminationStepTests`.

## Test Plan
- [ ] `dotnet test` — new `JobNameTests`, `PostCommitExecutorTests`, and updated suites green
- [ ] Start an async transition; verify the Dapr job id equals the persisted `InstanceJob.JobId`
- [ ] Cancel an instance with a scheduled transition; verify cancellation-by-id removes the job
- [ ] Trigger a subflow whose input mapping throws; verify the instance faults **and** an incident with stack trace is recorded

## Notes
- Includes an EF Core migration (`AddInstanceJobStructuredColumns`) — runs via DbMigrator on deploy.
- Pre-existing unrelated test failures exist on this branch (job-handoff WIP); the subflow-incident commit adds only passing tests and changes no failure counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce structured, per-transition job naming and tracking for Dapr-backed workflow jobs to make scheduling, resolution, and cancellation-by-id deterministic and to surface post-commit subflow failures as instance incidents with stack traces.

New Features:
- Add structured JobName/JobType model and wire it through async, scheduled, timeout, and long-poll jobs so each transition targets a deterministic, parseable job identity.
- Propagate a single caller-generated job id through InstanceJob, transition continuations, and Dapr enqueues so durable intent and background job identifiers stay aligned for reliable cancellation-by-id.

Bug Fixes:
- Record an instance incident and fault the instance when post-commit subflow input mapping fails, including the originating exception stack trace.
- Fix state-transition cancellation to match jobs by structured TransitionKey (with legacy suffix fallback) instead of brittle job-name suffix parsing.

Enhancements:
- Extend InstanceJob with JobType and TransitionKey projections and map them via EF so job queries and cancellation logic can resolve job purpose and targeted transition without parsing job names.
- Update async transition and continuation strategies to build payloads and job records from the new JobName abstraction and to use ambient transactions where appropriate for enqueue operations.
- Enhance post-commit execution to carry error details into PostCommitFaultRequest so the transition pipeline can create richer incidents on post-commit faults.
- Refine long-poll termination and workflow timeout scheduling to use structured JobName values and ambient unit-of-work enqueues for consistency with other jobs.

Build:
- Add EF Core migration AddInstanceJobStructuredColumns and update model snapshot to persist JobType and TransitionKey on InstanceJobs.

Documentation:
- Clarify XML docs and comments around job naming, job types, long-poll acknowledge semantics, and subflow mapping error handling to reflect the new structured model.

Tests:
- Add JobNameTests to validate structured job-name construction, parsing, and encoding semantics.
- Add PostCommitExecutorTests to verify that handler failures propagate stack traces into fault requests and result handling.
- Update transition strategy, continuation strategy, pipeline, and long-poll termination tests to cover the new job-id threading, JobName usage, and enqueue signatures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured job tracking for improved reliability in background task management and cancellation operations.
  * Enhanced incident recording for workflow failures with better error context and diagnostics.

* **Bug Fixes**
  * Improved job identification accuracy for more reliable task management.
  * Enhanced error diagnostics with stack trace capture for better issue visibility.

* **Chores**
  * Updated package version to 1.0.27.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->