### PR TITLE
feat(workflow,api): return workflow output mapping directly as sync response

### DIFF
--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
@@ -90,7 +90,7 @@ public sealed class InstanceController(
         }
 
         var result = await commandAppService.StartAsync(input, cancellationToken);
-        return WorkflowResultActionResultMapper.ToActionResult(result, HttpContext);
+        return InstanceResponseActionResultMapper.ToActionResult(result, HttpContext);
     }
 
     [ApiExplorerSettings(IgnoreApi = true)]
@@ -370,7 +370,7 @@ public sealed class InstanceController(
             input,
             cancellationToken);
 
-        return WorkflowResultActionResultMapper.ToActionResult(result, HttpContext);
+        return InstanceResponseActionResultMapper.ToActionResult(result, HttpContext);
     }
 
     /// <summary>

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceResponseActionResultMapper.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceResponseActionResultMapper.cs
@@ -1,0 +1,64 @@
+using BBT.Aether.Results;
+using BBT.Workflow.HttpApi.Results;
+using BBT.Workflow.Instances;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BBT.Workflow.Orchestration.Controllers.Instances;
+
+/// <summary>
+/// Maps instance operation results to HTTP responses. When a workflow output script ran
+/// (<see cref="InstanceOutputBase.HasOutputResponse"/>), the mapped payload is returned directly
+/// — with the script's status code and headers — bypassing the standard instance envelope,
+/// mirroring <c>FunctionResponseActionResultMapper</c>. Otherwise delegates to
+/// <see cref="WorkflowResultActionResultMapper"/>.
+/// </summary>
+internal static class InstanceResponseActionResultMapper
+{
+    private static readonly HashSet<string> RestrictedResponseHeaders = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "connection",
+        "content-length",
+        "content-type",         // ObjectResult negotiates this via output formatters
+        "date",                 // server writes its own
+        "host",                 // upstream internal hostname must not leak
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "server",               // orchestrator sets its own Server header
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "upgrade"
+    };
+
+    internal static IActionResult ToActionResult<T>(Result<T> result, HttpContext httpContext)
+        where T : InstanceOutputBase
+    {
+        if (result.IsSuccess && result.Value is { HasOutputResponse: true } output)
+        {
+            ApplyHeaders(output.OutputHeaders, httpContext);
+
+            // OutputData may be null → empty body with the configured/default status code.
+            return new ObjectResult(output.OutputData)
+            {
+                StatusCode = output.OutputStatusCode ?? StatusCodes.Status200OK
+            };
+        }
+
+        return WorkflowResultActionResultMapper.ToActionResult(result, httpContext);
+    }
+
+    private static void ApplyHeaders(Dictionary<string, string>? headers, HttpContext httpContext)
+    {
+        if (headers is null || headers.Count == 0)
+            return;
+
+        foreach (var (key, value) in headers)
+        {
+            if (RestrictedResponseHeaders.Contains(key))
+                continue;
+
+            httpContext.Response.Headers[key] = value;
+        }
+    }
+}

--- a/src/BBT.Workflow.Application/Instances/IWorkflowOutputMappingService.cs
+++ b/src/BBT.Workflow.Application/Instances/IWorkflowOutputMappingService.cs
@@ -1,22 +1,31 @@
-using System.Text.Json;
 using BBT.Aether.Results;
 using BBT.Workflow.Scripting;
 
 namespace BBT.Workflow.Instances;
 
 /// <summary>
-/// Executes a workflow-level output mapping script and returns the mapped data
-/// to replace the default instance attributes in a sync response.
+/// Result of a workflow output mapping script: the mapped payload plus optional
+/// HTTP status code and headers. <see cref="Data"/> may be null (intentional empty response).
+/// </summary>
+public sealed record WorkflowOutputResult(
+    object? Data,
+    int? StatusCode,
+    Dictionary<string, string>? Headers);
+
+/// <summary>
+/// Executes a workflow-level output mapping script and returns the mapped payload
+/// to be returned directly as the sync HTTP response body (bypassing the standard envelope).
 /// </summary>
 public interface IWorkflowOutputMappingService
 {
     /// <summary>
     /// Compiles and runs the workflow's <see cref="Definitions.Workflow.Output"/> script
     /// using the provided <see cref="ScriptContext"/>.
-    /// Returns <c>null</c> when no output script is configured or the script produces no data.
-    /// Returns <see cref="Result{T}.Fail"/> when the script throws, so the caller can fall back gracefully.
+    /// Returns <c>null</c> when no output script is configured (or on script failure, logged
+    /// non-blocking) so the caller keeps the standard envelope. When the script runs, returns a
+    /// <see cref="WorkflowOutputResult"/> whose <see cref="WorkflowOutputResult.Data"/> may be null.
     /// </summary>
-    Task<Result<JsonElement?>> ApplyAsync(
+    Task<Result<WorkflowOutputResult?>> ApplyAsync(
         Definitions.Workflow workflow,
         ScriptContext scriptContext,
         CancellationToken cancellationToken = default);

--- a/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
@@ -700,6 +700,7 @@ public sealed class InstanceCommandAppService(
         var attributes = filteredAttributes ?? rawAttributes;
 
         Dictionary<string, object> extensions = new();
+        WorkflowOutputResult? outputResponse = null;
         if (workflow is not null)
         {
             var scriptContext = await scriptContextFactory.NewBuilder(instanceRepository)
@@ -710,9 +711,15 @@ public sealed class InstanceCommandAppService(
                 .WithBody(latestData?.Data ?? new JsonData("{}"))
                 .BuildAsync(cancellationToken);
 
-            var outputResult = await workflowOutputMappingService.ApplyAsync(workflow, scriptContext, cancellationToken);
-            if (outputResult.IsSuccess && outputResult.Value.HasValue)
-                attributes = outputResult.Value;
+            // Workflow output mapping bypasses the standard envelope, but NEVER for subflow
+            // instances: correlation forward (sub start) and subflow transitions rely on the
+            // standard model, so output is ignored even when configured.
+            if (!instance.IsSubItem)
+            {
+                var outputResult = await workflowOutputMappingService.ApplyAsync(workflow, scriptContext, cancellationToken);
+                if (outputResult.IsSuccess && outputResult.Value is { } wo)
+                    outputResponse = wo;
+            }
 
             var extensionsResult = await instanceExtensionService.ProcessExtensionsAsync(
                 extensionRequested,
@@ -735,6 +742,7 @@ public sealed class InstanceCommandAppService(
             start.Extensions = extensions;
             start.PipelineInstance = null;
             start.ETag = representationEtagService.Generate(start);
+            ApplyOutputResponse(start, outputResponse);
         }
         else if (output is TransitionOutput transition)
         {
@@ -744,9 +752,25 @@ public sealed class InstanceCommandAppService(
             transition.Extensions = extensions;
             transition.PipelineInstance = null;
             transition.ETag = representationEtagService.Generate(transition);
+            ApplyOutputResponse(transition, outputResponse);
         }
 
         return Result<TOutput>.Ok(output);
+    }
+
+    /// <summary>
+    /// Copies the workflow output mapping result onto the output DTO. When set, the controller
+    /// mapper returns the payload directly (bypassing the standard envelope), even if Data is null.
+    /// </summary>
+    private static void ApplyOutputResponse(InstanceOutputBase output, WorkflowOutputResult? outputResponse)
+    {
+        if (outputResponse is null)
+            return;
+
+        output.HasOutputResponse = true;
+        output.OutputData = outputResponse.Data;
+        output.OutputStatusCode = outputResponse.StatusCode;
+        output.OutputHeaders = outputResponse.Headers;
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Application/Instances/WorkflowOutputMappingService.cs
+++ b/src/BBT.Workflow.Application/Instances/WorkflowOutputMappingService.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 using BBT.Aether.Results;
 using BBT.Workflow.Logging;
@@ -13,13 +14,14 @@ public sealed class WorkflowOutputMappingService(
     : IWorkflowOutputMappingService
 {
     /// <inheritdoc />
-    public async Task<Result<JsonElement?>> ApplyAsync(
+    public async Task<Result<WorkflowOutputResult?>> ApplyAsync(
         Definitions.Workflow workflow,
         ScriptContext scriptContext,
         CancellationToken cancellationToken = default)
     {
+        // Not configured → signal "no output" so the caller keeps the standard envelope.
         if (workflow.Output is null || !workflow.Output.HasMappingCode)
-            return Result<JsonElement?>.Ok(null);
+            return Result<WorkflowOutputResult?>.Ok(null);
 
         try
         {
@@ -30,16 +32,45 @@ public sealed class WorkflowOutputMappingService(
 
             var response = await handler.OutputHandler(scriptContext);
 
-            var element = response.Data is null
-                ? (JsonElement?)null
-                : JsonSerializer.SerializeToElement(response.Data);
-
-            return Result<JsonElement?>.Ok(element);
+            // Output ran — Data may legitimately be null (intentional empty response).
+            return Result<WorkflowOutputResult?>.Ok(new WorkflowOutputResult(
+                (object?)response.Data,
+                response.StatusCode,
+                NormalizeHeaders((object?)response.Headers)));
         }
         catch (Exception ex)
         {
             logger.WorkflowOutputScriptFailed(workflow.Key, ex);
-            return Result<JsonElement?>.Ok(null);
+            // On failure fall back to the standard envelope (non-blocking).
+            return Result<WorkflowOutputResult?>.Ok(null);
+        }
+    }
+
+    /// <summary>
+    /// Converts the script's dynamic Headers value to a string dictionary,
+    /// mirroring <c>FunctionAppService.NormalizeHeaders</c>.
+    /// </summary>
+    private static Dictionary<string, string>? NormalizeHeaders(object? value)
+    {
+        if (value is null)
+            return null;
+
+        try
+        {
+            var headers = value switch
+            {
+                Dictionary<string, string> typedHeaders => typedHeaders,
+                IDictionary<string, object?> objectHeaders => objectHeaders
+                    .Where(header => header.Value != null)
+                    .ToDictionary(header => header.Key, header => Convert.ToString(header.Value, CultureInfo.InvariantCulture) ?? string.Empty),
+                _ => JsonSerializer.Deserialize<Dictionary<string, string>>(JsonSerializer.Serialize(value))
+            };
+
+            return headers is { Count: > 0 } ? headers : null;
+        }
+        catch
+        {
+            return null;
         }
     }
 }

--- a/src/BBT.Workflow.Domain/Instances/DTOs/InstanceOutputBase.cs
+++ b/src/BBT.Workflow.Domain/Instances/DTOs/InstanceOutputBase.cs
@@ -57,4 +57,25 @@ public abstract class InstanceOutputBase
     /// </summary>
     [JsonIgnore]
     public Instance? PipelineInstance { get; set; }
+
+    /// <summary>
+    /// True when a workflow output script ran (sync=true, non-subflow, script configured).
+    /// Signals the mapper to bypass the standard envelope and return the mapped payload
+    /// directly — even when <see cref="OutputData"/> is null (intentional empty response).
+    /// Not serialized — internal transport between AppService and the controller mapper only.
+    /// </summary>
+    [JsonIgnore]
+    public bool HasOutputResponse { get; set; }
+
+    /// <summary>Mapped payload returned as the raw response body. May be null. Not serialized.</summary>
+    [JsonIgnore]
+    public object? OutputData { get; set; }
+
+    /// <summary>Optional HTTP status code from the output script. Not serialized.</summary>
+    [JsonIgnore]
+    public int? OutputStatusCode { get; set; }
+
+    /// <summary>Optional response headers from the output script. Not serialized.</summary>
+    [JsonIgnore]
+    public Dictionary<string, string>? OutputHeaders { get; set; }
 }


### PR DESCRIPTION
## Summary
- When a flow has an `output` script and `sync=true`, the mapped payload is now returned **directly** as the HTTP response body (with the script's status code + headers), bypassing the standard `StartInstanceOutput`/`TransitionOutput` envelope — like Function endpoints. Previously it was written into `attributes`.
- Bypass is **skipped for subflow instances** (`instance.IsSubItem`): both `/sub/instances/start` and subflow transitions keep the standard model, since correlation forward relies on it.
- The bypass decision is driven by "output script ran" — not by whether `Data` is non-null — so an output can intentionally return an empty response.

## Changes
- `src/BBT.Workflow.Domain/Instances/DTOs/InstanceOutputBase.cs` — internal (non-serialized) `HasOutputResponse` / `OutputData` / `OutputStatusCode` / `OutputHeaders`
- `src/BBT.Workflow.Application/Instances/IWorkflowOutputMappingService.cs` — `WorkflowOutputResult` record; `ApplyAsync` returns full Data/StatusCode/Headers
- `src/BBT.Workflow.Application/Instances/WorkflowOutputMappingService.cs` — returns `WorkflowOutputResult`, normalizes dynamic headers
- `src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs` — `IsSubItem` gate; `ApplyOutputResponse` helper; no longer overwrites `attributes`
- `orchestration/.../Controllers/Instances/InstanceResponseActionResultMapper.cs` — new mapper (raw payload when `HasOutputResponse`, else delegates)
- `orchestration/.../Controllers/Instances/InstanceController.cs` — `StartAsync`/`TransitionAsync` use new mapper; `StartSubAsync` unchanged

## Test Plan
- [ ] Output + sync=true (normal flow) → body is the raw mapping output (no envelope)
- [ ] No output script → standard envelope (no regression)
- [ ] Output + sync=false → unchanged `{ id, status }`
- [ ] `/sub/instances/start` with output configured → standard model (correlation forward works)
- [ ] Subflow instance transition with output configured → standard model
- [ ] Output returns null Data → empty body + script status/headers (no fallback to envelope)
- [ ] Output sets Headers/StatusCode → reflected on the HTTP response

## Summary by Sourcery

Return workflow output mapping results directly in synchronous instance HTTP responses while preserving the standard envelope for subflow instances.

New Features:
- Support direct HTTP responses from workflow output scripts, including custom status codes and headers, for sync instance start and transition operations.

Enhancements:
- Introduce WorkflowOutputResult and internal output response fields on instance outputs to carry mapped payload, status code, and headers from application services to controllers.
- Add a dedicated instance response mapper that mirrors function endpoint behavior and applies script-defined headers while filtering restricted ones.
- Normalize dynamic header values from workflow output scripts into a consistent string dictionary format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow instance responses can now return mapped output directly, including custom status codes and headers when available.
  * Start and transition actions now use the updated instance response handling for more flexible HTTP replies.

* **Bug Fixes**
  * Improved response handling for synchronous workflow operations, including cases where output is intentionally empty.
  * Restricted headers are filtered out before being added to the response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->