### PR TITLE
fix(chain-reaper): open read-only UoW in flow-key discovery scope

### DIFF
--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/HostedServices/ChainReaperHostedService.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/HostedServices/ChainReaperHostedService.cs
@@ -1,4 +1,5 @@
 using BBT.Aether.MultiSchema;
+using BBT.Aether.Uow;
 using BBT.Workflow.BackgroundJobs.Options;
 using BBT.Workflow.BackgroundJobs.Recovery;
 using BBT.Workflow.Hosting;
@@ -79,9 +80,14 @@ public sealed class ChainReaperHostedService(
     private async Task SweepAllFlowSchemasAsync(CancellationToken stoppingToken)
     {
         // 1) Discover all flow keys (own scope; the repository switches to sys_flows internally).
+        //    GetActiveFlowKeysAsync calls GetDbSetAsync which requires an active UoW — open a
+        //    read-only RequiresNew scope so Aether's DbContextProvider has one available.
         IReadOnlyList<string> flowKeys;
         await using (var discoveryScope = scopeFactory.CreateAsyncScope())
         {
+            var uowManager = discoveryScope.ServiceProvider.GetRequiredService<IUnitOfWorkManager>();
+            await using var uow = uowManager.Begin(
+                new UnitOfWorkOptions { IsTransactional = false, Scope = UnitOfWorkScopeOption.RequiresNew });
             var instanceRepository = discoveryScope.ServiceProvider.GetRequiredService<IInstanceRepository>();
             flowKeys = await instanceRepository.GetActiveFlowKeysAsync(stoppingToken);
         }


### PR DESCRIPTION
## Summary
- `ChainReaperHostedService` threw `InvalidOperationException: No active UnitOfWork` on every sweep because `GetActiveFlowKeysAsync` calls `AetherDbContextProvider.GetDbSetAsync`, which requires an active UoW — but `BackgroundService` has no ambient UoW.
- Fixed by opening a non-transactional `RequiresNew` `IUnitOfWork` around the discovery scope before calling the repository.

## Changes
- `orchestration/BBT.Workflow.Orchestration.HttpApi.Host/HostedServices/ChainReaperHostedService.cs`

## Test Plan
- [ ] Enable `EnableChainReaper: true` and start Orchestration host
- [ ] Verify no `InvalidOperationException: No active UnitOfWork` in logs after first sweep interval (~60s)
- [ ] Confirm ChainReaper sweep completes normally (`ChainReaperSweepCompleted` log entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent InvalidOperationException due to missing ambient UnitOfWork during ChainReaper flow-key discovery in the hosted service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved flow schema cleanup to ensure active flow keys are discovered with the proper unit-of-work context.
  * Reduced the chance of cleanup failures caused by missing database context during sweep operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->