### PR TITLE
fix(subflow): propagate sync caller mode through completion/fault resume

### DIFF
--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/HandleFinishStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/HandleFinishStep.cs
@@ -81,7 +81,7 @@ public sealed class HandleFinishStep(
         else
         {
             logger.InstanceCompleting(context.Instance.Id);
-            context.Instance.Complete(context.Domain);
+            context.Instance.Complete(context.Domain, context.CallerMode == ExecMode.Sync);
         }
     }
 }

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/TransitionPipeline.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/TransitionPipeline.cs
@@ -290,7 +290,7 @@ public class TransitionPipeline
             instance.AddIncident(incident);
         }
 
-        instance.Fault(context.Domain);
+        instance.Fault(context.Domain, context.CallerMode == ExecMode.Sync);
         await _instanceRepository.UpdateAsync(instance, true, cancellationToken);
         await faultUow.CommitAsync(cancellationToken);
 
@@ -326,7 +326,7 @@ public class TransitionPipeline
             context.Instance.AddIncident(incident);
         }
 
-        context.Instance.Fault(context.Domain);
+        context.Instance.Fault(context.Domain, context.CallerMode == ExecMode.Sync);
         context.ExtractAndDeferInstanceEvents();
         await _instanceRepository.UpdateAsync(context.Instance, true, cancellationToken);
 

--- a/src/BBT.Workflow.Application/SubFlow/DTOs/FlowCompletedInput.cs
+++ b/src/BBT.Workflow.Application/SubFlow/DTOs/FlowCompletedInput.cs
@@ -53,4 +53,10 @@ public record FlowCompletedInput
     /// Duration of the SubItem execution
     /// </summary>
     public TimeSpan? Duration { get; init; }
+
+    /// <summary>
+    /// Whether the completing pipeline chain was executed with a synchronous caller
+    /// (sync=true). The parent resume keeps the chain synchronous when set.
+    /// </summary>
+    public bool Sync { get; init; }
 }

--- a/src/BBT.Workflow.Application/SubFlow/DTOs/SubFlowFaultedInput.cs
+++ b/src/BBT.Workflow.Application/SubFlow/DTOs/SubFlowFaultedInput.cs
@@ -117,4 +117,10 @@ public record SubFlowFaultedInput
     /// Boundary level that matched in the SubFlow (if any)
     /// </summary>
     public string? IncidentBoundaryLevel { get; init; }
+
+    /// <summary>
+    /// Whether the faulting pipeline chain was executed with a synchronous caller
+    /// (sync=true). The parent error-boundary resume keeps the chain synchronous when set.
+    /// </summary>
+    public bool Sync { get; init; }
 }

--- a/src/BBT.Workflow.Application/SubFlow/Services/SubflowCompletionService.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubflowCompletionService.cs
@@ -141,7 +141,7 @@ public sealed class SubflowCompletionService(
                             errorLayer: "SubFlow",
                             stackTrace: parentWorkflowResult.Error.Detail);
                         parentInstance.AddIncident(loadIncident);
-                        parentInstance.Fault(completedInput.Domain);
+                        parentInstance.Fault(completedInput.Domain, completedInput.Sync);
                         await instanceRepository.UpdateAsync(parentInstance, true, cancellationToken);
                         await correlationUow.CommitAsync(cancellationToken);
                         return;
@@ -169,7 +169,7 @@ public sealed class SubflowCompletionService(
                             errorLayer: "SubFlow",
                             stackTrace: mappingResult.Error.Detail);
                         parentInstance.AddIncident(incident);
-                        parentInstance.Fault(completedInput.Domain);
+                        parentInstance.Fault(completedInput.Domain, completedInput.Sync);
                         await instanceRepository.UpdateAsync(parentInstance, true, cancellationToken);
                         await correlationUow.CommitAsync(cancellationToken);
                         return;
@@ -183,6 +183,7 @@ public sealed class SubflowCompletionService(
                     parentInstance,
                     parentWorkflow!,
                     completedInput.SubInstanceId,
+                    completedInput.Sync,
                     cancellationToken);
 
                 SubFlowActivityHelper.SetSuccess(activity);
@@ -209,6 +210,7 @@ public sealed class SubflowCompletionService(
         Instance parentInstance,
         Definitions.Workflow parentWorkflow,
         Guid subInstanceId,
+        bool sync,
         CancellationToken cancellationToken)
     {
         try
@@ -222,7 +224,9 @@ public sealed class SubflowCompletionService(
                 TransitionKey = "", // For logging purposes only
                 TriggerType = TriggerType.Manual,
                 Mode = ExecMode.Resume, // Use Resume mode for SubFlow completion
-                CallerMode = ExecMode.Async,
+                // Preserve the completing chain's caller mode so the resumed parent chain
+                // keeps starting/forwarding subflows synchronously when the caller was sync=true.
+                CallerMode = sync ? ExecMode.Sync : ExecMode.Async,
                 Headers = new Dictionary<string, string?>(),
                 Actor = ExecutionActor.System,
                 RequestedAt = DateTimeOffset.UtcNow,

--- a/src/BBT.Workflow.Application/SubFlow/Services/SubflowFaultService.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubflowFaultService.cs
@@ -97,7 +97,7 @@ public sealed class SubflowFaultService(
                     if (!parentWorkflowResult.IsSuccess)
                     {
                         RecordIncident(parentInstance, input, ErrorAction.Abort, null);
-                        parentInstance.Fault(input.Domain);
+                        parentInstance.Fault(input.Domain, input.Sync);
                         await instanceRepository.UpdateAsync(parentInstance, true, cancellationToken);
                         await uow.CommitAsync(cancellationToken);
                         return;
@@ -134,7 +134,7 @@ public sealed class SubflowFaultService(
                     }
                     else if (string.IsNullOrWhiteSpace(actionResult.TransitionKey))
                     {
-                        parentInstance.Fault(input.Domain);
+                        parentInstance.Fault(input.Domain, input.Sync);
                     }
 
                     var mappingResult = await outputMappingService.ApplyAsync(
@@ -165,6 +165,7 @@ public sealed class SubflowFaultService(
                         parentWorkflow!,
                         actionResult.TransitionKey,
                         input.SubInstanceId,
+                        input.Sync,
                         cancellationToken);
                 }
                 else if (actionResult?.ShouldContinue == true)
@@ -173,6 +174,7 @@ public sealed class SubflowFaultService(
                         parentInstance,
                         parentWorkflow!,
                         input.SubInstanceId,
+                        input.Sync,
                         cancellationToken);
                 }
 
@@ -251,6 +253,7 @@ public sealed class SubflowFaultService(
         Definitions.Workflow parentWorkflow,
         string transitionKey,
         Guid subInstanceId,
+        bool sync,
         CancellationToken cancellationToken)
     {
         try
@@ -259,7 +262,8 @@ public sealed class SubflowFaultService(
                 parentInstance,
                 parentWorkflow,
                 transitionKey,
-                isErrorBoundaryTransition: true);
+                isErrorBoundaryTransition: true,
+                sync);
 
             var result = await workflowExecutionService.ExecuteTransitionAsync(input, cancellationToken);
             if (!result.IsSuccess)
@@ -283,6 +287,7 @@ public sealed class SubflowFaultService(
         Instance parentInstance,
         Definitions.Workflow parentWorkflow,
         Guid subInstanceId,
+        bool sync,
         CancellationToken cancellationToken)
     {
         try
@@ -291,7 +296,8 @@ public sealed class SubflowFaultService(
                 parentInstance,
                 parentWorkflow,
                 transitionKey: string.Empty,
-                isErrorBoundaryTransition: false);
+                isErrorBoundaryTransition: false,
+                sync);
             input.Mode = ExecMode.Resume;
             input.Execution!.ResumeFrom = LifecycleOrder.ClearBusyOnResumeStep;
             input.Execution.IsSubFlowResume = true;
@@ -318,7 +324,8 @@ public sealed class SubflowFaultService(
         Instance parentInstance,
         Definitions.Workflow parentWorkflow,
         string transitionKey,
-        bool isErrorBoundaryTransition)
+        bool isErrorBoundaryTransition,
+        bool sync)
     {
         return new WorkflowExecutionContext
         {
@@ -329,7 +336,9 @@ public sealed class SubflowFaultService(
             TransitionKey = transitionKey,
             TriggerType = TriggerType.Automatic,
             Mode = ExecMode.Sync,
-            CallerMode = ExecMode.Async,
+            // Preserve the faulting chain's caller mode so the parent's error-boundary
+            // resume keeps starting/forwarding subflows synchronously when the caller was sync=true.
+            CallerMode = sync ? ExecMode.Sync : ExecMode.Async,
             Headers = new Dictionary<string, string?>(),
             Actor = ExecutionActor.System,
             RequestedAt = DateTimeOffset.UtcNow,

--- a/src/BBT.Workflow.Domain/Instances/Instance.cs
+++ b/src/BBT.Workflow.Domain/Instances/Instance.cs
@@ -358,7 +358,8 @@ public sealed class Instance : AggregateRoot<Guid>, ICreationAuditedObject, IMod
     /// Sets the instance status to Completed and records the completion time.
     /// </summary>
     /// <param name="domain">The domain of the instance.</param>
-    public void Complete(string domain)
+    /// <param name="sync">Whether the completing pipeline chain runs with a synchronous caller (sync=true).</param>
+    public void Complete(string domain, bool sync = false)
     {
         Status = InstanceStatus.Completed;
         ChainToken = null;
@@ -395,7 +396,8 @@ public sealed class Instance : AggregateRoot<Guid>, ICreationAuditedObject, IMod
                     InstanceData = latestData?.Data.JsonElement,
                     CompletedAt = CompletedAt.Value,
                     Duration = Duration,
-                    RootInstanceId = rootId != Id ? rootId : (Guid?)null
+                    RootInstanceId = rootId != Id ? rootId : (Guid?)null,
+                    Sync = sync
                 });
             }
         }
@@ -407,7 +409,8 @@ public sealed class Instance : AggregateRoot<Guid>, ICreationAuditedObject, IMod
     /// Correlations are intentionally kept open (not completed) so retry can cascade through them.
     /// </summary>
     /// <param name="domain">The domain of the instance.</param>
-    public void Fault(string domain)
+    /// <param name="sync">Whether the faulting pipeline chain runs with a synchronous caller (sync=true).</param>
+    public void Fault(string domain, bool sync = false)
     {
         Status = InstanceStatus.Faulted;
         ChainToken = null;
@@ -473,7 +476,8 @@ public sealed class Instance : AggregateRoot<Guid>, ICreationAuditedObject, IMod
                     IncidentState = activeIncident?.State,
                     IncidentBoundaryAction = activeIncident?.BoundaryAction,
                     IncidentBoundaryLevel = activeIncident?.BoundaryLevel,
-                    RootInstanceId = rootId != Id ? rootId : (Guid?)null
+                    RootInstanceId = rootId != Id ? rootId : (Guid?)null,
+                    Sync = sync
                 });
             }
         }

--- a/src/BBT.Workflow.Events.Contracts/Instances/Events/InstanceSubCompletedEvent.cs
+++ b/src/BBT.Workflow.Events.Contracts/Instances/Events/InstanceSubCompletedEvent.cs
@@ -70,6 +70,12 @@ public class InstanceSubCompletedEvent : IDistributedEvent
     /// </summary>
     public Guid? RootInstanceId { get; init; }
 
+    /// <summary>
+    /// Whether the completing pipeline chain was executed with a synchronous caller
+    /// (sync=true). Carried to the parent so its resume keeps the chain synchronous.
+    /// </summary>
+    public bool Sync { get; init; }
+
     public override string ToString()
     {
         return $"{nameof(InstanceSubCompletedEvent)}: InstanceId={InstanceId} Domain={Domain} Flow={Flow} Version={Version} SubInstanceId={SubInstanceId} CompletedState={CompletedState}";

--- a/src/BBT.Workflow.Events.Contracts/Instances/Events/InstanceSubFaultedEvent.cs
+++ b/src/BBT.Workflow.Events.Contracts/Instances/Events/InstanceSubFaultedEvent.cs
@@ -135,6 +135,12 @@ public class InstanceSubFaultedEvent : IDistributedEvent
     /// </summary>
     public Guid? RootInstanceId { get; init; }
 
+    /// <summary>
+    /// Whether the faulting pipeline chain was executed with a synchronous caller
+    /// (sync=true). Carried to the parent so its error-boundary resume keeps the chain synchronous.
+    /// </summary>
+    public bool Sync { get; init; }
+
     public override string ToString()
     {
         return $"{nameof(InstanceSubFaultedEvent)}: InstanceId={InstanceId} Domain={Domain} Flow={Flow} Version={Version} SubInstanceId={SubInstanceId} FaultedState={FaultedState}";

--- a/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceSubCompletedEventHook.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceSubCompletedEventHook.cs
@@ -106,7 +106,8 @@ public sealed class InstanceSubCompletedEventHook(
             Duration = eventData.Duration,
             SubInstanceId = eventData.SubInstanceId,
             InstanceData = eventData.InstanceData,
-            Version = eventData.Version
+            Version = eventData.Version,
+            Sync = eventData.Sync
         };
     }
 }

--- a/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceSubFaultedEventHook.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Events/InstanceSubFaultedEventHook.cs
@@ -110,7 +110,8 @@ public sealed class InstanceSubFaultedEventHook(
             IncidentTransition = eventData.IncidentTransition,
             IncidentState = eventData.IncidentState,
             IncidentBoundaryAction = eventData.IncidentBoundaryAction,
-            IncidentBoundaryLevel = eventData.IncidentBoundaryLevel
+            IncidentBoundaryLevel = eventData.IncidentBoundaryLevel,
+            Sync = eventData.Sync
         };
     }
 }

--- a/test/BBT.Workflow.Application.Tests/SubFlow/SubflowCompletionServiceTests.cs
+++ b/test/BBT.Workflow.Application.Tests/SubFlow/SubflowCompletionServiceTests.cs
@@ -73,6 +73,52 @@ public sealed class SubflowCompletionServiceTests
             Times.Never);
     }
 
+    [Theory]
+    [InlineData(true, ExecMode.Sync)]
+    [InlineData(false, ExecMode.Async)]
+    public async Task CompletionAsync_ResumesParentPipelineWithCallerModeFromInput(bool sync, ExecMode expectedCallerMode)
+    {
+        var parentInstance = CreateParentInstance(out var subInstanceId);
+        var input = CreateInput(parentInstance.Id, subInstanceId, sync);
+        var parentWorkflow = WorkflowFactory.CreateDefault("parent-flow", "bank", "1.0.0");
+
+        _instanceRepository
+            .Setup(x => x.FindAsync(parentInstance.Id, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(parentInstance);
+        _instanceRepository
+            .Setup(x => x.UpdateAsync(parentInstance, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(parentInstance);
+        _componentCacheStore
+            .Setup(x => x.GetFlowAsync("bank", "parent-flow", "1.0.0", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<Definitions.Workflow>.Ok(parentWorkflow));
+        _outputMappingService
+            .Setup(x => x.ApplyAsync(
+                parentInstance,
+                parentWorkflow,
+                It.IsAny<string>(),
+                It.IsAny<JsonElement?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Ok());
+        _workflowExecutionService
+            .Setup(x => x.ExecuteTransitionAsync(It.IsAny<WorkflowExecutionContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<TransitionOutput>.Ok(new TransitionOutput
+            {
+                Id = parentInstance.Id,
+                Status = InstanceStatus.Active
+            }));
+
+        await CreateService().CompletionAsync(input, CancellationToken.None);
+
+        _workflowExecutionService.Verify(
+            x => x.ExecuteTransitionAsync(
+                It.Is<WorkflowExecutionContext>(ctx =>
+                    ctx.Mode == ExecMode.Resume &&
+                    ctx.CallerMode == expectedCallerMode &&
+                    ctx.Execution!.IsSubFlowResume),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
     private SubflowCompletionService CreateService()
         => new(
             _uowManager.Object,
@@ -101,7 +147,7 @@ public sealed class SubflowCompletionServiceTests
         return parentInstance;
     }
 
-    private static FlowCompletedInput CreateInput(Guid parentInstanceId, Guid subInstanceId)
+    private static FlowCompletedInput CreateInput(Guid parentInstanceId, Guid subInstanceId, bool sync = false)
         => new()
         {
             InstanceId = parentInstanceId,
@@ -111,7 +157,8 @@ public sealed class SubflowCompletionServiceTests
             SubInstanceId = subInstanceId,
             CompletedState = "child-done",
             InstanceData = CreateJsonElement("""{"result":"ok"}"""),
-            CompletedAt = DateTime.UtcNow
+            CompletedAt = DateTime.UtcNow,
+            Sync = sync
         };
 
     private static JsonElement CreateJsonElement(string json)

--- a/test/BBT.Workflow.Application.Tests/SubFlow/SubflowFaultServiceTests.cs
+++ b/test/BBT.Workflow.Application.Tests/SubFlow/SubflowFaultServiceTests.cs
@@ -166,6 +166,38 @@ public sealed class SubflowFaultServiceTests
         incidentVisibleToMapping.ShouldBeTrue();
     }
 
+    [Theory]
+    [InlineData(true, ExecMode.Sync)]
+    [InlineData(false, ExecMode.Async)]
+    public async Task FaultAsync_WithNotifyBoundary_ShouldPropagateCallerModeFromInput(bool sync, ExecMode expectedCallerMode)
+    {
+        var parentInstance = CreateParentInstance(out var subInstanceId);
+        var parentWorkflow = CreateParentWorkflow(
+            ErrorBoundary.Builder()
+                .OnError(ErrorAction.Notify, transition: "error-fallback")
+                .Build());
+        var input = CreateInput(parentInstance.Id, subInstanceId, CreateJsonElement("""{"result":404}"""), sync);
+
+        SetupParent(parentInstance, parentWorkflow);
+        _workflowExecutionService
+            .Setup(x => x.ExecuteTransitionAsync(It.IsAny<WorkflowExecutionContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<TransitionOutput>.Ok(new TransitionOutput
+            {
+                Id = parentInstance.Id,
+                Status = InstanceStatus.Active
+            }));
+
+        await CreateService().FaultAsync(input, CancellationToken.None);
+
+        _workflowExecutionService.Verify(
+            x => x.ExecuteTransitionAsync(
+                It.Is<WorkflowExecutionContext>(ctx =>
+                    ctx.TransitionKey == "error-fallback" &&
+                    ctx.CallerMode == expectedCallerMode),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
     private SubflowFaultService CreateService()
     {
         var resolver = new ErrorBoundaryResolver(Mock.Of<ILogger<ErrorBoundaryResolver>>());
@@ -225,10 +257,12 @@ public sealed class SubflowFaultServiceTests
     private static SubFlowFaultedInput CreateInput(
         Guid parentInstanceId,
         Guid subInstanceId,
-        JsonElement childData)
+        JsonElement childData,
+        bool sync = false)
     {
         return new SubFlowFaultedInput
         {
+            Sync = sync,
             InstanceId = parentInstanceId,
             Domain = "bank",
             Flow = "parent-flow",

--- a/test/BBT.Workflow.Domain.Tests/Instances/InstanceTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Instances/InstanceTests.cs
@@ -885,6 +885,83 @@ public class InstanceTests : DomainTestBase<DomainEntryPoint>
         Assert.Equal(42, faultedEvent.InstanceData.Value.GetProperty("childValue").GetInt32());
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Complete_WhenInstanceIsSubItem_ShouldCarrySyncFlagOnSubCompletedEvent(bool sync)
+    {
+        // Arrange
+        var parentInstanceId = Guid.NewGuid();
+        var instance = InstanceFactory.CreateDefault();
+        instance.ExtraProperties[DomainConsts.MetaDataKeys.FlowType] = WorkflowType.SubFlow.Code;
+        instance.ExtraProperties[DomainConsts.MetaDataKeys.Id] = parentInstanceId.ToString();
+        instance.ExtraProperties[DomainConsts.MetaDataKeys.Domain] = "test-domain";
+        instance.ExtraProperties[DomainConsts.MetaDataKeys.Flow] = "parent-flow";
+        instance.ExtraProperties[DomainConsts.MetaDataKeys.Version] = "1.0.0";
+
+        // Act
+        instance.Complete("child-domain", sync);
+
+        // Assert
+        var completedEvent = instance.GetDomainEvents()
+            .Select(e => e.Event)
+            .OfType<InstanceSubCompletedEvent>()
+            .Single();
+
+        Assert.Equal(parentInstanceId, completedEvent.InstanceId);
+        Assert.Equal(sync, completedEvent.Sync);
+    }
+
+    [Fact]
+    public void Complete_WithoutSyncArgument_ShouldDefaultSubCompletedEventSyncToFalse()
+    {
+        // Arrange
+        var instance = InstanceFactory.CreateDefault();
+        instance.ExtraProperties[DomainConsts.MetaDataKeys.FlowType] = WorkflowType.SubFlow.Code;
+        instance.ExtraProperties[DomainConsts.MetaDataKeys.Id] = Guid.NewGuid().ToString();
+        instance.ExtraProperties[DomainConsts.MetaDataKeys.Domain] = "test-domain";
+        instance.ExtraProperties[DomainConsts.MetaDataKeys.Flow] = "parent-flow";
+        instance.ExtraProperties[DomainConsts.MetaDataKeys.Version] = "1.0.0";
+
+        // Act
+        instance.Complete("child-domain");
+
+        // Assert
+        var completedEvent = instance.GetDomainEvents()
+            .Select(e => e.Event)
+            .OfType<InstanceSubCompletedEvent>()
+            .Single();
+
+        Assert.False(completedEvent.Sync);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Fault_WhenInstanceIsSubFlow_ShouldCarrySyncFlagOnSubFaultedEvent(bool sync)
+    {
+        // Arrange
+        var parentInstanceId = Guid.NewGuid();
+        var instance = InstanceFactory.CreateDefault();
+        instance.ExtraProperties[DomainConsts.MetaDataKeys.FlowType] = WorkflowType.SubFlow.Code;
+        instance.ExtraProperties[DomainConsts.MetaDataKeys.Id] = parentInstanceId.ToString();
+        instance.ExtraProperties[DomainConsts.MetaDataKeys.Domain] = "test-domain";
+        instance.ExtraProperties[DomainConsts.MetaDataKeys.Flow] = "parent-flow";
+        instance.ExtraProperties[DomainConsts.MetaDataKeys.Version] = "1.0.0";
+
+        // Act
+        instance.Fault("child-domain", sync);
+
+        // Assert
+        var faultedEvent = instance.GetDomainEvents()
+            .Select(e => e.Event)
+            .OfType<InstanceSubFaultedEvent>()
+            .Single();
+
+        Assert.Equal(parentInstanceId, faultedEvent.InstanceId);
+        Assert.Equal(sync, faultedEvent.Sync);
+    }
+
     private static void AddLatestDataForTest(Instance instance, JsonData data)
     {
         var ctor = typeof(InstanceData).GetConstructor(

--- a/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/InstanceSubCompletedEventHandler.cs
+++ b/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/InstanceSubCompletedEventHandler.cs
@@ -66,7 +66,11 @@ internal sealed class InstanceSubCompletedEventHandler(
                 CompletedState = eventData.CompletedState,
                 InstanceData = eventData.InstanceData,
                 CompletedAt = eventData.CompletedAt,
-                Duration = eventData.Duration
+                Duration = eventData.Duration,
+                // At-least-once async retry path: the sync caller (if any) was already answered
+                // by the synchronous hook. Force async here so a retried resume never blocks the
+                // worker with an inline sync chain; idempotent guards make duplicates no-ops.
+                Sync = false
             };
 
             var route = $"api/v1/{eventData.Domain}/workflows/{eventData.Flow}/instances/{eventData.InstanceId}/complete";

--- a/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/InstanceSubFaultedEventHandler.cs
+++ b/workers/BBT.Workflow.Workers.Inbox/Handlers/Instances/InstanceSubFaultedEventHandler.cs
@@ -78,7 +78,11 @@ internal sealed class InstanceSubFaultedEventHandler(
                 IncidentTransition = eventData.IncidentTransition,
                 IncidentState = eventData.IncidentState,
                 IncidentBoundaryAction = eventData.IncidentBoundaryAction,
-                IncidentBoundaryLevel = eventData.IncidentBoundaryLevel
+                IncidentBoundaryLevel = eventData.IncidentBoundaryLevel,
+                // At-least-once async retry path: the sync caller (if any) was already answered
+                // by the synchronous hook. Force async here so a retried resume never blocks the
+                // worker with an inline sync chain; idempotent guards make duplicates no-ops.
+                Sync = false
             };
 
             var route = $"api/v1/{eventData.Domain}/workflows/{eventData.Flow}/instances/{eventData.InstanceId}/sub/fault";


### PR DESCRIPTION
## Summary
- A `sync=true` start/transition behaved like `sync=false` after the first subflow completed: the parent resume context was rebuilt with a hardcoded `CallerMode = ExecMode.Async` in `SubflowCompletionService` / `SubflowFaultService`, so the next subflow start/forward in the resumed chain ran async and was enqueued as a Dapr `TransitionJob` (one job per hop with `TransitionPerJob=true`), returning `Busy` before the chain settled.
- The completing pipeline's `CallerMode` is now carried end-to-end through the subflow completion/fault callback chain, so auto transitions, subflow starts and subflow forwards stay inline (no BackgroundJob/outbox dependency) for sync callers.
- The creation-time instance `Sync` metadata was deliberately not used as the source: an async-created subflow can later complete under a sync forwarded transition (and vice versa). The correct source is the completing pipeline's `CallerMode` at finish time.

## Changes
- `src/BBT.Workflow.Domain/Instances/Instance.cs` — `Complete(domain, bool sync = false)` / `Fault(domain, bool sync = false)`; the upward `InstanceSubCompletedEvent` / `InstanceSubFaultedEvent` carry the flag. Downward fault/cancel cascade events intentionally stay async.
- `src/BBT.Workflow.Events.Contracts/.../InstanceSubCompletedEvent.cs`, `InstanceSubFaultedEvent.cs` — new optional `Sync` field (JSON backward compatible in both directions).
- `src/BBT.Workflow.Application/SubFlow/DTOs/FlowCompletedInput.cs`, `SubFlowFaultedInput.cs` — new `Sync` field; flows through the remote (cross-domain) path automatically since the whole DTO is serialized.
- `src/BBT.Workflow.Application/SubFlow/Services/SubflowCompletionService.cs`, `SubflowFaultService.cs` — resume / error-boundary contexts now set `CallerMode = input.Sync ? Sync : Async`; parent `Fault(...)` calls forward the flag.
- `src/BBT.Workflow.Application/.../HandleFinishStep.cs`, `TransitionPipeline.cs` — pass `context.CallerMode == ExecMode.Sync` into `Complete`/`Fault`.
- `src/BBT.Workflow.Infrastructure/.../InstanceSubCompletedEventHook.cs`, `InstanceSubFaultedEventHook.cs` — map `Sync` from event to input.
- `workers/BBT.Workflow.Workers.Inbox/.../InstanceSubCompletedEventHandler.cs`, `InstanceSubFaultedEventHandler.cs` — force `Sync = false` on the at-least-once retry path: the sync caller was already answered by the synchronous hook; idempotent guards keep duplicates as no-ops and the worker is never blocked by an inline sync chain.
- Tests: `InstanceTests` (event carries the flag; default stays false), `SubflowCompletionServiceTests` / `SubflowFaultServiceTests` (resume context `CallerMode` follows `input.Sync`).

## Test Plan
- [x] `dotnet build vnext.sln` — clean
- [x] `dotnet test test/BBT.Workflow.Application.Tests --filter "FullyQualifiedName~Subflow"` — 40/40 passed (4 new theory cases)
- [x] `dotnet test test/BBT.Workflow.Domain.Tests` — 5 new sync-flag tests + existing Complete/Fault tests pass
- [ ] E2E: start a flow with two sequential subflows using `sync=true` — response should return the final status only after the whole chain settles, with no `TransitionJob` enqueued in logs

## Notes
- Async mode (`sync=false` + `TransitionPerJob=true`) is unchanged — every new field/parameter defaults to `false`.
- Mixed-version deployments degrade gracefully: a missing `Sync` field deserializes as `false` (current behavior).
- `LongPollAckResumeService` also hardcodes `CallerMode=Async`; left out of scope since long-poll is inherently an async human-wait point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Propagate the synchronous caller mode flag through subflow completion and fault handling so resumed parent workflows preserve synchronous execution when appropriate, including across distributed events and retries.

Bug Fixes:
- Ensure subflow completion and fault events carry a sync flag so parent workflows continue executing synchronously instead of falling back to async after the first subflow completes.

Enhancements:
- Extend instance completion and fault APIs, DTOs, and event contracts with an optional sync flag and wire it through completion and fault services to control parent caller mode.
- Adjust transition pipeline finish and fault steps to pass the current caller mode into instance completion and fault logic.
- Update infrastructure hooks and inbox workers so sync behavior is preserved on the primary path while retries are forced to async to avoid blocking workers.

Tests:
- Add unit tests for instances and subflow services to verify sync flag propagation and that workflow execution contexts use the correct caller mode on resume and error-boundary transitions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for preserving synchronous vs. asynchronous execution when completing or faulting subflows and child workflows.

* **Bug Fixes**
  * Fixed parent workflow resume and error handling so the original execution mode is carried through more consistently.
  * Improved event handling so completion and fault notifications keep the correct sync state during retries and parent recovery.

* **Tests**
  * Expanded automated coverage for sync-aware completion and fault scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->