### PR TITLE
fix(subflow): propagate faulted status through nested subflow output mapping failures

### DIFF
--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/TransitionPipeline.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/TransitionPipeline.cs
@@ -1,4 +1,5 @@
 using BBT.Aether.Results;
+using BBT.Aether.Uow;
 using BBT.Workflow.BackgroundJobs;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Execution.Continuations;
@@ -26,6 +27,7 @@ public class TransitionPipeline
     private readonly ITransitionContextFactory _contextFactory;
     private readonly IPostCommitExecutor _postCommitExecutor;
     private readonly IInstanceRepository _instanceRepository;
+    private readonly IUnitOfWorkManager _uowManager;
     private readonly ITransitionValidationService _validationService;
     private readonly IPipelineProfileResolver _profileResolver;
     private readonly IStateNotificationScheduler _stateNotificationScheduler;
@@ -49,6 +51,7 @@ public class TransitionPipeline
         ITransitionContextFactory contextFactory,
         IPostCommitExecutor postCommitExecutor,
         IInstanceRepository instanceRepository,
+        IUnitOfWorkManager uowManager,
         ITransitionValidationService validationService,
         IPipelineProfileResolver profileResolver,
         IStateNotificationScheduler stateNotificationScheduler,
@@ -62,6 +65,7 @@ public class TransitionPipeline
         _contextFactory = contextFactory;
         _postCommitExecutor = postCommitExecutor;
         _instanceRepository = instanceRepository;
+        _uowManager = uowManager;
         _validationService = validationService;
         _profileResolver = profileResolver;
         _stateNotificationScheduler = stateNotificationScheduler;
@@ -255,20 +259,27 @@ public class TransitionPipeline
     /// <summary>
     /// Marks the workflow instance as faulted. Already within lock scope —
     /// no re-acquisition needed.
+    /// Uses a RequiresNew UoW scope so that any dirty state left on the current
+    /// DbContext by the failed pipeline step does not block SaveChanges.
     /// </summary>
     private async Task MarkInstanceFaultedAsync(
         TransitionExecutionContext context,
         Error error,
         CancellationToken cancellationToken)
     {
-        _logger.LogWarning(
-            "Marking instance {InstanceId} as faulted due to unhandled pipeline error: {ErrorCode} - {ErrorMessage}",
-            context.InstanceId, error.Code, error.Message);
+        _logger.InstanceFaultedDueToPipelineError(context.InstanceId, error.Code, error.Message);
 
-        if (!context.Instance.HasActiveIncident)
+        await using var faultUow = _uowManager.Begin(
+            new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew });
+
+        // Reload in the new scope so we operate on a clean, tracked entity.
+        var instance = await _instanceRepository.FindAsync(context.InstanceId, true, cancellationToken)
+                       ?? context.Instance;
+
+        if (!instance.HasActiveIncident)
         {
             var incident = InstanceIncidentFactory.Create(
-                state: context.Instance.GetCurrentState,
+                state: instance.GetCurrentState,
                 transition: context.TransitionKey,
                 taskKey: null,
                 message: error.Message ?? "Unhandled pipeline error",
@@ -276,16 +287,14 @@ public class TransitionPipeline
                 errorLayer: "Pipeline",
                 traceId: context.TraceId);
 
-            context.Instance.AddIncident(incident);
+            instance.AddIncident(incident);
         }
 
-        context.Instance.Fault(context.Domain);
-        context.ExtractAndDeferInstanceEvents();
-        await _instanceRepository.UpdateAsync(context.Instance, true, cancellationToken);
+        instance.Fault(context.Domain);
+        await _instanceRepository.UpdateAsync(instance, true, cancellationToken);
+        await faultUow.CommitAsync(cancellationToken);
 
-        _logger.LogInformation(
-            "Instance {InstanceId} marked as faulted successfully. Client will receive Status = 'F'",
-            context.InstanceId);
+        _logger.InstanceFaultedSuccessfully(context.InstanceId);
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Application/SubFlow/Contracts/ISubflowOutputMappingService.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Contracts/ISubflowOutputMappingService.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using BBT.Aether.Results;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Instances;
 
@@ -12,8 +13,10 @@ public interface ISubflowOutputMappingService
     /// <summary>
     /// Executes the parent SubFlow state's <see cref="Scripting.ISubFlowMapping.OutputHandler"/> with the child data
     /// as the script body, then persists mapped data and script mutations on the parent instance.
+    /// Returns <see cref="Result.Ok()"/> on success or <see cref="Result.Fail"/> when the OutputHandler throws,
+    /// so callers can decide whether to fault the instance instead of silently continuing.
     /// </summary>
-    Task ApplyAsync(
+    Task<Result> ApplyAsync(
         Instance parentInstance,
         Definitions.Workflow parentWorkflow,
         string parentStateKey,

--- a/src/BBT.Workflow.Application/SubFlow/Services/SubflowCompletionService.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubflowCompletionService.cs
@@ -79,6 +79,17 @@ public sealed class SubflowCompletionService(
                         return;
                     }
 
+                    // Idempotency: if parent is already in a terminal state the subflow completion
+                    // has already been processed (or the parent was terminated via another path).
+                    // No pipeline resume is needed — just return cleanly.
+                    if (parentInstance.Status.Equals(InstanceStatus.Completed) ||
+                        parentInstance.Status.Equals(InstanceStatus.Faulted))
+                    {
+                        activity?.SetTag("vnext.subflow.result", "parent_already_terminal");
+                        await correlationUow.CommitAsync(cancellationToken);
+                        return;
+                    }
+
                     var correlation = parentInstance.FindCorrelationBySubInstanceId(completedInput.SubInstanceId);
                     if (correlation == null)
                     {
@@ -124,13 +135,32 @@ public sealed class SubflowCompletionService(
 
                     parentWorkflow = parentWorkflowResult.Value!;
 
-                    await outputMappingService.ApplyAsync(
+                    var mappingResult = await outputMappingService.ApplyAsync(
                         parentInstance,
                         parentWorkflow,
                         correlation.ParentState,
                         completedInput.InstanceData,
                         cancellationToken);
-                    
+
+                    if (!mappingResult.IsSuccess)
+                    {
+                        // Output mapping failed — fault the parent instead of resuming the pipeline.
+                        // Retrying would never succeed; faulting propagates the error to A via InstanceSubFaultedEvent.
+                        var incident = InstanceIncidentFactory.Create(
+                            state: parentInstance.GetCurrentState,
+                            transition: string.Empty,
+                            taskKey: null,
+                            message: mappingResult.Error.Message ?? "SubFlow output mapping failed",
+                            errorCode: mappingResult.Error.Code ?? WorkflowErrorCodes.SubflowOutputMappingFailed,
+                            errorLayer: "SubFlow",
+                            stackTrace: mappingResult.Error.Detail);
+                        parentInstance.AddIncident(incident);
+                        parentInstance.Fault(completedInput.Domain);
+                        await instanceRepository.UpdateAsync(parentInstance, true, cancellationToken);
+                        await correlationUow.CommitAsync(cancellationToken);
+                        return;
+                    }
+
                     await correlationUow.CommitAsync(cancellationToken);
                 }
                 
@@ -195,8 +225,13 @@ public sealed class SubflowCompletionService(
             
             if (!result.IsSuccess)
             {
-                // Check if this is an auto-transition condition not met
-                if (result.Error.Code != WorkflowErrorCodes.AutoTransitionConditionNotMet)
+                // AutoTransitionConditionNotMet: normal — no matching auto-transition, instance stays Active.
+                // InstanceCompleted: race condition — parent was completed between Phase 1 commit and
+                // Phase 2 execution (e.g. timeout, cancel, or duplicate delivery). Both are non-fatal.
+                var isSoftError = result.Error.Code == WorkflowErrorCodes.AutoTransitionConditionNotMet
+                               || result.Error.Code == WorkflowErrorCodes.InstanceCompleted;
+
+                if (!isSoftError)
                 {
                     logger.TransitionRuleFailed(
                         "subflow",
@@ -204,13 +239,15 @@ public sealed class SubflowCompletionService(
                         result.Error.Message ?? "Unknown error");
                 }
 
-                throw new SubflowCompletionException(
-                    parentWorkflow.Domain,
-                    parentWorkflow.Key,
-                    parentInstance.Id.ToString(),
-                    result.Error.Code,
-                    result.Error.Message ?? "Unknown error"
-                );
+                if (!isSoftError)
+                {
+                    throw new SubflowCompletionException(
+                        parentWorkflow.Domain,
+                        parentWorkflow.Key,
+                        parentInstance.Id.ToString(),
+                        result.Error.Code,
+                        result.Error.Message ?? "Unknown error");
+                }
             }
         }
         catch (Exception ex)

--- a/src/BBT.Workflow.Application/SubFlow/Services/SubflowFaultService.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubflowFaultService.cs
@@ -137,12 +137,22 @@ public sealed class SubflowFaultService(
                         parentInstance.Fault(input.Domain);
                     }
 
-                    await outputMappingService.ApplyAsync(
+                    var mappingResult = await outputMappingService.ApplyAsync(
                         parentInstance,
                         parentWorkflow,
                         correlation.ParentState,
                         input.InstanceData,
                         cancellationToken);
+
+                    // Output mapping failure is non-blocking here: the instance is already
+                    // marked Faulted/transitioned above. Just log and proceed so the fault
+                    // is committed and propagated upward via InstanceSubFaultedEvent.
+                    if (!mappingResult.IsSuccess)
+                    {
+                        logger.SubFlowOutputMappingFailed(
+                            new Exception(mappingResult.Error.Message),
+                            parentInstance.Id);
+                    }
 
                     await instanceRepository.UpdateAsync(parentInstance, true, cancellationToken);
                     await uow.CommitAsync(cancellationToken);

--- a/src/BBT.Workflow.Application/SubFlow/Services/SubflowOutputMappingService.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubflowOutputMappingService.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using BBT.Aether.Guids;
+using BBT.Aether.Results;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Logging;
@@ -20,7 +21,7 @@ public sealed class SubflowOutputMappingService(
     : ISubflowOutputMappingService
 {
     /// <inheritdoc />
-    public async Task ApplyAsync(
+    public async Task<Result> ApplyAsync(
         Instance parentInstance,
         Definitions.Workflow parentWorkflow,
         string parentStateKey,
@@ -29,12 +30,12 @@ public sealed class SubflowOutputMappingService(
     {
         var parentStateResult = parentWorkflow.GetState(parentStateKey);
         if (!parentStateResult.IsSuccess)
-            return;
+            return Result.Ok();
 
         var parentState = parentStateResult.Value!;
         var subFlowConfig = parentState.SubFlow;
         if (subFlowConfig?.Mapping is null || !subFlowConfig.Mapping.HasMappingCode)
-            return;
+            return Result.Ok();
 
         try
         {
@@ -76,10 +77,16 @@ public sealed class SubflowOutputMappingService(
             {
                 await instanceRepository.UpdateAsync(parentInstance, true, cancellationToken);
             }
+
+            return Result.Ok();
         }
         catch (Exception ex)
         {
-            logger.SubFlowCompletionFailed(ex, Guid.Empty, parentInstance.Id);
+            logger.SubFlowOutputMappingFailed(ex, parentInstance.Id);
+            return Result.Fail(WorkflowErrors.SubFlowOutputMappingFailed(
+                parentInstance.Id,
+                ex.Message,
+                stackTrace: ex.ToString()));
         }
     }
 }

--- a/src/BBT.Workflow.Domain/Logging/WorkflowErrors.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowErrors.cs
@@ -374,6 +374,18 @@ public static class WorkflowErrors
             detail: stackTrace ?? subFlowKey);
 
     /// <summary>
+    /// SubFlow output mapping script execution failed.
+    /// </summary>
+    /// <param name="parentInstanceId">The ID of the parent instance whose output mapping failed.</param>
+    /// <param name="reason">The exception message from the failed OutputHandler.</param>
+    /// <param name="stackTrace">Full exception stack trace stored in <see cref="Error.Detail"/>.</param>
+    public static Error SubFlowOutputMappingFailed(Guid parentInstanceId, string reason, string? stackTrace = null)
+        => Error.Failure(
+            WorkflowErrorCodes.SubflowOutputMappingFailed,
+            $"SubFlow output mapping failed for parent instance '{parentInstanceId}': {reason}",
+            detail: stackTrace);
+
+    /// <summary>
     /// Correlation not found for SubFlow start.
     /// </summary>
     /// <param name="correlationId">The correlation ID that was not found.</param>

--- a/src/BBT.Workflow.Domain/Logging/WorkflowEventIds.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowEventIds.cs
@@ -79,6 +79,7 @@ public static class WorkflowEventIds
     public static readonly EventId SubFlowStateChangeApplied = new(40028, nameof(SubFlowStateChangeApplied));
     public static readonly EventId SubFlowStateChangedEventReceived = new(40029, nameof(SubFlowStateChangedEventReceived));
     public static readonly EventId SubFlowStateUpdateFailed = new(40079, nameof(SubFlowStateUpdateFailed));
+    public static readonly EventId SubFlowOutputMappingFailed = new(40080, nameof(SubFlowOutputMappingFailed));
 
     // Warning (40040-40069)
     public static readonly EventId SubFlowCorrelationNotFound = new(40043, nameof(SubFlowCorrelationNotFound));

--- a/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
@@ -585,6 +585,30 @@ public static partial class WorkflowLogs
         int excludedCount,
         string transitionKey);
 
+    /// <summary>
+    /// Logs when an instance is about to be marked faulted due to an unhandled pipeline error.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 10130,
+        Level = LogLevel.Warning,
+        Message = "Marking instance {InstanceId} as faulted due to unhandled pipeline error: {ErrorCode} - {ErrorMessage}")]
+    public static partial void InstanceFaultedDueToPipelineError(
+        this ILogger logger,
+        Guid instanceId,
+        string? errorCode,
+        string? errorMessage);
+
+    /// <summary>
+    /// Logs when an instance has been successfully persisted as faulted.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 10131,
+        Level = LogLevel.Information,
+        Message = "Instance {InstanceId} marked as faulted successfully. Client will receive Status = 'F'")]
+    public static partial void InstanceFaultedSuccessfully(
+        this ILogger logger,
+        Guid instanceId);
+
     #endregion
 
     #region Task Execution
@@ -907,6 +931,18 @@ public static partial class WorkflowLogs
         Message = "SubFlow output mapping started for parent instance {ParentInstanceId}")]
     public static partial void SubFlowOutputMappingStarted(
         this ILogger logger,
+        Guid parentInstanceId);
+
+    /// <summary>
+    /// Logs when SubFlow output mapping script execution fails.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 40080,
+        Level = LogLevel.Error,
+        Message = "SubFlow output mapping failed for parent instance {ParentInstanceId}")]
+    public static partial void SubFlowOutputMappingFailed(
+        this ILogger logger,
+        Exception exception,
         Guid parentInstanceId);
 
     /// <summary>

--- a/src/BBT.Workflow.Domain/WorkflowErrorCodes.cs
+++ b/src/BBT.Workflow.Domain/WorkflowErrorCodes.cs
@@ -45,6 +45,7 @@ public static class WorkflowErrorCodes
     public const string InstanceNotFaulted = "Instance:100027";
     public const string NoIncompleteTransitionFound = "Instance:100028";
     public const string TimeoutConfigMissing = "Instance:100029";
+    public const string SubflowOutputMappingFailed = "Instance:100030";
 
     #endregion
     

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/TransitionPipelineTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/TransitionPipelineTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using BBT.Aether.Results;
+using BBT.Aether.Uow;
 using BBT.Workflow.BackgroundJobs;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Execution;
@@ -34,6 +35,7 @@ public class TransitionPipelineTests
     private readonly ITransitionContextFactory _mockContextFactory;
     private readonly IPostCommitExecutor _mockPostCommitExecutor;
     private readonly IInstanceRepository _mockInstanceRepository;
+    private readonly IUnitOfWorkManager _mockUowManager;
     private readonly ITransitionValidationService _mockValidationService;
     private readonly IStateNotificationScheduler _mockStateNotificationScheduler;
     private readonly List<ITransitionStep> _mockSteps;
@@ -48,6 +50,7 @@ public class TransitionPipelineTests
         _mockContextFactory = Substitute.For<ITransitionContextFactory>();
         _mockPostCommitExecutor = Substitute.For<IPostCommitExecutor>();
         _mockInstanceRepository = Substitute.For<IInstanceRepository>();
+        _mockUowManager = Substitute.For<IUnitOfWorkManager>();
         _mockValidationService = Substitute.For<ITransitionValidationService>();
         _mockStateNotificationScheduler = Substitute.For<IStateNotificationScheduler>();
         _mockSteps = new List<ITransitionStep>();
@@ -119,6 +122,7 @@ public class TransitionPipelineTests
             _mockContextFactory,
             _mockPostCommitExecutor,
             _mockInstanceRepository,
+            _mockUowManager,
             _mockValidationService,
             new PipelineProfileResolver(),
             _mockStateNotificationScheduler,

--- a/test/BBT.Workflow.Application.Tests/SubFlow/SubflowFaultServiceTests.cs
+++ b/test/BBT.Workflow.Application.Tests/SubFlow/SubflowFaultServiceTests.cs
@@ -37,8 +37,17 @@ public sealed class SubflowFaultServiceTests
             .Returns(ValueTask.CompletedTask);
 
         _uowManager
-            .Setup(m => m.BeginAsync(It.IsAny<UnitOfWorkOptions>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(_uow.Object);
+            .Setup(m => m.Begin(It.IsAny<UnitOfWorkOptions>()))
+            .Returns(_uow.Object);
+
+        _outputMappingService
+            .Setup(x => x.ApplyAsync(
+                It.IsAny<Instance>(),
+                It.IsAny<Definitions.Workflow>(),
+                It.IsAny<string>(),
+                It.IsAny<JsonElement?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Ok());
     }
 
     [Fact]
@@ -126,7 +135,7 @@ public sealed class SubflowFaultServiceTests
         parentInstance.FindCorrelationBySubInstanceId(subInstanceId)!.IsCompleted.ShouldBeFalse();
         parentInstance.Status.ShouldBe(InstanceStatus.Busy);
         _uowManager.Verify(
-            x => x.BeginAsync(It.IsAny<UnitOfWorkOptions>(), It.IsAny<CancellationToken>()),
+            x => x.Begin(It.IsAny<UnitOfWorkOptions>()),
             Times.Exactly(2));
     }
 
@@ -150,7 +159,7 @@ public sealed class SubflowFaultServiceTests
                 It.IsAny<JsonElement?>(),
                 It.IsAny<CancellationToken>()))
             .Callback(() => incidentVisibleToMapping = parentInstance.HasActiveIncident)
-            .Returns(Task.CompletedTask);
+            .ReturnsAsync(Result.Ok());
 
         await CreateService().FaultAsync(input, CancellationToken.None);
 


### PR DESCRIPTION
## Summary
- Fix a bug where a nested subflow scenario (A → SubFlow B → SubFlow C) would permanently stall Flow A when B's output mapping script threw an exception after C completed
- `SubflowOutputMappingService.ApplyAsync` was silently swallowing all exceptions; it now returns `Result<T>` so callers can react to failures
- `SubflowCompletionService` now faults the parent instance directly when output mapping fails, preventing the lost-event trap that left Flow A stuck forever
- `SubflowCompletionService` now guards against already-terminal parent instances and treats `InstanceCompleted` as a soft (non-fatal) error in `ResumePipelineAsync`, fixing a `SubflowCompletionException` thrown when a parent was completed via another path (timeout/cancel/race)
- `TransitionPipeline.MarkInstanceFaultedAsync` now persists the fault in a `RequiresNew` UoW scope, preventing an EF Core `ConcurrencyDetector` error caused by a failed step leaving a dirty DbContext

## Changes
- `SubflowOutputMappingService.cs` / `ISubflowOutputMappingService.cs` — `ApplyAsync` returns `Task<Result>` instead of `Task`; catch block returns `Result.Fail` with message + stack trace
- `SubflowCompletionService.cs` — terminal state guard added; output mapping failure faults parent instead of proceeding to `ResumePipelineAsync`; `InstanceCompleted` treated as soft error in resume path
- `SubflowFaultService.cs` — updated to handle new `Task<Result>` return type; logs on failure but continues (fault already committed)
- `TransitionPipeline.cs` — `MarkInstanceFaultedAsync` uses `RequiresNew` UoW scope + reloads instance fresh to avoid dirty-DbContext `SaveChangesAsync` failures; `IUnitOfWorkManager` injected
- `WorkflowErrorCodes.cs` — new constant `SubflowOutputMappingFailed = "Instance:100030"`
- `WorkflowErrors.cs` — new factory `SubFlowOutputMappingFailed(parentInstanceId, reason, stackTrace)`
- `WorkflowLogs.cs` / `WorkflowEventIds.cs` — new log extensions: `SubFlowOutputMappingFailed` (40080), `InstanceFaultedDueToPipelineError` (10130), `InstanceFaultedSuccessfully` (10131)
- `SubflowFaultServiceTests.cs` / `TransitionPipelineTests.cs` — updated mocks for new signatures

## Test Plan
- [ ] Nested subflow scenario: A → SubFlow B → SubFlow C; C completes, B's output mapping script throws → expect B Faulted, A Faulted (no permanent stall)
- [ ] Normal completion (no mapping error) still resumes parent pipeline correctly
- [ ] Parent already Completed when subflow completion event arrives → no `SubflowCompletionException`, no error log
- [ ] Pipeline step failure during transition → `MarkInstanceFaultedAsync` persists fault without EF Core ConcurrencyDetector error
- [ ] All existing SubFlow and Pipeline unit tests pass (116 tests)

## Summary by Sourcery

Ensure subflow output mapping failures fault the parent workflow instance instead of stalling nested flows and improve fault persistence robustness in the transition pipeline.

Bug Fixes:
- Prevent nested subflows from permanently stalling when a child subflow output mapping script throws after completion by faulting the parent instance.
- Avoid SubflowCompletionException when a subflow completion event arrives for a parent instance that has already reached a terminal state via another path.
- Eliminate EF Core concurrency detector errors when marking an instance faulted after a failed pipeline step by persisting the fault in an isolated unit-of-work scope.

Enhancements:
- Return structured Result objects from subflow output mapping execution so callers can react to failures instead of silently swallowing exceptions.
- Add workflow error codes and structured error factories for subflow output mapping failures to improve observability and diagnostics.
- Introduce dedicated logging events for subflow output mapping failures and pipeline-driven instance faulting for clearer operational traces.

Tests:
- Update subflow faulting and transition pipeline tests to cover the new output mapping result contract and fault persistence behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subflow output mapping now returns success or failure details, allowing failures to be handled more reliably.
  * Workflow faults now produce clearer logging and error information.

* **Bug Fixes**
  * Improved fault handling so failed updates are saved safely even when an error occurs.
  * Subflow completion now avoids duplicate processing when the parent workflow is already finished.
  * Mapping failures now create a visible incident instead of silently continuing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->