### PR TITLE
feat(observability): extend X-Root-Instance-Id propagation across all execution paths

### DIFF
--- a/src/BBT.Workflow.Application/BackgroundJobs/Handlers/FlowTimeoutJobHandler.cs
+++ b/src/BBT.Workflow.Application/BackgroundJobs/Handlers/FlowTimeoutJobHandler.cs
@@ -82,6 +82,17 @@ public sealed class FlowTimeoutJobHandler(
                         return;
                     }
 
+                    var rootId = instance.GetRootInstanceId();
+                    using var rootScope = rootId != args.InstanceId
+                        ? logger.BeginScope(new Dictionary<string, object>
+                          { [TelemetryConstants.TagNames.RootInstanceId] = rootId })
+                        : null;
+                    if (rootId != args.InstanceId)
+                    {
+                        activity?.SetTag(TelemetryConstants.TagNames.RootInstanceId, rootId.ToString());
+                        activity?.SetBaggage(TelemetryConstants.TagNames.RootInstanceId, rootId.ToString());
+                    }
+
                     if (workflow.Timeout is null)
                     {
                         logger.TimeoutConfigMissing(instance.Flow);

--- a/src/BBT.Workflow.Application/BackgroundJobs/Handlers/StateNotifyJobHandler.cs
+++ b/src/BBT.Workflow.Application/BackgroundJobs/Handlers/StateNotifyJobHandler.cs
@@ -89,6 +89,17 @@ public sealed class StateNotifyJobHandler(
             .WithBody(args.Data)
             .BuildAsync(cancellationToken);
 
+        var rootId = scriptContext.Instance?.GetRootInstanceId();
+        using var rootScope = (rootId.HasValue && rootId.Value != args.InstanceId)
+            ? logger.BeginScope(new Dictionary<string, object>
+              { [TelemetryConstants.TagNames.RootInstanceId] = rootId.Value })
+            : null;
+        if (rootId.HasValue && rootId.Value != args.InstanceId)
+        {
+            activity?.SetTag(TelemetryConstants.TagNames.RootInstanceId, rootId.Value.ToString());
+            activity?.SetBaggage(TelemetryConstants.TagNames.RootInstanceId, rootId.Value.ToString());
+        }
+
         var state = scriptContext.Workflow?.States.SingleOrDefault(s => s.Key == args.StateKey);
 
         var entries = state?.Notifications

--- a/src/BBT.Workflow.Application/Execution/PostCommit/Handlers/ForwardToSubflowJobHandler.cs
+++ b/src/BBT.Workflow.Application/Execution/PostCommit/Handlers/ForwardToSubflowJobHandler.cs
@@ -21,12 +21,17 @@ public sealed class ForwardToSubflowJobHandler(
         TransitionExecutionContext context,
         CancellationToken cancellationToken)
     {
-        using (logger.BeginScope(new Dictionary<string, object>
+        var rootId = context.Instance?.GetRootInstanceId();
+        var scopeProps = new Dictionary<string, object>
         {
             [TelemetryConstants.TagNames.InstanceId] = context.InstanceId,
             [TelemetryConstants.TagNames.ParentInstanceId] = job.ParentInstanceId,
             [TelemetryConstants.TagNames.SubflowInstanceId] = job.SubflowInstanceId
-        }))
+        };
+        if (rootId.HasValue && rootId.Value != context.InstanceId)
+            scopeProps[TelemetryConstants.TagNames.RootInstanceId] = rootId.Value;
+
+        using (logger.BeginScope(scopeProps))
         {
             logger.SubFlowForwardStarted(job.TransitionKey, job.SubflowInstanceId, job.ParentInstanceId);
 

--- a/src/BBT.Workflow.Application/Functions/FunctionAppService.cs
+++ b/src/BBT.Workflow.Application/Functions/FunctionAppService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
 using System.Globalization;
@@ -69,6 +70,13 @@ public sealed class FunctionAppService(
             var instance = await instanceRepository.FindByIdentifierAsync(instanceKey, cancellationToken);
             if (instance == null)
                 return Result<FunctionResponseOutput>.Fail(WorkflowErrors.InstanceNotFound(instanceKey));
+
+            var rootId = instance.GetRootInstanceId();
+            if (rootId != instance.Id)
+            {
+                Activity.Current?.SetTag(TelemetryConstants.TagNames.RootInstanceId, rootId.ToString());
+                Activity.Current?.SetBaggage(TelemetryConstants.TagNames.RootInstanceId, rootId.ToString());
+            }
 
             return await componentCacheStore
                 .GetFlowAsync(domain, flow, instance.FlowVersion, cancellationToken)

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using BBT.Aether;
 using BBT.Aether.Application.Services;
 using BBT.Aether.Domain.Entities;
@@ -56,7 +57,21 @@ public sealed class InstanceQueryAppService(
         InstanceStatus.Faulted,
         InstanceStatus.Passive
     ];
-    
+
+    private IDisposable? BeginRootIdScopeIfSubflow(Instance instance)
+    {
+        var rootId = instance.GetRootInstanceId();
+        if (rootId == instance.Id)
+            return null;
+
+        Activity.Current?.SetTag(TelemetryConstants.TagNames.RootInstanceId, rootId.ToString());
+        Activity.Current?.SetBaggage(TelemetryConstants.TagNames.RootInstanceId, rootId.ToString());
+        return logger.BeginScope(new Dictionary<string, object>
+        {
+            [TelemetryConstants.TagNames.RootInstanceId] = rootId
+        });
+    }
+
     public async Task<ConditionalResult<GetInstanceOutput>> GetInstanceAsync(
         GetInstanceInput input,
         CancellationToken cancellationToken = default)
@@ -462,7 +477,19 @@ public sealed class InstanceQueryAppService(
         CancellationToken cancellationToken)
     {
         var instance = await instanceRepository.FindByIdentifierAsReadOnlyAsync(instanceIdentifier, cancellationToken);
-        return instance.EnsureNotNull(WorkflowErrors.InstanceNotFound(instanceIdentifier));
+        var result = instance.EnsureNotNull(WorkflowErrors.InstanceNotFound(instanceIdentifier));
+        if (result.IsSuccess)
+        {
+            var inst = result.Value!;
+            var rootId = inst.GetRootInstanceId();
+            if (rootId != inst.Id)
+            {
+                Activity.Current?.SetTag(TelemetryConstants.TagNames.RootInstanceId, rootId.ToString());
+                Activity.Current?.SetBaggage(TelemetryConstants.TagNames.RootInstanceId, rootId.ToString());
+            }
+        }
+
+        return result;
     }
 
     /// <summary>
@@ -762,6 +789,7 @@ public sealed class InstanceQueryAppService(
             .MatchAsync(
                 onSuccess: async data =>
                 {
+                    using var rootScope = BeginRootIdScopeIfSubflow(data.instance);
                     if (!await IsInstanceQueryAllowedAsync(data.workflow, data.instance, input.Roles, input.Headers, input.QueryParams, cancellationToken))
                         return ConditionalResult<GetInstanceStateOutput>.Fail(WorkflowErrors.QueryAccessDenied(data.instance.GetEffectiveState));
 

--- a/src/BBT.Workflow.Application/Tasks/Executors/Remote/RemoteInvokerService.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Remote/RemoteInvokerService.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Text.Json;
 using BBT.Aether.Results;
+using BBT.Workflow.Logging;
 using BBT.Workflow.Scripting;
 using BBT.Workflow.Tasks;
 using Dapr.Client;
@@ -69,6 +70,11 @@ public sealed class RemoteInvokerService : IRemoteInvokerService
                 traceContext.WorkflowKey ?? "unknown",
                 traceContext.WorkflowVersion ?? "latest",
                 traceContext.InstanceId));
+
+            // Forward root instance ID from Activity baggage (set by TransitionExecutor for subflow instances)
+            var rootIdBaggage = Activity.Current?.GetBaggageItem(TelemetryConstants.TagNames.RootInstanceId);
+            if (!string.IsNullOrEmpty(rootIdBaggage))
+                httpRequest.Headers.TryAddWithoutValidation(TelemetryConstants.HeaderNames.RootInstanceId, rootIdBaggage);
 
             var response = await _daprClient.InvokeMethodAsync<TaskInvokeResponse>(
                 httpRequest, invocationCts.Token);

--- a/src/BBT.Workflow.Domain/Instances/Instance.cs
+++ b/src/BBT.Workflow.Domain/Instances/Instance.cs
@@ -359,13 +359,15 @@ public sealed class Instance : AggregateRoot<Guid>, ICreationAuditedObject, IMod
         Duration = CompletedAt - CreatedAt;
 
         // Publish cleanup event to cancel all scheduled jobs
+        var rootId = this.GetRootInstanceId();
         AddDistributedEvent(new InstanceCompletedCleanupEvent
         {
             InstanceId = Id,
             Domain = domain,
             Flow = Flow,
             Version =  FlowVersion,
-            CompletedAt = CompletedAt.Value
+            CompletedAt = CompletedAt.Value,
+            RootInstanceId = rootId != Id ? rootId : (Guid?)null
         });
 
         // Publish completion event for SubItems (SubFlow or SubProcess)
@@ -385,7 +387,8 @@ public sealed class Instance : AggregateRoot<Guid>, ICreationAuditedObject, IMod
                     CompletedState = GetCurrentState,
                     InstanceData = latestData?.Data.JsonElement,
                     CompletedAt = CompletedAt.Value,
-                    Duration = Duration
+                    Duration = Duration,
+                    RootInstanceId = rootId != Id ? rootId : (Guid?)null
                 });
             }
         }
@@ -404,13 +407,15 @@ public sealed class Instance : AggregateRoot<Guid>, ICreationAuditedObject, IMod
         CompletedAt = DateTime.UtcNow;
         Duration = CompletedAt - CreatedAt;
 
+        var rootId = this.GetRootInstanceId();
         AddDistributedEvent(new InstanceFaultedCleanupEvent
         {
             InstanceId = Id,
             Domain = domain,
             Flow = Flow,
             Version = FlowVersion,
-            FaultedAt = CompletedAt.Value
+            FaultedAt = CompletedAt.Value,
+            RootInstanceId = rootId != Id ? rootId : (Guid?)null
         });
 
         // Downward: notify active SubFlow children to fault themselves
@@ -424,7 +429,8 @@ public sealed class Instance : AggregateRoot<Guid>, ICreationAuditedObject, IMod
                 Domain = correlation.SubFlowDomain,
                 Flow = correlation.SubFlowName,
                 Version = correlation.SubFlowVersion,
-                FaultedAt = CompletedAt.Value
+                FaultedAt = CompletedAt.Value,
+                RootInstanceId = rootId != Id ? rootId : (Guid?)null
             });
         }
 
@@ -459,7 +465,8 @@ public sealed class Instance : AggregateRoot<Guid>, ICreationAuditedObject, IMod
                     IncidentTransition = activeIncident?.Transition,
                     IncidentState = activeIncident?.State,
                     IncidentBoundaryAction = activeIncident?.BoundaryAction,
-                    IncidentBoundaryLevel = activeIncident?.BoundaryLevel
+                    IncidentBoundaryLevel = activeIncident?.BoundaryLevel,
+                    RootInstanceId = rootId != Id ? rootId : (Guid?)null
                 });
             }
         }
@@ -513,6 +520,7 @@ public sealed class Instance : AggregateRoot<Guid>, ICreationAuditedObject, IMod
         Duration = CompletedAt - CreatedAt;
 
         // Publish cancellation event - event handler will handle cleanup (jobs, correlations)
+        var rootId = this.GetRootInstanceId();
         AddDistributedEvent(new InstanceCanceledEvent
         {
             InstanceId = Id,
@@ -521,7 +529,8 @@ public sealed class Instance : AggregateRoot<Guid>, ICreationAuditedObject, IMod
             Version =   FlowVersion,
             CanceledState = GetCurrentState,
             CanceledAt = CompletedAt.Value,
-            Duration = Duration
+            Duration = Duration,
+            RootInstanceId = rootId != Id ? rootId : (Guid?)null
         });
 
         foreach (var correlation in ActiveCorrelations)
@@ -534,7 +543,8 @@ public sealed class Instance : AggregateRoot<Guid>, ICreationAuditedObject, IMod
                 Domain = correlation.SubFlowDomain,
                 Flow = correlation.SubFlowName,
                 CompletedAt = correlation.CompletedAt!.Value,
-                Version = correlation.SubFlowVersion
+                Version = correlation.SubFlowVersion,
+                RootInstanceId = rootId != Id ? rootId : (Guid?)null
             });
         }
     }
@@ -796,6 +806,7 @@ public sealed class Instance : AggregateRoot<Guid>, ICreationAuditedObject, IMod
         var contractInfo = ExtraProperties.ToSubFlowContractInfo();
         if (contractInfo.Id != Guid.Empty)
         {
+            var rootId = this.GetRootInstanceId();
             AddDistributedEvent(new InstanceSubStateChangedEvent
             {
                 ParentInstanceId = contractInfo.Id,
@@ -807,7 +818,8 @@ public sealed class Instance : AggregateRoot<Guid>, ICreationAuditedObject, IMod
                 PreviousState = previousState,
                 NewStateType = (int)(EffectiveStateType ?? StateType.Intermediate),
                 NewStateSubType = (int)(EffectiveStateSubType ?? StateSubType.None),
-                ChangedAt = DateTime.UtcNow
+                ChangedAt = DateTime.UtcNow,
+                RootInstanceId = rootId != Id ? rootId : (Guid?)null
             });
         }
     }

--- a/src/BBT.Workflow.Events.Contracts/Instances/Events/ChildSubflowCancelRequestedEvent.cs
+++ b/src/BBT.Workflow.Events.Contracts/Instances/Events/ChildSubflowCancelRequestedEvent.cs
@@ -39,4 +39,10 @@ public class ChildSubflowCancelRequestedEvent: IDistributedEvent
     /// Completed at
     /// </summary>
     public required DateTime CompletedAt { get; init; }
+
+    /// <summary>
+    /// The root ancestor instance ID for nested subflow chains.
+    /// <c>null</c> when this is a root (non-subflow) instance.
+    /// </summary>
+    public Guid? RootInstanceId { get; init; }
 }

--- a/src/BBT.Workflow.Events.Contracts/Instances/Events/ChildSubflowFaultRequestedEvent.cs
+++ b/src/BBT.Workflow.Events.Contracts/Instances/Events/ChildSubflowFaultRequestedEvent.cs
@@ -39,4 +39,10 @@ public class ChildSubflowFaultRequestedEvent : IDistributedEvent
     /// When the parent instance faulted
     /// </summary>
     public required DateTime FaultedAt { get; init; }
+
+    /// <summary>
+    /// The root ancestor instance ID for nested subflow chains.
+    /// <c>null</c> when this is a root (non-subflow) instance.
+    /// </summary>
+    public Guid? RootInstanceId { get; init; }
 }

--- a/src/BBT.Workflow.Events.Contracts/Instances/Events/InstanceCanceledEvent.cs
+++ b/src/BBT.Workflow.Events.Contracts/Instances/Events/InstanceCanceledEvent.cs
@@ -52,5 +52,11 @@ public class InstanceCanceledEvent : IDistributedEvent
     /// Duration of the instance execution before cancellation
     /// </summary>
     public TimeSpan? Duration { get; init; }
+
+    /// <summary>
+    /// The root ancestor instance ID for nested subflow chains.
+    /// <c>null</c> when this is a root (non-subflow) instance.
+    /// </summary>
+    public Guid? RootInstanceId { get; init; }
 }
 

--- a/src/BBT.Workflow.Events.Contracts/Instances/Events/InstanceCompletedCleanupEvent.cs
+++ b/src/BBT.Workflow.Events.Contracts/Instances/Events/InstanceCompletedCleanupEvent.cs
@@ -42,4 +42,10 @@ public class InstanceCompletedCleanupEvent : IDistributedEvent
     /// When the instance was completed
     /// </summary>
     public required DateTime CompletedAt { get; init; }
+
+    /// <summary>
+    /// The root ancestor instance ID for nested subflow chains.
+    /// <c>null</c> when this is a root (non-subflow) instance.
+    /// </summary>
+    public Guid? RootInstanceId { get; init; }
 }

--- a/src/BBT.Workflow.Events.Contracts/Instances/Events/InstanceFaultedCleanupEvent.cs
+++ b/src/BBT.Workflow.Events.Contracts/Instances/Events/InstanceFaultedCleanupEvent.cs
@@ -42,4 +42,10 @@ public class InstanceFaultedCleanupEvent : IDistributedEvent
     /// When the instance faulted
     /// </summary>
     public required DateTime FaultedAt { get; init; }
+
+    /// <summary>
+    /// The root ancestor instance ID for nested subflow chains.
+    /// <c>null</c> when this is a root (non-subflow) instance.
+    /// </summary>
+    public Guid? RootInstanceId { get; init; }
 }

--- a/src/BBT.Workflow.Events.Contracts/Instances/Events/InstanceSubCompletedEvent.cs
+++ b/src/BBT.Workflow.Events.Contracts/Instances/Events/InstanceSubCompletedEvent.cs
@@ -64,6 +64,12 @@ public class InstanceSubCompletedEvent : IDistributedEvent
     /// </summary>
     public TimeSpan? Duration { get; init; }
 
+    /// <summary>
+    /// The root ancestor instance ID for nested subflow chains.
+    /// <c>null</c> when this is a root (non-subflow) instance.
+    /// </summary>
+    public Guid? RootInstanceId { get; init; }
+
     public override string ToString()
     {
         return $"{nameof(InstanceSubCompletedEvent)}: InstanceId={InstanceId} Domain={Domain} Flow={Flow} Version={Version} SubInstanceId={SubInstanceId} CompletedState={CompletedState}";

--- a/src/BBT.Workflow.Events.Contracts/Instances/Events/InstanceSubFaultedEvent.cs
+++ b/src/BBT.Workflow.Events.Contracts/Instances/Events/InstanceSubFaultedEvent.cs
@@ -129,6 +129,12 @@ public class InstanceSubFaultedEvent : IDistributedEvent
     /// </summary>
     public string? IncidentBoundaryLevel { get; init; }
 
+    /// <summary>
+    /// The root ancestor instance ID for nested subflow chains.
+    /// <c>null</c> when this is a root (non-subflow) instance.
+    /// </summary>
+    public Guid? RootInstanceId { get; init; }
+
     public override string ToString()
     {
         return $"{nameof(InstanceSubFaultedEvent)}: InstanceId={InstanceId} Domain={Domain} Flow={Flow} Version={Version} SubInstanceId={SubInstanceId} FaultedState={FaultedState}";

--- a/src/BBT.Workflow.Events.Contracts/Instances/Events/InstanceSubStateChangedEvent.cs
+++ b/src/BBT.Workflow.Events.Contracts/Instances/Events/InstanceSubStateChangedEvent.cs
@@ -70,6 +70,12 @@ public class InstanceSubStateChangedEvent : IDistributedEvent
     /// </summary>
     public required DateTime ChangedAt { get; init; }
 
+    /// <summary>
+    /// The root ancestor instance ID for nested subflow chains.
+    /// <c>null</c> when this is a root (non-subflow) instance.
+    /// </summary>
+    public Guid? RootInstanceId { get; init; }
+
     public override string ToString()
     {
         return $"{nameof(InstanceSubStateChangedEvent)}: ParentInstanceId={ParentInstanceId} SubInstanceId={SubInstanceId} Domain={Domain} Flow={Flow} PreviousState={PreviousState} NewState={NewState}";

--- a/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceCanceledEventHook.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceCanceledEventHook.cs
@@ -38,13 +38,17 @@ public sealed class InstanceCanceledEventHook(
         EventHookContext context,
         CancellationToken cancellationToken = default)
     {
-        using (logger.BeginScope(new Dictionary<string, object>
+        var scopeProps = new Dictionary<string, object>
         {
             [TelemetryConstants.TagNames.Domain] = eventData.Domain,
             [TelemetryConstants.TagNames.Flow] = eventData.Flow,
             [TelemetryConstants.TagNames.FlowVersion] = eventData.Version ?? "N/A",
             [TelemetryConstants.TagNames.InstanceId] = eventData.InstanceId,
-        }))
+        };
+        if (eventData.RootInstanceId.HasValue)
+            scopeProps[TelemetryConstants.TagNames.RootInstanceId] = eventData.RootInstanceId.Value;
+
+        using (logger.BeginScope(scopeProps))
         {
             logger.InstanceCanceledEventReceived(eventData.InstanceId, eventData.Flow);
 

--- a/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceCompletedCleanupEventHook.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceCompletedCleanupEventHook.cs
@@ -38,13 +38,17 @@ public sealed class InstanceCompletedCleanupEventHook(
         EventHookContext context,
         CancellationToken cancellationToken = default)
     {
-        using (logger.BeginScope(new Dictionary<string, object>
+        var scopeProps = new Dictionary<string, object>
         {
             [TelemetryConstants.TagNames.Domain] = eventData.Domain,
             [TelemetryConstants.TagNames.Flow] = eventData.Flow,
             [TelemetryConstants.TagNames.FlowVersion] = eventData.Version ?? "N/A",
             [TelemetryConstants.TagNames.InstanceId] = eventData.InstanceId,
-        }))
+        };
+        if (eventData.RootInstanceId.HasValue)
+            scopeProps[TelemetryConstants.TagNames.RootInstanceId] = eventData.RootInstanceId.Value;
+
+        using (logger.BeginScope(scopeProps))
         {
             logger.InstanceCompletedCleanupHookProcessing(eventData.InstanceId, eventData.Flow);
 

--- a/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceFaultedCleanupEventHook.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceFaultedCleanupEventHook.cs
@@ -37,13 +37,17 @@ public sealed class InstanceFaultedCleanupEventHook(
         EventHookContext context,
         CancellationToken cancellationToken = default)
     {
-        using (logger.BeginScope(new Dictionary<string, object>
+        var scopeProps = new Dictionary<string, object>
         {
             [TelemetryConstants.TagNames.Domain] = eventData.Domain,
             [TelemetryConstants.TagNames.Flow] = eventData.Flow,
             [TelemetryConstants.TagNames.FlowVersion] = eventData.Version ?? "N/A",
             [TelemetryConstants.TagNames.InstanceId] = eventData.InstanceId,
-        }))
+        };
+        if (eventData.RootInstanceId.HasValue)
+            scopeProps[TelemetryConstants.TagNames.RootInstanceId] = eventData.RootInstanceId.Value;
+
+        using (logger.BeginScope(scopeProps))
         {
             logger.InstanceFaultedCleanupHookProcessing(eventData.InstanceId, eventData.Flow);
 

--- a/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceSubCompletedEventHook.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceSubCompletedEventHook.cs
@@ -34,14 +34,18 @@ public sealed class InstanceSubCompletedEventHook(
         EventHookContext context,
         CancellationToken cancellationToken = default)
     {
-        using (logger.BeginScope(new Dictionary<string, object>
+        var scopeProps = new Dictionary<string, object>
         {
             [TelemetryConstants.TagNames.Domain] = eventData.Domain,
             [TelemetryConstants.TagNames.Flow] = eventData.Flow,
             [TelemetryConstants.TagNames.FlowVersion] = eventData.Version ?? "N/A",
             [TelemetryConstants.TagNames.InstanceId] = eventData.InstanceId,
             [TelemetryConstants.TagNames.SubflowInstanceId] = eventData.SubInstanceId,
-        }))
+        };
+        if (eventData.RootInstanceId.HasValue)
+            scopeProps[TelemetryConstants.TagNames.RootInstanceId] = eventData.RootInstanceId.Value;
+
+        using (logger.BeginScope(scopeProps))
         {
             logger.SubFlowEventReceived(eventData.SubInstanceId, eventData.InstanceId, eventData.Domain, eventData.Flow);
 

--- a/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceSubFaultedEventHook.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceSubFaultedEventHook.cs
@@ -29,14 +29,18 @@ public sealed class InstanceSubFaultedEventHook(
         EventHookContext context,
         CancellationToken cancellationToken = default)
     {
-        using (logger.BeginScope(new Dictionary<string, object>
+        var scopeProps = new Dictionary<string, object>
         {
             [TelemetryConstants.TagNames.Domain] = eventData.Domain,
             [TelemetryConstants.TagNames.Flow] = eventData.Flow,
             [TelemetryConstants.TagNames.FlowVersion] = eventData.Version ?? "N/A",
             [TelemetryConstants.TagNames.InstanceId] = eventData.InstanceId,
             [TelemetryConstants.TagNames.SubflowInstanceId] = eventData.SubInstanceId,
-        }))
+        };
+        if (eventData.RootInstanceId.HasValue)
+            scopeProps[TelemetryConstants.TagNames.RootInstanceId] = eventData.RootInstanceId.Value;
+
+        using (logger.BeginScope(scopeProps))
         {
             logger.SubFlowFaultReceived(eventData.SubInstanceId, eventData.InstanceId, eventData.Domain, eventData.Flow);
 

--- a/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceSubStateChangedEventHook.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceSubStateChangedEventHook.cs
@@ -35,7 +35,7 @@ public sealed class InstanceSubStateChangedEventHook(
         EventHookContext context,
         CancellationToken cancellationToken = default)
     {
-        using (logger.BeginScope(new Dictionary<string, object>
+        var scopeProps = new Dictionary<string, object>
         {
             [TelemetryConstants.TagNames.Domain] = eventData.Domain,
             [TelemetryConstants.TagNames.Flow] = eventData.Flow,
@@ -43,7 +43,11 @@ public sealed class InstanceSubStateChangedEventHook(
             [TelemetryConstants.TagNames.InstanceId] = eventData.ParentInstanceId,
             [TelemetryConstants.TagNames.ParentInstanceId] = eventData.ParentInstanceId,
             [TelemetryConstants.TagNames.SubflowInstanceId] = eventData.SubInstanceId,
-        }))
+        };
+        if (eventData.RootInstanceId.HasValue)
+            scopeProps[TelemetryConstants.TagNames.RootInstanceId] = eventData.RootInstanceId.Value;
+
+        using (logger.BeginScope(scopeProps))
         {
             logger.SubFlowStateChangedEventReceived(
                 eventData.SubInstanceId,

--- a/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceSubStateChangedEventHook.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceSubStateChangedEventHook.cs
@@ -78,7 +78,7 @@ public sealed class InstanceSubStateChangedEventHook(
                         ["hook_error"] = "SubFlowStateUpdateFailed",
                         ["error_code"] = error.Code ?? "unknown",
                         ["error_prefix"] = error.Prefix ?? "unknown",
-                        ["error_message"] = error.Message
+                        ["error_message"] = error.Message ?? string.Empty
                     };
 
                     if (!string.IsNullOrEmpty(error.Target))

--- a/workers/BBT.Workflow.Workers.Inbox/Forwarding/DaprOrchestrationForwarder.cs
+++ b/workers/BBT.Workflow.Workers.Inbox/Forwarding/DaprOrchestrationForwarder.cs
@@ -1,9 +1,9 @@
+using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Json;
+using BBT.Workflow.Logging;
 using Dapr.Client;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 
 namespace BBT.Workflow.Workers.Inbox.Forwarding;
 
@@ -63,6 +63,10 @@ public sealed class DaprOrchestrationForwarder : IOrchestrationForwarder
         request.Headers.Add(
             WorkflowInfo.Name,
             WorkflowInfo.Generate(domain, workflow, version ?? "latest", instanceId));
+
+        var rootIdBaggage = Activity.Current?.GetBaggageItem(TelemetryConstants.TagNames.RootInstanceId);
+        if (!string.IsNullOrEmpty(rootIdBaggage))
+            request.Headers.TryAddWithoutValidation(TelemetryConstants.HeaderNames.RootInstanceId, rootIdBaggage);
 
         HttpResponseMessage response;
         try

--- a/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/ChildSubflowCancelRequestedEventHandler.cs
+++ b/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/ChildSubflowCancelRequestedEventHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using BBT.Aether.Events;
 using BBT.Workflow.Instances.Events;
 using BBT.Workflow.Logging;
@@ -31,13 +32,20 @@ internal sealed class ChildSubflowCancelRequestedEventHandler(
             return;
         }
 
-        using (logger.BeginScope(new Dictionary<string, object>
+        var scopeProps = new Dictionary<string, object>
         {
             [TelemetryConstants.TagNames.Domain] = eventData.Domain,
             [TelemetryConstants.TagNames.Flow] = eventData.Flow,
             [TelemetryConstants.TagNames.FlowVersion] = eventData.Version ?? "N/A",
             [TelemetryConstants.TagNames.InstanceId] = eventData.InstanceId,
-        }))
+        };
+        if (eventData.RootInstanceId.HasValue)
+        {
+            scopeProps[TelemetryConstants.TagNames.RootInstanceId] = eventData.RootInstanceId.Value;
+            Activity.Current?.SetBaggage(TelemetryConstants.TagNames.RootInstanceId,
+                eventData.RootInstanceId.Value.ToString());
+        }
+        using (logger.BeginScope(scopeProps))
         {
             logger.ChildSubflowCancelRequestReceived(
                 eventData.InstanceId,

--- a/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/ChildSubflowFaultRequestedEventHandler.cs
+++ b/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/ChildSubflowFaultRequestedEventHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using BBT.Aether.Events;
 using BBT.Workflow.Instances.Events;
 using BBT.Workflow.Logging;
@@ -31,13 +32,20 @@ internal sealed class ChildSubflowFaultRequestedEventHandler(
             return;
         }
 
-        using (logger.BeginScope(new Dictionary<string, object>
+        var scopeProps = new Dictionary<string, object>
         {
             [TelemetryConstants.TagNames.Domain] = eventData.Domain,
             [TelemetryConstants.TagNames.Flow] = eventData.Flow,
             [TelemetryConstants.TagNames.FlowVersion] = eventData.Version ?? "N/A",
             [TelemetryConstants.TagNames.InstanceId] = eventData.InstanceId,
-        }))
+        };
+        if (eventData.RootInstanceId.HasValue)
+        {
+            scopeProps[TelemetryConstants.TagNames.RootInstanceId] = eventData.RootInstanceId.Value;
+            Activity.Current?.SetBaggage(TelemetryConstants.TagNames.RootInstanceId,
+                eventData.RootInstanceId.Value.ToString());
+        }
+        using (logger.BeginScope(scopeProps))
         {
             logger.ChildSubflowFaultRequestReceived(
                 eventData.InstanceId,

--- a/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/InstanceCanceledEventHandler.cs
+++ b/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/InstanceCanceledEventHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using BBT.Aether.Events;
 using BBT.Workflow.Instances.Events;
 using BBT.Workflow.Logging;
@@ -31,13 +32,20 @@ internal sealed class InstanceCanceledEventHandler(
             return;
         }
 
-        using (logger.BeginScope(new Dictionary<string, object>
+        var scopeProps = new Dictionary<string, object>
         {
             [TelemetryConstants.TagNames.Domain] = eventData.Domain,
             [TelemetryConstants.TagNames.Flow] = eventData.Flow,
             [TelemetryConstants.TagNames.FlowVersion] = eventData.Version ?? "N/A",
             [TelemetryConstants.TagNames.InstanceId] = eventData.InstanceId,
-        }))
+        };
+        if (eventData.RootInstanceId.HasValue)
+        {
+            scopeProps[TelemetryConstants.TagNames.RootInstanceId] = eventData.RootInstanceId.Value;
+            Activity.Current?.SetBaggage(TelemetryConstants.TagNames.RootInstanceId,
+                eventData.RootInstanceId.Value.ToString());
+        }
+        using (logger.BeginScope(scopeProps))
         {
             logger.InstanceCanceledEventReceived(eventData.InstanceId, eventData.Flow);
 

--- a/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/InstanceCompletedCleanupEventHandler.cs
+++ b/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/InstanceCompletedCleanupEventHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using BBT.Aether.Events;
 using BBT.Workflow.Instances.Events;
 using BBT.Workflow.Logging;
@@ -30,13 +31,20 @@ internal sealed class InstanceCompletedCleanupEventHandler(
             return;
         }
 
-        using (logger.BeginScope(new Dictionary<string, object>
+        var scopeProps = new Dictionary<string, object>
         {
             [TelemetryConstants.TagNames.Domain] = eventData.Domain,
             [TelemetryConstants.TagNames.Flow] = eventData.Flow,
             [TelemetryConstants.TagNames.FlowVersion] = eventData.Version ?? "N/A",
             [TelemetryConstants.TagNames.InstanceId] = eventData.InstanceId,
-        }))
+        };
+        if (eventData.RootInstanceId.HasValue)
+        {
+            scopeProps[TelemetryConstants.TagNames.RootInstanceId] = eventData.RootInstanceId.Value;
+            Activity.Current?.SetBaggage(TelemetryConstants.TagNames.RootInstanceId,
+                eventData.RootInstanceId.Value.ToString());
+        }
+        using (logger.BeginScope(scopeProps))
         {
             logger.InstanceCompletedCleanupEventReceived(eventData.InstanceId, eventData.Flow);
 

--- a/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/InstanceFaultedCleanupEventHandler.cs
+++ b/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/InstanceFaultedCleanupEventHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using BBT.Aether.Events;
 using BBT.Workflow.Instances.Events;
 using BBT.Workflow.Logging;
@@ -30,13 +31,20 @@ internal sealed class InstanceFaultedCleanupEventHandler(
             return;
         }
 
-        using (logger.BeginScope(new Dictionary<string, object>
+        var scopeProps = new Dictionary<string, object>
         {
             [TelemetryConstants.TagNames.Domain] = eventData.Domain,
             [TelemetryConstants.TagNames.Flow] = eventData.Flow,
             [TelemetryConstants.TagNames.FlowVersion] = eventData.Version ?? "N/A",
             [TelemetryConstants.TagNames.InstanceId] = eventData.InstanceId,
-        }))
+        };
+        if (eventData.RootInstanceId.HasValue)
+        {
+            scopeProps[TelemetryConstants.TagNames.RootInstanceId] = eventData.RootInstanceId.Value;
+            Activity.Current?.SetBaggage(TelemetryConstants.TagNames.RootInstanceId,
+                eventData.RootInstanceId.Value.ToString());
+        }
+        using (logger.BeginScope(scopeProps))
         {
             logger.InstanceFaultedCleanupEventReceived(eventData.InstanceId, eventData.Flow);
 

--- a/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/InstanceSubCompletedEventHandler.cs
+++ b/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/InstanceSubCompletedEventHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using BBT.Aether.Events;
 using BBT.Workflow.Instances.Events;
 using BBT.Workflow.Logging;
@@ -33,14 +34,21 @@ internal sealed class InstanceSubCompletedEventHandler(
             return;
         }
 
-        using (logger.BeginScope(new Dictionary<string, object>
+        var scopeProps = new Dictionary<string, object>
         {
             [TelemetryConstants.TagNames.Domain] = eventData.Domain,
             [TelemetryConstants.TagNames.Flow] = eventData.Flow,
             [TelemetryConstants.TagNames.FlowVersion] = eventData.Version ?? "N/A",
             [TelemetryConstants.TagNames.InstanceId] = eventData.InstanceId,
             [TelemetryConstants.TagNames.SubflowInstanceId] = eventData.SubInstanceId,
-        }))
+        };
+        if (eventData.RootInstanceId.HasValue)
+        {
+            scopeProps[TelemetryConstants.TagNames.RootInstanceId] = eventData.RootInstanceId.Value;
+            Activity.Current?.SetBaggage(TelemetryConstants.TagNames.RootInstanceId,
+                eventData.RootInstanceId.Value.ToString());
+        }
+        using (logger.BeginScope(scopeProps))
         {
             logger.SubFlowEventReceived(
                 eventData.SubInstanceId,

--- a/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/InstanceSubFaultedEventHandler.cs
+++ b/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/InstanceSubFaultedEventHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using BBT.Aether.Events;
 using BBT.Workflow.Instances.Events;
 using BBT.Workflow.Logging;
@@ -32,14 +33,21 @@ internal sealed class InstanceSubFaultedEventHandler(
             return;
         }
 
-        using (logger.BeginScope(new Dictionary<string, object>
+        var scopeProps = new Dictionary<string, object>
         {
             [TelemetryConstants.TagNames.Domain] = eventData.Domain,
             [TelemetryConstants.TagNames.Flow] = eventData.Flow,
             [TelemetryConstants.TagNames.FlowVersion] = eventData.Version ?? "N/A",
             [TelemetryConstants.TagNames.InstanceId] = eventData.InstanceId,
             [TelemetryConstants.TagNames.SubflowInstanceId] = eventData.SubInstanceId,
-        }))
+        };
+        if (eventData.RootInstanceId.HasValue)
+        {
+            scopeProps[TelemetryConstants.TagNames.RootInstanceId] = eventData.RootInstanceId.Value;
+            Activity.Current?.SetBaggage(TelemetryConstants.TagNames.RootInstanceId,
+                eventData.RootInstanceId.Value.ToString());
+        }
+        using (logger.BeginScope(scopeProps))
         {
             logger.SubFlowFaultReceived(
                 eventData.SubInstanceId,

--- a/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/InstanceSubStateChangedEventHandler.cs
+++ b/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/InstanceSubStateChangedEventHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using BBT.Aether.Events;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Instances.Events;
@@ -33,7 +34,7 @@ internal sealed class InstanceSubStateChangedEventHandler(
             return;
         }
 
-        using (logger.BeginScope(new Dictionary<string, object>
+        var scopeProps = new Dictionary<string, object>
         {
             [TelemetryConstants.TagNames.Domain] = eventData.Domain,
             [TelemetryConstants.TagNames.Flow] = eventData.Flow,
@@ -41,7 +42,14 @@ internal sealed class InstanceSubStateChangedEventHandler(
             [TelemetryConstants.TagNames.InstanceId] = eventData.ParentInstanceId,
             [TelemetryConstants.TagNames.ParentInstanceId] = eventData.ParentInstanceId,
             [TelemetryConstants.TagNames.SubflowInstanceId] = eventData.SubInstanceId,
-        }))
+        };
+        if (eventData.RootInstanceId.HasValue)
+        {
+            scopeProps[TelemetryConstants.TagNames.RootInstanceId] = eventData.RootInstanceId.Value;
+            Activity.Current?.SetBaggage(TelemetryConstants.TagNames.RootInstanceId,
+                eventData.RootInstanceId.Value.ToString());
+        }
+        using (logger.BeginScope(scopeProps))
         {
             logger.SubFlowStateChangedEventReceived(
                 eventData.SubInstanceId,


### PR DESCRIPTION
## Summary
- Propagates `X-Root-Instance-Id` / `vnext.root.instance.id` through every execution path so searching by root instance ID in Jaeger or structured logs surfaces the full subflow chain (A→B→C→D)
- Adds `Guid? RootInstanceId` to 8 distributed event contracts and populates it in `Instance.cs` lifecycle methods, enabling downstream handlers and hooks to enrich their scopes without extra DB queries
- Forwards the header to the Execution service via Dapr (baggage-based), to InboxHandlers via event data, and stamps Activity tags/baggage at every entry point for full OTel trace correlation

## Changes
- `RemoteInvokerService.cs` — reads `vnext.root.instance.id` from Activity baggage, forwards as `X-Root-Instance-Id` to Execution API
- `FlowTimeoutJobHandler.cs`, `StateNotifyJobHandler.cs`, `ForwardToSubflowJobHandler.cs` — conditional nested log scope + Activity enrichment after instance load
- `Instance.cs` (Domain) — computes `GetRootInstanceId()` once per lifecycle method; sets `RootInstanceId` on all 8 `AddDistributedEvent` calls
- 8 event contracts in `BBT.Workflow.Events.Contracts` — `Guid? RootInstanceId { get; init; }` added
- 6 event hooks in `BBT.Workflow.Infrastructure` — conditional `RootInstanceId` appended to `BeginScope` dict
- 8 InboxHandlers + `DaprOrchestrationForwarder` — Activity baggage set in handlers; forwarder forwards `X-Root-Instance-Id` header
- `InstanceQueryAppService.cs` — `BeginRootIdScopeIfSubflow` helper + Activity enrichment across all function paths
- `FunctionAppService.cs` — Activity-only enrichment after instance load

## Test Plan
- [ ] Start a flow A that launches subflow B; trigger a transition on B
- [ ] In Jaeger, search by `vnext.root.instance.id = <A.id>` — spans from both A and B should appear
- [ ] Call `GET /functions/state` for instance B; structured logs should include `vnext.root.instance.id`
- [ ] Check Inbox worker logs after B completes — `vnext.root.instance.id` should appear in all handler scopes
- [ ] Full solution build passes: `dotnet build vnext.sln --no-restore` → 0 errors

## Summary by Sourcery

Propagate the root workflow instance identifier through events, handlers, and HTTP/Dapr calls to enable end-to-end observability and trace correlation across subflow chains.

Enhancements:
- Add optional RootInstanceId to instance lifecycle distributed events and populate it based on the computed root instance for non-root flows.
- Enrich logging scopes and OpenTelemetry Activity tags/baggage with RootInstanceId in query, job, function, subflow forwarding, and event hook paths for subflow instances.
- Forward the root instance ID via HTTP headers in remote task invocation and Dapr orchestration forwarding based on Activity baggage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved tracking and traceability for nested workflow and subflow actions across instance queries, forwarding, notifications, and background processing.
  * Workflow events now carry richer context so related actions can be correlated more easily.

* **Bug Fixes**
  * Better handling of subflow-related completions, cancellations, faults, and state changes to preserve the correct workflow lineage.
  * Outbound workflow requests now include additional context when available, helping downstream processing stay consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->