### PR TITLE
Handle transient lock conflicts in transition jobs with retry

### DIFF
--- a/src/BBT.Workflow.Application/BackgroundJobs/Handlers/TransitionJobHandler.cs
+++ b/src/BBT.Workflow.Application/BackgroundJobs/Handlers/TransitionJobHandler.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using BBT.Aether.BackgroundJob;
+using BBT.Aether.Results;
 using BBT.Aether.MultiSchema;
 using BBT.Workflow.BackgroundJobs.Options;
 using BBT.Workflow.BackgroundJobs.Payloads;
@@ -56,9 +57,10 @@ public sealed class TransitionJobHandler(
                     cancellationToken, executionCts.Token);
 
                 bool needsRecovery = false;
+                (string Message, string ErrorCode)? recoveryReason = null;
 
                 try
-                {   
+                {
                     // Expose the original raw request body to mappings built inside this job (no live
                     // HttpContext here) so background signature verification (JWS/mTLS) can run.
                     using var rawBodyScope = RawBodyExecutionScope.Set(args.RawBody);
@@ -95,13 +97,28 @@ public sealed class TransitionJobHandler(
                     // instead of running in-process.
                     context.EnqueueContinuations = executionOptions.Value.TransitionPerJob;
 
-                    // Use the background-specific method that handles pre-reserved instances
-                    var result = await workflowExecutionService.ExecuteTransitionAsync(context, linkedCts.Token);
+                    // Use the background-specific method that handles pre-reserved instances.
+                    // Lock conflicts are transient (the enqueue accept lock or a finishing chain
+                    // may still hold the execution lock for a few ms) — retry with backoff.
+                    var result = await ExecuteWithLockConflictRetryAsync(context, args, linkedCts.Token);
 
                     if (!result.IsSuccess)
                     {
                         activity?.SetStatus(ActivityStatusCode.Error, result.Error.Message);
                         logger.JobFailed(args.JobName, args.InstanceId, result.Error.Message ?? "Unknown error");
+
+                        if (IsLockConflict(result.Error))
+                        {
+                            // Retries exhausted: do NOT leave the instance silently stranded in Busy —
+                            // route it through recovery so it becomes Faulted (visible + retryable).
+                            var maxAttempts = executionOptions.Value.LockConflictRetry.MaxAttempts;
+                            logger.TransitionJobLockConflictRetriesExhausted(
+                                args.JobName, maxAttempts, args.InstanceId, args.TransitionKey);
+                            needsRecovery = true;
+                            recoveryReason = (
+                                $"Transition job could not acquire the instance lock after {maxAttempts} attempts",
+                                "JOB_LOCK_CONFLICT");
+                        }
                     }
                     else
                     {
@@ -143,7 +160,15 @@ public sealed class TransitionJobHandler(
                     if (needsRecovery)
                     {
                         // CancellationToken.None: recovery must complete even if host is shutting down
-                        await recoveryService.FaultInstanceAsync(args, CancellationToken.None);
+                        if (recoveryReason is { } reason)
+                        {
+                            await recoveryService.FaultInstanceAsync(
+                                args, reason.Message, reason.ErrorCode, CancellationToken.None);
+                        }
+                        else
+                        {
+                            await recoveryService.FaultInstanceAsync(args, CancellationToken.None);
+                        }
                     }
 
                     await jobRepository.MarkAsProcessedAsync(args.InstanceId, args.JobName, CancellationToken.None);
@@ -151,4 +176,43 @@ public sealed class TransitionJobHandler(
             }
         }
     }
+
+    /// <summary>
+    /// Executes the transition pipeline, retrying transient instance-lock conflicts with
+    /// bounded exponential backoff (100→200→400→800ms with defaults). The race window is
+    /// milliseconds wide — the Dapr job fires ~5ms after scheduling while another holder
+    /// (enqueue accept lock, finishing auto-chain) may still hold the execution lock.
+    /// Delays run on the linked token so the job's execution budget still applies.
+    /// </summary>
+    private async Task<Result<TransitionOutput>> ExecuteWithLockConflictRetryAsync(
+        WorkflowExecutionContext context,
+        TransitionJobPayload args,
+        CancellationToken cancellationToken)
+    {
+        var retryOptions = executionOptions.Value.LockConflictRetry;
+        var maxAttempts = Math.Max(1, retryOptions.MaxAttempts);
+
+        var result = await workflowExecutionService.ExecuteTransitionAsync(context, cancellationToken);
+
+        for (var attempt = 1; attempt < maxAttempts && !result.IsSuccess && IsLockConflict(result.Error); attempt++)
+        {
+            var delayMs = retryOptions.BaseDelayMilliseconds * (1 << (attempt - 1));
+            logger.TransitionJobLockConflictRetry(
+                args.JobName, args.InstanceId, attempt, maxAttempts, delayMs);
+
+            await Task.Delay(delayMs, cancellationToken);
+            result = await workflowExecutionService.ExecuteTransitionAsync(context, cancellationToken);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Identifies a transient instance-lock conflict. Within the job's sync pipeline path,
+    /// <see cref="WorkflowErrorCodes.ConflictWorkflow"/> is produced only by
+    /// <c>WorkflowErrors.InstanceLockConflict</c> (pipeline entry and cancel preflight),
+    /// both of which are retry-safe contention signals.
+    /// </summary>
+    private static bool IsLockConflict(Error error)
+        => error.Code == WorkflowErrorCodes.ConflictWorkflow;
 }

--- a/src/BBT.Workflow.Application/BackgroundJobs/Handlers/TransitionJobHandler.cs
+++ b/src/BBT.Workflow.Application/BackgroundJobs/Handlers/TransitionJobHandler.cs
@@ -191,12 +191,17 @@ public sealed class TransitionJobHandler(
     {
         var retryOptions = executionOptions.Value.LockConflictRetry;
         var maxAttempts = Math.Max(1, retryOptions.MaxAttempts);
+        var baseDelayMs = Math.Max(0, retryOptions.BaseDelayMilliseconds);
 
         var result = await workflowExecutionService.ExecuteTransitionAsync(context, cancellationToken);
 
         for (var attempt = 1; attempt < maxAttempts && !result.IsSuccess && IsLockConflict(result.Error); attempt++)
         {
-            var delayMs = retryOptions.BaseDelayMilliseconds * (1 << (attempt - 1));
+            // Guard misconfigured options: cap the shift and compute in long so the delay
+            // can never go negative (Task.Delay would throw ArgumentOutOfRangeException).
+            var shift = Math.Min(attempt - 1, 30);
+            var delayMs = (int)Math.Min((long)baseDelayMs << shift, int.MaxValue);
+
             logger.TransitionJobLockConflictRetry(
                 args.JobName, args.InstanceId, attempt, maxAttempts, delayMs);
 

--- a/src/BBT.Workflow.Application/BackgroundJobs/Options/WorkflowExecutionOptions.cs
+++ b/src/BBT.Workflow.Application/BackgroundJobs/Options/WorkflowExecutionOptions.cs
@@ -66,10 +66,32 @@ public sealed class WorkflowExecutionOptions
     /// fix in the resume/revert path is already applied.
     /// </summary>
     public bool InProcessSameDomainForwarding { get; set; }
+
+    /// <summary>
+    /// In-handler retry policy for transient instance-lock conflicts inside transition jobs.
+    /// The Dapr job can fire while a competing holder (e.g. the enqueue accept lock or a
+    /// finishing chain) still holds the instance execution lock for a few milliseconds;
+    /// a short bounded retry absorbs that instead of losing the transition.
+    /// </summary>
+    public LockConflictRetryOptions LockConflictRetry { get; set; } = new();
 }
 
 public sealed class TransitionJobFailurePolicyOptions
 {
     public int MaxRetries { get; set; } = 5;
     public int IntervalSeconds { get; set; } = 30;
+}
+
+/// <summary>
+/// Bounded exponential-backoff retry settings for instance-lock conflicts in
+/// <c>TransitionJobHandler</c>. Worst case total delay with defaults:
+/// 100 + 200 + 400 + 800 = 1.5s across 5 attempts.
+/// </summary>
+public sealed class LockConflictRetryOptions
+{
+    /// <summary>Maximum pipeline execution attempts (first try included). Default: 5.</summary>
+    public int MaxAttempts { get; set; } = 5;
+
+    /// <summary>Base delay before the first retry; doubles per attempt. Default: 100ms.</summary>
+    public int BaseDelayMilliseconds { get; set; } = 100;
 }

--- a/src/BBT.Workflow.Application/BackgroundJobs/Recovery/IJobTimeoutRecoveryService.cs
+++ b/src/BBT.Workflow.Application/BackgroundJobs/Recovery/IJobTimeoutRecoveryService.cs
@@ -9,4 +9,15 @@ public interface IJobTimeoutRecoveryService
     /// Faults the instance, records an incident, and closes any open transition record.
     /// </summary>
     Task FaultInstanceAsync(TransitionJobPayload args, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Recovers an instance stuck in Busy status with a caller-supplied incident reason.
+    /// Faults the instance, records an incident with the given message and error code,
+    /// and closes any open transition record.
+    /// </summary>
+    Task FaultInstanceAsync(
+        TransitionJobPayload args,
+        string incidentMessage,
+        string incidentErrorCode,
+        CancellationToken cancellationToken);
 }

--- a/src/BBT.Workflow.Application/BackgroundJobs/Recovery/JobTimeoutRecoveryService.cs
+++ b/src/BBT.Workflow.Application/BackgroundJobs/Recovery/JobTimeoutRecoveryService.cs
@@ -16,7 +16,18 @@ public sealed class JobTimeoutRecoveryService(
     IOptions<WorkflowExecutionOptions> options,
     ILogger<JobTimeoutRecoveryService> logger) : IJobTimeoutRecoveryService
 {
-    public async Task FaultInstanceAsync(TransitionJobPayload args, CancellationToken cancellationToken)
+    public Task FaultInstanceAsync(TransitionJobPayload args, CancellationToken cancellationToken)
+        => FaultInstanceAsync(
+            args,
+            $"Job execution timed out or was cancelled after {options.Value.TransitionJobTimeoutSeconds}s",
+            "JOB_EXECUTION_TIMEOUT",
+            cancellationToken);
+
+    public async Task FaultInstanceAsync(
+        TransitionJobPayload args,
+        string incidentMessage,
+        string incidentErrorCode,
+        CancellationToken cancellationToken)
     {
         try
         {
@@ -43,8 +54,8 @@ public sealed class JobTimeoutRecoveryService(
                 state: instance.GetCurrentState,
                 transition: args.TransitionKey,
                 taskKey: null,
-                message: $"Job execution timed out or was cancelled after {options.Value.TransitionJobTimeoutSeconds}s",
-                errorCode: "JOB_EXECUTION_TIMEOUT",
+                message: incidentMessage,
+                errorCode: incidentErrorCode,
                 errorLayer: "Job",
                 boundaryAction: "Abort",
                 boundaryLevel: "Job");

--- a/src/BBT.Workflow.Application/Execution/Transitions/Strategy/AsyncTransitionStrategy.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Strategy/AsyncTransitionStrategy.cs
@@ -18,12 +18,17 @@ namespace BBT.Workflow.Execution.Strategies;
 /// Asynchronous transition execution strategy.
 /// Executes transitions as background jobs for better scalability and fault tolerance.
 /// Acquires a distributed lock before processing to prevent concurrent enqueuing for
-/// the same instance. Reserved transitions (cancel, exit, updateData, timeout, subflow
-/// resume, shared) lock on their own type-scoped key independent of the base instance
-/// lock — so they are accepted and enqueued even while the main flow is Busy, mirroring
-/// the sync <see cref="Pipeline.TransitionPipeline"/>. Under the lock, checks if an active
-/// job already exists and returns 409 if so. Sets the instance to Busy before enqueueing so callers immediately see
-/// the correct in-progress status.
+/// the same instance. The enqueue lock uses an <see cref="EnqueueLockSuffix"/>-scoped key
+/// (accept scope) that is distinct from the execution lock key the job consumer acquires
+/// in <see cref="Pipeline.TransitionPipeline"/> — the Dapr job fires ~5ms after scheduling,
+/// while this lock is still held, so sharing the key would make the consumer's non-blocking
+/// acquire fail (race condition). Reserved transitions (cancel, exit, updateData, timeout,
+/// subflow resume, shared) scope the suffix onto their own type-specific key so they are
+/// accepted and enqueued even while the main flow is Busy, mirroring the sync pipeline.
+/// Under the lock, checks if an active job already exists (409) and rejects non-reserved
+/// requests when the instance is already Busy (409) — the explicit replacement for the
+/// implicit rejection the previously shared lock key provided. Sets the instance to Busy
+/// before enqueueing so callers immediately see the correct in-progress status.
 /// <para>
 /// Enqueue atomicity is governed by <c>WorkflowExecutionOptions.DirectEnqueueContinuations</c>:
 /// when ON (default), the durable intent + Dapr schedule commit in one unit of work (transactional
@@ -47,6 +52,12 @@ public sealed class AsyncTransitionStrategy(
     /// Lock lease duration in seconds — covers the check + enqueue + UoW commit cycle.
     /// </summary>
     private const int DefaultLockLeaseSeconds = 30;
+
+    /// <summary>
+    /// Suffix scoping the accept/enqueue lock away from the execution lock key used by the
+    /// job consumer (TransitionPipeline). Must never be used on the consumer side.
+    /// </summary>
+    public const string EnqueueLockSuffix = ":enqueue";
 
     public ExecMode Mode => ExecMode.Async;
 
@@ -111,13 +122,14 @@ public sealed class AsyncTransitionStrategy(
             Result<TransitionExecutionContext>.Fail(WorkflowErrors.InstanceLockConflict(ctx.InstanceId));
 
         // Reserved transitions (cancel, exit, updateData, timeout, subflow resume, shared)
-        // lock on their own type-scoped key — independent of the base instance lock — so the
-        // request is accepted and enqueued even while the main flow holds the instance lock.
-        // Mirrors TransitionPipeline.RunAsync; execution safety is enforced when the job runs
-        // through the sync pipeline.
-        var lockKey = reservedTransitionResolver.IsReserved(ctx)
+        // scope onto their own type-specific key so the request is accepted and enqueued even
+        // while the main flow is Busy. The EnqueueLockSuffix keeps this accept-scope lock
+        // distinct from the execution lock the job consumer acquires in TransitionPipeline —
+        // the Dapr job fires while this lock is still held, so sharing the key would race.
+        var isReserved = reservedTransitionResolver.IsReserved(ctx);
+        var lockKey = (isReserved
             ? reservedTransitionResolver.GetOwnLockKey(ctx)
-            : ctx.LockKey;
+            : ctx.LockKey) + EnqueueLockSuffix;
 
         var lockAcquired = await distributedLockService.ExecuteWithLockAsync(
             lockKey,
@@ -132,7 +144,28 @@ public sealed class AsyncTransitionStrategy(
                 }
 
                 if (!ctx.Directives.IsInternalResume)
-                    await instanceBusyManager.MarkBusyWithPropagationAsync(ctx.Instance.Id, cancellationToken);
+                {
+                    if (isReserved)
+                    {
+                        // Reserved transitions are accepted while the instance is Busy by design.
+                        await instanceBusyManager.MarkBusyWithPropagationAsync(ctx.Instance.Id, cancellationToken);
+                    }
+                    else
+                    {
+                        // Explicit Busy admission guard: with the accept lock scoped away from the
+                        // execution lock, an in-flight transition no longer blocks this key — reject
+                        // here so a normal transition cannot be accepted while another is queued/running.
+                        var busyOutcome = await instanceBusyManager.TryMarkBusyWithPropagationAsync(
+                            ctx.Instance.Id, cancellationToken);
+                        if (busyOutcome == BusyMarkOutcome.AlreadyBusy)
+                        {
+                            logger.AsyncTransitionRejectedInstanceBusy(ctx.TransitionKey, ctx.InstanceId);
+                            lockScopeResult = Result<TransitionExecutionContext>.Fail(
+                                WorkflowErrors.InstanceBusy(ctx.InstanceId, ctx.TransitionKey));
+                            return;
+                        }
+                    }
+                }
 
                 var enqueueResult = await EnqueueAndSaveJobAsync(context, ctx, activity, cancellationToken);
                 lockScopeResult = enqueueResult.Match(

--- a/src/BBT.Workflow.Application/Instances/Managers/IInstanceBusyManager.cs
+++ b/src/BBT.Workflow.Application/Instances/Managers/IInstanceBusyManager.cs
@@ -1,6 +1,21 @@
 namespace BBT.Workflow.Instances;
 
 /// <summary>
+/// Outcome of an attempt to mark an instance as Busy.
+/// </summary>
+public enum BusyMarkOutcome
+{
+    /// <summary>The instance was transitioned to Busy.</summary>
+    Marked = 0,
+
+    /// <summary>The instance was already Busy — a transition is queued or executing.</summary>
+    AlreadyBusy = 1,
+
+    /// <summary>No mark applied: the instance was not found or is Completed.</summary>
+    Skipped = 2
+}
+
+/// <summary>
 /// Manages the Busy status of workflow instances with isolated transactions.
 /// Consolidates pre-pipeline busy marking, async pre-enqueue marking, and SubFlow chain propagation.
 /// </summary>
@@ -18,4 +33,12 @@ public interface IInstanceBusyManager
     /// Idempotent: silently no-ops when the instance is already Busy or Completed.
     /// </summary>
     Task MarkBusyWithPropagationAsync(Guid instanceId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Attempts to mark an instance as Busy with SubFlow propagation, reporting the prior state.
+    /// Unlike <see cref="MarkBusyWithPropagationAsync"/>, an already-Busy instance short-circuits
+    /// with <see cref="BusyMarkOutcome.AlreadyBusy"/> (no propagation) so callers can reject the
+    /// request instead of silently proceeding.
+    /// </summary>
+    Task<BusyMarkOutcome> TryMarkBusyWithPropagationAsync(Guid instanceId, CancellationToken cancellationToken = default);
 }

--- a/src/BBT.Workflow.Application/Instances/Managers/InstanceBusyManager.cs
+++ b/src/BBT.Workflow.Application/Instances/Managers/InstanceBusyManager.cs
@@ -48,16 +48,50 @@ public sealed class InstanceBusyManager(
 
         if (instance is { IsBusy: false, IsCompleted: false })
         {
-            await using var uow = uowManager.Begin(
-                new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew, IsTransactional = true });
-
-            instance.Busy();
-            await instanceRepository.UpdateAsync(instance, false, cancellationToken);
-            await uow.CommitAsync(cancellationToken);
-
-            logger.InstanceMarkedBusy(instanceId);
+            await MarkBusyCoreAsync(instance, cancellationToken);
         }
 
+        await PropagateToSubflowAsync(instance, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<BusyMarkOutcome> TryMarkBusyWithPropagationAsync(
+        Guid instanceId, CancellationToken cancellationToken = default)
+    {
+        var instance = await instanceRepository.FindWithActiveSubFlowAsync(instanceId, cancellationToken);
+
+        if (instance is null || instance.IsCompleted)
+            return BusyMarkOutcome.Skipped;
+
+        if (instance.IsBusy)
+            return BusyMarkOutcome.AlreadyBusy;
+
+        await MarkBusyCoreAsync(instance, cancellationToken);
+        await PropagateToSubflowAsync(instance, cancellationToken);
+
+        return BusyMarkOutcome.Marked;
+    }
+
+    /// <summary>
+    /// Persists the Busy flip for an already-loaded instance in an isolated RequiresNew transaction.
+    /// </summary>
+    private async Task MarkBusyCoreAsync(Instance instance, CancellationToken cancellationToken)
+    {
+        await using var uow = uowManager.Begin(
+            new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew, IsTransactional = true });
+
+        instance.Busy();
+        await instanceRepository.UpdateAsync(instance, false, cancellationToken);
+        await uow.CommitAsync(cancellationToken);
+
+        logger.InstanceMarkedBusy(instance.Id);
+    }
+
+    /// <summary>
+    /// Propagates the Busy mark to the active SubFlow (if any) via the instance command gateway.
+    /// </summary>
+    private async Task PropagateToSubflowAsync(Instance instance, CancellationToken cancellationToken)
+    {
         var subflow = instance.Subflow;
         if (subflow is not null)
         {

--- a/src/BBT.Workflow.Domain/Logging/WorkflowErrors.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowErrors.cs
@@ -306,6 +306,19 @@ public static class WorkflowErrors
             target: instanceId.ToString());
 
     /// <summary>
+    /// Instance is Busy: a transition is already queued or executing.
+    /// Returned when a new non-reserved async transition is requested while the
+    /// instance is in Busy status (queued job or running pipeline).
+    /// </summary>
+    /// <param name="instanceId">The instance that is busy.</param>
+    /// <param name="transitionKey">The transition key that was rejected.</param>
+    public static Error InstanceBusy(Guid instanceId, string transitionKey)
+        => Error.Conflict(
+            WorkflowErrorCodes.InstanceBusy,
+            $"Instance is busy; transition '{transitionKey}' cannot be accepted while another transition is queued or executing",
+            target: instanceId.ToString());
+
+    /// <summary>
     /// A background job for this transition is already active.
     /// Returned when sync=false is requested but an active job with the same
     /// instance and transition key already exists in the queue.

--- a/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
@@ -1246,6 +1246,48 @@ public static partial class WorkflowLogs
         string instanceId);
 
     /// <summary>
+    /// Logs when an async transition request is rejected because the instance is Busy
+    /// (a transition is already queued or executing).
+    /// </summary>
+    [LoggerMessage(
+        EventId = 40120,
+        Level = LogLevel.Warning,
+        Message = "Async transition {TransitionKey} rejected for instance {InstanceId}: instance is busy")]
+    public static partial void AsyncTransitionRejectedInstanceBusy(
+        this ILogger logger,
+        string transitionKey,
+        Guid instanceId);
+
+    /// <summary>
+    /// Logs a transient instance-lock conflict inside a transition job; the handler retries with backoff.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 40121,
+        Level = LogLevel.Warning,
+        Message = "Transition job {JobName} hit instance lock conflict for instance {InstanceId} (attempt {Attempt}/{MaxAttempts}); retrying in {DelayMs}ms")]
+    public static partial void TransitionJobLockConflictRetry(
+        this ILogger logger,
+        string jobName,
+        Guid instanceId,
+        int attempt,
+        int maxAttempts,
+        int delayMs);
+
+    /// <summary>
+    /// Logs when a transition job exhausted all lock-conflict retries; the instance is routed to recovery (Faulted).
+    /// </summary>
+    [LoggerMessage(
+        EventId = 40122,
+        Level = LogLevel.Error,
+        Message = "Transition job {JobName} exhausted {MaxAttempts} lock-conflict retries for instance {InstanceId} on transition {TransitionKey}; faulting instance")]
+    public static partial void TransitionJobLockConflictRetriesExhausted(
+        this ILogger logger,
+        string jobName,
+        int maxAttempts,
+        Guid instanceId,
+        string transitionKey);
+
+    /// <summary>
     /// Logs when start transition validation fails.
     /// </summary>
     [LoggerMessage(

--- a/src/BBT.Workflow.Domain/WorkflowErrorCodes.cs
+++ b/src/BBT.Workflow.Domain/WorkflowErrorCodes.cs
@@ -46,6 +46,7 @@ public static class WorkflowErrorCodes
     public const string NoIncompleteTransitionFound = "Instance:100028";
     public const string TimeoutConfigMissing = "Instance:100029";
     public const string SubflowOutputMappingFailed = "Instance:100030";
+    public const string InstanceBusy = "Instance:100031";
 
     #endregion
     

--- a/src/BBT.Workflow.HttpApi.Shared/Microsoft/Extensions/DependencyInjection/WorkflowApiBaseServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.HttpApi.Shared/Microsoft/Extensions/DependencyInjection/WorkflowApiBaseServiceCollectionExtensions.cs
@@ -295,6 +295,7 @@ public static class WorkflowApiBaseServiceCollectionExtensions
             // Instance errors
             opt.Map(WorkflowErrorCodes.NotFoundDomain, HttpStatusCode.BadRequest);
             opt.Map(WorkflowErrorCodes.ConflictWorkflow, HttpStatusCode.Conflict);
+            opt.Map(WorkflowErrorCodes.InstanceBusy, HttpStatusCode.Conflict);
             opt.Map(WorkflowErrorCodes.RuntimeSchemaInvalidState, HttpStatusCode.BadRequest);
             opt.Map(WorkflowErrorCodes.TransitionLocked, HttpStatusCode.Conflict);
             opt.Map(WorkflowErrorCodes.AutoTransitionConditionNotMet, HttpStatusCode.BadRequest);

--- a/test/BBT.Workflow.Application.Tests/BackgroundJobs/Handlers/TransitionJobHandlerTests.cs
+++ b/test/BBT.Workflow.Application.Tests/BackgroundJobs/Handlers/TransitionJobHandlerTests.cs
@@ -10,6 +10,7 @@ using BBT.Workflow.BackgroundJobs.Recovery;
 using BBT.Workflow.Execution;
 using BBT.Workflow.Execution.Services;
 using BBT.Workflow.Instances;
+using BBT.Workflow.Logging;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -43,18 +44,31 @@ public class TransitionJobHandlerTests
             .Setup(r => r.FaultInstanceAsync(
                 It.IsAny<TransitionJobPayload>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
+
+        _recoveryService
+            .Setup(r => r.FaultInstanceAsync(
+                It.IsAny<TransitionJobPayload>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
     }
 
-    private TransitionJobHandler CreateHandler(int timeoutSeconds = 300)
+    private TransitionJobHandler CreateHandler(
+        int timeoutSeconds = 300,
+        LockConflictRetryOptions? lockConflictRetry = null)
     {
         var options = Options.Create(new WorkflowExecutionOptions
         {
-            TransitionJobTimeoutSeconds = timeoutSeconds
+            TransitionJobTimeoutSeconds = timeoutSeconds,
+            // 1ms backoff keeps retry tests fast without changing the retry logic under test.
+            LockConflictRetry = lockConflictRetry ?? new LockConflictRetryOptions { BaseDelayMilliseconds = 1 }
         });
         return new TransitionJobHandler(
             _jobRepo.Object, _executionService.Object, _currentSchema.Object,
             _recoveryService.Object, options, _hostLifetime.Object, _logger.Object);
     }
+
+    private static Result<TransitionOutput> LockConflictResult()
+        => Result<TransitionOutput>.Fail(WorkflowErrors.InstanceLockConflict(Guid.NewGuid()));
 
     private static TransitionJobPayload CreatePayload(Guid? instanceId = null) => new()
     {
@@ -193,6 +207,125 @@ public class TransitionJobHandlerTests
         _recoveryService.Verify(
             r => r.FaultInstanceAsync(It.IsAny<TransitionJobPayload>(), It.IsAny<CancellationToken>()),
             Times.Never);
+    }
+
+    /// <summary>
+    /// Transient lock conflicts (producer accept lock / finishing chain still holds the
+    /// execution lock) must be retried; success on a later attempt needs no recovery.
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_WhenLockConflictThenSuccess_RetriesWithoutRecovery()
+    {
+        var instanceId = Guid.NewGuid();
+        var payload = CreatePayload(instanceId);
+        var handler = CreateHandler();
+        var calls = 0;
+
+        _executionService
+            .Setup(s => s.ExecuteTransitionAsync(
+                It.IsAny<WorkflowExecutionContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => ++calls <= 2
+                ? LockConflictResult()
+                : Result<TransitionOutput>.Ok(new TransitionOutput { Status = InstanceStatus.Active }));
+
+        await handler.HandleAsync(payload, CancellationToken.None);
+
+        Assert.Equal(3, calls);
+        _recoveryService.Verify(
+            r => r.FaultInstanceAsync(It.IsAny<TransitionJobPayload>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _recoveryService.Verify(
+            r => r.FaultInstanceAsync(
+                It.IsAny<TransitionJobPayload>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        _jobRepo.Verify(
+            r => r.MarkAsProcessedAsync(instanceId, payload.JobName, CancellationToken.None),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Persistent lock conflict → exactly MaxAttempts executions, then the instance is
+    /// routed to recovery (Faulted) instead of being silently stranded in Busy.
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_WhenLockConflictExhausted_FaultsInstance()
+    {
+        var instanceId = Guid.NewGuid();
+        var payload = CreatePayload(instanceId);
+        var handler = CreateHandler(
+            lockConflictRetry: new LockConflictRetryOptions { MaxAttempts = 3, BaseDelayMilliseconds = 1 });
+
+        _executionService
+            .Setup(s => s.ExecuteTransitionAsync(
+                It.IsAny<WorkflowExecutionContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(LockConflictResult);
+
+        await handler.HandleAsync(payload, CancellationToken.None);
+
+        _executionService.Verify(
+            s => s.ExecuteTransitionAsync(
+                It.IsAny<WorkflowExecutionContext>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(3));
+        _recoveryService.Verify(
+            r => r.FaultInstanceAsync(
+                payload, It.IsAny<string>(), "JOB_LOCK_CONFLICT", CancellationToken.None),
+            Times.Once);
+        _jobRepo.Verify(
+            r => r.MarkAsProcessedAsync(instanceId, payload.JobName, CancellationToken.None),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Non-conflict business failures must not be retried (single execution, no recovery).
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_WhenNonConflictFailure_DoesNotRetry()
+    {
+        var payload = CreatePayload();
+        var handler = CreateHandler();
+
+        _executionService
+            .Setup(s => s.ExecuteTransitionAsync(
+                It.IsAny<WorkflowExecutionContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<TransitionOutput>.Fail(
+                Error.Validation("Transition:NotFound", "Transition not found")));
+
+        await handler.HandleAsync(payload, CancellationToken.None);
+
+        _executionService.Verify(
+            s => s.ExecuteTransitionAsync(
+                It.IsAny<WorkflowExecutionContext>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _recoveryService.Verify(
+            r => r.FaultInstanceAsync(
+                It.IsAny<TransitionJobPayload>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// Execution budget expiring during a retry backoff delay must route into the existing
+    /// timeout recovery path — no unhandled exception.
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_WhenBudgetExpiresDuringRetryDelay_CallsRecovery()
+    {
+        var payload = CreatePayload();
+        var handler = CreateHandler(
+            timeoutSeconds: 1,
+            lockConflictRetry: new LockConflictRetryOptions { MaxAttempts = 5, BaseDelayMilliseconds = 60_000 });
+
+        _executionService
+            .Setup(s => s.ExecuteTransitionAsync(
+                It.IsAny<WorkflowExecutionContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(LockConflictResult);
+
+        await handler.HandleAsync(payload, CancellationToken.None);
+
+        _recoveryService.Verify(
+            r => r.FaultInstanceAsync(payload, CancellationToken.None),
+            Times.Once);
     }
 
     /// <summary>

--- a/test/BBT.Workflow.Application.Tests/BackgroundJobs/Handlers/TransitionJobHandlerTests.cs
+++ b/test/BBT.Workflow.Application.Tests/BackgroundJobs/Handlers/TransitionJobHandlerTests.cs
@@ -277,6 +277,36 @@ public class TransitionJobHandlerTests
     }
 
     /// <summary>
+    /// Misconfigured retry options (negative base delay, attempts beyond the shift range)
+    /// must not produce negative delays — Task.Delay would throw ArgumentOutOfRangeException.
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_WithMisconfiguredRetryOptions_DoesNotThrow()
+    {
+        var instanceId = Guid.NewGuid();
+        var payload = CreatePayload(instanceId);
+        var handler = CreateHandler(
+            lockConflictRetry: new LockConflictRetryOptions { MaxAttempts = 40, BaseDelayMilliseconds = -100 });
+
+        _executionService
+            .Setup(s => s.ExecuteTransitionAsync(
+                It.IsAny<WorkflowExecutionContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(LockConflictResult);
+
+        await handler.HandleAsync(payload, CancellationToken.None);
+
+        // Negative base delay clamps to 0 and the shift is capped, so all 40 attempts run
+        // instantly instead of crashing the job pipeline.
+        _executionService.Verify(
+            s => s.ExecuteTransitionAsync(
+                It.IsAny<WorkflowExecutionContext>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(40));
+        _jobRepo.Verify(
+            r => r.MarkAsProcessedAsync(instanceId, payload.JobName, CancellationToken.None),
+            Times.Once);
+    }
+
+    /// <summary>
     /// Non-conflict business failures must not be retried (single execution, no recovery).
     /// </summary>
     [Fact]

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Strategy/AsyncTransitionStrategyTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Strategy/AsyncTransitionStrategyTests.cs
@@ -55,6 +55,10 @@ public class AsyncTransitionStrategyTests
             .Setup(x => x.MarkBusyWithPropagationAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
+        _mockBusyManager
+            .Setup(x => x.TryMarkBusyWithPropagationAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BusyMarkOutcome.Marked);
+
         _mockEnqueueGateway
             .Setup(x => x.EnqueueAsync(
                 It.IsAny<TransitionJobPayload>(),
@@ -118,9 +122,9 @@ public class AsyncTransitionStrategyTests
         var enqueueCalledAfterBusy = false;
 
         _mockBusyManager
-            .Setup(x => x.MarkBusyWithPropagationAsync(txCtx.Instance.Id, It.IsAny<CancellationToken>()))
+            .Setup(x => x.TryMarkBusyWithPropagationAsync(txCtx.Instance.Id, It.IsAny<CancellationToken>()))
             .Callback(() => busyManagerCalled = true)
-            .Returns(Task.CompletedTask);
+            .ReturnsAsync(BusyMarkOutcome.Marked);
 
         _mockEnqueueGateway
             .Setup(x => x.EnqueueAsync(
@@ -232,15 +236,35 @@ public class AsyncTransitionStrategyTests
     #region Busy manager delegation
 
     [Fact]
-    public async Task ExecuteAsync_ShouldDelegateBusyMarkingToManager()
+    public async Task ExecuteAsync_WithNormalTransition_ShouldTryMarkBusyViaManager()
     {
         var (wfCtx, txCtx) = SetupSuccessfulContext();
 
         await _strategy.ExecuteAsync(wfCtx, CancellationToken.None);
 
         _mockBusyManager.Verify(
+            x => x.TryMarkBusyWithPropagationAsync(txCtx.Instance.Id, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _mockBusyManager.Verify(
+            x => x.MarkBusyWithPropagationAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithReservedTransition_ShouldMarkBusyUnconditionally()
+    {
+        // Reserved transitions (cancel/exit/...) are accepted while the instance is Busy by design,
+        // so they must not go through the Try guard.
+        var (wfCtx, txCtx) = SetupSuccessfulContext(transitionKey: "cancel");
+
+        await _strategy.ExecuteAsync(wfCtx, CancellationToken.None);
+
+        _mockBusyManager.Verify(
             x => x.MarkBusyWithPropagationAsync(txCtx.Instance.Id, It.IsAny<CancellationToken>()),
             Times.Once);
+        _mockBusyManager.Verify(
+            x => x.TryMarkBusyWithPropagationAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]
@@ -254,25 +278,76 @@ public class AsyncTransitionStrategyTests
         _mockBusyManager.Verify(
             x => x.MarkBusyWithPropagationAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
             Times.Never);
+        _mockBusyManager.Verify(
+            x => x.TryMarkBusyWithPropagationAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenInstanceAlreadyBusy_ShouldReturn409WithoutEnqueue()
+    {
+        var (wfCtx, txCtx) = SetupSuccessfulContext();
+
+        _mockBusyManager
+            .Setup(x => x.TryMarkBusyWithPropagationAsync(txCtx.Instance.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BusyMarkOutcome.AlreadyBusy);
+
+        var result = await _strategy.ExecuteAsync(wfCtx, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeFalse();
+        result.Error.Code.ShouldBe(WorkflowErrorCodes.InstanceBusy);
+
+        _mockEnqueueGateway.Verify(
+            x => x.EnqueueAsync(
+                It.IsAny<TransitionJobPayload>(),
+                It.IsAny<TransitionContinuationRequested>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenBusyMarkSkipped_ShouldStillEnqueue()
+    {
+        // Skipped = instance not found or completed — preserves the previous silent no-op
+        // semantics; upstream instance resolution gates those states.
+        var (wfCtx, txCtx) = SetupSuccessfulContext();
+
+        _mockBusyManager
+            .Setup(x => x.TryMarkBusyWithPropagationAsync(txCtx.Instance.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BusyMarkOutcome.Skipped);
+
+        var result = await _strategy.ExecuteAsync(wfCtx, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+
+        _mockEnqueueGateway.Verify(
+            x => x.EnqueueAsync(
+                It.IsAny<TransitionJobPayload>(),
+                It.IsAny<TransitionContinuationRequested>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     #endregion
 
-    #region Reserved transition lock key
+    #region Enqueue lock key scoping
 
     [Fact]
-    public async Task ExecuteAsync_WithNormalTransition_ShouldLockOnBaseInstanceKey()
+    public async Task ExecuteAsync_WithNormalTransition_ShouldLockOnEnqueueSuffixedKey()
     {
         var (wfCtx, txCtx) = SetupSuccessfulContext();
         var capturedKey = CaptureLockKey();
 
         await _strategy.ExecuteAsync(wfCtx, CancellationToken.None);
 
-        capturedKey().ShouldBe(txCtx.LockKey);
+        capturedKey().ShouldBe(txCtx.LockKey + AsyncTransitionStrategy.EnqueueLockSuffix);
+        // Invariant: the producer must never lock the consumer's execution key —
+        // the Dapr job fires while this lock is still held (race condition).
+        capturedKey().ShouldNotBe(txCtx.LockKey);
     }
 
     [Fact]
-    public async Task ExecuteAsync_WithReservedTransition_ShouldLockOnOwnTypeScopedKey()
+    public async Task ExecuteAsync_WithReservedTransition_ShouldLockOnOwnTypeScopedEnqueueKey()
     {
         var (wfCtx, txCtx) = SetupSuccessfulContext(transitionKey: "cancel");
         var capturedKey = CaptureLockKey();
@@ -280,7 +355,9 @@ public class AsyncTransitionStrategyTests
         await _strategy.ExecuteAsync(wfCtx, CancellationToken.None);
 
         _reservedTransitionResolver.IsReserved(txCtx).ShouldBeTrue();
-        capturedKey().ShouldBe(txCtx.LockKey + ":cancel");
+        capturedKey().ShouldBe(txCtx.LockKey + ":cancel" + AsyncTransitionStrategy.EnqueueLockSuffix);
+        // Invariant: never the consumer's reserved execution key either.
+        capturedKey().ShouldNotBe(txCtx.LockKey + ":cancel");
         capturedKey().ShouldNotBe(txCtx.LockKey);
     }
 

--- a/test/BBT.Workflow.Application.Tests/Instances/Managers/InstanceBusyManagerTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/Managers/InstanceBusyManagerTests.cs
@@ -202,4 +202,71 @@ public sealed class InstanceBusyManagerTests
             It.Is<MarkBusyInput>(i => i.InstanceId == subflowInstanceId),
             It.IsAny<CancellationToken>()), Times.Once);
     }
+
+    // ─── TryMarkBusyWithPropagationAsync ─────────────────────────────────────
+
+    [Fact]
+    public async Task TryMarkBusyWithPropagationAsync_WhenInstanceNotFound_ShouldReturnSkipped()
+    {
+        // Arrange
+        var instanceId = Guid.NewGuid();
+        _instanceRepository
+            .Setup(r => r.FindWithActiveSubFlowAsync(instanceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Instance?)null);
+
+        // Act
+        var outcome = await CreateSut().TryMarkBusyWithPropagationAsync(instanceId);
+
+        // Assert
+        outcome.ShouldBe(BusyMarkOutcome.Skipped);
+        _uowManager.Verify(m => m.Begin(It.IsAny<UnitOfWorkOptions>()), Times.Never);
+        _instanceCommandGateway.Verify(g => g.MarkBusyAsync(It.IsAny<MarkBusyInput>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task TryMarkBusyWithPropagationAsync_WhenAlreadyBusy_ShouldReturnAlreadyBusyWithoutPropagation()
+    {
+        // Arrange
+        var instanceId = Guid.NewGuid();
+        var instance = Instance.Create(instanceId, "test-flow", "1.0.0");
+        instance.Busy();
+
+        _instanceRepository
+            .Setup(r => r.FindWithActiveSubFlowAsync(instanceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(instance);
+
+        // Act
+        var outcome = await CreateSut().TryMarkBusyWithPropagationAsync(instanceId);
+
+        // Assert — short-circuits: no UoW, no gateway propagation
+        outcome.ShouldBe(BusyMarkOutcome.AlreadyBusy);
+        _uowManager.Verify(m => m.Begin(It.IsAny<UnitOfWorkOptions>()), Times.Never);
+        _instanceCommandGateway.Verify(g => g.MarkBusyAsync(It.IsAny<MarkBusyInput>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task TryMarkBusyWithPropagationAsync_WhenInstanceActive_ShouldMarkAndReturnMarked()
+    {
+        // Arrange
+        var instanceId = Guid.NewGuid();
+        var instance = Instance.Create(instanceId, "test-flow", "1.0.0");
+
+        _instanceRepository
+            .Setup(r => r.FindWithActiveSubFlowAsync(instanceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(instance);
+
+        _instanceRepository
+            .Setup(r => r.UpdateAsync(instance, false, It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(instance));
+
+        // Act
+        var outcome = await CreateSut().TryMarkBusyWithPropagationAsync(instanceId);
+
+        // Assert
+        outcome.ShouldBe(BusyMarkOutcome.Marked);
+        _uowManager.Verify(m => m.Begin(It.Is<UnitOfWorkOptions>(o =>
+            o.Scope == UnitOfWorkScopeOption.RequiresNew)), Times.Once);
+        _uow.Verify(u => u.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
+        instance.IsBusy.ShouldBeTrue();
+    }
 }

--- a/vnext-meta/known-issues.json
+++ b/vnext-meta/known-issues.json
@@ -51,6 +51,16 @@
       "fixedIn": null
     },
     {
+      "id": "async-transition-enqueue-lock-race-silent-loss",
+      "affectedVersions": ">=0.0.26 <0.0.69",
+      "severity": "error",
+      "component": "transition",
+      "path": null,
+      "title": "Async (sync=false) transition jobs could fire while the enqueue-side distributed lock still held the same instance key; the job consumer failed with a lock conflict that was silently swallowed, losing the transition and stranding the instance in Busy status.",
+      "workaround": "Retry the transition after the instance is recovered; upgrade to a fixed version where the enqueue lock is scoped with an :enqueue suffix and the job handler retries lock conflicts and faults the instance on exhaustion.",
+      "fixedIn": "0.0.69"
+    },
+    {
       "id": "duplicate-async-transition-job-conflict",
       "affectedVersions": ">=0.0.26",
       "severity": "info",


### PR DESCRIPTION
## Summary

Fixes a race condition where async transition jobs could fire while the enqueue-side distributed lock still held the instance execution key, causing the job consumer to fail with a silent lock conflict and strand the instance in Busy status. Introduces bounded exponential-backoff retry logic in `TransitionJobHandler` to absorb transient conflicts, and adds explicit Busy admission control in `AsyncTransitionStrategy` to reject concurrent non-reserved transitions.

## Key Changes

### TransitionJobHandler (Job Consumer)
- **Lock conflict retry loop**: `ExecuteWithLockConflictRetryAsync()` retries the transition pipeline on `WorkflowErrors.InstanceLockConflict` with bounded exponential backoff (100→200→400→800ms by default, configurable via `LockConflictRetryOptions`)
- **Exhaustion recovery**: When retries are exhausted, routes the instance to recovery (Faulted) instead of silently stranding it in Busy, with incident code `JOB_LOCK_CONFLICT`
- **Logging**: Added `TransitionJobLockConflictRetry` and `TransitionJobLockConflictRetriesExhausted` log events for observability

### AsyncTransitionStrategy (Producer/Enqueue Side)
- **Lock key scoping**: Enqueue lock now uses `EnqueueLockSuffix` (`:enqueue`) to separate the accept-scope lock from the execution lock the job consumer acquires in `TransitionPipeline`
  - Normal transitions: `{instanceId}:enqueue`
  - Reserved transitions: `{instanceId}:{type}:enqueue`
  - This prevents the race where the Dapr job fires (~5ms after scheduling) while the enqueue lock is still held
- **Busy admission control**: Replaced implicit rejection (shared lock key) with explicit `TryMarkBusyWithPropagationAsync()` call
  - Non-reserved transitions: rejected with 409 if instance is already Busy
  - Reserved transitions: unconditionally marked Busy (accepted while main flow is Busy by design)

### InstanceBusyManager
- **New method**: `TryMarkBusyWithPropagationAsync()` returns `BusyMarkOutcome` enum:
  - `Marked`: instance transitioned to Busy
  - `AlreadyBusy`: instance was already Busy (short-circuits, no propagation)
  - `Skipped`: instance not found or completed
- **Refactored**: Extracted `MarkBusyCoreAsync()` and `PropagateToSubflowAsync()` for code reuse

### Configuration & Error Handling
- **New `LockConflictRetryOptions`**: `MaxAttempts` (default 5) and `BaseDelayMilliseconds` (default 100)
- **New error**: `WorkflowErrors.InstanceBusy()` with code `InstanceBusy` for explicit Busy rejection
- **Recovery service overload**: `FaultInstanceAsync()` now accepts caller-supplied incident message and error code
- **Known issue documented**: Added entry to `vnext-meta/known-issues.json` for the race condition (affects ≥0.0.26 <0.0.69)

## Implementation Details

- Retry delays run on the linked execution budget token, so the job's timeout still applies
- Non-conflict business failures are not retried (single execution, no recovery)
- Execution budget expiring during retry backoff routes to the existing timeout recovery path
- All tests updated to use `LockConflictRetryOptions` with 1ms backoff for speed without changing retry logic
- Reserved transitions (cancel, exit, updateData, timeout, subflow resume, shared) continue to be accepted while main flow is Busy, mirroring sync pipeline behavior


## Summary by Sourcery

Improve reliability and admission control of async workflow transitions by handling transient instance-lock conflicts in transition jobs and explicitly rejecting non-reserved transitions when an instance is already busy.

Bug Fixes:
- Prevent instances being silently stranded in Busy status by routing exhausted lock-conflict retries in transition jobs to recovery with a faulted incident.
- Eliminate a race between enqueue-side and consumer-side locks by scoping async enqueue locks away from execution locks, avoiding transient lock conflicts that previously lost transitions.

Enhancements:
- Introduce bounded exponential-backoff retry policy for instance-lock conflicts in transition jobs, configurable via workflow execution options.
- Add explicit Busy admission control for async transitions using a new outcome-reporting busy manager API, allowing non-reserved requests to be rejected when an instance is already busy.
- Refactor instance busy marking into reusable core and subflow propagation methods and extend recovery services to accept caller-supplied incident messages and error codes.
- Expand logging around async transitions and transition jobs to surface busy rejections and lock-conflict retry/exhaustion events for better observability.

Documentation:
- Document the known async transition race condition and its version range in vnext-meta known issues.

Tests:
- Add and update unit tests for transition job lock-conflict retry behavior, busy admission outcomes, enqueue lock key scoping, and the new busy manager and recovery behaviors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic retries for transient instance-lock conflicts during transition processing.
  * Added configurable retry attempts and backoff delays.
  * Added clear conflict responses when transitions target an already busy instance.

* **Bug Fixes**
  * Prevented transitions from being lost due to enqueue and execution lock conflicts.
  * Instances are now faulted with specific recovery details when retries are exhausted.
  * Improved separation of enqueue and execution locking to reduce race conditions.

* **Documentation**
  * Added a known-issue entry and workaround for affected async transition scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->