### PR TITLE
fix(jobname): keep readable dotted names Dapr-safe (drop ~ marker and…

### DIFF
--- a/src/BBT.Workflow.Domain/Instances/JobName.cs
+++ b/src/BBT.Workflow.Domain/Instances/JobName.cs
@@ -8,61 +8,43 @@ namespace BBT.Workflow.Instances;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Wire format: <c>vnext.job.v1.{type}.{instanceId}[.{segment}]</c>
+/// Wire format: <c>vnext.job.v1.{type}.{instanceId}[.{sourceState}].{key}</c>
 /// </para>
 /// <list type="bullet">
-///   <item>Delimiter is <c>.</c> — unreserved in URL path segments (RFC 3986), so it survives
-///   Dapr's scheduler / etcd-backed store unmodified. The classic URN <c>:</c> delimiter is
-///   intentionally avoided because Dapr job names are used in URL paths.</item>
+///   <item>Delimiter is <c>.</c> — accepted by Dapr's Jobs API (the name becomes the
+///   <c>/job/{name}</c> callback route). Every field uses only <c>[A-Za-z0-9_-]</c>, so the whole
+///   name stays within the Dapr-safe alphabet with no escaping/marker characters.</item>
 ///   <item><c>vnext.job.v1</c> is a fixed namespace + format version so the parser can reject
-///   foreign / legacy names deterministically and the scheme can evolve.</item>
+///   foreign names deterministically and the scheme can evolve.</item>
 ///   <item><c>{type}</c> is a short controlled-vocabulary code (never free text) — see
-///   <see cref="JobType"/>. This is what distinguishes async vs scheduled transitions, which
-///   shared an identical name before this scheme.</item>
+///   <see cref="JobType"/>. This distinguishes async vs scheduled transitions, which shared an
+///   identical name before this scheme.</item>
 ///   <item><c>{instanceId}</c> is a GUID in "N" format (32 hex, no dashes).</item>
-///   <item><c>{segment}</c> is the optional, type-specific final segment (the transition key for
-///   transition jobs, the well-known key for long-poll-ack, absent for timeout). As the reserved
-///   final segment it is the only part allowed to carry arbitrary user input; it is Base64Url
-///   encoded (with a <c>~</c> marker) whenever it contains a character outside
-///   <c>[A-Za-z0-9_-]</c>, guaranteeing collision-free, reversible round-trips.</item>
+///   <item><c>{sourceState}</c> (transition jobs only) is the state the transition fires from. It
+///   scopes the name so two transitions that share a key across different states do not collide
+///   into one Dapr job. Omitted for long-poll-ack / state-notify, and for legacy names written
+///   before source-state scoping (which parse with <see cref="SourceState"/> = <c>null</c>).</item>
+///   <item><c>{key}</c> is the final field: the transition key for transition jobs, the well-known
+///   key for long-poll-ack, the state key for state-notify; absent for timeout.</item>
 /// </list>
+/// <para>
+/// State and transition keys are required to be within <c>[A-Za-z0-9_-]</c> (no <c>.</c>). A key
+/// with any other character would previously produce a name Dapr rejects; the builder now fails
+/// fast with a clear error instead.
+/// </para>
 /// </remarks>
 public sealed record JobName
 {
     private const string Prefix = "vnext.job.v1";
     private const char Delimiter = '.';
-    private const char EncodedMarker = '~';
 
-    /// <summary>
-    /// Separates the source-state key from the transition key inside the composite segment used by
-    /// <c>tx</c>/<c>sx</c> jobs. The ASCII unit-separator (U+001F) never appears in a state or
-    /// transition key and is not URL-safe, so the composite is always Base64Url-encoded on the wire.
-    /// </summary>
-    private const char CompositeSeparator = '';
-
-    private JobName(JobType type, Guid instanceId, string? segment, string value)
+    private JobName(JobType type, Guid instanceId, string? sourceState, string? transitionKey, string value)
     {
         Type = type;
         InstanceId = instanceId;
-        Segment = segment;
+        SourceState = sourceState;
+        TransitionKey = transitionKey;
         Value = value;
-
-        // Decode the composite segment into its source-state / transition-key parts. Names written
-        // before source-state scoping (and non-composite segments like long-poll-ack) carry no
-        // separator, so SourceState stays null and the whole segment is the transition key.
-        if (segment is not null)
-        {
-            var separatorIndex = segment.IndexOf(CompositeSeparator);
-            if (separatorIndex >= 0)
-            {
-                SourceState = segment[..separatorIndex];
-                TransitionKey = segment[(separatorIndex + 1)..];
-            }
-            else
-            {
-                TransitionKey = segment;
-            }
-        }
     }
 
     /// <summary>The job kind decoded from the name.</summary>
@@ -72,58 +54,55 @@ public sealed record JobName
     public Guid InstanceId { get; }
 
     /// <summary>
-    /// The decoded final segment: the composite <c>{sourceState}{transitionKey}</c> for
-    /// source-state-scoped transition jobs, the transition key or well-known job key otherwise, or
-    /// <c>null</c> for timeout jobs. Prefer <see cref="SourceState"/> / <see cref="TransitionKey"/>
-    /// for structured access.
-    /// </summary>
-    public string? Segment { get; }
-
-    /// <summary>
-    /// The source-state key the transition fires from, decoded from the composite segment. <c>null</c>
-    /// for jobs without source-state scoping (timeout, long-poll-ack, state-notify, and legacy names).
-    /// Disambiguates two transitions that share a name across different states in one instance.
+    /// The source-state key the transition fires from. <c>null</c> for jobs without source-state
+    /// scoping (timeout, long-poll-ack, state-notify) and for legacy names. Disambiguates two
+    /// transitions that share a key across different states in one instance.
     /// </summary>
     public string? SourceState { get; }
 
     /// <summary>
-    /// The transition key (or well-known job key) this job targets, decoded from the segment.
-    /// <c>null</c> for timeout jobs.
+    /// The transition key (or well-known job key / state key) this job targets. <c>null</c> for
+    /// timeout jobs.
     /// </summary>
     public string? TransitionKey { get; }
 
-    /// <summary>The encoded wire string persisted as the Dapr job name and on the instance-job row.</summary>
+    /// <summary>Back-compatible alias for the final key field. Prefer <see cref="TransitionKey"/>.</summary>
+    public string? Segment => TransitionKey;
+
+    /// <summary>The wire string persisted as the Dapr job name and on the instance-job row.</summary>
     public string Value { get; }
 
     /// <summary>
     /// Builds the name of an async transition continuation job, scoped by the source state so that
-    /// two transitions sharing a name across different states never collide into one Dapr job.
+    /// two transitions sharing a key across different states never collide into one Dapr job.
     /// </summary>
     public static JobName ForAsyncTransition(Guid instanceId, string sourceState, string transitionKey)
-        => Build(JobType.AsyncTransition, instanceId, ComposeSegment(sourceState, transitionKey));
+        => BuildScopedTransition(JobType.AsyncTransition, instanceId, sourceState, transitionKey);
 
     /// <summary>
     /// Builds the name of a timer-based scheduled transition job, scoped by the source state (see
     /// <see cref="ForAsyncTransition"/> for the collision rationale).
     /// </summary>
     public static JobName ForScheduledTransition(Guid instanceId, string sourceState, string transitionKey)
-        => Build(JobType.ScheduledTransition, instanceId, ComposeSegment(sourceState, transitionKey));
+        => BuildScopedTransition(JobType.ScheduledTransition, instanceId, sourceState, transitionKey);
 
     /// <summary>Builds the name of a workflow timeout job.</summary>
     public static JobName ForTimeout(Guid instanceId)
-        => Build(JobType.Timeout, instanceId, segment: null);
+        => Build(JobType.Timeout, instanceId, sourceState: null, transitionKey: null);
 
     /// <summary>Builds the name of a long-poll acknowledge fallback job.</summary>
     public static JobName ForLongPollAck(Guid instanceId)
-        => Build(JobType.LongPollAck, instanceId, LongPollAckConstants.JobKey);
+        => Build(JobType.LongPollAck, instanceId, sourceState: null,
+            transitionKey: ValidateKey(LongPollAckConstants.JobKey, nameof(LongPollAckConstants.JobKey)));
 
     /// <summary>Builds the name of a state-level notification dispatch job.</summary>
     public static JobName ForStateNotify(Guid instanceId, string stateKey)
-        => Build(JobType.StateNotify, instanceId, stateKey);
+        => Build(JobType.StateNotify, instanceId, sourceState: null,
+            transitionKey: ValidateKey(stateKey, nameof(stateKey)));
 
     /// <summary>
     /// Attempts to parse a structured job name. Returns <c>false</c> for any value that does not
-    /// match the <c>vnext.job.v1</c> scheme (e.g. legacy names written before the rollout).
+    /// match the <c>vnext.job.v1</c> scheme (e.g. foreign names).
     /// </summary>
     public static bool TryParse(string? value, out JobName result)
     {
@@ -133,15 +112,15 @@ public sealed record JobName
             return false;
         }
 
-        string expectedPrefix = Prefix + Delimiter; // "vnext.job.v1."
+        var expectedPrefix = Prefix + Delimiter; // "vnext.job.v1."
         if (!value.StartsWith(expectedPrefix, StringComparison.Ordinal))
         {
             return false;
         }
 
-        // Remaining: {type}.{instanceId}[.{segment}] — segment never contains the delimiter on
-        // the wire (it is encoded when it would), but split with a bound for defensiveness.
-        var parts = value[expectedPrefix.Length..].Split(Delimiter, 3);
+        // {type}.{instanceId}[.{sourceState}].{key} — every field is a plain, delimiter-free token,
+        // so a full split is unambiguous.
+        var parts = value[expectedPrefix.Length..].Split(Delimiter);
         if (parts.Length < 2)
         {
             return false;
@@ -158,8 +137,51 @@ public sealed record JobName
             return false;
         }
 
-        var segment = parts.Length == 3 ? Decode(parts[2]) : null;
-        result = new JobName(type, instanceId, segment, value);
+        var trailing = parts.Length - 2; // number of key fields after type + instanceId
+        string? sourceState = null;
+        string? transitionKey = null;
+
+        switch (type)
+        {
+            case JobType.Timeout:
+                if (trailing != 0)
+                {
+                    return false;
+                }
+                break;
+
+            case JobType.AsyncTransition:
+            case JobType.ScheduledTransition:
+                // Current: {sourceState}.{key}. Legacy (pre source-state scoping): {key} only.
+                if (trailing == 2)
+                {
+                    sourceState = parts[2];
+                    transitionKey = parts[3];
+                }
+                else if (trailing == 1)
+                {
+                    transitionKey = parts[2];
+                }
+                else
+                {
+                    return false;
+                }
+                break;
+
+            case JobType.LongPollAck:
+            case JobType.StateNotify:
+                if (trailing != 1)
+                {
+                    return false;
+                }
+                transitionKey = parts[2];
+                break;
+
+            default:
+                return false;
+        }
+
+        result = new JobName(type, instanceId, sourceState, transitionKey, value);
         return true;
     }
 
@@ -172,34 +194,30 @@ public sealed record JobName
     /// <inheritdoc />
     public override string ToString() => Value;
 
-    /// <summary>
-    /// Composes the <c>{sourceState}{transitionKey}</c> segment. When no source state is available
-    /// (e.g. legacy call paths) it degrades to the bare transition key so the name stays parseable.
-    /// </summary>
-    private static string ComposeSegment(string sourceState, string transitionKey)
+    private static JobName BuildScopedTransition(
+        JobType type, Guid instanceId, string sourceState, string transitionKey)
     {
-        if (transitionKey.IndexOf(CompositeSeparator) >= 0 ||
-            (sourceState is not null && sourceState.IndexOf(CompositeSeparator) >= 0))
-        {
-            throw new ArgumentException(
-                "State and transition keys must not contain the composite separator (U+001F).");
-        }
+        ValidateKey(transitionKey, nameof(transitionKey));
 
-        return string.IsNullOrEmpty(sourceState)
-            ? transitionKey
-            : sourceState + CompositeSeparator + transitionKey;
+        // No source state available (rare edge paths) → emit a legacy-shaped single-key name.
+        var source = string.IsNullOrEmpty(sourceState) ? null : ValidateKey(sourceState, nameof(sourceState));
+        return Build(type, instanceId, source, transitionKey);
     }
 
-    private static JobName Build(JobType type, Guid instanceId, string? segment)
+    private static JobName Build(JobType type, Guid instanceId, string? sourceState, string? transitionKey)
     {
         var builder = new StringBuilder(Prefix)
             .Append(Delimiter).Append(ToWireCode(type))
             .Append(Delimiter).Append(instanceId.ToString("N"));
 
-        var decodedSegment = string.IsNullOrEmpty(segment) ? null : segment;
-        if (decodedSegment is not null)
+        if (sourceState is not null)
         {
-            builder.Append(Delimiter).Append(Encode(decodedSegment));
+            builder.Append(Delimiter).Append(sourceState);
+        }
+
+        if (transitionKey is not null)
+        {
+            builder.Append(Delimiter).Append(transitionKey);
         }
 
         var value = builder.ToString();
@@ -207,10 +225,27 @@ public sealed record JobName
         {
             throw new ArgumentException(
                 $"Job name length {value.Length} exceeds the maximum of {InstanceJobConstants.MaxJobNameLength}.",
-                nameof(segment));
+                nameof(transitionKey));
         }
 
-        return new JobName(type, instanceId, decodedSegment, value);
+        return new JobName(type, instanceId, sourceState, transitionKey, value);
+    }
+
+    /// <summary>
+    /// Ensures a state/transition key is a non-empty, Dapr-safe token (<c>[A-Za-z0-9_-]</c>).
+    /// Throws <see cref="ArgumentException"/> otherwise — such a key cannot form a valid Dapr job name.
+    /// </summary>
+    private static string ValidateKey(string key, string paramName)
+    {
+        if (string.IsNullOrEmpty(key) || !IsSafe(key))
+        {
+            throw new ArgumentException(
+                $"State/transition key '{key}' must be non-empty and contain only [A-Za-z0-9_-] " +
+                "to form a valid Dapr job name.",
+                paramName);
+        }
+
+        return key;
     }
 
     private static string ToWireCode(JobType type) => type switch
@@ -233,38 +268,7 @@ public sealed record JobName
         _ => JobType.Unknown
     };
 
-    private static string Encode(string raw)
-    {
-        if (IsUrlSafe(raw))
-        {
-            return raw;
-        }
-
-        var base64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(raw))
-            .TrimEnd('=')
-            .Replace('+', '-')
-            .Replace('/', '_');
-        return EncodedMarker + base64;
-    }
-
-    private static string Decode(string segment)
-    {
-        if (segment.Length == 0 || segment[0] != EncodedMarker)
-        {
-            return segment;
-        }
-
-        var base64 = segment[1..].Replace('-', '+').Replace('_', '/');
-        base64 += (base64.Length % 4) switch
-        {
-            2 => "==",
-            3 => "=",
-            _ => string.Empty
-        };
-        return Encoding.UTF8.GetString(Convert.FromBase64String(base64));
-    }
-
-    private static bool IsUrlSafe(string value)
+    private static bool IsSafe(string value)
     {
         foreach (var c in value)
         {

--- a/test/BBT.Workflow.Domain.Tests/Instances/JobNameTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Instances/JobNameTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.RegularExpressions;
 using BBT.Workflow.Execution.LongPoll;
 using Xunit;
 
@@ -6,22 +7,30 @@ namespace BBT.Workflow.Instances;
 
 /// <summary>
 /// Unit tests for the structured <see cref="JobName"/> value object: builder/parser round-trips,
-/// segment encoding collision cases, source-state scoping, job-type distinctness, and legacy-name rejection.
+/// source-state scoping, the Dapr-safe character alphabet, key validation, and legacy single-field
+/// read-compatibility.
 /// </summary>
 public class JobNameTests
 {
     private static readonly Guid Instance = Guid.Parse("550e8400-e29b-41d4-a716-446655440000");
+    private const string InstanceN = "550e8400e29b41d4a716446655440000";
+
+    // Dapr's Jobs API only accepts names in this alphabet (the name becomes the /job/{name} route).
+    private static readonly Regex DaprSafe = new("^[A-Za-z0-9_.-]+$", RegexOptions.Compiled);
 
     [Fact]
-    public void ForAsyncTransition_ShouldRoundTrip()
+    public void ForAsyncTransition_ShouldProduceReadableName_AndRoundTrip()
     {
-        var jobName = JobName.ForAsyncTransition(Instance, "state-a", "approve");
+        var jobName = JobName.ForAsyncTransition(Instance, "wait-ivr", "go-to-transfer-ivr");
+
+        // Readable, dot-delimited, no marker/encoding characters.
+        Assert.Equal($"vnext.job.v1.tx.{InstanceN}.wait-ivr.go-to-transfer-ivr", jobName.Value);
 
         Assert.True(JobName.TryParse(jobName.Value, out var parsed));
         Assert.Equal(JobType.AsyncTransition, parsed.Type);
         Assert.Equal(Instance, parsed.InstanceId);
-        Assert.Equal("state-a", parsed.SourceState);
-        Assert.Equal("approve", parsed.TransitionKey);
+        Assert.Equal("wait-ivr", parsed.SourceState);
+        Assert.Equal("go-to-transfer-ivr", parsed.TransitionKey);
     }
 
     [Fact]
@@ -68,11 +77,21 @@ public class JobNameTests
     }
 
     [Fact]
-    public void ForTimeout_ShouldHaveNoSegment_AndNullSourceState()
+    public void EmptySourceState_ShouldDegradeToSingleKeyName()
+    {
+        var jobName = JobName.ForAsyncTransition(Instance, "", "approve");
+
+        Assert.Equal($"vnext.job.v1.tx.{InstanceN}.approve", jobName.Value);
+        Assert.Null(JobName.Parse(jobName.Value).SourceState);
+        Assert.Equal("approve", JobName.Parse(jobName.Value).TransitionKey);
+    }
+
+    [Fact]
+    public void ForTimeout_ShouldHaveNoKey_AndNullSourceState()
     {
         var jobName = JobName.ForTimeout(Instance);
 
-        Assert.Equal("vnext.job.v1.to.550e8400e29b41d4a716446655440000", jobName.Value);
+        Assert.Equal($"vnext.job.v1.to.{InstanceN}", jobName.Value);
 
         Assert.True(JobName.TryParse(jobName.Value, out var parsed));
         Assert.Equal(JobType.Timeout, parsed.Type);
@@ -93,10 +112,10 @@ public class JobNameTests
     }
 
     [Fact]
-    public void LegacyV1PlainSegment_ShouldParse_AsNullSourceState()
+    public void LegacySingleFieldName_ShouldParse_AsNullSourceState()
     {
-        // A pre-rollout tx name (no source-state composite) must still parse cleanly.
-        var parsed = JobName.Parse("vnext.job.v1.tx.550e8400e29b41d4a716446655440000.approve");
+        // A pre-rollout tx name (no source-state field) must still parse cleanly.
+        var parsed = JobName.Parse($"vnext.job.v1.tx.{InstanceN}.approve");
 
         Assert.Null(parsed.SourceState);
         Assert.Equal("approve", parsed.TransitionKey);
@@ -105,24 +124,40 @@ public class JobNameTests
 
     [Theory]
     [InlineData("approve")]
-    [InlineData("go-back")]               // hyphen — the original suffix-match bug case
-    [InlineData("step_1")]
-    [InlineData("a.b.c")]                 // dots — would collide with the delimiter if not encoded
-    [InlineData("with:colon")]
-    [InlineData("with space")]
-    [InlineData("son-aşama")]             // non-ascii
-    [InlineData("emoji-🚀-key")]
-    [InlineData("-leading")]
-    [InlineData("trailing-")]
-    public void SourceStateAndKey_ShouldRoundTripForArbitraryKeys(string key)
+    [InlineData("go-back")]      // hyphen — the original suffix-match bug case
+    [InlineData("go-to-transfer-ivr")]
+    [InlineData("step_1")]       // underscore
+    [InlineData("State-A_1")]
+    public void SafeKeys_ShouldRoundTripPlain(string key)
     {
         var jobName = JobName.ForAsyncTransition(Instance, key, key);
+
+        Assert.Matches(DaprSafe, jobName.Value);
+        Assert.DoesNotContain("~", jobName.Value);
 
         Assert.True(JobName.TryParse(jobName.Value, out var parsed));
         Assert.Equal(key, parsed.SourceState);
         Assert.Equal(key, parsed.TransitionKey);
         Assert.Equal(JobType.AsyncTransition, parsed.Type);
         Assert.Equal(Instance, parsed.InstanceId);
+    }
+
+    [Theory]
+    [InlineData("a.b.c")]        // dots collide with the delimiter
+    [InlineData("with space")]
+    [InlineData("son-aşama")]    // non-ascii
+    [InlineData("emoji-🚀-key")]
+    [InlineData("with:colon")]
+    public void NonDaprSafeKey_ShouldThrow(string key)
+    {
+        Assert.Throws<ArgumentException>(() => JobName.ForAsyncTransition(Instance, "state-a", key));
+        Assert.Throws<ArgumentException>(() => JobName.ForAsyncTransition(Instance, key, "approve"));
+    }
+
+    [Fact]
+    public void EmptyTransitionKey_ShouldThrow()
+    {
+        Assert.Throws<ArgumentException>(() => JobName.ForAsyncTransition(Instance, "state-a", ""));
     }
 
     [Fact]
@@ -136,14 +171,13 @@ public class JobNameTests
 
     [Theory]
     [InlineData("trans-550e8400-e29b-41d4-a716-446655440000-approve")]
-    [InlineData("timeout-550e8400-e29b-41d4-a716-446655440000")]
-    [InlineData("lpack-550e8400-e29b-41d4-a716-446655440000-longpoll-ack")]
     [InlineData("")]
     [InlineData(null)]
-    [InlineData("vnext.job.v1.zz.550e8400e29b41d4a716446655440000")]   // unknown type code
-    [InlineData("vnext.job.v1.tx.not-a-guid.approve")]                 // bad instance id
+    [InlineData("vnext.job.v1.zz.550e8400e29b41d4a716446655440000")]        // unknown type code
+    [InlineData("vnext.job.v1.tx.not-a-guid.approve")]                      // bad instance id
+    [InlineData("vnext.job.v1.to.550e8400e29b41d4a716446655440000.extra")]  // timeout must have no key
     [InlineData("garbage")]
-    public void TryParse_ShouldRejectLegacyAndInvalidNames(string? value)
+    public void TryParse_ShouldRejectForeignAndInvalidNames(string? value)
     {
         Assert.False(JobName.TryParse(value, out _));
     }


### PR DESCRIPTION
… U+001F)

The real Dapr-routing problem was the '~' EncodedMarker and the U+001F composite separator (which forced every scoped name through '~' Base64Url encoding) — NOT the '.' delimiter, which Dapr accepts (e.g. vnext.job.v1.tx.{id}.go-to-transfer-ivr has always worked).

Redesign, keeping the '.' scheme:
- Express source-state scoping as a second plain '.'-field: vnext.job.v1.{type}.{id}.{sourceState}.{transitionKey} — fully readable, no encoding, no marker characters.
- Removed the '~' marker, the U+001F ComposeSegment, and the Base64Url path.
- State/transition keys are validated to [A-Za-z0-9_-] (dot-free); a non-conforming key now fails fast with a clear ArgumentException instead of silently producing a '~' name Dapr rejects. Such keys never yielded a valid job name before.
- Legacy single-field names (vnext.job.v1.tx.{id}.{key}) still parse as SourceState=null.

Reverts the earlier underscore-scheme change; keeps InstanceJob.SourceState and source-state-scoped cancellation intact.

## Summary by Sourcery

Redesign job name wire format to keep readable dotted names while enforcing a Dapr-safe alphabet and explicit source-state scoping.

New Features:
- Introduce explicit source-state field in job names to scope transition jobs and avoid collisions across states.
- Add validation for state and transition keys to require a Dapr-safe token alphabet and fail fast on invalid keys.

Enhancements:
- Simplify job name composition by removing the Base64Url encoding path, the '~' marker, and the composite U+001F separator.
- Maintain backward compatibility by parsing legacy single-field transition names with a null source state and exposing the final key via a Segment alias.

Tests:
- Update and extend JobName tests to cover the new dotted wire format, Dapr-safe character constraints, key validation failures, and legacy name parsing behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Job names are now easier to read, using plain dot-delimited text instead of encoded segments.
  * Transition and timeout names now round-trip more consistently, with clearer handling of source state and key values.

* **Bug Fixes**
  * Improved parsing of existing job names, including support for some older formats.
  * Added validation to reject empty or unsupported job-name parts, reducing invalid-name issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->