### PR TITLE
fix(subflow): pass workflow scripts to input mapping compilation

### DIFF
--- a/src/BBT.Workflow.Application/SubFlow/Services/SubflowStarter.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubflowStarter.cs
@@ -45,7 +45,7 @@ public sealed class SubflowStarter(
         ScriptResponse? inputMappingResult = null;
         if (subFlowConfig.Mapping != null)
         {
-            var mappingResult = await HandleInputMappingAsync(subFlowConfig, context, cancellationToken);
+            var mappingResult = await HandleInputMappingAsync(subFlowConfig, workflow, context, cancellationToken);
             if (!mappingResult.IsSuccess)
             {
                 return Result.Fail(mappingResult.Error);
@@ -230,11 +230,13 @@ public sealed class SubflowStarter(
     /// Handles input mapping for SubFlow/SubProcess by compiling and executing the mapping script.
     /// </summary>
     /// <param name="subFlowConfig">The SubFlow configuration containing mapping information.</param>
+    /// <param name="workflow">The parent workflow definition, used to supply flow-level script settings.</param>
     /// <param name="context">The script context for mapping execution.</param>
     /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
     /// <returns>Result containing the mapping response or error.</returns>
     private async Task<Result<ScriptResponse?>> HandleInputMappingAsync(
         Definitions.SubFlow subFlowConfig,
+        Definitions.Workflow workflow,
         ScriptContext context,
         CancellationToken cancellationToken = default)
     {
@@ -250,6 +252,7 @@ public sealed class SubflowStarter(
             {
                 var subFlowMapping = await scriptEngine.CompileToInstanceAsync<ISubFlowMapping>(
                     subFlowConfig.Mapping,
+                    flowScripts: workflow.Scripts,
                     cancellationToken: ct);
                 return await subFlowMapping.InputHandler(context);
             }
@@ -258,6 +261,7 @@ public sealed class SubflowStarter(
             {
                 var subProcessMapping = await scriptEngine.CompileToInstanceAsync<ISubProcessMapping>(
                     subFlowConfig.Mapping,
+                    flowScripts: workflow.Scripts,
                     cancellationToken: ct);
                 return await subProcessMapping.InputHandler(context);
             }


### PR DESCRIPTION
## Summary
- `SubflowStarter.HandleInputMappingAsync` was calling `ScriptEngine.CompileToInstanceAsync` without forwarding the parent workflow's flow-level `ScriptSettings` (`flowScripts` parameter)
- This caused `sys-mapping` helpers declared in `workflow.scripts.helpers` to be unavailable inside `InputHandler` for both SubFlow and SubProcess types
- `SubflowOutputMappingService` (output mapping) already passed `flowScripts: parentWorkflow.Scripts` correctly — this fix brings input mapping to parity

## Changes
- `src/BBT.Workflow.Application/SubFlow/Services/SubflowStarter.cs`
  - `HandleInputMappingAsync` accepts a new `workflow` parameter
  - Both `CompileToInstanceAsync<ISubFlowMapping>` and `CompileToInstanceAsync<ISubProcessMapping>` now receive `flowScripts: workflow.Scripts`

## Test Plan
- [ ] Define a helper in `workflow.scripts.helpers` of a parent flow
- [ ] Reference that helper inside a subflow `mapping.inputHandler` script
- [ ] Start the parent flow and trigger the subflow state — verify the input mapping executes without "type not found" compilation errors
- [ ] Run `dotnet test test/BBT.Workflow.Application.Tests --filter SubFlow`

## Summary by Sourcery

Bug Fixes:
- Forward parent workflow script settings to subflow and subprocess input mapping compilation so helpers defined in workflow-level scripts are available during input handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Subflow input mapping now uses the parent workflow’s scripts during execution, improving consistency when launching subflows.
  * Mapping compilation and execution behavior remains the same, but now runs with the correct workflow context for more reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->