### PR TITLE
feat(workflow,api): add output model for sync response and free-form payload support

### DIFF
--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
 using BBT.Aether;
 using BBT.Aether.AspNetCore.Controllers;
 using BBT.Aether.AspNetCore.Results;
@@ -49,25 +50,39 @@ public sealed class InstanceController(
     public async Task<IActionResult> StartAsync(
         [FromRoute] string domain,
         [FromRoute] string workflow,
-        [FromBody] CreateInstanceDto request,
+        [FromBody] JsonElement? body,
         [FromQuery] string? version = null,
         [FromQuery] bool sync = false,
         [FromQuery] string[]? extensions = null,
         CancellationToken cancellationToken = default
     )
     {
+        var httpContext = httpContextAccessor.HttpContext;
+        var headers = httpContext?.Request.Headers ?? new HeaderDictionary();
+
+        CreateInstanceDto request;
+        if (PayloadModeDetector.IsStandard(headers, body))
+        {
+            request = body is null
+                ? new CreateInstanceDto()
+                : JsonSerializer.Deserialize<CreateInstanceDto>(body.Value) ?? new CreateInstanceDto();
+        }
+        else
+        {
+            request = new CreateInstanceDto { Attributes = body };
+        }
+
         var input = new StartInstanceInput(domain, workflow, version, sync)
         {
             Instance = new CreateInstanceInput
             {
-                Key = request?.Key,
-                Tags = request?.Tags,
-                Attributes = request?.Attributes,
-                Stage = request?.Stage
+                Key = request.Key,
+                Tags = request.Tags,
+                Attributes = request.Attributes,
+                Stage = request.Stage
             },
             Extensions = extensions
         };
-        var httpContext = httpContextAccessor.HttpContext;
         if (httpContext is not null)
         {
             input.Headers = httpContext.Request.Headers.ToDictionary(s => s.Key.ToLower(), s => s.Value.FirstOrDefault()?.ToString());
@@ -316,17 +331,33 @@ public sealed class InstanceController(
         [FromRoute] string workflow,
         [FromRoute] string instance,
         [FromRoute] string transitionKey,
-        [FromBody] TransitionDataInput? data = null,
+        [FromBody] JsonElement? body = null,
         [FromQuery] bool sync = false,
         [FromQuery] string[]? extensions = null,
         CancellationToken cancellationToken = default
     )
     {
+        var httpContext = httpContextAccessor.HttpContext;
+        var headers = httpContext?.Request.Headers ?? new HeaderDictionary();
+
+        TransitionDataInput? data;
+        if (body is null)
+        {
+            data = null;
+        }
+        else if (PayloadModeDetector.IsStandard(headers, body))
+        {
+            data = JsonSerializer.Deserialize<TransitionDataInput>(body.Value);
+        }
+        else
+        {
+            data = new TransitionDataInput(body);
+        }
+
         var input = new TransitionInput(domain, workflow, data, sync)
         {
             Extensions = extensions
         };
-        var httpContext = httpContextAccessor.HttpContext;
         if (httpContext is not null)
         {
             input.Headers = httpContext.Request.Headers.ToDictionary(s => s.Key.ToLower(), s => s.Value.FirstOrDefault()?.ToString());
@@ -338,7 +369,7 @@ public sealed class InstanceController(
             transitionKey,
             input,
             cancellationToken);
-        
+
         return WorkflowResultActionResultMapper.ToActionResult(result, HttpContext);
     }
 

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/PayloadModeDetector.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/PayloadModeDetector.cs
@@ -1,0 +1,39 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+
+namespace BBT.Workflow.Orchestration.Controllers.Instances;
+
+/// <summary>
+/// Detects whether an incoming request body should be treated as a standard vNext payload
+/// (containing <c>attributes</c>, <c>key</c>, <c>tags</c> etc.) or as a free-form payload
+/// that must be normalized by wrapping the entire body under <c>attributes</c>.
+/// </summary>
+internal static class PayloadModeDetector
+{
+    /// <summary>Header name that explicitly overrides auto-detection.</summary>
+    private const string HeaderName = "x-vnext-payload-mode";
+
+    /// <summary>
+    /// Returns <c>true</c> when the body should be treated as a standard payload,
+    /// <c>false</c> when it is a free-form payload that needs normalization.
+    /// </summary>
+    /// <remarks>
+    /// Resolution order:
+    /// <list type="number">
+    ///   <item><c>x-vnext-payload-mode: standard</c> → standard</item>
+    ///   <item><c>x-vnext-payload-mode: raw</c> → free-form</item>
+    ///   <item>Body contains top-level <c>attributes</c> property → standard</item>
+    ///   <item>Body absent or no <c>attributes</c> property → free-form</item>
+    /// </list>
+    /// </remarks>
+    internal static bool IsStandard(IHeaderDictionary headers, JsonElement? body)
+    {
+        if (headers.TryGetValue(HeaderName, out var mode))
+            return !string.Equals(mode, "raw", StringComparison.OrdinalIgnoreCase);
+
+        if (body is null || body.Value.ValueKind != JsonValueKind.Object)
+            return true;
+
+        return body.Value.TryGetProperty("attributes", out _);
+    }
+}

--- a/src/BBT.Workflow.Application/Instances/IWorkflowOutputMappingService.cs
+++ b/src/BBT.Workflow.Application/Instances/IWorkflowOutputMappingService.cs
@@ -1,0 +1,23 @@
+using System.Text.Json;
+using BBT.Aether.Results;
+using BBT.Workflow.Scripting;
+
+namespace BBT.Workflow.Instances;
+
+/// <summary>
+/// Executes a workflow-level output mapping script and returns the mapped data
+/// to replace the default instance attributes in a sync response.
+/// </summary>
+public interface IWorkflowOutputMappingService
+{
+    /// <summary>
+    /// Compiles and runs the workflow's <see cref="Definitions.Workflow.Output"/> script
+    /// using the provided <see cref="ScriptContext"/>.
+    /// Returns <c>null</c> when no output script is configured or the script produces no data.
+    /// Returns <see cref="Result{T}.Fail"/> when the script throws, so the caller can fall back gracefully.
+    /// </summary>
+    Task<Result<JsonElement?>> ApplyAsync(
+        Definitions.Workflow workflow,
+        ScriptContext scriptContext,
+        CancellationToken cancellationToken = default);
+}

--- a/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
@@ -60,6 +60,7 @@ public sealed class InstanceCommandAppService(
     IInstanceCancellationService cancellationService,
     ILongPollAckResumeService longPollAckResumeService,
     IInstanceCommandGateway instanceCommandGateway,
+    IWorkflowOutputMappingService workflowOutputMappingService,
     ICurrentUser currentUser,
     ILogger<InstanceCommandAppService> logger)
     : ApplicationService(serviceProvider), IInstanceCommandAppService
@@ -708,6 +709,10 @@ public sealed class InstanceCommandAppService(
                 .WithTransition(string.Empty)
                 .WithBody(latestData?.Data ?? new JsonData("{}"))
                 .BuildAsync(cancellationToken);
+
+            var outputResult = await workflowOutputMappingService.ApplyAsync(workflow, scriptContext, cancellationToken);
+            if (outputResult.IsSuccess && outputResult.Value.HasValue)
+                attributes = outputResult.Value;
 
             var extensionsResult = await instanceExtensionService.ProcessExtensionsAsync(
                 extensionRequested,

--- a/src/BBT.Workflow.Application/Instances/WorkflowOutputMappingService.cs
+++ b/src/BBT.Workflow.Application/Instances/WorkflowOutputMappingService.cs
@@ -1,0 +1,45 @@
+using System.Text.Json;
+using BBT.Aether.Results;
+using BBT.Workflow.Logging;
+using BBT.Workflow.Scripting;
+using Microsoft.Extensions.Logging;
+
+namespace BBT.Workflow.Instances;
+
+/// <inheritdoc cref="IWorkflowOutputMappingService" />
+public sealed class WorkflowOutputMappingService(
+    IScriptEngine scriptEngine,
+    ILogger<WorkflowOutputMappingService> logger)
+    : IWorkflowOutputMappingService
+{
+    /// <inheritdoc />
+    public async Task<Result<JsonElement?>> ApplyAsync(
+        Definitions.Workflow workflow,
+        ScriptContext scriptContext,
+        CancellationToken cancellationToken = default)
+    {
+        if (workflow.Output is null || !workflow.Output.HasMappingCode)
+            return Result<JsonElement?>.Ok(null);
+
+        try
+        {
+            var handler = await scriptEngine.CompileToInstanceAsync<IOutputHandler>(
+                workflow.Output,
+                flowScripts: workflow.Scripts,
+                cancellationToken: cancellationToken);
+
+            var response = await handler.OutputHandler(scriptContext);
+
+            var element = response.Data is null
+                ? (JsonElement?)null
+                : JsonSerializer.SerializeToElement(response.Data);
+
+            return Result<JsonElement?>.Ok(element);
+        }
+        catch (Exception ex)
+        {
+            logger.WorkflowOutputScriptFailed(workflow.Key, ex);
+            return Result<JsonElement?>.Ok(null);
+        }
+    }
+}

--- a/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
@@ -66,6 +66,7 @@ public static class WorkflowApplicationModuleServiceCollectionExtensions
         services.AddScoped<IRepresentationEtagService, RepresentationEtagService>();
         services.AddScoped<ISchemaFieldFilterService, SchemaFieldFilterService>();
         services.AddScoped<IInstanceExtensionService, InstanceExtensionService>();
+        services.AddScoped<IWorkflowOutputMappingService, WorkflowOutputMappingService>();
         services.AddScoped<ISubflowOutputMappingService, SubflowOutputMappingService>();
         services.AddScoped<ISubflowCompletionService, SubflowCompletionService>();
         services.AddScoped<ISubflowFaultService, SubflowFaultService>();

--- a/src/BBT.Workflow.Domain/Definitions/Workflow.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Workflow.cs
@@ -168,6 +168,14 @@ public sealed class Workflow : IDomainEntity, IReference, IReferenceSetter, IHas
     public ScriptSettings? Scripts { get; private set; }
 
     /// <summary>
+    /// Optional output mapping script executed when the workflow is called with <c>sync=true</c>.
+    /// When defined, the script result replaces the default instance attributes in the sync response.
+    /// Implements <see cref="BBT.Workflow.Scripting.IOutputHandler"/>.
+    /// </summary>
+    [JsonInclude] [JsonPropertyName("output")]
+    public ScriptCode? Output { get; private set; }
+
+    /// <summary>
     /// Root-level query roles for state-based visibility. When a state has no queryRoles, this is used.
     /// </summary>
     [JsonIgnore]
@@ -271,6 +279,11 @@ public sealed class Workflow : IDomainEntity, IReference, IReferenceSetter, IHas
     public void SetTimeout(WorkflowTimeout timeout)
     {
         Timeout = timeout;
+    }
+
+    public void SetOutput(ScriptCode output)
+    {
+        Output = output;
     }
 
     public void SetCancel(Transition cancel)

--- a/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
@@ -609,6 +609,19 @@ public static partial class WorkflowLogs
         this ILogger logger,
         Guid instanceId);
 
+    /// <summary>
+    /// Logs when the workflow-level output script fails during sync response enrichment.
+    /// Execution continues and falls back to raw instance attributes.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 10132,
+        Level = LogLevel.Error,
+        Message = "Workflow '{WorkflowKey}' output script failed. Falling back to raw instance attributes.")]
+    public static partial void WorkflowOutputScriptFailed(
+        this ILogger logger,
+        string workflowKey,
+        Exception exception);
+
     #endregion
 
     #region Task Execution

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceCommandAppServiceLongPollAckTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceCommandAppServiceLongPollAckTests.cs
@@ -95,6 +95,7 @@ public class InstanceCommandAppServiceLongPollAckTests : IDisposable
             cancellationService: _cancellationService,
             longPollAckResumeService: _resumeService,
             instanceCommandGateway: _gateway,
+            workflowOutputMappingService: Substitute.For<IWorkflowOutputMappingService>(),
             currentUser: Substitute.For<ICurrentUser>(),
             logger: Substitute.For<ILogger<InstanceCommandAppService>>());
     }


### PR DESCRIPTION
## Summary
- Add optional `output: ScriptCode?` field to `Workflow` definition; when `sync=true` and a script is configured, it compiles to `IOutputHandler` and its result replaces raw instance attributes in the sync response
- Introduce `WorkflowOutputMappingService` (mirrors `SubflowOutputMappingService`) with non-blocking error fallback
- Add free-form JSON payload support to instance start and transition endpoints; `PayloadModeDetector` resolves mode via `x-vnext-payload-mode` header or presence of top-level `attributes` key

## Changes
- `src/BBT.Workflow.Domain/Definitions/Workflow.cs` — new `Output` property + `SetOutput()`
- `src/BBT.Workflow.Application/Instances/IWorkflowOutputMappingService.cs` — new interface
- `src/BBT.Workflow.Application/Instances/WorkflowOutputMappingService.cs` — new service
- `src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs` — inject + call `WorkflowOutputMappingService` in `EnrichOutputCoreAsync`
- `orchestration/.../Controllers/Instances/PayloadModeDetector.cs` — new detector helper
- `orchestration/.../Controllers/Instances/InstanceController.cs` — `StartAsync` and `TransitionAsync` now accept `JsonElement?` body

## Test Plan
- [ ] Workflow with `output` script + `sync=true` start returns script-mapped data instead of raw attributes
- [ ] Workflow without `output` script returns raw attributes as before (no regression)
- [ ] Output script error falls back gracefully to raw attributes
- [ ] Free-form body `{"customer_id":"123"}` normalized to `{"attributes":{"customer_id":"123"}}`
- [ ] Standard body `{"attributes":{"customerId":"123"}}` passes through unchanged
- [ ] `x-vnext-payload-mode: raw` header forces free-form even when body contains `attributes`
- [ ] `x-vnext-payload-mode: standard` header forces standard even when body has no `attributes`

## Summary by Sourcery

Add workflow-level output mapping for synchronous responses and enable flexible payload handling in instance APIs.

New Features:
- Allow workflows to define an optional output script whose result overrides default attributes in synchronous responses.
- Introduce a workflow output mapping service to compile and execute workflow output scripts during sync response enrichment.
- Support free-form JSON request bodies for instance start and transition endpoints with automatic normalization or header-controlled payload mode.

Enhancements:
- Log workflow output script failures and gracefully fall back to raw instance attributes without breaking responses.

Tests:
- Update long-poll acknowledgement service tests to account for the new workflow output mapping dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Requests can now accept either standard structured JSON or raw/free-form payloads for instance start and transition actions.
  * Synchronous workflow responses can now apply workflow-level output mapping before returning data.

* **Bug Fixes**
  * Improved handling of varied request formats with automatic fallback behavior.
  * If output mapping fails, the system now continues with the original response data instead of failing the request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->