### PR TITLE
Fix I i Problem

### DIFF
--- a/src/BBT.Workflow.Domain/QueryExtensions/GraphQL/GraphQLJsonFilterService.cs
+++ b/src/BBT.Workflow.Domain/QueryExtensions/GraphQL/GraphQLJsonFilterService.cs
@@ -447,7 +447,11 @@ public static class GraphQLJsonFilterService
         {
             try
             {
-                var stringValue = ConvertToString(value);
+                // Array-valued operators (in, nin, between) arrive as object[] from the JSON
+                // filter syntax. InstanceColumnConditionBuilder expects a comma-separated
+                // string, so flatten the array element-by-element instead of calling
+                // ConvertToString on the array itself (which would yield "System.Object[]").
+                var stringValue = ConvertOperatorValueToString(value);
                 var (conditionSql, conditionParams) = InstanceColumnConditionBuilder.BuildCondition(
                     columnName, op, stringValue, ref parameterIndex);
                 
@@ -775,6 +779,22 @@ public static class GraphQLJsonFilterService
         };
     }
 
+    /// <summary>
+    /// Converts an operator value to the string form expected by
+    /// <see cref="InstanceColumnConditionBuilder"/>. Array values (used by in/nin/between)
+    /// are flattened to a comma-separated string by converting each element individually;
+    /// scalar values fall back to <see cref="ConvertToString"/>.
+    /// </summary>
+    private static string ConvertOperatorValueToString(object? value)
+    {
+        if (value is object[] array)
+        {
+            return string.Join(",", array.Select(ConvertToString));
+        }
+
+        return ConvertToString(value);
+    }
+
     private static string BuildEqualsCondition(
         string field, object? value, string jsonColumnName,
         List<NpgsqlParameter> parameters, ref int parameterIndex)
@@ -997,7 +1017,7 @@ public static class GraphQLJsonFilterService
         parameters.Add(new NpgsqlParameter { Value = $"%{stringValue}%" });
 
         var accessor = BuildJsonTextAccessor(field, jsonColumnName);
-        return $"{accessor} ILIKE {{{paramIndex}}}";
+        return $"{accessor} COLLATE \"tr-TR-x-icu\" ILIKE {{{paramIndex}}}";
     }
 
     private static string BuildStartsWithCondition(
@@ -1009,7 +1029,7 @@ public static class GraphQLJsonFilterService
         parameters.Add(new NpgsqlParameter { Value = $"{stringValue}%" });
 
         var accessor = BuildJsonTextAccessor(field, jsonColumnName);
-        return $"{accessor} ILIKE {{{paramIndex}}}";
+        return $"{accessor} COLLATE \"tr-TR-x-icu\" ILIKE {{{paramIndex}}}";
     }
 
     private static string BuildEndsWithCondition(
@@ -1021,7 +1041,7 @@ public static class GraphQLJsonFilterService
         parameters.Add(new NpgsqlParameter { Value = $"%{stringValue}" });
 
         var accessor = BuildJsonTextAccessor(field, jsonColumnName);
-        return $"{accessor} ILIKE {{{paramIndex}}}";
+        return $"{accessor} COLLATE \"tr-TR-x-icu\" ILIKE {{{paramIndex}}}";
     }
 
     private static string BuildInCondition(

--- a/src/BBT.Workflow.Domain/QueryExtensions/InstanceColumnConditionBuilder.cs
+++ b/src/BBT.Workflow.Domain/QueryExtensions/InstanceColumnConditionBuilder.cs
@@ -14,7 +14,7 @@ public static class InstanceColumnConditionBuilder
     /// Build PostgreSQL WHERE condition for an Instance table column
     /// </summary>
     /// <param name="columnName">Instance column name (e.g., "Key", "Status", "CreatedAt")</param>
-    /// <param name="operatorType">Filter operator (eq, ne, gt, ge, lt, le, between, like, startswith, endswith, in, nin)</param>
+    /// <param name="operatorType">Filter operator (eq, ne, gt, ge, lt, le, between, like, startswith, endswith, in, nin, isnull)</param>
     /// <param name="value">Filter value (string representation)</param>
     /// <param name="parameterIndex">Parameter index counter (ref for auto-increment)</param>
     /// <returns>Tuple of (SQL condition string, list of NpgsqlParameters)</returns>
@@ -32,6 +32,13 @@ public static class InstanceColumnConditionBuilder
 
         // Get properly cased column name
         var properColumnName = InstanceFieldDiscriminator.GetInstanceColumnName(columnName);
+
+        // isnull is value-resolution independent and applies uniformly to every column
+        // (including Status), so handle it before any column-specific resolution.
+        if (operatorType.Equals("isnull", StringComparison.OrdinalIgnoreCase))
+        {
+            return BuildIsNullCondition(properColumnName, value);
+        }
 
         // Special handling for Status column - resolve names to codes
         if (properColumnName.Equals("Status", StringComparison.OrdinalIgnoreCase))
@@ -54,6 +61,7 @@ public static class InstanceColumnConditionBuilder
             "endswith" => BuildEndsWithCondition(properColumnName, value, ref parameterIndex),
             "in" => BuildInCondition(properColumnName, value, ref parameterIndex),
             "nin" => BuildNotInCondition(properColumnName, value, ref parameterIndex),
+            // Note: "isnull" is handled earlier (before Status resolution) so it never reaches here.
             _ => throw new ArgumentException($"Unsupported operator: {operatorType}", nameof(operatorType))
         };
     }
@@ -170,7 +178,7 @@ public static class InstanceColumnConditionBuilder
         var escapedValue = EscapeLikePattern(value);
         parameters.Add(new NpgsqlParameter { Value = $"%{escapedValue}%" });
 
-        var condition = $"s.\"{columnName}\" ILIKE {{{paramIndex}}}";
+        var condition = $"s.\"{columnName}\" COLLATE \"tr-TR-x-icu\" ILIKE {{{paramIndex}}}";
         return (condition, parameters);
     }
 
@@ -186,7 +194,7 @@ public static class InstanceColumnConditionBuilder
         var escapedValue = EscapeLikePattern(value);
         parameters.Add(new NpgsqlParameter { Value = $"{escapedValue}%" });
 
-        var condition = $"s.\"{columnName}\" ILIKE {{{paramIndex}}}";
+        var condition = $"s.\"{columnName}\" COLLATE \"tr-TR-x-icu\" ILIKE {{{paramIndex}}}";
         return (condition, parameters);
     }
 
@@ -202,7 +210,7 @@ public static class InstanceColumnConditionBuilder
         var escapedValue = EscapeLikePattern(value);
         parameters.Add(new NpgsqlParameter { Value = $"%{escapedValue}" });
 
-        var condition = $"s.\"{columnName}\" ILIKE {{{paramIndex}}}";
+        var condition = $"s.\"{columnName}\" COLLATE \"tr-TR-x-icu\" ILIKE {{{paramIndex}}}";
         return (condition, parameters);
     }
 
@@ -252,6 +260,21 @@ public static class InstanceColumnConditionBuilder
 
         var condition = $"s.\"{columnName}\" NOT IN ({string.Join(", ", paramPlaceholders)})";
         return (condition, parameters);
+    }
+
+    /// <summary>
+    /// Build IS NULL / IS NOT NULL condition.
+    /// The value selects the check: "true" => IS NULL, "false" => IS NOT NULL.
+    /// Defaults to IS NULL when the value is missing or unparseable,
+    /// matching the JSON attribute filter semantics.
+    /// </summary>
+    private static (string, List<NpgsqlParameter>) BuildIsNullCondition(
+        string columnName, string value)
+    {
+        var isNull = !bool.TryParse(value, out var parsed) || parsed;
+        var sqlOperator = isNull ? "IS NULL" : "IS NOT NULL";
+        var condition = $"s.\"{columnName}\" {sqlOperator}";
+        return (condition, new List<NpgsqlParameter>());
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Domain/QueryExtensions/PostgreSqlJsonFilterService.cs
+++ b/src/BBT.Workflow.Domain/QueryExtensions/PostgreSqlJsonFilterService.cs
@@ -613,7 +613,7 @@ public static class PostgreSqlJsonFilterService
         // Use BuildJsonTextAccessor for proper nested/single level handling
         var accessor = BuildJsonTextAccessor(field, jsonColumnName);
         
-        var condition = $"{accessor} ILIKE {{{paramIndex}}}";
+        var condition = $"{accessor} COLLATE \"tr-TR-x-icu\" ILIKE {{{paramIndex}}}";
         
         return (condition, parameters);
     }
@@ -628,7 +628,7 @@ public static class PostgreSqlJsonFilterService
         // Use BuildJsonTextAccessor for proper nested/single level handling
         var accessor = BuildJsonTextAccessor(field, jsonColumnName);
         
-        var condition = $"{accessor} ILIKE {{{paramIndex}}}";
+        var condition = $"{accessor} COLLATE \"tr-TR-x-icu\" ILIKE {{{paramIndex}}}";
         
         return (condition, parameters);
     }
@@ -643,7 +643,7 @@ public static class PostgreSqlJsonFilterService
         // Use BuildJsonTextAccessor for proper nested/single level handling
         var accessor = BuildJsonTextAccessor(field, jsonColumnName);
         
-        var condition = $"{accessor} ILIKE {{{paramIndex}}}";
+        var condition = $"{accessor} COLLATE \"tr-TR-x-icu\" ILIKE {{{paramIndex}}}";
         
         return (condition, parameters);
     }

--- a/test/BBT.Workflow.Application.Tests/Tasks/Executors/GetInstancesTaskExecutorTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Tasks/Executors/GetInstancesTaskExecutorTests.cs
@@ -56,8 +56,18 @@ public sealed class GetInstancesTaskExecutorTests
         var gateway = Substitute.For<IInstanceQueryGateway>();
         var groups = new List<GroupSummary>
         {
-            new() { Name = "open", Count = 2 },
-            new() { Name = "done", Count = 3 }
+            new()
+            {
+                Name = "open",
+                Count = 2,
+                Keys = new Dictionary<string, object?> { ["status"] = "open" }
+            },
+            new()
+            {
+                Name = "done",
+                Count = 3,
+                Keys = new Dictionary<string, object?> { ["status"] = "done" }
+            }
         };
         gateway.GetInstanceListAsync(Arg.Any<GetInstanceListInput>(), Arg.Any<CancellationToken>())
             .Returns(Result.Ok(InstanceListWithGroupsResponse<GetInstanceOutput>.FromGroups(groups)));
@@ -82,6 +92,51 @@ public sealed class GetInstancesTaskExecutorTests
         using var doc = JsonDocument.Parse(dataJson);
         Assert.Equal(2, doc.RootElement.GetProperty("items").GetArrayLength());
         Assert.Equal("open", doc.RootElement.GetProperty("items")[0].GetProperty("name").GetString());
+        var keys0 = doc.RootElement.GetProperty("items")[0].GetProperty("keys");
+        Assert.Equal("open", keys0.GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenListReturnsMultiKeyGroups_SerializesKeysPerField()
+    {
+        var task = WorkflowTaskFactory.CreateGetInstancesTask(
+            domain: "test-domain",
+            flow: "test-flow",
+            filter: """{"groupBy":{"fields":["attributes.scope","attributes.channel"]}}""");
+
+        var gateway = Substitute.For<IInstanceQueryGateway>();
+        var groups = new List<GroupSummary>
+        {
+            new()
+            {
+                Name = "scope-a_EFT",
+                Sum = 1000m,
+                Keys = new Dictionary<string, object?>
+                {
+                    ["attributes.scope"] = "scope-a",
+                    ["attributes.channel"] = "EFT"
+                }
+            }
+        };
+        gateway.GetInstanceListAsync(Arg.Any<GetInstanceListInput>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok(InstanceListWithGroupsResponse<GetInstanceOutput>.FromGroups(groups)));
+
+        var runtime = Substitute.For<IRuntimeInfoProvider>();
+        runtime.Domain.Returns("test-domain");
+
+        var executor = CreateExecutor(gateway, runtime);
+
+        var result = await executor.ExecuteAsync(CreateContext(task), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        var dataJson = JsonSerializer.Serialize(result.Value!.Data, JsonSerializerConstants.JsonOptions);
+        using var doc = JsonDocument.Parse(dataJson);
+        var item0 = doc.RootElement.GetProperty("items")[0];
+        Assert.Equal("scope-a_EFT", item0.GetProperty("name").GetString());
+        Assert.Equal(1000m, item0.GetProperty("sum").GetDecimal());
+        var keys = item0.GetProperty("keys");
+        Assert.Equal("scope-a", keys.GetProperty("attributes.scope").GetString());
+        Assert.Equal("EFT", keys.GetProperty("attributes.channel").GetString());
     }
 
     [Fact]

--- a/test/BBT.Workflow.Domain.Tests/QueryExtensions/InstanceColumnArrayFilterTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/QueryExtensions/InstanceColumnArrayFilterTests.cs
@@ -1,0 +1,120 @@
+using System.Collections.Generic;
+using System.Linq;
+using BBT.Workflow.Definitions.GraphQL;
+using Npgsql;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Domain.Tests.QueryExtensions;
+
+/// <summary>
+/// End-to-end tests for array-valued filter operators (in, nin, between) on Instance columns.
+/// These operators arrive as JSON arrays (object[]) and must be flattened to a comma-separated
+/// string before reaching InstanceColumnConditionBuilder — otherwise the array collapses to the
+/// literal "System.Object[]" and the filter silently matches nothing.
+/// </summary>
+public class InstanceColumnArrayFilterTests
+{
+    private static (string instanceWhere, List<NpgsqlParameter> parameters) BuildInstanceWhere(string json)
+    {
+        var node = GraphQLFilterParser.ParseFilter(json);
+        node.ShouldNotBeNull();
+
+        var parameters = new List<NpgsqlParameter>();
+        var parameterIndex = 0;
+        var (_, instanceWhere) = GraphQLJsonFilterService.BuildSeparatedWhereClausesForSql(
+            node, "Data", parameters, ref parameterIndex);
+
+        return (instanceWhere, parameters);
+    }
+
+    [Fact]
+    public void In_OnInstanceColumn_WithJsonArray_ShouldBuildInClause()
+    {
+        // Arrange
+        var json = """{"key":{"in":["k1","k2","k3"]}}""";
+
+        // Act
+        var (instanceWhere, parameters) = BuildInstanceWhere(json);
+
+        // Assert
+        instanceWhere.ShouldBe("s.\"Key\" IN ({0}, {1}, {2})");
+        parameters.Count.ShouldBe(3);
+        parameters.Select(p => p.Value).ShouldBe(new object[] { "k1", "k2", "k3" });
+        // Regression guard: the array must never collapse to "System.Object[]"
+        parameters.ShouldNotContain(p => Equals(p.Value, "System.Object[]"));
+    }
+
+    [Fact]
+    public void In_OnStatusColumn_WithJsonArray_ShouldResolveStatusCodes()
+    {
+        // Arrange
+        var json = """{"status":{"in":["Active","Busy"]}}""";
+
+        // Act
+        var (instanceWhere, parameters) = BuildInstanceWhere(json);
+
+        // Assert
+        instanceWhere.ShouldBe("s.\"Status\" IN ({0}, {1})");
+        parameters.Count.ShouldBe(2);
+        parameters[0].Value.ShouldBe("A"); // Active -> A
+        parameters[1].Value.ShouldBe("B"); // Busy -> B
+    }
+
+    [Fact]
+    public void NotIn_OnInstanceColumn_WithJsonArray_ShouldBuildNotInClause()
+    {
+        // Arrange
+        var json = """{"key":{"nin":["k1","k2"]}}""";
+
+        // Act
+        var (instanceWhere, parameters) = BuildInstanceWhere(json);
+
+        // Assert
+        instanceWhere.ShouldBe("s.\"Key\" NOT IN ({0}, {1})");
+        parameters.Count.ShouldBe(2);
+        parameters.Select(p => p.Value).ShouldBe(new object[] { "k1", "k2" });
+    }
+
+    [Fact]
+    public void Between_OnInstanceColumn_WithJsonArray_ShouldBuildBetweenClause()
+    {
+        // Arrange
+        var json = """{"createdAt":{"between":["2024-01-01","2024-12-31"]}}""";
+
+        // Act
+        var (instanceWhere, parameters) = BuildInstanceWhere(json);
+
+        // Assert
+        instanceWhere.ShouldBe("s.\"CreatedAt\" BETWEEN {0} AND {1}");
+        parameters.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void IsNull_OnInstanceColumn_ShouldBuildIsNullClause()
+    {
+        // Arrange
+        var json = """{"completedAt":{"isNull":true}}""";
+
+        // Act
+        var (instanceWhere, parameters) = BuildInstanceWhere(json);
+
+        // Assert
+        instanceWhere.ShouldBe("s.\"CompletedAt\" IS NULL");
+        parameters.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void IsNull_False_OnInstanceColumn_ShouldBuildIsNotNullClause()
+    {
+        // Arrange
+        var json = """{"completedAt":{"isNull":false}}""";
+
+        // Act
+        var (instanceWhere, parameters) = BuildInstanceWhere(json);
+
+        // Assert
+        instanceWhere.ShouldBe("s.\"CompletedAt\" IS NOT NULL");
+        parameters.ShouldBeEmpty();
+    }
+}

--- a/test/BBT.Workflow.Domain.Tests/QueryExtensions/InstanceColumnFilterTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/QueryExtensions/InstanceColumnFilterTests.cs
@@ -325,6 +325,83 @@ public class InstanceColumnFilterTests
     }
 
     [Fact]
+    public void BuildCondition_IsNull_True_ShouldBuildIsNullCondition()
+    {
+        // Arrange
+        var parameterIndex = 0;
+
+        // Act
+        var (condition, parameters) = InstanceColumnConditionBuilder.BuildCondition(
+            "CompletedAt", "isnull", "true", ref parameterIndex);
+
+        // Assert
+        condition.ShouldBe("s.\"CompletedAt\" IS NULL");
+        parameters.ShouldBeEmpty();
+        parameterIndex.ShouldBe(0); // No parameter consumed
+    }
+
+    [Fact]
+    public void BuildCondition_IsNull_False_ShouldBuildIsNotNullCondition()
+    {
+        // Arrange
+        var parameterIndex = 0;
+
+        // Act
+        var (condition, parameters) = InstanceColumnConditionBuilder.BuildCondition(
+            "CompletedAt", "isnull", "false", ref parameterIndex);
+
+        // Assert
+        condition.ShouldBe("s.\"CompletedAt\" IS NOT NULL");
+        parameters.ShouldBeEmpty();
+        parameterIndex.ShouldBe(0);
+    }
+
+    [Fact]
+    public void BuildCondition_IsNull_IsCaseInsensitive()
+    {
+        // Arrange
+        var parameterIndex = 0;
+
+        // Act - GetOperators() yields the operator as "isNull"; BuildCondition lower-cases it
+        var (condition, parameters) = InstanceColumnConditionBuilder.BuildCondition(
+            "ModifiedAt", "isNull", "True", ref parameterIndex);
+
+        // Assert
+        condition.ShouldBe("s.\"ModifiedAt\" IS NULL");
+        parameters.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void BuildCondition_IsNull_UnparseableValue_ShouldDefaultToIsNull()
+    {
+        // Arrange
+        var parameterIndex = 0;
+
+        // Act - matches JSON attribute filter semantics: default to IS NULL
+        var (condition, parameters) = InstanceColumnConditionBuilder.BuildCondition(
+            "CompletedAt", "isnull", "", ref parameterIndex);
+
+        // Assert
+        condition.ShouldBe("s.\"CompletedAt\" IS NULL");
+        parameters.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void BuildCondition_IsNull_OnStatusColumn_ShouldNotResolveStatusCode()
+    {
+        // Arrange - isnull must be handled before Status name-to-code resolution
+        var parameterIndex = 0;
+
+        // Act
+        var (condition, parameters) = InstanceColumnConditionBuilder.BuildCondition(
+            "Status", "isnull", "false", ref parameterIndex);
+
+        // Assert
+        condition.ShouldBe("s.\"Status\" IS NOT NULL");
+        parameters.ShouldBeEmpty();
+    }
+
+    [Fact]
     public void BuildCondition_InvalidColumn_ShouldThrow()
     {
         // Arrange


### PR DESCRIPTION
## Summary by Sourcery

Add null-check filtering and array-valued operator handling for instance column queries, align LIKE-based comparisons with Turkish collation, and extend tests to cover new filtering and grouping behaviors.

Bug Fixes:
- Ensure array-valued operators (in, nin, between) from JSON filters are flattened correctly instead of producing unusable "System.Object[]" parameter values.
- Fix ILIKE-based comparisons on instance and JSON fields to use Turkish collation to handle locale-specific casing correctly.
- Support case-insensitive isNull operator handling for instance columns without interfering with Status name-to-code resolution.

Enhancements:
- Add support for isnull operator on instance columns, defaulting to IS NULL semantics when the value is missing or unparseable.
- Expose group key fields in instance list task executor responses so grouped results include their grouping keys in the serialized output.

Tests:
- Add end-to-end tests for array-valued operators and isNull handling on instance columns via GraphQL JSON filters.
- Extend instance column condition tests to cover isNull operator semantics and interactions with Status resolution.
- Update GetInstances task executor tests to validate serialization of group keys for single- and multi-key groupings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `isnull` filtering, allowing results to be matched against missing or present values.
  * Improved handling of array-based filters such as `in`, `not in`, and `between` for more accurate matching.
  * Grouped results can now include multiple grouping keys in the returned output.

* **Bug Fixes**
  * Fixed SQL generation for array filter values so they are processed correctly instead of collapsing into a single value.
  * Improved case-insensitive text matching for Turkish-language comparisons in search and filter conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->