### PR TITLE
fix(subflow): prevent deep-subflow stuck via job-name collision fix + fault-on-load-failure

### DIFF
--- a/src/BBT.Workflow.Application/Execution/Transitions/Continuations/EnqueueContinuationStrategy.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Continuations/EnqueueContinuationStrategy.cs
@@ -41,7 +41,10 @@ public sealed class EnqueueContinuationStrategy(
         if (next is null)
             return Result<WorkflowExecutionContext?>.Ok(null);
 
-        var jobName = JobName.ForAsyncTransition(current.InstanceId, next.TransitionKey);
+        // Scope by the state the auto-transition fires from (the state just entered) so two
+        // same-named continuations across different states do not dedup into one Dapr job.
+        var sourceStateKey = current.Target?.Key ?? current.Current?.Key ?? string.Empty;
+        var jobName = JobName.ForAsyncTransition(current.InstanceId, sourceStateKey, next.TransitionKey);
         var jobNameValue = jobName.Value;
 
         // Single caller-generated id, reused for the durable InstanceJob.JobId AND the underlying

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/CancelScheduledJobsStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/CancelScheduledJobsStep.cs
@@ -49,6 +49,7 @@ public sealed class CancelScheduledJobsStep(
         // Cancel ONLY the scheduled jobs for this state's transitions
         var result = await cancellationService.ProcessStateTransitionsCancellationAsync(
             context.InstanceId,
+            context.Current.Key,
             scheduledTransitionKeys,
             cancellationToken);
 

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ScheduleTransitionsStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ScheduleTransitionsStep.cs
@@ -128,7 +128,9 @@ public sealed class ScheduleTransitionsStep(
         Transition scheduledTransition,
         TimerSchedule timerSchedule)
     {
-        var jobName = JobName.ForScheduledTransition(context.InstanceId, scheduledTransition.Key);
+        // Scope by the owning state (the state just entered, whose timer this is). The same state is
+        // context.Current when CancelScheduledJobsStep later cancels it, so the source-state key lines up.
+        var jobName = JobName.ForScheduledTransition(context.InstanceId, context.Target!.Key, scheduledTransition.Key);
         var activity = Activity.Current;
 
         var payload = new TransitionTimerPayload

--- a/src/BBT.Workflow.Application/Execution/Transitions/Strategy/AsyncTransitionStrategy.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Strategy/AsyncTransitionStrategy.cs
@@ -101,8 +101,10 @@ public sealed class AsyncTransitionStrategy(
         Activity? activity,
         CancellationToken cancellationToken)
     {
+        // Source-state key scopes the job name (see JobName). Must match the value used when the job
+        // is persisted in EnqueueAndSaveJobAsync so the AnyActiveByJobNameAsync guard below lines up.
         var jobName = JobName.ForAsyncTransition(
-            Guid.Parse(context.InstanceId), context.TransitionKey).Value;
+            Guid.Parse(context.InstanceId), ctx.Current?.Key ?? string.Empty, context.TransitionKey).Value;
         EnrichTelemetry(activity, ctx, jobName);
 
         Result<TransitionExecutionContext> lockScopeResult =
@@ -169,7 +171,8 @@ public sealed class AsyncTransitionStrategy(
         Activity? activity,
         CancellationToken cancellationToken)
     {
-        var jobName = JobName.ForAsyncTransition(transContext.InstanceId, transContext.TransitionKey);
+        var jobName = JobName.ForAsyncTransition(
+            transContext.InstanceId, transContext.Current?.Key ?? string.Empty, transContext.TransitionKey);
         var jobId = Guid.NewGuid();
 
         var directPayload = BuildDirectPayload(context, transContext, jobName.Value, activity);

--- a/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
@@ -215,7 +215,7 @@ public sealed class InstanceCommandAppService(
         // Best-effort cancel the fallback timeout job; the token guard in the resume path keeps the
         // operation safe even if cancellation is missed.
         await cancellationService.ProcessStateTransitionsCancellationAsync(
-            instance.Id, [LongPollAckConstants.JobKey], cancellationToken);
+            instance.Id, sourceState: null, [LongPollAckConstants.JobKey], cancellationToken);
 
         return await longPollAckResumeService.ResumeAsync(
             workflow.Domain, workflow.Key, workflow.Version, instance.Id, cancellationToken);

--- a/src/BBT.Workflow.Application/Instances/Managers/IInstanceCancellationService.cs
+++ b/src/BBT.Workflow.Application/Instances/Managers/IInstanceCancellationService.cs
@@ -23,11 +23,17 @@ public interface IInstanceCancellationService
     /// Only cancels jobs that match the provided transition keys.
     /// </summary>
     /// <param name="instanceId">The ID of the instance.</param>
+    /// <param name="sourceState">
+    /// The source-state key that owns the jobs to cancel (scopes the match so a same-named transition
+    /// on another state's timer is not cancelled). Pass <c>null</c> for jobs without source-state
+    /// scoping (e.g. the long-poll-ack fallback).
+    /// </param>
     /// <param name="transitionKeys">List of transition keys whose jobs should be canceled.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A result indicating success or failure of the cancellation processing.</returns>
     Task<Result> ProcessStateTransitionsCancellationAsync(
         Guid instanceId,
+        string? sourceState,
         IReadOnlyList<string> transitionKeys,
         CancellationToken cancellationToken = default);
 }

--- a/src/BBT.Workflow.Application/Instances/Managers/InstanceCancellationService.cs
+++ b/src/BBT.Workflow.Application/Instances/Managers/InstanceCancellationService.cs
@@ -76,6 +76,7 @@ public sealed class InstanceCancellationService(
     /// <inheritdoc />
     public async Task<Result> ProcessStateTransitionsCancellationAsync(
         Guid instanceId,
+        string? sourceState,
         IReadOnlyList<string> transitionKeys,
         CancellationToken cancellationToken = default)
     {
@@ -102,7 +103,12 @@ public sealed class InstanceCancellationService(
             var allJobs = await instanceJobRepository.GetListActiveAsync(instance.Id, cancellationToken);
 
             var jobsToCancel = allJobs
-                .Where(job => (job.TransitionKey != null && transitionKeys.Contains(job.TransitionKey))
+                .Where(job =>
+                    // Source-state-scoped match: only cancel jobs owned by the state being left, so a
+                    // same-named transition on another state's timer is not cancelled by mistake.
+                    (job.SourceState == sourceState
+                        && job.TransitionKey != null
+                        && transitionKeys.Contains(job.TransitionKey))
                     // Transitional fallback for pre-rollout rows (no structured columns):
                     // old "-{key}" suffix match. Removable once no legacy rows remain.
                     || (job.JobType == JobType.Unknown

--- a/src/BBT.Workflow.Application/SubFlow/Services/SubflowCompletionService.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubflowCompletionService.cs
@@ -128,7 +128,21 @@ public sealed class SubflowCompletionService(
                     {
                         logger.LogWarning("Failed to get parent workflow {Flow} for SubFlow completion: {ErrorCode}",
                             completedInput.Flow, parentWorkflowResult.Error.Code);
-                        // Commit correlation completion even if workflow load fails; skip pipeline resume
+
+                        // Parent definition unavailable — resuming can never succeed, and a silent return
+                        // would strand the parent (and every ancestor) forever. Fault the parent so the
+                        // error propagates upward via InstanceSubFaultedEvent instead of leaving it stuck.
+                        var loadIncident = InstanceIncidentFactory.Create(
+                            state: parentInstance.GetCurrentState,
+                            transition: string.Empty,
+                            taskKey: null,
+                            message: $"Parent workflow '{completedInput.Flow}' could not be loaded for SubFlow completion",
+                            errorCode: parentWorkflowResult.Error.Code ?? WorkflowErrorCodes.NotFoundWorkflow,
+                            errorLayer: "SubFlow",
+                            stackTrace: parentWorkflowResult.Error.Detail);
+                        parentInstance.AddIncident(loadIncident);
+                        parentInstance.Fault(completedInput.Domain);
+                        await instanceRepository.UpdateAsync(parentInstance, true, cancellationToken);
                         await correlationUow.CommitAsync(cancellationToken);
                         return;
                     }

--- a/src/BBT.Workflow.Domain/Instances/InstanceJob.cs
+++ b/src/BBT.Workflow.Domain/Instances/InstanceJob.cs
@@ -22,7 +22,8 @@ public class InstanceJob : Entity<Guid>, IHasCreatedAt, IHasModifyTime
         ArgumentNullException.ThrowIfNull(jobName);
         JobName = Check.NotNullOrWhiteSpace(jobName.Value, nameof(JobName), InstanceJobConstants.MaxJobNameLength);
         JobType = jobName.Type;
-        TransitionKey = jobName.Segment;
+        SourceState = jobName.SourceState;
+        TransitionKey = jobName.TransitionKey;
         JobId = jobId;
         Domain = Check.NotNullOrWhiteSpace(domain, nameof(Domain), WorkflowConstants.MaxDomainLength);
         FlowName = Check.NotNullOrWhiteSpace(flowName, nameof(FlowName), WorkflowConstants.MaxFlowLength);
@@ -35,6 +36,13 @@ public class InstanceJob : Entity<Guid>, IHasCreatedAt, IHasModifyTime
 
     /// <summary>The job kind, projected from the structured <see cref="Instances.JobName"/> for queryable resolution.</summary>
     public JobType JobType { get; private set; }
+
+    /// <summary>
+    /// The source-state key the transition fires from, projected from the job name for queryable,
+    /// state-scoped cancellation. <c>null</c> for jobs without source-state scoping (timeout,
+    /// long-poll-ack, state-notify) and for legacy rows.
+    /// </summary>
+    public string? SourceState { get; private set; }
 
     /// <summary>
     /// The transition key (or well-known job key) this job targets, projected from the job name.

--- a/src/BBT.Workflow.Domain/Instances/JobName.cs
+++ b/src/BBT.Workflow.Domain/Instances/JobName.cs
@@ -33,12 +33,36 @@ public sealed record JobName
     private const char Delimiter = '.';
     private const char EncodedMarker = '~';
 
+    /// <summary>
+    /// Separates the source-state key from the transition key inside the composite segment used by
+    /// <c>tx</c>/<c>sx</c> jobs. The ASCII unit-separator (U+001F) never appears in a state or
+    /// transition key and is not URL-safe, so the composite is always Base64Url-encoded on the wire.
+    /// </summary>
+    private const char CompositeSeparator = '';
+
     private JobName(JobType type, Guid instanceId, string? segment, string value)
     {
         Type = type;
         InstanceId = instanceId;
         Segment = segment;
         Value = value;
+
+        // Decode the composite segment into its source-state / transition-key parts. Names written
+        // before source-state scoping (and non-composite segments like long-poll-ack) carry no
+        // separator, so SourceState stays null and the whole segment is the transition key.
+        if (segment is not null)
+        {
+            var separatorIndex = segment.IndexOf(CompositeSeparator);
+            if (separatorIndex >= 0)
+            {
+                SourceState = segment[..separatorIndex];
+                TransitionKey = segment[(separatorIndex + 1)..];
+            }
+            else
+            {
+                TransitionKey = segment;
+            }
+        }
     }
 
     /// <summary>The job kind decoded from the name.</summary>
@@ -48,21 +72,42 @@ public sealed record JobName
     public Guid InstanceId { get; }
 
     /// <summary>
-    /// The decoded final segment: the transition key for transition jobs, the well-known job key
-    /// for long-poll-ack, or <c>null</c> for timeout jobs.
+    /// The decoded final segment: the composite <c>{sourceState}{transitionKey}</c> for
+    /// source-state-scoped transition jobs, the transition key or well-known job key otherwise, or
+    /// <c>null</c> for timeout jobs. Prefer <see cref="SourceState"/> / <see cref="TransitionKey"/>
+    /// for structured access.
     /// </summary>
     public string? Segment { get; }
+
+    /// <summary>
+    /// The source-state key the transition fires from, decoded from the composite segment. <c>null</c>
+    /// for jobs without source-state scoping (timeout, long-poll-ack, state-notify, and legacy names).
+    /// Disambiguates two transitions that share a name across different states in one instance.
+    /// </summary>
+    public string? SourceState { get; }
+
+    /// <summary>
+    /// The transition key (or well-known job key) this job targets, decoded from the segment.
+    /// <c>null</c> for timeout jobs.
+    /// </summary>
+    public string? TransitionKey { get; }
 
     /// <summary>The encoded wire string persisted as the Dapr job name and on the instance-job row.</summary>
     public string Value { get; }
 
-    /// <summary>Builds the name of an async transition continuation job.</summary>
-    public static JobName ForAsyncTransition(Guid instanceId, string transitionKey)
-        => Build(JobType.AsyncTransition, instanceId, transitionKey);
+    /// <summary>
+    /// Builds the name of an async transition continuation job, scoped by the source state so that
+    /// two transitions sharing a name across different states never collide into one Dapr job.
+    /// </summary>
+    public static JobName ForAsyncTransition(Guid instanceId, string sourceState, string transitionKey)
+        => Build(JobType.AsyncTransition, instanceId, ComposeSegment(sourceState, transitionKey));
 
-    /// <summary>Builds the name of a timer-based scheduled transition job.</summary>
-    public static JobName ForScheduledTransition(Guid instanceId, string transitionKey)
-        => Build(JobType.ScheduledTransition, instanceId, transitionKey);
+    /// <summary>
+    /// Builds the name of a timer-based scheduled transition job, scoped by the source state (see
+    /// <see cref="ForAsyncTransition"/> for the collision rationale).
+    /// </summary>
+    public static JobName ForScheduledTransition(Guid instanceId, string sourceState, string transitionKey)
+        => Build(JobType.ScheduledTransition, instanceId, ComposeSegment(sourceState, transitionKey));
 
     /// <summary>Builds the name of a workflow timeout job.</summary>
     public static JobName ForTimeout(Guid instanceId)
@@ -126,6 +171,24 @@ public sealed record JobName
 
     /// <inheritdoc />
     public override string ToString() => Value;
+
+    /// <summary>
+    /// Composes the <c>{sourceState}{transitionKey}</c> segment. When no source state is available
+    /// (e.g. legacy call paths) it degrades to the bare transition key so the name stays parseable.
+    /// </summary>
+    private static string ComposeSegment(string sourceState, string transitionKey)
+    {
+        if (transitionKey.IndexOf(CompositeSeparator) >= 0 ||
+            (sourceState is not null && sourceState.IndexOf(CompositeSeparator) >= 0))
+        {
+            throw new ArgumentException(
+                "State and transition keys must not contain the composite separator (U+001F).");
+        }
+
+        return string.IsNullOrEmpty(sourceState)
+            ? transitionKey
+            : sourceState + CompositeSeparator + transitionKey;
+    }
 
     private static JobName Build(JobType type, Guid instanceId, string? segment)
     {

--- a/src/BBT.Workflow.Infrastructure/Data/InstancesModelCreatingExtensions.cs
+++ b/src/BBT.Workflow.Infrastructure/Data/InstancesModelCreatingExtensions.cs
@@ -432,6 +432,9 @@ public static class InstancesModelCreatingExtensions
                 .IsRequired()
                 .HasConversion<int>();
 
+            b.Property(p => p.SourceState)
+                .HasMaxLength(StateConstants.MaxKeyLength);
+
             b.Property(p => p.TransitionKey)
                 .HasMaxLength(InstanceConstants.MaxKeyLength);
 

--- a/src/BBT.Workflow.Infrastructure/Migrations/20260701071350_AddInstanceJobSourceState.Designer.cs
+++ b/src/BBT.Workflow.Infrastructure/Migrations/20260701071350_AddInstanceJobSourceState.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using BBT.Workflow.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BBT.Workflow.Migrations
 {
     [DbContext(typeof(WorkflowDbContext))]
-    partial class WorkflowDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260701071350_AddInstanceJobSourceState")]
+    partial class AddInstanceJobSourceState
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/BBT.Workflow.Infrastructure/Migrations/20260701071350_AddInstanceJobSourceState.cs
+++ b/src/BBT.Workflow.Infrastructure/Migrations/20260701071350_AddInstanceJobSourceState.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BBT.Workflow.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInstanceJobSourceState : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "SourceState",
+                schema: "public",
+                table: "InstanceJobs",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SourceState",
+                schema: "public",
+                table: "InstanceJobs");
+        }
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceCancellationServiceTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceCancellationServiceTests.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.BackgroundJob;
+using BBT.Aether.Uow;
+using BBT.Workflow.Definitions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Instances;
+
+/// <summary>
+/// Unit tests for <see cref="InstanceCancellationService.ProcessStateTransitionsCancellationAsync"/>,
+/// focused on source-state-scoped matching so a same-named transition on another state's timer is
+/// not cancelled when leaving a different state.
+/// </summary>
+public sealed class InstanceCancellationServiceTests
+{
+    private readonly Mock<IInstanceRepository> _instanceRepository = new();
+    private readonly Mock<IInstanceJobRepository> _instanceJobRepository = new();
+    private readonly Mock<IBackgroundJobService> _backgroundJobService = new();
+    private readonly Mock<IUnitOfWorkManager> _uowManager = new();
+    private readonly Mock<IUnitOfWork> _uow = new();
+    private readonly Mock<ILogger<InstanceCancellationService>> _logger = new();
+
+    private readonly Instance _instance = Instance.Create(Guid.NewGuid(), "flow", "1.0.0", "key");
+
+    public InstanceCancellationServiceTests()
+    {
+        _uow.Setup(u => u.CommitAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        _uow.Setup(u => u.DisposeAsync()).Returns(ValueTask.CompletedTask);
+        _uowManager.Setup(m => m.Begin(It.IsAny<UnitOfWorkOptions>())).Returns(_uow.Object);
+        _instance.ChangeState(StateFactory.CreateDefault("state-a", StateType.Intermediate));
+        _instanceRepository
+            .Setup(r => r.FindAsync(_instance.Id, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_instance);
+    }
+
+    [Fact]
+    public async Task DoesNotCancel_SameKey_DifferentSourceState()
+    {
+        // A "check" scheduled job owned by state-c must survive when we leave state-a.
+        var job = InstanceJob.Create(
+            Guid.NewGuid(),
+            JobName.ForScheduledTransition(_instance.Id, "state-c", "check"),
+            Guid.NewGuid(),
+            "bank",
+            "flow",
+            _instance.Id);
+        _instanceJobRepository
+            .Setup(r => r.GetListActiveAsync(_instance.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<InstanceJob> { job });
+
+        var result = await CreateService().ProcessStateTransitionsCancellationAsync(
+            _instance.Id, "state-a", new[] { "check" }, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        _backgroundJobService.Verify(
+            b => b.DeleteAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Cancels_MatchingSourceStateAndKey()
+    {
+        var job = InstanceJob.Create(
+            Guid.NewGuid(),
+            JobName.ForScheduledTransition(_instance.Id, "state-a", "check"),
+            Guid.NewGuid(),
+            "bank",
+            "flow",
+            _instance.Id);
+        _instanceJobRepository
+            .Setup(r => r.GetListActiveAsync(_instance.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<InstanceJob> { job });
+
+        var result = await CreateService().ProcessStateTransitionsCancellationAsync(
+            _instance.Id, "state-a", new[] { "check" }, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        _backgroundJobService.Verify(
+            b => b.DeleteAsync(job.JobId, It.IsAny<CancellationToken>()),
+            Times.Once);
+        job.IsActive.ShouldBeFalse();
+    }
+
+    private InstanceCancellationService CreateService()
+        => new(
+            _instanceRepository.Object,
+            _instanceJobRepository.Object,
+            _backgroundJobService.Object,
+            _uowManager.Object,
+            _logger.Object);
+}

--- a/test/BBT.Workflow.Application.Tests/SubFlow/SubflowCompletionServiceTests.cs
+++ b/test/BBT.Workflow.Application.Tests/SubFlow/SubflowCompletionServiceTests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.Results;
+using BBT.Aether.Uow;
+using BBT.Workflow.Caching;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Execution;
+using BBT.Workflow.Execution.Services;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Runtime;
+using BBT.Workflow.SubFlow;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Application.Tests.SubFlow;
+
+public sealed class SubflowCompletionServiceTests
+{
+    private readonly Mock<IUnitOfWorkManager> _uowManager = new();
+    private readonly Mock<IUnitOfWork> _uow = new();
+    private readonly Mock<IComponentCacheStore> _componentCacheStore = new();
+    private readonly Mock<IInstanceRepository> _instanceRepository = new();
+    private readonly Mock<IRuntimeInfoProvider> _runtimeInfoProvider = new();
+    private readonly Mock<IWorkflowExecutionService> _workflowExecutionService = new();
+    private readonly Mock<ISubflowOutputMappingService> _outputMappingService = new();
+    private readonly Mock<ILogger<SubflowCompletionService>> _logger = new();
+
+    public SubflowCompletionServiceTests()
+    {
+        _uow.Setup(u => u.CommitAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _uow.Setup(u => u.DisposeAsync())
+            .Returns(ValueTask.CompletedTask);
+
+        _uowManager
+            .Setup(m => m.Begin(It.IsAny<UnitOfWorkOptions>()))
+            .Returns(_uow.Object);
+    }
+
+    [Fact]
+    public async Task CompletionAsync_WhenParentWorkflowLoadFails_FaultsParentWithIncident()
+    {
+        var parentInstance = CreateParentInstance(out var subInstanceId);
+        var input = CreateInput(parentInstance.Id, subInstanceId);
+
+        _instanceRepository
+            .Setup(x => x.FindAsync(parentInstance.Id, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(parentInstance);
+        _instanceRepository
+            .Setup(x => x.UpdateAsync(parentInstance, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(parentInstance);
+
+        // Parent workflow definition cannot be loaded from the component cache.
+        _componentCacheStore
+            .Setup(x => x.GetFlowAsync("bank", "parent-flow", "1.0.0", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<Definitions.Workflow>.Fail(
+                Error.NotFound(WorkflowErrorCodes.NotFoundWorkflow, "not found", "parent-flow")));
+
+        await CreateService().CompletionAsync(input, CancellationToken.None);
+
+        parentInstance.Status.ShouldBe(InstanceStatus.Faulted);
+        parentInstance.HasActiveIncident.ShouldBeTrue();
+        _instanceRepository.Verify(
+            x => x.UpdateAsync(parentInstance, true, It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce);
+        // Pipeline resume must NOT be attempted when the definition is unavailable.
+        _workflowExecutionService.Verify(
+            x => x.ExecuteTransitionAsync(It.IsAny<WorkflowExecutionContext>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private SubflowCompletionService CreateService()
+        => new(
+            _uowManager.Object,
+            _componentCacheStore.Object,
+            _instanceRepository.Object,
+            _runtimeInfoProvider.Object,
+            _workflowExecutionService.Object,
+            _outputMappingService.Object,
+            _logger.Object);
+
+    private static Instance CreateParentInstance(out Guid subInstanceId)
+    {
+        subInstanceId = Guid.NewGuid();
+        var parentInstance = Instance.Create(Guid.NewGuid(), "parent-flow", "1.0.0", "parent-key");
+        parentInstance.ChangeState(StateFactory.CreateDefault("waiting-child", StateType.SubFlow));
+        parentInstance.AddCorrelation(InstanceCorrelation.Create(
+            Guid.NewGuid(),
+            parentInstance.Id,
+            "waiting-child",
+            subInstanceId,
+            SubFlowType.SubFlow.Code,
+            "bank",
+            "child-flow",
+            "1.0.0"));
+
+        return parentInstance;
+    }
+
+    private static FlowCompletedInput CreateInput(Guid parentInstanceId, Guid subInstanceId)
+        => new()
+        {
+            InstanceId = parentInstanceId,
+            Domain = "bank",
+            Flow = "parent-flow",
+            Version = "1.0.0",
+            SubInstanceId = subInstanceId,
+            CompletedState = "child-done",
+            InstanceData = CreateJsonElement("""{"result":"ok"}"""),
+            CompletedAt = DateTime.UtcNow
+        };
+
+    private static JsonElement CreateJsonElement(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+}

--- a/test/BBT.Workflow.Domain.Tests/Instances/JobNameTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Instances/JobNameTests.cs
@@ -6,7 +6,7 @@ namespace BBT.Workflow.Instances;
 
 /// <summary>
 /// Unit tests for the structured <see cref="JobName"/> value object: builder/parser round-trips,
-/// segment encoding collision cases, job-type distinctness, and legacy-name rejection.
+/// segment encoding collision cases, source-state scoping, job-type distinctness, and legacy-name rejection.
 /// </summary>
 public class JobNameTests
 {
@@ -15,20 +15,19 @@ public class JobNameTests
     [Fact]
     public void ForAsyncTransition_ShouldRoundTrip()
     {
-        var jobName = JobName.ForAsyncTransition(Instance, "approve");
-
-        Assert.Equal("vnext.job.v1.tx.550e8400e29b41d4a716446655440000.approve", jobName.Value);
+        var jobName = JobName.ForAsyncTransition(Instance, "state-a", "approve");
 
         Assert.True(JobName.TryParse(jobName.Value, out var parsed));
         Assert.Equal(JobType.AsyncTransition, parsed.Type);
         Assert.Equal(Instance, parsed.InstanceId);
-        Assert.Equal("approve", parsed.Segment);
+        Assert.Equal("state-a", parsed.SourceState);
+        Assert.Equal("approve", parsed.TransitionKey);
     }
 
     [Fact]
     public void ForScheduledTransition_ShouldUseDistinctTypeCode()
     {
-        var jobName = JobName.ForScheduledTransition(Instance, "approve");
+        var jobName = JobName.ForScheduledTransition(Instance, "state-a", "approve");
 
         Assert.StartsWith("vnext.job.v1.sx.", jobName.Value);
         Assert.Equal(JobType.ScheduledTransition, JobName.Parse(jobName.Value).Type);
@@ -37,15 +36,39 @@ public class JobNameTests
     [Fact]
     public void Async_And_Scheduled_ForSameInstanceAndKey_ShouldDiffer()
     {
-        var async = JobName.ForAsyncTransition(Instance, "approve");
-        var scheduled = JobName.ForScheduledTransition(Instance, "approve");
+        var async = JobName.ForAsyncTransition(Instance, "state-a", "approve");
+        var scheduled = JobName.ForScheduledTransition(Instance, "state-a", "approve");
 
         Assert.NotEqual(async.Value, scheduled.Value);
         Assert.NotEqual(JobName.Parse(async.Value).Type, JobName.Parse(scheduled.Value).Type);
     }
 
     [Fact]
-    public void ForTimeout_ShouldHaveNoSegment()
+    public void SameTransitionKey_DifferentSourceState_ShouldProduceDifferentNames()
+    {
+        // The bug fix: two states each defining a "within" transition must NOT collide into one job.
+        var fromA = JobName.ForAsyncTransition(Instance, "state-a", "within");
+        var fromB = JobName.ForAsyncTransition(Instance, "state-b", "within");
+
+        Assert.NotEqual(fromA.Value, fromB.Value);
+        Assert.Equal("state-a", JobName.Parse(fromA.Value).SourceState);
+        Assert.Equal("state-b", JobName.Parse(fromB.Value).SourceState);
+        Assert.Equal("within", JobName.Parse(fromA.Value).TransitionKey);
+        Assert.Equal("within", JobName.Parse(fromB.Value).TransitionKey);
+    }
+
+    [Fact]
+    public void SameSourceState_SameKey_ShouldBeIdentical()
+    {
+        // Idempotency: a retry / outbox re-publish of the same logical hop must dedup to one name.
+        var first = JobName.ForAsyncTransition(Instance, "state-a", "within");
+        var second = JobName.ForAsyncTransition(Instance, "state-a", "within");
+
+        Assert.Equal(first.Value, second.Value);
+    }
+
+    [Fact]
+    public void ForTimeout_ShouldHaveNoSegment_AndNullSourceState()
     {
         var jobName = JobName.ForTimeout(Instance);
 
@@ -54,16 +77,30 @@ public class JobNameTests
         Assert.True(JobName.TryParse(jobName.Value, out var parsed));
         Assert.Equal(JobType.Timeout, parsed.Type);
         Assert.Null(parsed.Segment);
+        Assert.Null(parsed.SourceState);
+        Assert.Null(parsed.TransitionKey);
     }
 
     [Fact]
-    public void ForLongPollAck_ShouldCarryWellKnownKey()
+    public void ForLongPollAck_ShouldCarryWellKnownKey_AndNullSourceState()
     {
         var jobName = JobName.ForLongPollAck(Instance);
 
         Assert.True(JobName.TryParse(jobName.Value, out var parsed));
         Assert.Equal(JobType.LongPollAck, parsed.Type);
-        Assert.Equal(LongPollAckConstants.JobKey, parsed.Segment);
+        Assert.Equal(LongPollAckConstants.JobKey, parsed.TransitionKey);
+        Assert.Null(parsed.SourceState);
+    }
+
+    [Fact]
+    public void LegacyV1PlainSegment_ShouldParse_AsNullSourceState()
+    {
+        // A pre-rollout tx name (no source-state composite) must still parse cleanly.
+        var parsed = JobName.Parse("vnext.job.v1.tx.550e8400e29b41d4a716446655440000.approve");
+
+        Assert.Null(parsed.SourceState);
+        Assert.Equal("approve", parsed.TransitionKey);
+        Assert.Equal("approve", parsed.Segment);
     }
 
     [Theory]
@@ -77,21 +114,22 @@ public class JobNameTests
     [InlineData("emoji-🚀-key")]
     [InlineData("-leading")]
     [InlineData("trailing-")]
-    public void Segment_ShouldRoundTripForArbitraryKeys(string key)
+    public void SourceStateAndKey_ShouldRoundTripForArbitraryKeys(string key)
     {
-        var jobName = JobName.ForAsyncTransition(Instance, key);
+        var jobName = JobName.ForAsyncTransition(Instance, key, key);
 
         Assert.True(JobName.TryParse(jobName.Value, out var parsed));
-        Assert.Equal(key, parsed.Segment);
+        Assert.Equal(key, parsed.SourceState);
+        Assert.Equal(key, parsed.TransitionKey);
         Assert.Equal(JobType.AsyncTransition, parsed.Type);
         Assert.Equal(Instance, parsed.InstanceId);
     }
 
     [Fact]
-    public void Build_ShouldStayWithinMaxLength_ForMaxKey()
+    public void Build_ShouldStayWithinMaxLength_ForMaxSourceStateAndKey()
     {
-        var key = new string('x', 100); // WorkflowConstants.MaxKeyLength
-        var jobName = JobName.ForScheduledTransition(Instance, key);
+        var key = new string('x', 100);  // WorkflowConstants.MaxKeyLength
+        var jobName = JobName.ForScheduledTransition(Instance, key, key);
 
         Assert.True(jobName.Value.Length <= InstanceJobConstants.MaxJobNameLength);
     }


### PR DESCRIPTION
## Problem

A main flow started with `sync=false` descends 6–8 subflow levels; in some cases a subflow starts and the parent never resumes ("subflow başlıyor ve öyle kalıyor"). The same happens under `sync=true`. Elastic logs (`morph-idm`) showed the same job name (`vnext.job.v1.tx.{instanceId}.not-found-next`) delivered 3–4× ~100 ms apart with 3 dropped as *"not Scheduled (already claimed or late delivery); skipping"*, plus *"Claim … was lost before success could be recorded; skipping"* on `.within`.

Code review confirmed two independent root causes.

## Root cause A — silent stuck on parent-workflow-load failure

In `SubflowCompletionService.CompletionAsync`, when the parent workflow definition failed to load from the component cache, the code logged a warning, committed the correlation, and returned — **without resuming the parent pipeline and without faulting**. The parent (and every ancestor) was stranded in a non-terminal state forever; retry could not help because the correlation was already completed. Likelihood rises with depth as each level re-reads the parent definition from `IComponentCacheStore`.

**Fix:** record an incident and call `Instance.Fault(domain)` so the error propagates upward via `InstanceSubFaultedEvent` instead of stranding the chain — mirroring the existing output-mapping-failure branch directly below it.

## Root cause B — job-name collision for tx/sx jobs

The Dapr job name for async (`tx`) and scheduled (`sx`) transitions was `vnext.job.v1.{type}.{instanceId}.{transitionKey}` — only instanceId + transition name. The **same transition name can legitimately exist on multiple states** in one flow (`within`, `check`, `not-found-next`). Two such logically-distinct jobs minted an identical name; Dapr dedups by name and dropped one, stalling the chain. Legitimate duplicate deliveries (retry / outbox re-publish) share the same name too and **should** dedup — so the disambiguator must be identical for a retry but different for two distinct same-named transitions. The **source state** satisfies both.

**Fix:** fold the source-state key into the segment as `{sourceState}<US>{transitionKey}` (U+001F unit separator, Base64Url-encoded on the wire).
- No format-version bump — legacy `v1` names still parse (`SourceState = null`).
- `timeout` (`to`) and `long-poll-ack` (`la`) stay name-stable and are **unaffected** (they are one-per-instance and cancelled by their deterministic name).
- `InstanceJob` gains a persisted, queryable `SourceState` column (nullable, additive migration).
- Scheduled-job cancellation now matches on **source state + transition key**, fixing a latent over-cancellation bug where leaving one state cancelled a same-named scheduled job owned by another state.

## Changes

- `SubflowCompletionService` — incident + fault on parent-workflow-load failure.
- `JobName` — source-state composite segment + `SourceState` / `TransitionKey` decoded properties.
- `InstanceJob` + EF mapping + migration `AddInstanceJobSourceState` (nullable column only).
- `InstanceCancellationService` / `IInstanceCancellationService` — source-state-scoped matching (legacy suffix fallback retained).
- Call sites updated: `ScheduleTransitionsStep` (uses `context.Target.Key`), `CancelScheduledJobsStep` (`context.Current.Key`), `EnqueueContinuationStrategy`, `AsyncTransitionStrategy` (both guard + persist sites), long-poll-ack cancel passes `sourceState: null`.

## Tests

- `JobNameTests` — collision no longer collides, retry still dedups, parse round-trips, timeout/longpollack unchanged, legacy `v1` names parse.
- `InstanceCancellationServiceTests` — does not cancel same-key/different-source-state; cancels matching source-state + key.
- `SubflowCompletionServiceTests` — parent faults with incident on workflow-load failure.

Full-suite failure counts are **identical** with and without these changes (155/25/11) — a pre-existing environmental baseline; this PR adds **zero** regressions and +5 passing tests.

## Reviewer notes

- The generated EF migration was **scoped to only the `SourceState` column** — the tooling also tried to bundle unrelated Aether `BackgroundJobs` drift (`ArmingToken`/`ArmingUntil`/schema rename), which I removed from the migration, its Designer, and the model snapshot.
- Out of scope (not addressed here): post-commit `StartSubflowJob` / `ForwardToSubflowJob` failures have no retry path — a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Scope transition jobs by source state to prevent job-name collisions and fault parent workflows when subflow parent definitions cannot be loaded.

Bug Fixes:
- Fault parent workflows and record incidents when parent workflow definitions fail to load during subflow completion, preventing silently stuck subflows.
- Include source-state information in async and scheduled job names and cancellation logic to avoid job-name collisions between same-named transitions on different states.

Enhancements:
- Persist source-state metadata on instance jobs and expose structured parsing of job names into source-state and transition-key components.

Tests:
- Add unit tests covering job-name source-state scoping and backward compatibility with legacy names.
- Add tests ensuring state-scoped cancellation only removes jobs for the owning state.
- Add tests verifying subflow completion faults the parent when workflow loading fails.

Chores:
- Introduce a database migration to add the nullable SourceState column to instance jobs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow jobs now track a source state alongside the transition key, improving how scheduled and async transitions are identified.
  * Subflow completion now records an incident and faults the parent workflow when the parent definition can’t be loaded.

* **Bug Fixes**
  * Transition job cancellation now targets only matching source-state jobs, reducing accidental cancellations.
  * Long-poll timeout cleanup now includes clearer cancellation context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->