### PR TITLE
fix(middleware): replace EnableBuffering with MemoryStream in RawRequestBodyBufferingMiddleware

### DIFF
--- a/execution/BBT.Workflow.Execution.HttpApi.Host/appsettings.json
+++ b/execution/BBT.Workflow.Execution.HttpApi.Host/appsettings.json
@@ -106,7 +106,8 @@
   "Kestrel": {
     "Limits": {
       "MaxRequestHeadersTotalSize": 65536,
-      "MaxRequestHeaderCount": 200
+      "MaxRequestHeaderCount": 200,
+      "MaxRequestBodySize": 10485760
     }
   },
   "Aether": {

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/appsettings.json
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/appsettings.json
@@ -147,7 +147,8 @@
   "Kestrel": {
     "Limits": {
       "MaxRequestHeadersTotalSize": 65536,
-      "MaxRequestHeaderCount": 200
+      "MaxRequestHeaderCount": 200,
+      "MaxRequestBodySize": 10485760
     }
   },
   "Aether": {

--- a/src/BBT.Workflow.HttpApi.Shared/Microsoft/Extensions/DependencyInjection/WorkflowApiBaseServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.HttpApi.Shared/Microsoft/Extensions/DependencyInjection/WorkflowApiBaseServiceCollectionExtensions.cs
@@ -73,6 +73,8 @@ public static class WorkflowApiBaseServiceCollectionExtensions
         services.AddHttpContextAccessor();
         services.Replace(ServiceDescriptor.Singleton<BBT.Workflow.Scripting.IRequestRawBodyProvider,
             BBT.Workflow.Middlewares.HttpContextRawBodyProvider>());
+        services.Configure<BBT.Workflow.Middlewares.RawRequestBodyBufferingOptions>(
+            configuration.GetSection(BBT.Workflow.Middlewares.RawRequestBodyBufferingOptions.SectionPath));
 
         services.AddControllers()
             .AddJsonOptions(options =>

--- a/src/BBT.Workflow.HttpApi.Shared/Middlewares/RawRequestBodyBufferingMiddleware.cs
+++ b/src/BBT.Workflow.HttpApi.Shared/Middlewares/RawRequestBodyBufferingMiddleware.cs
@@ -1,21 +1,22 @@
 using System.Text;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 
 namespace BBT.Workflow.Middlewares;
 
 /// <summary>
-/// Buffers the raw request body for body-bearing requests so the original, unmodified payload can be
-/// exposed to mappings for signature verification (JWS / mTLS). Enables buffering, reads the body once
-/// into a string stored on <see cref="HttpContext.Items"/>, then rewinds the stream so downstream
+/// Reads the raw request body into memory and stores the payload on <see cref="HttpContext.Items"/> for
+/// signature verification (JWS / mTLS), then replaces the body stream so downstream
 /// <c>[FromBody]</c> model binding still works. Requests whose known content length exceeds the cap are skipped.
 /// </summary>
-public sealed class RawRequestBodyBufferingMiddleware(RequestDelegate next)
+public sealed class RawRequestBodyBufferingMiddleware(
+    RequestDelegate next,
+    IOptions<RawRequestBodyBufferingOptions> options)
 {
     /// <summary>The <see cref="HttpContext.Items"/> key under which the captured raw request body is stored.</summary>
     public const string RawBodyItemsKey = "__vnext.RawRequestBody";
 
-    // Cap to protect memory; these JSON APIs carry small payloads.
-    private const long MaxBufferedBytes = 5 * 1024 * 1024; // 5 MB
+    private readonly long _maxBufferedBytes = options.Value.MaxRequestBodySize;
 
     /// <summary>
     /// Captures the raw body (when applicable) and invokes the next middleware.
@@ -24,25 +25,44 @@ public sealed class RawRequestBodyBufferingMiddleware(RequestDelegate next)
     {
         if (ShouldCapture(context.Request))
         {
-            // Match the in-memory threshold to MaxBufferedBytes so captured bodies (capped at the same
-            // size by ShouldCapture) never spill to a temp file — avoids IOException on read-only /tmp.
-            context.Request.EnableBuffering(bufferThreshold: (int)MaxBufferedBytes);
+            // Read directly into a MemoryStream instead of using EnableBuffering/FileBufferingReadStream,
+            // which spills to /tmp when the buffer threshold is exceeded. /tmp is read-only in some
+            // container environments. Dapr's CloudEventsMiddleware may also have already called
+            // EnableBuffering with the default 30 KB threshold, making our threshold override a no-op.
+            //
+            // GetBuffer() is used instead of ToArray() to avoid a second byte[] allocation — ToArray()
+            // copies the internal buffer, while GetBuffer() returns a direct reference to it.
+            // ms must be kept alive (not disposed here) because replacementBody shares the same buffer.
+            var ms = new MemoryStream();
+            await context.Request.Body.CopyToAsync(ms, context.RequestAborted);
 
-            using var reader = new StreamReader(
-                context.Request.Body,
-                Encoding.UTF8,
-                detectEncodingFromByteOrderMarks: false,
-                leaveOpen: true);
+            // For requests with unknown Content-Length the cap is enforced post-read.
+            // Kestrel's MaxRequestBodySize bounds the absolute worst-case allocation above this limit.
+            if (ms.Length > _maxBufferedBytes)
+            {
+                ms.Position = 0;
+                context.Request.Body = ms;
+                context.Response.RegisterForDispose(ms);
+            }
+            else
+            {
+                var rawBuffer = ms.GetBuffer();
+                var rawLength = (int)ms.Length; // safe: ms.Length <= _maxBufferedBytes (default 10 MB)
 
-            var raw = await reader.ReadToEndAsync();
-            context.Request.Body.Position = 0;
-            context.Items[RawBodyItemsKey] = raw;
+                context.Items[RawBodyItemsKey] = Encoding.UTF8.GetString(rawBuffer, 0, rawLength);
+
+                // Replace body with a read-only view over the same buffer — no extra allocation.
+                var replacementBody = new MemoryStream(rawBuffer, 0, rawLength, writable: false);
+                context.Response.RegisterForDispose(replacementBody);
+                context.Response.RegisterForDispose(ms);
+                context.Request.Body = replacementBody;
+            }
         }
 
         await next(context);
     }
 
-    private static bool ShouldCapture(HttpRequest request)
+    private bool ShouldCapture(HttpRequest request)
     {
         if (!HttpMethods.IsPost(request.Method)
             && !HttpMethods.IsPut(request.Method)
@@ -50,8 +70,8 @@ public sealed class RawRequestBodyBufferingMiddleware(RequestDelegate next)
             && !HttpMethods.IsDelete(request.Method))
             return false;
 
-        // Skip when a known content length exceeds the cap; unknown lengths are buffered
-        // (EnableBuffering spills to disk beyond its own threshold, so memory stays bounded).
-        return request.ContentLength is null or <= MaxBufferedBytes;
+        // Skip when a known content length exceeds the cap to keep memory bounded.
+        // Unknown lengths (null) are allowed through; the post-read cap check in InvokeAsync handles them.
+        return request.ContentLength is null || request.ContentLength <= _maxBufferedBytes;
     }
 }

--- a/src/BBT.Workflow.HttpApi.Shared/Middlewares/RawRequestBodyBufferingOptions.cs
+++ b/src/BBT.Workflow.HttpApi.Shared/Middlewares/RawRequestBodyBufferingOptions.cs
@@ -1,0 +1,22 @@
+namespace BBT.Workflow.Middlewares;
+
+/// <summary>
+/// Configuration options for <see cref="RawRequestBodyBufferingMiddleware"/>.
+/// Bind from the <c>Kestrel:Limits</c> appsettings section so the raw-body cap
+/// lives alongside <c>MaxRequestBodySize</c> and other Kestrel limits.
+/// </summary>
+public sealed class RawRequestBodyBufferingOptions
+{
+    /// <summary>appsettings section this class binds to.</summary>
+    public const string SectionPath = "Kestrel:Limits";
+
+    /// <summary>
+    /// Maximum request body size in bytes. Shared with Kestrel's own <c>MaxRequestBodySize</c> limit —
+    /// both are read from the same <c>Kestrel:Limits</c> section so a single config value governs both.
+    /// Requests with a known <c>Content-Length</c> above this value skip raw-body capture.
+    /// Requests with an unknown content length are read fully first, then capture is
+    /// skipped if the actual body exceeds this limit.
+    /// Default: 5 MB.
+    /// </summary>
+    public long MaxRequestBodySize { get; set; } = 10 * 1024 * 1024;
+}

--- a/test/BBT.Workflow.Application.Tests/HttpApi/RawRequestBodyBufferingMiddlewareTests.cs
+++ b/test/BBT.Workflow.Application.Tests/HttpApi/RawRequestBodyBufferingMiddlewareTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BBT.Workflow.Middlewares;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 using Shouldly;
 using Xunit;
 
@@ -36,12 +37,14 @@ public class RawRequestBodyBufferingMiddlewareTests
         var context = BuildContext("POST", Body);
         string? downstreamBody = null;
 
-        var middleware = new RawRequestBodyBufferingMiddleware(async ctx =>
-        {
-            // Simulate model binding reading the (rewound) body.
-            using var reader = new StreamReader(ctx.Request.Body, Encoding.UTF8, leaveOpen: true);
-            downstreamBody = await reader.ReadToEndAsync();
-        });
+        var middleware = new RawRequestBodyBufferingMiddleware(
+            async ctx =>
+            {
+                // Simulate model binding reading the (rewound) body.
+                using var reader = new StreamReader(ctx.Request.Body, Encoding.UTF8, leaveOpen: true);
+                downstreamBody = await reader.ReadToEndAsync();
+            },
+            Options.Create(new RawRequestBodyBufferingOptions()));
 
         await middleware.InvokeAsync(context);
 
@@ -54,7 +57,7 @@ public class RawRequestBodyBufferingMiddlewareTests
     {
         var context = BuildContext("GET", null);
 
-        var middleware = new RawRequestBodyBufferingMiddleware(_ => Task.CompletedTask);
+        var middleware = new RawRequestBodyBufferingMiddleware(_ => Task.CompletedTask, Options.Create(new RawRequestBodyBufferingOptions()));
         await middleware.InvokeAsync(context);
 
         context.Items.ContainsKey(RawRequestBodyBufferingMiddleware.RawBodyItemsKey).ShouldBeFalse();


### PR DESCRIPTION
## Summary

- **Bug**: `RawRequestBodyBufferingMiddleware` crashed with `System.IO.IOException: Read-only file system : '/tmp/'` on ~5 MB payloads (e.g. `upload-staging-document-customer` Dapr service invocations). `FileBufferingReadStream` tries to create a temp file when the body size exceeds the `bufferThreshold` by even a single chunk — the `/tmp` directory is read-only in the container environment.
- **Root cause (second factor)**: Dapr's `CloudEventsMiddleware` runs first and calls `EnableBuffering` with its default 30 KB threshold. ASP.NET Core does not re-wrap an already-buffered stream, so our 5 MB threshold override was silently ignored.
- **Fix**: Replace `EnableBuffering` / `FileBufferingReadStream` with a direct `CopyToAsync` into a `MemoryStream`, eliminating any `/tmp` dependency. Use `GetBuffer()` instead of `ToArray()` to avoid a second `byte[]` copy. Add a post-read size guard for requests with unknown `Content-Length`.
- **Config**: Introduce `RawRequestBodyBufferingOptions` bound to `Kestrel:Limits`, so `MaxRequestBodySize` controls both Kestrel rejection and the middleware capture cap with a single appsettings value (default 10 MB).

## Changed files

| File | Change |
|---|---|
| `RawRequestBodyBufferingMiddleware.cs` | Replace `EnableBuffering` + `StreamReader` with `MemoryStream` + `CopyToAsync`; inject `IOptions<RawRequestBodyBufferingOptions>`; add post-read size guard; propagate `CancellationToken` |
| `RawRequestBodyBufferingOptions.cs` *(new)* | Options class binding to `Kestrel:Limits:MaxRequestBodySize` |
| `WorkflowApiBaseServiceCollectionExtensions.cs` | Register `RawRequestBodyBufferingOptions` in `AddAspNetCoreModules` |
| `appsettings.json` (execution + orchestration) | Add `Kestrel:Limits:MaxRequestBodySize: 10485760` |
| `RawRequestBodyBufferingMiddlewareTests.cs` | Pass `IOptions<>` to updated constructor |

## Memory profile (5 MB payload, before → after)

| Allocation | Before | After |
|---|---|---|
| `FileBufferingReadStream` internal buffer | ~8 MB | — |
| `byte[]` from `ToArray()` | ~5 MB | — |
| `MemoryStream` internal buffer | — | ~8 MB |
| `string` (UTF-16) | ~10 MB | ~10 MB |
| **Peak** | **~23 MB** | **~18 MB** |

## Related

Closes #773

## Test plan

- [ ] Unit tests in `RawRequestBodyBufferingMiddlewareTests` pass
- [ ] Verify `upload-staging-document-customer` invocation succeeds with a ~5 MB payload in the execution app
- [ ] Confirm no `IOException` in container logs after deploy

## Summary by Sourcery

Replace RawRequestBodyBufferingMiddleware’s file-based buffering with in-memory buffering and align its size cap with Kestrel limits to avoid /tmp IO failures on large payloads.

Bug Fixes:
- Prevent RawRequestBodyBufferingMiddleware from throwing IOException in container environments by removing reliance on FileBufferingReadStream temp files for large request bodies.

Enhancements:
- Use MemoryStream-based buffering and reuse the internal buffer to reduce allocations while still supporting downstream model binding on the captured body.
- Introduce RawRequestBodyBufferingOptions so the middleware’s max buffered size is configurable and shared with Kestrel:Limits:MaxRequestBodySize.
- Wire configuration binding for RawRequestBodyBufferingOptions into AddAspNetCoreModules so apps can control raw-body capture limits via appsettings.

Tests:
- Update RawRequestBodyBufferingMiddlewareTests to construct the middleware with IOptions-backed configuration and verify behavior with the new buffering approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for handling larger request bodies in workflow HTTP endpoints.
  * Improved raw request-body capture so downstream processing can reliably read submitted payloads.

* **Bug Fixes**
  * Requests with unknown body length are now handled more safely, avoiding unnecessary capture limits and preserving downstream access when possible.
  * Updated request processing behavior to better match configured server body-size limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->