### PR TITLE
v0.0.67

### DIFF
--- a/src/BBT.Workflow.Application/BackgroundJobs/Handlers/FlowTimeoutJobHandler.cs
+++ b/src/BBT.Workflow.Application/BackgroundJobs/Handlers/FlowTimeoutJobHandler.cs
@@ -82,6 +82,17 @@ public sealed class FlowTimeoutJobHandler(
                         return;
                     }
 
+                    var rootId = instance.GetRootInstanceId();
+                    using var rootScope = rootId != args.InstanceId
+                        ? logger.BeginScope(new Dictionary<string, object>
+                          { [TelemetryConstants.TagNames.RootInstanceId] = rootId })
+                        : null;
+                    if (rootId != args.InstanceId)
+                    {
+                        activity?.SetTag(TelemetryConstants.TagNames.RootInstanceId, rootId.ToString());
+                        activity?.SetBaggage(TelemetryConstants.TagNames.RootInstanceId, rootId.ToString());
+                    }
+
                     if (workflow.Timeout is null)
                     {
                         logger.TimeoutConfigMissing(instance.Flow);

--- a/src/BBT.Workflow.Application/BackgroundJobs/Handlers/StateNotifyJobHandler.cs
+++ b/src/BBT.Workflow.Application/BackgroundJobs/Handlers/StateNotifyJobHandler.cs
@@ -89,6 +89,17 @@ public sealed class StateNotifyJobHandler(
             .WithBody(args.Data)
             .BuildAsync(cancellationToken);
 
+        var rootId = scriptContext.Instance?.GetRootInstanceId();
+        using var rootScope = (rootId.HasValue && rootId.Value != args.InstanceId)
+            ? logger.BeginScope(new Dictionary<string, object>
+              { [TelemetryConstants.TagNames.RootInstanceId] = rootId.Value })
+            : null;
+        if (rootId.HasValue && rootId.Value != args.InstanceId)
+        {
+            activity?.SetTag(TelemetryConstants.TagNames.RootInstanceId, rootId.Value.ToString());
+            activity?.SetBaggage(TelemetryConstants.TagNames.RootInstanceId, rootId.Value.ToString());
+        }
+
         var state = scriptContext.Workflow?.States.SingleOrDefault(s => s.Key == args.StateKey);
 
         var entries = state?.Notifications

--- a/src/BBT.Workflow.Application/Execution/PostCommit/Handlers/ForwardToSubflowJobHandler.cs
+++ b/src/BBT.Workflow.Application/Execution/PostCommit/Handlers/ForwardToSubflowJobHandler.cs
@@ -21,12 +21,17 @@ public sealed class ForwardToSubflowJobHandler(
         TransitionExecutionContext context,
         CancellationToken cancellationToken)
     {
-        using (logger.BeginScope(new Dictionary<string, object>
+        var rootId = context.Instance?.GetRootInstanceId();
+        var scopeProps = new Dictionary<string, object>
         {
             [TelemetryConstants.TagNames.InstanceId] = context.InstanceId,
             [TelemetryConstants.TagNames.ParentInstanceId] = job.ParentInstanceId,
             [TelemetryConstants.TagNames.SubflowInstanceId] = job.SubflowInstanceId
-        }))
+        };
+        if (rootId.HasValue && rootId.Value != context.InstanceId)
+            scopeProps[TelemetryConstants.TagNames.RootInstanceId] = rootId.Value;
+
+        using (logger.BeginScope(scopeProps))
         {
             logger.SubFlowForwardStarted(job.TransitionKey, job.SubflowInstanceId, job.ParentInstanceId);
 

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/TransitionPipeline.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/TransitionPipeline.cs
@@ -1,4 +1,5 @@
 using BBT.Aether.Results;
+using BBT.Aether.Uow;
 using BBT.Workflow.BackgroundJobs;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Execution.Continuations;
@@ -26,6 +27,7 @@ public class TransitionPipeline
     private readonly ITransitionContextFactory _contextFactory;
     private readonly IPostCommitExecutor _postCommitExecutor;
     private readonly IInstanceRepository _instanceRepository;
+    private readonly IUnitOfWorkManager _uowManager;
     private readonly ITransitionValidationService _validationService;
     private readonly IPipelineProfileResolver _profileResolver;
     private readonly IStateNotificationScheduler _stateNotificationScheduler;
@@ -49,6 +51,7 @@ public class TransitionPipeline
         ITransitionContextFactory contextFactory,
         IPostCommitExecutor postCommitExecutor,
         IInstanceRepository instanceRepository,
+        IUnitOfWorkManager uowManager,
         ITransitionValidationService validationService,
         IPipelineProfileResolver profileResolver,
         IStateNotificationScheduler stateNotificationScheduler,
@@ -62,6 +65,7 @@ public class TransitionPipeline
         _contextFactory = contextFactory;
         _postCommitExecutor = postCommitExecutor;
         _instanceRepository = instanceRepository;
+        _uowManager = uowManager;
         _validationService = validationService;
         _profileResolver = profileResolver;
         _stateNotificationScheduler = stateNotificationScheduler;
@@ -255,20 +259,27 @@ public class TransitionPipeline
     /// <summary>
     /// Marks the workflow instance as faulted. Already within lock scope —
     /// no re-acquisition needed.
+    /// Uses a RequiresNew UoW scope so that any dirty state left on the current
+    /// DbContext by the failed pipeline step does not block SaveChanges.
     /// </summary>
     private async Task MarkInstanceFaultedAsync(
         TransitionExecutionContext context,
         Error error,
         CancellationToken cancellationToken)
     {
-        _logger.LogWarning(
-            "Marking instance {InstanceId} as faulted due to unhandled pipeline error: {ErrorCode} - {ErrorMessage}",
-            context.InstanceId, error.Code, error.Message);
+        _logger.InstanceFaultedDueToPipelineError(context.InstanceId, error.Code, error.Message);
 
-        if (!context.Instance.HasActiveIncident)
+        await using var faultUow = _uowManager.Begin(
+            new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew });
+
+        // Reload in the new scope so we operate on a clean, tracked entity.
+        var instance = await _instanceRepository.FindAsync(context.InstanceId, true, cancellationToken)
+                       ?? context.Instance;
+
+        if (!instance.HasActiveIncident)
         {
             var incident = InstanceIncidentFactory.Create(
-                state: context.Instance.GetCurrentState,
+                state: instance.GetCurrentState,
                 transition: context.TransitionKey,
                 taskKey: null,
                 message: error.Message ?? "Unhandled pipeline error",
@@ -276,16 +287,14 @@ public class TransitionPipeline
                 errorLayer: "Pipeline",
                 traceId: context.TraceId);
 
-            context.Instance.AddIncident(incident);
+            instance.AddIncident(incident);
         }
 
-        context.Instance.Fault(context.Domain);
-        context.ExtractAndDeferInstanceEvents();
-        await _instanceRepository.UpdateAsync(context.Instance, true, cancellationToken);
+        instance.Fault(context.Domain);
+        await _instanceRepository.UpdateAsync(instance, true, cancellationToken);
+        await faultUow.CommitAsync(cancellationToken);
 
-        _logger.LogInformation(
-            "Instance {InstanceId} marked as faulted successfully. Client will receive Status = 'F'",
-            context.InstanceId);
+        _logger.InstanceFaultedSuccessfully(context.InstanceId);
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Application/Functions/FunctionAppService.cs
+++ b/src/BBT.Workflow.Application/Functions/FunctionAppService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
 using System.Globalization;
@@ -69,6 +70,13 @@ public sealed class FunctionAppService(
             var instance = await instanceRepository.FindByIdentifierAsync(instanceKey, cancellationToken);
             if (instance == null)
                 return Result<FunctionResponseOutput>.Fail(WorkflowErrors.InstanceNotFound(instanceKey));
+
+            var rootId = instance.GetRootInstanceId();
+            if (rootId != instance.Id)
+            {
+                Activity.Current?.SetTag(TelemetryConstants.TagNames.RootInstanceId, rootId.ToString());
+                Activity.Current?.SetBaggage(TelemetryConstants.TagNames.RootInstanceId, rootId.ToString());
+            }
 
             return await componentCacheStore
                 .GetFlowAsync(domain, flow, instance.FlowVersion, cancellationToken)

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using BBT.Aether;
 using BBT.Aether.Application.Services;
 using BBT.Aether.Domain.Entities;
@@ -56,7 +57,21 @@ public sealed class InstanceQueryAppService(
         InstanceStatus.Faulted,
         InstanceStatus.Passive
     ];
-    
+
+    private IDisposable? BeginRootIdScopeIfSubflow(Instance instance)
+    {
+        var rootId = instance.GetRootInstanceId();
+        if (rootId == instance.Id)
+            return null;
+
+        Activity.Current?.SetTag(TelemetryConstants.TagNames.RootInstanceId, rootId.ToString());
+        Activity.Current?.SetBaggage(TelemetryConstants.TagNames.RootInstanceId, rootId.ToString());
+        return logger.BeginScope(new Dictionary<string, object>
+        {
+            [TelemetryConstants.TagNames.RootInstanceId] = rootId
+        });
+    }
+
     public async Task<ConditionalResult<GetInstanceOutput>> GetInstanceAsync(
         GetInstanceInput input,
         CancellationToken cancellationToken = default)
@@ -462,7 +477,19 @@ public sealed class InstanceQueryAppService(
         CancellationToken cancellationToken)
     {
         var instance = await instanceRepository.FindByIdentifierAsReadOnlyAsync(instanceIdentifier, cancellationToken);
-        return instance.EnsureNotNull(WorkflowErrors.InstanceNotFound(instanceIdentifier));
+        var result = instance.EnsureNotNull(WorkflowErrors.InstanceNotFound(instanceIdentifier));
+        if (result.IsSuccess)
+        {
+            var inst = result.Value!;
+            var rootId = inst.GetRootInstanceId();
+            if (rootId != inst.Id)
+            {
+                Activity.Current?.SetTag(TelemetryConstants.TagNames.RootInstanceId, rootId.ToString());
+                Activity.Current?.SetBaggage(TelemetryConstants.TagNames.RootInstanceId, rootId.ToString());
+            }
+        }
+
+        return result;
     }
 
     /// <summary>
@@ -762,6 +789,7 @@ public sealed class InstanceQueryAppService(
             .MatchAsync(
                 onSuccess: async data =>
                 {
+                    using var rootScope = BeginRootIdScopeIfSubflow(data.instance);
                     if (!await IsInstanceQueryAllowedAsync(data.workflow, data.instance, input.Roles, input.Headers, input.QueryParams, cancellationToken))
                         return ConditionalResult<GetInstanceStateOutput>.Fail(WorkflowErrors.QueryAccessDenied(data.instance.GetEffectiveState));
 

--- a/src/BBT.Workflow.Application/SubFlow/Contracts/ISubflowOutputMappingService.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Contracts/ISubflowOutputMappingService.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using BBT.Aether.Results;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Instances;
 
@@ -12,8 +13,10 @@ public interface ISubflowOutputMappingService
     /// <summary>
     /// Executes the parent SubFlow state's <see cref="Scripting.ISubFlowMapping.OutputHandler"/> with the child data
     /// as the script body, then persists mapped data and script mutations on the parent instance.
+    /// Returns <see cref="Result.Ok()"/> on success or <see cref="Result.Fail"/> when the OutputHandler throws,
+    /// so callers can decide whether to fault the instance instead of silently continuing.
     /// </summary>
-    Task ApplyAsync(
+    Task<Result> ApplyAsync(
         Instance parentInstance,
         Definitions.Workflow parentWorkflow,
         string parentStateKey,

--- a/src/BBT.Workflow.Application/SubFlow/Services/SubflowCompletionService.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubflowCompletionService.cs
@@ -79,6 +79,17 @@ public sealed class SubflowCompletionService(
                         return;
                     }
 
+                    // Idempotency: if parent is already in a terminal state the subflow completion
+                    // has already been processed (or the parent was terminated via another path).
+                    // No pipeline resume is needed — just return cleanly.
+                    if (parentInstance.Status.Equals(InstanceStatus.Completed) ||
+                        parentInstance.Status.Equals(InstanceStatus.Faulted))
+                    {
+                        activity?.SetTag("vnext.subflow.result", "parent_already_terminal");
+                        await correlationUow.CommitAsync(cancellationToken);
+                        return;
+                    }
+
                     var correlation = parentInstance.FindCorrelationBySubInstanceId(completedInput.SubInstanceId);
                     if (correlation == null)
                     {
@@ -124,13 +135,32 @@ public sealed class SubflowCompletionService(
 
                     parentWorkflow = parentWorkflowResult.Value!;
 
-                    await outputMappingService.ApplyAsync(
+                    var mappingResult = await outputMappingService.ApplyAsync(
                         parentInstance,
                         parentWorkflow,
                         correlation.ParentState,
                         completedInput.InstanceData,
                         cancellationToken);
-                    
+
+                    if (!mappingResult.IsSuccess)
+                    {
+                        // Output mapping failed — fault the parent instead of resuming the pipeline.
+                        // Retrying would never succeed; faulting propagates the error to A via InstanceSubFaultedEvent.
+                        var incident = InstanceIncidentFactory.Create(
+                            state: parentInstance.GetCurrentState,
+                            transition: string.Empty,
+                            taskKey: null,
+                            message: mappingResult.Error.Message ?? "SubFlow output mapping failed",
+                            errorCode: mappingResult.Error.Code ?? WorkflowErrorCodes.SubflowOutputMappingFailed,
+                            errorLayer: "SubFlow",
+                            stackTrace: mappingResult.Error.Detail);
+                        parentInstance.AddIncident(incident);
+                        parentInstance.Fault(completedInput.Domain);
+                        await instanceRepository.UpdateAsync(parentInstance, true, cancellationToken);
+                        await correlationUow.CommitAsync(cancellationToken);
+                        return;
+                    }
+
                     await correlationUow.CommitAsync(cancellationToken);
                 }
                 
@@ -195,8 +225,13 @@ public sealed class SubflowCompletionService(
             
             if (!result.IsSuccess)
             {
-                // Check if this is an auto-transition condition not met
-                if (result.Error.Code != WorkflowErrorCodes.AutoTransitionConditionNotMet)
+                // AutoTransitionConditionNotMet: normal — no matching auto-transition, instance stays Active.
+                // InstanceCompleted: race condition — parent was completed between Phase 1 commit and
+                // Phase 2 execution (e.g. timeout, cancel, or duplicate delivery). Both are non-fatal.
+                var isSoftError = result.Error.Code == WorkflowErrorCodes.AutoTransitionConditionNotMet
+                               || result.Error.Code == WorkflowErrorCodes.InstanceCompleted;
+
+                if (!isSoftError)
                 {
                     logger.TransitionRuleFailed(
                         "subflow",
@@ -204,13 +239,15 @@ public sealed class SubflowCompletionService(
                         result.Error.Message ?? "Unknown error");
                 }
 
-                throw new SubflowCompletionException(
-                    parentWorkflow.Domain,
-                    parentWorkflow.Key,
-                    parentInstance.Id.ToString(),
-                    result.Error.Code,
-                    result.Error.Message ?? "Unknown error"
-                );
+                if (!isSoftError)
+                {
+                    throw new SubflowCompletionException(
+                        parentWorkflow.Domain,
+                        parentWorkflow.Key,
+                        parentInstance.Id.ToString(),
+                        result.Error.Code,
+                        result.Error.Message ?? "Unknown error");
+                }
             }
         }
         catch (Exception ex)

--- a/src/BBT.Workflow.Application/SubFlow/Services/SubflowFaultService.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubflowFaultService.cs
@@ -137,12 +137,22 @@ public sealed class SubflowFaultService(
                         parentInstance.Fault(input.Domain);
                     }
 
-                    await outputMappingService.ApplyAsync(
+                    var mappingResult = await outputMappingService.ApplyAsync(
                         parentInstance,
                         parentWorkflow,
                         correlation.ParentState,
                         input.InstanceData,
                         cancellationToken);
+
+                    // Output mapping failure is non-blocking here: the instance is already
+                    // marked Faulted/transitioned above. Just log and proceed so the fault
+                    // is committed and propagated upward via InstanceSubFaultedEvent.
+                    if (!mappingResult.IsSuccess)
+                    {
+                        logger.SubFlowOutputMappingFailed(
+                            new Exception(mappingResult.Error.Message),
+                            parentInstance.Id);
+                    }
 
                     await instanceRepository.UpdateAsync(parentInstance, true, cancellationToken);
                     await uow.CommitAsync(cancellationToken);

--- a/src/BBT.Workflow.Application/SubFlow/Services/SubflowOutputMappingService.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubflowOutputMappingService.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using BBT.Aether.Guids;
+using BBT.Aether.Results;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Logging;
@@ -20,7 +21,7 @@ public sealed class SubflowOutputMappingService(
     : ISubflowOutputMappingService
 {
     /// <inheritdoc />
-    public async Task ApplyAsync(
+    public async Task<Result> ApplyAsync(
         Instance parentInstance,
         Definitions.Workflow parentWorkflow,
         string parentStateKey,
@@ -29,12 +30,12 @@ public sealed class SubflowOutputMappingService(
     {
         var parentStateResult = parentWorkflow.GetState(parentStateKey);
         if (!parentStateResult.IsSuccess)
-            return;
+            return Result.Ok();
 
         var parentState = parentStateResult.Value!;
         var subFlowConfig = parentState.SubFlow;
         if (subFlowConfig?.Mapping is null || !subFlowConfig.Mapping.HasMappingCode)
-            return;
+            return Result.Ok();
 
         try
         {
@@ -76,10 +77,16 @@ public sealed class SubflowOutputMappingService(
             {
                 await instanceRepository.UpdateAsync(parentInstance, true, cancellationToken);
             }
+
+            return Result.Ok();
         }
         catch (Exception ex)
         {
-            logger.SubFlowCompletionFailed(ex, Guid.Empty, parentInstance.Id);
+            logger.SubFlowOutputMappingFailed(ex, parentInstance.Id);
+            return Result.Fail(WorkflowErrors.SubFlowOutputMappingFailed(
+                parentInstance.Id,
+                ex.Message,
+                stackTrace: ex.ToString()));
         }
     }
 }

--- a/src/BBT.Workflow.Application/Tasks/Executors/Remote/RemoteInvokerService.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Remote/RemoteInvokerService.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Text.Json;
 using BBT.Aether.Results;
+using BBT.Workflow.Logging;
 using BBT.Workflow.Scripting;
 using BBT.Workflow.Tasks;
 using Dapr.Client;
@@ -69,6 +70,11 @@ public sealed class RemoteInvokerService : IRemoteInvokerService
                 traceContext.WorkflowKey ?? "unknown",
                 traceContext.WorkflowVersion ?? "latest",
                 traceContext.InstanceId));
+
+            // Forward root instance ID from Activity baggage (set by TransitionExecutor for subflow instances)
+            var rootIdBaggage = Activity.Current?.GetBaggageItem(TelemetryConstants.TagNames.RootInstanceId);
+            if (!string.IsNullOrEmpty(rootIdBaggage))
+                httpRequest.Headers.TryAddWithoutValidation(TelemetryConstants.HeaderNames.RootInstanceId, rootIdBaggage);
 
             var response = await _daprClient.InvokeMethodAsync<TaskInvokeResponse>(
                 httpRequest, invocationCts.Token);

--- a/src/BBT.Workflow.Domain/Instances/Instance.cs
+++ b/src/BBT.Workflow.Domain/Instances/Instance.cs
@@ -359,13 +359,15 @@ public sealed class Instance : AggregateRoot<Guid>, ICreationAuditedObject, IMod
         Duration = CompletedAt - CreatedAt;
 
         // Publish cleanup event to cancel all scheduled jobs
+        var rootId = this.GetRootInstanceId();
         AddDistributedEvent(new InstanceCompletedCleanupEvent
         {
             InstanceId = Id,
             Domain = domain,
             Flow = Flow,
             Version =  FlowVersion,
-            CompletedAt = CompletedAt.Value
+            CompletedAt = CompletedAt.Value,
+            RootInstanceId = rootId != Id ? rootId : (Guid?)null
         });
 
         // Publish completion event for SubItems (SubFlow or SubProcess)
@@ -385,7 +387,8 @@ public sealed class Instance : AggregateRoot<Guid>, ICreationAuditedObject, IMod
                     CompletedState = GetCurrentState,
                     InstanceData = latestData?.Data.JsonElement,
                     CompletedAt = CompletedAt.Value,
-                    Duration = Duration
+                    Duration = Duration,
+                    RootInstanceId = rootId != Id ? rootId : (Guid?)null
                 });
             }
         }
@@ -404,13 +407,15 @@ public sealed class Instance : AggregateRoot<Guid>, ICreationAuditedObject, IMod
         CompletedAt = DateTime.UtcNow;
         Duration = CompletedAt - CreatedAt;
 
+        var rootId = this.GetRootInstanceId();
         AddDistributedEvent(new InstanceFaultedCleanupEvent
         {
             InstanceId = Id,
             Domain = domain,
             Flow = Flow,
             Version = FlowVersion,
-            FaultedAt = CompletedAt.Value
+            FaultedAt = CompletedAt.Value,
+            RootInstanceId = rootId != Id ? rootId : (Guid?)null
         });
 
         // Downward: notify active SubFlow children to fault themselves
@@ -424,7 +429,8 @@ public sealed class Instance : AggregateRoot<Guid>, ICreationAuditedObject, IMod
                 Domain = correlation.SubFlowDomain,
                 Flow = correlation.SubFlowName,
                 Version = correlation.SubFlowVersion,
-                FaultedAt = CompletedAt.Value
+                FaultedAt = CompletedAt.Value,
+                RootInstanceId = rootId != Id ? rootId : (Guid?)null
             });
         }
 
@@ -459,7 +465,8 @@ public sealed class Instance : AggregateRoot<Guid>, ICreationAuditedObject, IMod
                     IncidentTransition = activeIncident?.Transition,
                     IncidentState = activeIncident?.State,
                     IncidentBoundaryAction = activeIncident?.BoundaryAction,
-                    IncidentBoundaryLevel = activeIncident?.BoundaryLevel
+                    IncidentBoundaryLevel = activeIncident?.BoundaryLevel,
+                    RootInstanceId = rootId != Id ? rootId : (Guid?)null
                 });
             }
         }
@@ -513,6 +520,7 @@ public sealed class Instance : AggregateRoot<Guid>, ICreationAuditedObject, IMod
         Duration = CompletedAt - CreatedAt;
 
         // Publish cancellation event - event handler will handle cleanup (jobs, correlations)
+        var rootId = this.GetRootInstanceId();
         AddDistributedEvent(new InstanceCanceledEvent
         {
             InstanceId = Id,
@@ -521,7 +529,8 @@ public sealed class Instance : AggregateRoot<Guid>, ICreationAuditedObject, IMod
             Version =   FlowVersion,
             CanceledState = GetCurrentState,
             CanceledAt = CompletedAt.Value,
-            Duration = Duration
+            Duration = Duration,
+            RootInstanceId = rootId != Id ? rootId : (Guid?)null
         });
 
         foreach (var correlation in ActiveCorrelations)
@@ -534,7 +543,8 @@ public sealed class Instance : AggregateRoot<Guid>, ICreationAuditedObject, IMod
                 Domain = correlation.SubFlowDomain,
                 Flow = correlation.SubFlowName,
                 CompletedAt = correlation.CompletedAt!.Value,
-                Version = correlation.SubFlowVersion
+                Version = correlation.SubFlowVersion,
+                RootInstanceId = rootId != Id ? rootId : (Guid?)null
             });
         }
     }
@@ -796,6 +806,7 @@ public sealed class Instance : AggregateRoot<Guid>, ICreationAuditedObject, IMod
         var contractInfo = ExtraProperties.ToSubFlowContractInfo();
         if (contractInfo.Id != Guid.Empty)
         {
+            var rootId = this.GetRootInstanceId();
             AddDistributedEvent(new InstanceSubStateChangedEvent
             {
                 ParentInstanceId = contractInfo.Id,
@@ -807,7 +818,8 @@ public sealed class Instance : AggregateRoot<Guid>, ICreationAuditedObject, IMod
                 PreviousState = previousState,
                 NewStateType = (int)(EffectiveStateType ?? StateType.Intermediate),
                 NewStateSubType = (int)(EffectiveStateSubType ?? StateSubType.None),
-                ChangedAt = DateTime.UtcNow
+                ChangedAt = DateTime.UtcNow,
+                RootInstanceId = rootId != Id ? rootId : (Guid?)null
             });
         }
     }

--- a/src/BBT.Workflow.Domain/Logging/WorkflowErrors.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowErrors.cs
@@ -374,6 +374,18 @@ public static class WorkflowErrors
             detail: stackTrace ?? subFlowKey);
 
     /// <summary>
+    /// SubFlow output mapping script execution failed.
+    /// </summary>
+    /// <param name="parentInstanceId">The ID of the parent instance whose output mapping failed.</param>
+    /// <param name="reason">The exception message from the failed OutputHandler.</param>
+    /// <param name="stackTrace">Full exception stack trace stored in <see cref="Error.Detail"/>.</param>
+    public static Error SubFlowOutputMappingFailed(Guid parentInstanceId, string reason, string? stackTrace = null)
+        => Error.Failure(
+            WorkflowErrorCodes.SubflowOutputMappingFailed,
+            $"SubFlow output mapping failed for parent instance '{parentInstanceId}': {reason}",
+            detail: stackTrace);
+
+    /// <summary>
     /// Correlation not found for SubFlow start.
     /// </summary>
     /// <param name="correlationId">The correlation ID that was not found.</param>

--- a/src/BBT.Workflow.Domain/Logging/WorkflowEventIds.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowEventIds.cs
@@ -79,6 +79,7 @@ public static class WorkflowEventIds
     public static readonly EventId SubFlowStateChangeApplied = new(40028, nameof(SubFlowStateChangeApplied));
     public static readonly EventId SubFlowStateChangedEventReceived = new(40029, nameof(SubFlowStateChangedEventReceived));
     public static readonly EventId SubFlowStateUpdateFailed = new(40079, nameof(SubFlowStateUpdateFailed));
+    public static readonly EventId SubFlowOutputMappingFailed = new(40080, nameof(SubFlowOutputMappingFailed));
 
     // Warning (40040-40069)
     public static readonly EventId SubFlowCorrelationNotFound = new(40043, nameof(SubFlowCorrelationNotFound));

--- a/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
@@ -585,6 +585,30 @@ public static partial class WorkflowLogs
         int excludedCount,
         string transitionKey);
 
+    /// <summary>
+    /// Logs when an instance is about to be marked faulted due to an unhandled pipeline error.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 10130,
+        Level = LogLevel.Warning,
+        Message = "Marking instance {InstanceId} as faulted due to unhandled pipeline error: {ErrorCode} - {ErrorMessage}")]
+    public static partial void InstanceFaultedDueToPipelineError(
+        this ILogger logger,
+        Guid instanceId,
+        string? errorCode,
+        string? errorMessage);
+
+    /// <summary>
+    /// Logs when an instance has been successfully persisted as faulted.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 10131,
+        Level = LogLevel.Information,
+        Message = "Instance {InstanceId} marked as faulted successfully. Client will receive Status = 'F'")]
+    public static partial void InstanceFaultedSuccessfully(
+        this ILogger logger,
+        Guid instanceId);
+
     #endregion
 
     #region Task Execution
@@ -907,6 +931,18 @@ public static partial class WorkflowLogs
         Message = "SubFlow output mapping started for parent instance {ParentInstanceId}")]
     public static partial void SubFlowOutputMappingStarted(
         this ILogger logger,
+        Guid parentInstanceId);
+
+    /// <summary>
+    /// Logs when SubFlow output mapping script execution fails.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 40080,
+        Level = LogLevel.Error,
+        Message = "SubFlow output mapping failed for parent instance {ParentInstanceId}")]
+    public static partial void SubFlowOutputMappingFailed(
+        this ILogger logger,
+        Exception exception,
         Guid parentInstanceId);
 
     /// <summary>

--- a/src/BBT.Workflow.Domain/WorkflowErrorCodes.cs
+++ b/src/BBT.Workflow.Domain/WorkflowErrorCodes.cs
@@ -45,6 +45,7 @@ public static class WorkflowErrorCodes
     public const string InstanceNotFaulted = "Instance:100027";
     public const string NoIncompleteTransitionFound = "Instance:100028";
     public const string TimeoutConfigMissing = "Instance:100029";
+    public const string SubflowOutputMappingFailed = "Instance:100030";
 
     #endregion
     

--- a/src/BBT.Workflow.Events.Contracts/Instances/Events/ChildSubflowCancelRequestedEvent.cs
+++ b/src/BBT.Workflow.Events.Contracts/Instances/Events/ChildSubflowCancelRequestedEvent.cs
@@ -39,4 +39,10 @@ public class ChildSubflowCancelRequestedEvent: IDistributedEvent
     /// Completed at
     /// </summary>
     public required DateTime CompletedAt { get; init; }
+
+    /// <summary>
+    /// The root ancestor instance ID for nested subflow chains.
+    /// <c>null</c> when this is a root (non-subflow) instance.
+    /// </summary>
+    public Guid? RootInstanceId { get; init; }
 }

--- a/src/BBT.Workflow.Events.Contracts/Instances/Events/ChildSubflowFaultRequestedEvent.cs
+++ b/src/BBT.Workflow.Events.Contracts/Instances/Events/ChildSubflowFaultRequestedEvent.cs
@@ -39,4 +39,10 @@ public class ChildSubflowFaultRequestedEvent : IDistributedEvent
     /// When the parent instance faulted
     /// </summary>
     public required DateTime FaultedAt { get; init; }
+
+    /// <summary>
+    /// The root ancestor instance ID for nested subflow chains.
+    /// <c>null</c> when this is a root (non-subflow) instance.
+    /// </summary>
+    public Guid? RootInstanceId { get; init; }
 }

--- a/src/BBT.Workflow.Events.Contracts/Instances/Events/InstanceCanceledEvent.cs
+++ b/src/BBT.Workflow.Events.Contracts/Instances/Events/InstanceCanceledEvent.cs
@@ -52,5 +52,11 @@ public class InstanceCanceledEvent : IDistributedEvent
     /// Duration of the instance execution before cancellation
     /// </summary>
     public TimeSpan? Duration { get; init; }
+
+    /// <summary>
+    /// The root ancestor instance ID for nested subflow chains.
+    /// <c>null</c> when this is a root (non-subflow) instance.
+    /// </summary>
+    public Guid? RootInstanceId { get; init; }
 }
 

--- a/src/BBT.Workflow.Events.Contracts/Instances/Events/InstanceCompletedCleanupEvent.cs
+++ b/src/BBT.Workflow.Events.Contracts/Instances/Events/InstanceCompletedCleanupEvent.cs
@@ -42,4 +42,10 @@ public class InstanceCompletedCleanupEvent : IDistributedEvent
     /// When the instance was completed
     /// </summary>
     public required DateTime CompletedAt { get; init; }
+
+    /// <summary>
+    /// The root ancestor instance ID for nested subflow chains.
+    /// <c>null</c> when this is a root (non-subflow) instance.
+    /// </summary>
+    public Guid? RootInstanceId { get; init; }
 }

--- a/src/BBT.Workflow.Events.Contracts/Instances/Events/InstanceFaultedCleanupEvent.cs
+++ b/src/BBT.Workflow.Events.Contracts/Instances/Events/InstanceFaultedCleanupEvent.cs
@@ -42,4 +42,10 @@ public class InstanceFaultedCleanupEvent : IDistributedEvent
     /// When the instance faulted
     /// </summary>
     public required DateTime FaultedAt { get; init; }
+
+    /// <summary>
+    /// The root ancestor instance ID for nested subflow chains.
+    /// <c>null</c> when this is a root (non-subflow) instance.
+    /// </summary>
+    public Guid? RootInstanceId { get; init; }
 }

--- a/src/BBT.Workflow.Events.Contracts/Instances/Events/InstanceSubCompletedEvent.cs
+++ b/src/BBT.Workflow.Events.Contracts/Instances/Events/InstanceSubCompletedEvent.cs
@@ -64,6 +64,12 @@ public class InstanceSubCompletedEvent : IDistributedEvent
     /// </summary>
     public TimeSpan? Duration { get; init; }
 
+    /// <summary>
+    /// The root ancestor instance ID for nested subflow chains.
+    /// <c>null</c> when this is a root (non-subflow) instance.
+    /// </summary>
+    public Guid? RootInstanceId { get; init; }
+
     public override string ToString()
     {
         return $"{nameof(InstanceSubCompletedEvent)}: InstanceId={InstanceId} Domain={Domain} Flow={Flow} Version={Version} SubInstanceId={SubInstanceId} CompletedState={CompletedState}";

--- a/src/BBT.Workflow.Events.Contracts/Instances/Events/InstanceSubFaultedEvent.cs
+++ b/src/BBT.Workflow.Events.Contracts/Instances/Events/InstanceSubFaultedEvent.cs
@@ -129,6 +129,12 @@ public class InstanceSubFaultedEvent : IDistributedEvent
     /// </summary>
     public string? IncidentBoundaryLevel { get; init; }
 
+    /// <summary>
+    /// The root ancestor instance ID for nested subflow chains.
+    /// <c>null</c> when this is a root (non-subflow) instance.
+    /// </summary>
+    public Guid? RootInstanceId { get; init; }
+
     public override string ToString()
     {
         return $"{nameof(InstanceSubFaultedEvent)}: InstanceId={InstanceId} Domain={Domain} Flow={Flow} Version={Version} SubInstanceId={SubInstanceId} FaultedState={FaultedState}";

--- a/src/BBT.Workflow.Events.Contracts/Instances/Events/InstanceSubStateChangedEvent.cs
+++ b/src/BBT.Workflow.Events.Contracts/Instances/Events/InstanceSubStateChangedEvent.cs
@@ -70,6 +70,12 @@ public class InstanceSubStateChangedEvent : IDistributedEvent
     /// </summary>
     public required DateTime ChangedAt { get; init; }
 
+    /// <summary>
+    /// The root ancestor instance ID for nested subflow chains.
+    /// <c>null</c> when this is a root (non-subflow) instance.
+    /// </summary>
+    public Guid? RootInstanceId { get; init; }
+
     public override string ToString()
     {
         return $"{nameof(InstanceSubStateChangedEvent)}: ParentInstanceId={ParentInstanceId} SubInstanceId={SubInstanceId} Domain={Domain} Flow={Flow} PreviousState={PreviousState} NewState={NewState}";

--- a/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceCanceledEventHook.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceCanceledEventHook.cs
@@ -38,13 +38,17 @@ public sealed class InstanceCanceledEventHook(
         EventHookContext context,
         CancellationToken cancellationToken = default)
     {
-        using (logger.BeginScope(new Dictionary<string, object>
+        var scopeProps = new Dictionary<string, object>
         {
             [TelemetryConstants.TagNames.Domain] = eventData.Domain,
             [TelemetryConstants.TagNames.Flow] = eventData.Flow,
             [TelemetryConstants.TagNames.FlowVersion] = eventData.Version ?? "N/A",
             [TelemetryConstants.TagNames.InstanceId] = eventData.InstanceId,
-        }))
+        };
+        if (eventData.RootInstanceId.HasValue)
+            scopeProps[TelemetryConstants.TagNames.RootInstanceId] = eventData.RootInstanceId.Value;
+
+        using (logger.BeginScope(scopeProps))
         {
             logger.InstanceCanceledEventReceived(eventData.InstanceId, eventData.Flow);
 

--- a/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceCompletedCleanupEventHook.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceCompletedCleanupEventHook.cs
@@ -38,13 +38,17 @@ public sealed class InstanceCompletedCleanupEventHook(
         EventHookContext context,
         CancellationToken cancellationToken = default)
     {
-        using (logger.BeginScope(new Dictionary<string, object>
+        var scopeProps = new Dictionary<string, object>
         {
             [TelemetryConstants.TagNames.Domain] = eventData.Domain,
             [TelemetryConstants.TagNames.Flow] = eventData.Flow,
             [TelemetryConstants.TagNames.FlowVersion] = eventData.Version ?? "N/A",
             [TelemetryConstants.TagNames.InstanceId] = eventData.InstanceId,
-        }))
+        };
+        if (eventData.RootInstanceId.HasValue)
+            scopeProps[TelemetryConstants.TagNames.RootInstanceId] = eventData.RootInstanceId.Value;
+
+        using (logger.BeginScope(scopeProps))
         {
             logger.InstanceCompletedCleanupHookProcessing(eventData.InstanceId, eventData.Flow);
 

--- a/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceFaultedCleanupEventHook.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceFaultedCleanupEventHook.cs
@@ -37,13 +37,17 @@ public sealed class InstanceFaultedCleanupEventHook(
         EventHookContext context,
         CancellationToken cancellationToken = default)
     {
-        using (logger.BeginScope(new Dictionary<string, object>
+        var scopeProps = new Dictionary<string, object>
         {
             [TelemetryConstants.TagNames.Domain] = eventData.Domain,
             [TelemetryConstants.TagNames.Flow] = eventData.Flow,
             [TelemetryConstants.TagNames.FlowVersion] = eventData.Version ?? "N/A",
             [TelemetryConstants.TagNames.InstanceId] = eventData.InstanceId,
-        }))
+        };
+        if (eventData.RootInstanceId.HasValue)
+            scopeProps[TelemetryConstants.TagNames.RootInstanceId] = eventData.RootInstanceId.Value;
+
+        using (logger.BeginScope(scopeProps))
         {
             logger.InstanceFaultedCleanupHookProcessing(eventData.InstanceId, eventData.Flow);
 

--- a/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceSubCompletedEventHook.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceSubCompletedEventHook.cs
@@ -34,14 +34,18 @@ public sealed class InstanceSubCompletedEventHook(
         EventHookContext context,
         CancellationToken cancellationToken = default)
     {
-        using (logger.BeginScope(new Dictionary<string, object>
+        var scopeProps = new Dictionary<string, object>
         {
             [TelemetryConstants.TagNames.Domain] = eventData.Domain,
             [TelemetryConstants.TagNames.Flow] = eventData.Flow,
             [TelemetryConstants.TagNames.FlowVersion] = eventData.Version ?? "N/A",
             [TelemetryConstants.TagNames.InstanceId] = eventData.InstanceId,
             [TelemetryConstants.TagNames.SubflowInstanceId] = eventData.SubInstanceId,
-        }))
+        };
+        if (eventData.RootInstanceId.HasValue)
+            scopeProps[TelemetryConstants.TagNames.RootInstanceId] = eventData.RootInstanceId.Value;
+
+        using (logger.BeginScope(scopeProps))
         {
             logger.SubFlowEventReceived(eventData.SubInstanceId, eventData.InstanceId, eventData.Domain, eventData.Flow);
 

--- a/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceSubFaultedEventHook.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceSubFaultedEventHook.cs
@@ -29,14 +29,18 @@ public sealed class InstanceSubFaultedEventHook(
         EventHookContext context,
         CancellationToken cancellationToken = default)
     {
-        using (logger.BeginScope(new Dictionary<string, object>
+        var scopeProps = new Dictionary<string, object>
         {
             [TelemetryConstants.TagNames.Domain] = eventData.Domain,
             [TelemetryConstants.TagNames.Flow] = eventData.Flow,
             [TelemetryConstants.TagNames.FlowVersion] = eventData.Version ?? "N/A",
             [TelemetryConstants.TagNames.InstanceId] = eventData.InstanceId,
             [TelemetryConstants.TagNames.SubflowInstanceId] = eventData.SubInstanceId,
-        }))
+        };
+        if (eventData.RootInstanceId.HasValue)
+            scopeProps[TelemetryConstants.TagNames.RootInstanceId] = eventData.RootInstanceId.Value;
+
+        using (logger.BeginScope(scopeProps))
         {
             logger.SubFlowFaultReceived(eventData.SubInstanceId, eventData.InstanceId, eventData.Domain, eventData.Flow);
 

--- a/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceSubStateChangedEventHook.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceSubStateChangedEventHook.cs
@@ -35,7 +35,7 @@ public sealed class InstanceSubStateChangedEventHook(
         EventHookContext context,
         CancellationToken cancellationToken = default)
     {
-        using (logger.BeginScope(new Dictionary<string, object>
+        var scopeProps = new Dictionary<string, object>
         {
             [TelemetryConstants.TagNames.Domain] = eventData.Domain,
             [TelemetryConstants.TagNames.Flow] = eventData.Flow,
@@ -43,7 +43,11 @@ public sealed class InstanceSubStateChangedEventHook(
             [TelemetryConstants.TagNames.InstanceId] = eventData.ParentInstanceId,
             [TelemetryConstants.TagNames.ParentInstanceId] = eventData.ParentInstanceId,
             [TelemetryConstants.TagNames.SubflowInstanceId] = eventData.SubInstanceId,
-        }))
+        };
+        if (eventData.RootInstanceId.HasValue)
+            scopeProps[TelemetryConstants.TagNames.RootInstanceId] = eventData.RootInstanceId.Value;
+
+        using (logger.BeginScope(scopeProps))
         {
             logger.SubFlowStateChangedEventReceived(
                 eventData.SubInstanceId,

--- a/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceSubStateChangedEventHook.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceSubStateChangedEventHook.cs
@@ -78,7 +78,7 @@ public sealed class InstanceSubStateChangedEventHook(
                         ["hook_error"] = "SubFlowStateUpdateFailed",
                         ["error_code"] = error.Code ?? "unknown",
                         ["error_prefix"] = error.Prefix ?? "unknown",
-                        ["error_message"] = error.Message
+                        ["error_message"] = error.Message ?? string.Empty
                     };
 
                     if (!string.IsNullOrEmpty(error.Target))

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/TransitionPipelineTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/TransitionPipelineTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using BBT.Aether.Results;
+using BBT.Aether.Uow;
 using BBT.Workflow.BackgroundJobs;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Execution;
@@ -34,6 +35,7 @@ public class TransitionPipelineTests
     private readonly ITransitionContextFactory _mockContextFactory;
     private readonly IPostCommitExecutor _mockPostCommitExecutor;
     private readonly IInstanceRepository _mockInstanceRepository;
+    private readonly IUnitOfWorkManager _mockUowManager;
     private readonly ITransitionValidationService _mockValidationService;
     private readonly IStateNotificationScheduler _mockStateNotificationScheduler;
     private readonly List<ITransitionStep> _mockSteps;
@@ -48,6 +50,7 @@ public class TransitionPipelineTests
         _mockContextFactory = Substitute.For<ITransitionContextFactory>();
         _mockPostCommitExecutor = Substitute.For<IPostCommitExecutor>();
         _mockInstanceRepository = Substitute.For<IInstanceRepository>();
+        _mockUowManager = Substitute.For<IUnitOfWorkManager>();
         _mockValidationService = Substitute.For<ITransitionValidationService>();
         _mockStateNotificationScheduler = Substitute.For<IStateNotificationScheduler>();
         _mockSteps = new List<ITransitionStep>();
@@ -119,6 +122,7 @@ public class TransitionPipelineTests
             _mockContextFactory,
             _mockPostCommitExecutor,
             _mockInstanceRepository,
+            _mockUowManager,
             _mockValidationService,
             new PipelineProfileResolver(),
             _mockStateNotificationScheduler,

--- a/test/BBT.Workflow.Application.Tests/SubFlow/SubflowFaultServiceTests.cs
+++ b/test/BBT.Workflow.Application.Tests/SubFlow/SubflowFaultServiceTests.cs
@@ -37,8 +37,17 @@ public sealed class SubflowFaultServiceTests
             .Returns(ValueTask.CompletedTask);
 
         _uowManager
-            .Setup(m => m.BeginAsync(It.IsAny<UnitOfWorkOptions>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(_uow.Object);
+            .Setup(m => m.Begin(It.IsAny<UnitOfWorkOptions>()))
+            .Returns(_uow.Object);
+
+        _outputMappingService
+            .Setup(x => x.ApplyAsync(
+                It.IsAny<Instance>(),
+                It.IsAny<Definitions.Workflow>(),
+                It.IsAny<string>(),
+                It.IsAny<JsonElement?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Ok());
     }
 
     [Fact]
@@ -126,7 +135,7 @@ public sealed class SubflowFaultServiceTests
         parentInstance.FindCorrelationBySubInstanceId(subInstanceId)!.IsCompleted.ShouldBeFalse();
         parentInstance.Status.ShouldBe(InstanceStatus.Busy);
         _uowManager.Verify(
-            x => x.BeginAsync(It.IsAny<UnitOfWorkOptions>(), It.IsAny<CancellationToken>()),
+            x => x.Begin(It.IsAny<UnitOfWorkOptions>()),
             Times.Exactly(2));
     }
 
@@ -150,7 +159,7 @@ public sealed class SubflowFaultServiceTests
                 It.IsAny<JsonElement?>(),
                 It.IsAny<CancellationToken>()))
             .Callback(() => incidentVisibleToMapping = parentInstance.HasActiveIncident)
-            .Returns(Task.CompletedTask);
+            .ReturnsAsync(Result.Ok());
 
         await CreateService().FaultAsync(input, CancellationToken.None);
 

--- a/workers/BBT.Workflow.Workers.Inbox/Forwarding/DaprOrchestrationForwarder.cs
+++ b/workers/BBT.Workflow.Workers.Inbox/Forwarding/DaprOrchestrationForwarder.cs
@@ -1,9 +1,9 @@
+using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Json;
+using BBT.Workflow.Logging;
 using Dapr.Client;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 
 namespace BBT.Workflow.Workers.Inbox.Forwarding;
 
@@ -63,6 +63,10 @@ public sealed class DaprOrchestrationForwarder : IOrchestrationForwarder
         request.Headers.Add(
             WorkflowInfo.Name,
             WorkflowInfo.Generate(domain, workflow, version ?? "latest", instanceId));
+
+        var rootIdBaggage = Activity.Current?.GetBaggageItem(TelemetryConstants.TagNames.RootInstanceId);
+        if (!string.IsNullOrEmpty(rootIdBaggage))
+            request.Headers.TryAddWithoutValidation(TelemetryConstants.HeaderNames.RootInstanceId, rootIdBaggage);
 
         HttpResponseMessage response;
         try

--- a/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/ChildSubflowCancelRequestedEventHandler.cs
+++ b/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/ChildSubflowCancelRequestedEventHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using BBT.Aether.Events;
 using BBT.Workflow.Instances.Events;
 using BBT.Workflow.Logging;
@@ -31,13 +32,20 @@ internal sealed class ChildSubflowCancelRequestedEventHandler(
             return;
         }
 
-        using (logger.BeginScope(new Dictionary<string, object>
+        var scopeProps = new Dictionary<string, object>
         {
             [TelemetryConstants.TagNames.Domain] = eventData.Domain,
             [TelemetryConstants.TagNames.Flow] = eventData.Flow,
             [TelemetryConstants.TagNames.FlowVersion] = eventData.Version ?? "N/A",
             [TelemetryConstants.TagNames.InstanceId] = eventData.InstanceId,
-        }))
+        };
+        if (eventData.RootInstanceId.HasValue)
+        {
+            scopeProps[TelemetryConstants.TagNames.RootInstanceId] = eventData.RootInstanceId.Value;
+            Activity.Current?.SetBaggage(TelemetryConstants.TagNames.RootInstanceId,
+                eventData.RootInstanceId.Value.ToString());
+        }
+        using (logger.BeginScope(scopeProps))
         {
             logger.ChildSubflowCancelRequestReceived(
                 eventData.InstanceId,

--- a/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/ChildSubflowFaultRequestedEventHandler.cs
+++ b/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/ChildSubflowFaultRequestedEventHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using BBT.Aether.Events;
 using BBT.Workflow.Instances.Events;
 using BBT.Workflow.Logging;
@@ -31,13 +32,20 @@ internal sealed class ChildSubflowFaultRequestedEventHandler(
             return;
         }
 
-        using (logger.BeginScope(new Dictionary<string, object>
+        var scopeProps = new Dictionary<string, object>
         {
             [TelemetryConstants.TagNames.Domain] = eventData.Domain,
             [TelemetryConstants.TagNames.Flow] = eventData.Flow,
             [TelemetryConstants.TagNames.FlowVersion] = eventData.Version ?? "N/A",
             [TelemetryConstants.TagNames.InstanceId] = eventData.InstanceId,
-        }))
+        };
+        if (eventData.RootInstanceId.HasValue)
+        {
+            scopeProps[TelemetryConstants.TagNames.RootInstanceId] = eventData.RootInstanceId.Value;
+            Activity.Current?.SetBaggage(TelemetryConstants.TagNames.RootInstanceId,
+                eventData.RootInstanceId.Value.ToString());
+        }
+        using (logger.BeginScope(scopeProps))
         {
             logger.ChildSubflowFaultRequestReceived(
                 eventData.InstanceId,

--- a/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/InstanceCanceledEventHandler.cs
+++ b/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/InstanceCanceledEventHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using BBT.Aether.Events;
 using BBT.Workflow.Instances.Events;
 using BBT.Workflow.Logging;
@@ -31,13 +32,20 @@ internal sealed class InstanceCanceledEventHandler(
             return;
         }
 
-        using (logger.BeginScope(new Dictionary<string, object>
+        var scopeProps = new Dictionary<string, object>
         {
             [TelemetryConstants.TagNames.Domain] = eventData.Domain,
             [TelemetryConstants.TagNames.Flow] = eventData.Flow,
             [TelemetryConstants.TagNames.FlowVersion] = eventData.Version ?? "N/A",
             [TelemetryConstants.TagNames.InstanceId] = eventData.InstanceId,
-        }))
+        };
+        if (eventData.RootInstanceId.HasValue)
+        {
+            scopeProps[TelemetryConstants.TagNames.RootInstanceId] = eventData.RootInstanceId.Value;
+            Activity.Current?.SetBaggage(TelemetryConstants.TagNames.RootInstanceId,
+                eventData.RootInstanceId.Value.ToString());
+        }
+        using (logger.BeginScope(scopeProps))
         {
             logger.InstanceCanceledEventReceived(eventData.InstanceId, eventData.Flow);
 

--- a/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/InstanceCompletedCleanupEventHandler.cs
+++ b/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/InstanceCompletedCleanupEventHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using BBT.Aether.Events;
 using BBT.Workflow.Instances.Events;
 using BBT.Workflow.Logging;
@@ -30,13 +31,20 @@ internal sealed class InstanceCompletedCleanupEventHandler(
             return;
         }
 
-        using (logger.BeginScope(new Dictionary<string, object>
+        var scopeProps = new Dictionary<string, object>
         {
             [TelemetryConstants.TagNames.Domain] = eventData.Domain,
             [TelemetryConstants.TagNames.Flow] = eventData.Flow,
             [TelemetryConstants.TagNames.FlowVersion] = eventData.Version ?? "N/A",
             [TelemetryConstants.TagNames.InstanceId] = eventData.InstanceId,
-        }))
+        };
+        if (eventData.RootInstanceId.HasValue)
+        {
+            scopeProps[TelemetryConstants.TagNames.RootInstanceId] = eventData.RootInstanceId.Value;
+            Activity.Current?.SetBaggage(TelemetryConstants.TagNames.RootInstanceId,
+                eventData.RootInstanceId.Value.ToString());
+        }
+        using (logger.BeginScope(scopeProps))
         {
             logger.InstanceCompletedCleanupEventReceived(eventData.InstanceId, eventData.Flow);
 

--- a/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/InstanceFaultedCleanupEventHandler.cs
+++ b/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/InstanceFaultedCleanupEventHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using BBT.Aether.Events;
 using BBT.Workflow.Instances.Events;
 using BBT.Workflow.Logging;
@@ -30,13 +31,20 @@ internal sealed class InstanceFaultedCleanupEventHandler(
             return;
         }
 
-        using (logger.BeginScope(new Dictionary<string, object>
+        var scopeProps = new Dictionary<string, object>
         {
             [TelemetryConstants.TagNames.Domain] = eventData.Domain,
             [TelemetryConstants.TagNames.Flow] = eventData.Flow,
             [TelemetryConstants.TagNames.FlowVersion] = eventData.Version ?? "N/A",
             [TelemetryConstants.TagNames.InstanceId] = eventData.InstanceId,
-        }))
+        };
+        if (eventData.RootInstanceId.HasValue)
+        {
+            scopeProps[TelemetryConstants.TagNames.RootInstanceId] = eventData.RootInstanceId.Value;
+            Activity.Current?.SetBaggage(TelemetryConstants.TagNames.RootInstanceId,
+                eventData.RootInstanceId.Value.ToString());
+        }
+        using (logger.BeginScope(scopeProps))
         {
             logger.InstanceFaultedCleanupEventReceived(eventData.InstanceId, eventData.Flow);
 

--- a/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/InstanceSubCompletedEventHandler.cs
+++ b/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/InstanceSubCompletedEventHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using BBT.Aether.Events;
 using BBT.Workflow.Instances.Events;
 using BBT.Workflow.Logging;
@@ -33,14 +34,21 @@ internal sealed class InstanceSubCompletedEventHandler(
             return;
         }
 
-        using (logger.BeginScope(new Dictionary<string, object>
+        var scopeProps = new Dictionary<string, object>
         {
             [TelemetryConstants.TagNames.Domain] = eventData.Domain,
             [TelemetryConstants.TagNames.Flow] = eventData.Flow,
             [TelemetryConstants.TagNames.FlowVersion] = eventData.Version ?? "N/A",
             [TelemetryConstants.TagNames.InstanceId] = eventData.InstanceId,
             [TelemetryConstants.TagNames.SubflowInstanceId] = eventData.SubInstanceId,
-        }))
+        };
+        if (eventData.RootInstanceId.HasValue)
+        {
+            scopeProps[TelemetryConstants.TagNames.RootInstanceId] = eventData.RootInstanceId.Value;
+            Activity.Current?.SetBaggage(TelemetryConstants.TagNames.RootInstanceId,
+                eventData.RootInstanceId.Value.ToString());
+        }
+        using (logger.BeginScope(scopeProps))
         {
             logger.SubFlowEventReceived(
                 eventData.SubInstanceId,

--- a/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/InstanceSubFaultedEventHandler.cs
+++ b/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/InstanceSubFaultedEventHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using BBT.Aether.Events;
 using BBT.Workflow.Instances.Events;
 using BBT.Workflow.Logging;
@@ -32,14 +33,21 @@ internal sealed class InstanceSubFaultedEventHandler(
             return;
         }
 
-        using (logger.BeginScope(new Dictionary<string, object>
+        var scopeProps = new Dictionary<string, object>
         {
             [TelemetryConstants.TagNames.Domain] = eventData.Domain,
             [TelemetryConstants.TagNames.Flow] = eventData.Flow,
             [TelemetryConstants.TagNames.FlowVersion] = eventData.Version ?? "N/A",
             [TelemetryConstants.TagNames.InstanceId] = eventData.InstanceId,
             [TelemetryConstants.TagNames.SubflowInstanceId] = eventData.SubInstanceId,
-        }))
+        };
+        if (eventData.RootInstanceId.HasValue)
+        {
+            scopeProps[TelemetryConstants.TagNames.RootInstanceId] = eventData.RootInstanceId.Value;
+            Activity.Current?.SetBaggage(TelemetryConstants.TagNames.RootInstanceId,
+                eventData.RootInstanceId.Value.ToString());
+        }
+        using (logger.BeginScope(scopeProps))
         {
             logger.SubFlowFaultReceived(
                 eventData.SubInstanceId,

--- a/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/InstanceSubStateChangedEventHandler.cs
+++ b/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/InstanceSubStateChangedEventHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using BBT.Aether.Events;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Instances.Events;
@@ -33,7 +34,7 @@ internal sealed class InstanceSubStateChangedEventHandler(
             return;
         }
 
-        using (logger.BeginScope(new Dictionary<string, object>
+        var scopeProps = new Dictionary<string, object>
         {
             [TelemetryConstants.TagNames.Domain] = eventData.Domain,
             [TelemetryConstants.TagNames.Flow] = eventData.Flow,
@@ -41,7 +42,14 @@ internal sealed class InstanceSubStateChangedEventHandler(
             [TelemetryConstants.TagNames.InstanceId] = eventData.ParentInstanceId,
             [TelemetryConstants.TagNames.ParentInstanceId] = eventData.ParentInstanceId,
             [TelemetryConstants.TagNames.SubflowInstanceId] = eventData.SubInstanceId,
-        }))
+        };
+        if (eventData.RootInstanceId.HasValue)
+        {
+            scopeProps[TelemetryConstants.TagNames.RootInstanceId] = eventData.RootInstanceId.Value;
+            Activity.Current?.SetBaggage(TelemetryConstants.TagNames.RootInstanceId,
+                eventData.RootInstanceId.Value.ToString());
+        }
+        using (logger.BeginScope(scopeProps))
         {
             logger.SubFlowStateChangedEventReceived(
                 eventData.SubInstanceId,


### PR DESCRIPTION
## Summary by Sourcery

Improve robustness and observability of SubFlow completion, fault handling and pipeline failure scenarios by introducing Result‑based output mapping, safer fault persistence with dedicated unit of work scopes, and consistent propagation of root instance identifiers through events, handlers and external calls.

New Features:
- Propagate root workflow instance identifiers through events, handlers, jobs and outbound HTTP calls for improved tracing of nested subflows.
- Expose SubFlow output mapping failures as structured errors and propagate them to clients and orchestration consumers via a dedicated error code and logging.

Bug Fixes:
- Ensure SubFlow completion is idempotent by short‑circuiting when the parent instance is already in a terminal state.
- Treat specific transition pipeline errors (auto‑transition not met, parent already completed) as non‑fatal so subflow completions do not raise unnecessary exceptions.

Enhancements:
- Fault workflow instances using a separate UnitOfWork scope and dedicated faulting logs to reliably persist pipeline failures even when the main DbContext is in a bad state.
- Make SubFlow output mapping a Result‑returning operation and fault the parent instance on mapping failure during SubFlow completion, while treating failures as non‑blocking during explicit SubFlow fault handling.
- Enrich instance query, function access and various job handlers with RootInstanceId telemetry tags, baggage and logging scopes to improve observability across subflow chains.
- Add new structured logging messages and event IDs around instance faulting and SubFlow output mapping failures.

Tests:
- Update SubFlow fault/completion tests to use the new synchronous UnitOfWork API and the Result‑based SubFlow output mapping contract, including assertions on incident visibility and unit of work usage.