### PR TITLE
fix(extensions): isolate parallel extension fetches in separate DI scopes

### DIFF
--- a/src/BBT.Workflow.Application/Extensions/Services/InstanceExtensionService.cs
+++ b/src/BBT.Workflow.Application/Extensions/Services/InstanceExtensionService.cs
@@ -8,6 +8,7 @@ using BBT.Workflow.Logging;
 using BBT.Workflow.Runtime;
 using BBT.Workflow.Scripting;
 using BBT.Workflow.Tasks.Coordinator;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace BBT.Workflow.Extentions;
@@ -20,6 +21,7 @@ public sealed class InstanceExtensionService(
     ITaskCoordinator taskCoordinator,
     IRuntimeInfoProvider runtimeInfoProvider,
     ICurrentSchema currentSchema,
+    IServiceScopeFactory serviceScopeFactory,
     ILogger<InstanceExtensionService> logger) : IInstanceExtensionService
 {
     /// <inheritdoc />
@@ -166,6 +168,7 @@ public sealed class InstanceExtensionService(
 
     /// <summary>
     /// Fetches extensions from references in parallel.
+    /// Each fetch runs in its own DI scope to avoid concurrent DbContext access.
     /// Failed fetches are filtered out - the system continues with available extensions.
     /// </summary>
     private async Task<List<Extension>> FetchExtensionsFromReferencesAsync(
@@ -177,7 +180,9 @@ public sealed class InstanceExtensionService(
 
         var extensionTasks = extensionReferences.Select(async reference =>
         {
-            var result = await componentCacheStore.GetExtensionAsync(reference, cancellationToken);
+            await using var scope = serviceScopeFactory.CreateAsyncScope();
+            var scopedCacheStore = scope.ServiceProvider.GetRequiredService<IComponentCacheStore>();
+            var result = await scopedCacheStore.GetExtensionAsync(reference, cancellationToken);
             return result.IsSuccess ? result.Value : null;
         });
 


### PR DESCRIPTION
## Summary

Fixes `System.InvalidOperationException: A second operation was started on this context instance before a previous operation completed` thrown during extension fetch on the Data/Extensions functions.

### Root cause

`InstanceExtensionService.FetchExtensionsFromReferencesAsync` used `Task.WhenAll` to fetch multiple extensions concurrently. On a cache miss, each task fell through to `EfCoreInstanceRepository.GetActiveDataListByKeyAsync → ToListAsync`, all hitting the **same scoped `DbContext`**. EF Core's `DbContext` is not thread-safe and rejects concurrent async operations.

### Fix

Each parallel fetch now creates its own `IServiceScopeFactory.CreateAsyncScope()`, resolving an isolated `IComponentCacheStore` (and its own `DbContext`) per task. This is the same pattern already used in `TaskCoordinator` for parallel task execution.

`IServiceScopeFactory` is injected into `InstanceExtensionService` via primary constructor.

## Changed files

- `src/BBT.Workflow.Application/Extensions/Services/InstanceExtensionService.cs`

## Test plan

- [ ] Cold-start request to Extensions/Data function on an instance with ≥2 extension references — no `InvalidOperationException`
- [ ] Warm cache (Redis hit) — no regression
- [ ] Single extension reference — no regression
- [ ] Build passes with 0 errors

Closes #771

## Summary by Sourcery

Isolate parallel extension fetch operations into separate dependency injection scopes to prevent concurrent DbContext usage when resolving extensions from references.

Bug Fixes:
- Prevent InvalidOperationException caused by concurrent EF Core DbContext access during parallel extension resolution.

Enhancements:
- Inject IServiceScopeFactory into InstanceExtensionService and use scoped IComponentCacheStore instances for parallel extension fetches.