### PR TITLE
fix(api): bind camelCase payload keys in start/transition endpoints

### DIFF
--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
@@ -65,7 +65,7 @@ public sealed class InstanceController(
         {
             request = body is null
                 ? new CreateInstanceDto()
-                : JsonSerializer.Deserialize<CreateInstanceDto>(body.Value) ?? new CreateInstanceDto();
+                : JsonSerializer.Deserialize<CreateInstanceDto>(body.Value, JsonSerializerOptions.Web) ?? new CreateInstanceDto();
         }
         else
         {
@@ -347,7 +347,7 @@ public sealed class InstanceController(
         }
         else if (PayloadModeDetector.IsStandard(headers, body))
         {
-            data = JsonSerializer.Deserialize<TransitionDataInput>(body.Value);
+            data = JsonSerializer.Deserialize<TransitionDataInput>(body.Value, JsonSerializerOptions.Web);
         }
         else
         {


### PR DESCRIPTION
## Summary
- Follow-up fix for #785 (already merged). The manual `JsonSerializer.Deserialize` in `StartAsync`/`TransitionAsync` used **default (case-sensitive)** options, so camelCase body keys (`key`, `stage`, `attributes`) failed to bind to the PascalCase DTO properties and produced null values.
- Use `JsonSerializerOptions.Web` to match ASP.NET's case-insensitive + camelCase pipeline.

## Changes
- `orchestration/.../Controllers/Instances/InstanceController.cs` — pass `JsonSerializerOptions.Web` to both deserialize calls

## Test Plan
- [ ] Standard body `{"key":"...","stage":"Initial","attributes":{...}}` now binds `Key`, `Stage`, `Attributes` correctly (no more nulls)
- [ ] Free-form body still wrapped under `attributes` (unchanged)

## Summary by Sourcery

Bug Fixes:
- Ensure camelCase request body keys bind to PascalCase DTO properties in StartAsync and TransitionAsync by using web-compatible JSON serializer options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of standard JSON payloads when starting or transitioning instances, making request parsing more consistent with common web JSON formatting.
  * Reduced the chance of deserialization issues for incoming payloads in these operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->