### PR TITLE
fix(execution): await task-failure persist to close ErrorBoundary DbContext race (#807)

### DIFF
--- a/monitoring/BBT.Workflow.Monitor.Application/Instances/MonitorInstanceQueryService.cs
+++ b/monitoring/BBT.Workflow.Monitor.Application/Instances/MonitorInstanceQueryService.cs
@@ -7,6 +7,7 @@ using BBT.Workflow;
 using BBT.Workflow.Caching;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Definitions.GraphQL;
+using BBT.Workflow.Definitions.Schemas;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Monitor.Common.DTOs;
 using BBT.Workflow.Monitor.Instances.DTOs;
@@ -62,6 +63,7 @@ public sealed class MonitorInstanceQueryService(
                 input.GroupBy,
                 input.Aggregations,
                 input.Sort,
+                null,
                 ct);
 
             if (result.Groups is { Count: > 0 })

--- a/src/BBT.Workflow.Application/Tasks/Coordinator/TaskExecutionEngine.cs
+++ b/src/BBT.Workflow.Application/Tasks/Coordinator/TaskExecutionEngine.cs
@@ -180,6 +180,7 @@ public sealed class TaskExecutionEngine : ITaskExecutionEngine
                 onExecuteTask,
                 boundaryChain,
                 totalStopwatch.ElapsedMilliseconds,
+                attempt,
                 cancellationToken);
         }
         catch (Exception ex)
@@ -203,6 +204,7 @@ public sealed class TaskExecutionEngine : ITaskExecutionEngine
     /// <param name="onExecuteTask">The task definition that failed.</param>
     /// <param name="boundaryChain">The compiled boundary chain for resolution.</param>
     /// <param name="totalDurationMs">Total execution duration including retries.</param>
+    /// <param name="attemptsMade">Number of retry attempts actually performed (0 when no Retry rule matched).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The execution result with appropriate boundary action.</returns>
     private async Task<Result<TasksExecutionResult>> HandlePostRetryFailureAsync(
@@ -210,6 +212,7 @@ public sealed class TaskExecutionEngine : ITaskExecutionEngine
         OnExecuteTask onExecuteTask,
         CompiledBoundaryChain boundaryChain,
         long totalDurationMs,
+        int attemptsMade,
         CancellationToken cancellationToken)
     {
         var taskKey = onExecuteTask.Task.Key;
@@ -233,9 +236,18 @@ public sealed class TaskExecutionEngine : ITaskExecutionEngine
                 failedResult.Error, taskKey, "Unknown", totalDurationMs);
         }
 
-        _logger.LogWarning(
-            "Retry exhausted for task {TaskKey}. Resolving fallback boundary action (excluding Retry). Error: {Error}",
-            taskKey, executionError.ErrorMessage);
+        if (attemptsMade > 0)
+        {
+            _logger.LogWarning(
+                "Retry exhausted for task {TaskKey} after {Attempts} attempt(s). Resolving fallback boundary action (excluding Retry). Error: {Error}",
+                taskKey, attemptsMade, executionError.ErrorMessage);
+        }
+        else
+        {
+            _logger.LogWarning(
+                "No matching Retry rule for task {TaskKey}. Resolving fallback boundary action. Error: {Error}",
+                taskKey, executionError.ErrorMessage);
+        }
 
         // Resolve boundary for fallback actions - EXCLUDE Retry since it's already exhausted
         var resolution = _boundaryResolver.ResolveExcluding(
@@ -417,7 +429,14 @@ public sealed class TaskExecutionEngine : ITaskExecutionEngine
     /// <summary>
     /// Records task failure metrics and persists the failure.
     /// </summary>
-    private void RecordFailure(
+    /// <remarks>
+    /// The completion persist is awaited (not fire-and-forget) so its SaveChanges cannot race the
+    /// pipeline's next write on the shared request-scoped DbContext, which previously tripped EF Core's
+    /// ConcurrencyDetector and faulted the instance even when an Ignore boundary should have handled the
+    /// failure (issue #807). Persistence errors are caught and logged so recording a failure never throws
+    /// an unhandled exception into the boundary-resolution path.
+    /// </remarks>
+    private async Task RecordFailureAsync(
         InstanceTask instanceTask,
         ITaskPersistenceStrategy? strategy,
         string taskType,
@@ -430,7 +449,15 @@ public sealed class TaskExecutionEngine : ITaskExecutionEngine
 
         if (strategy != null)
         {
-            _ = strategy.HandleCompletionAsync(instanceTask, cancellationToken);
+            try
+            {
+                await strategy.HandleCompletionAsync(instanceTask, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "Failed to persist task failure for {TaskKey}", instanceTask.TaskId);
+            }
         }
 
         _workflowMetrics.RecordTaskFailed(taskType, workflowKey, stopwatch.Elapsed.TotalSeconds);
@@ -519,7 +546,7 @@ public sealed class TaskExecutionEngine : ITaskExecutionEngine
         if (!executorResult.IsSuccess)
         {
             stopwatch.Stop();
-            RecordFailure(instanceTask, persistenceStrategy, taskTypeStr, workflowKey, stopwatch,
+            await RecordFailureAsync(instanceTask, persistenceStrategy, taskTypeStr, workflowKey, stopwatch,
                 executorResult.Error.Message, cancellationToken);
 
             var infraError = _errorFactory.CreateFromError(
@@ -559,7 +586,7 @@ public sealed class TaskExecutionEngine : ITaskExecutionEngine
         // 9. Handle infrastructure error - return without boundary resolution (not retriable)
         if (!executeResult.IsSuccess)
         {
-            RecordFailure(instanceTask, persistenceStrategy, taskTypeStr, workflowKey, stopwatch,
+            await RecordFailureAsync(instanceTask, persistenceStrategy, taskTypeStr, workflowKey, stopwatch,
                 executeResult.Error.Message ?? "Unknown infrastructure error", cancellationToken);
 
             var infraError = _errorFactory.CreateFromError(

--- a/src/BBT.Workflow.Application/Tasks/Coordinator/TaskExecutionEngine.cs
+++ b/src/BBT.Workflow.Application/Tasks/Coordinator/TaskExecutionEngine.cs
@@ -453,7 +453,7 @@ public sealed class TaskExecutionEngine : ITaskExecutionEngine
             {
                 await strategy.HandleCompletionAsync(instanceTask, cancellationToken);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 _logger.LogError(ex,
                     "Failed to persist task failure for {TaskKey}", instanceTask.TaskId);

--- a/test/BBT.Workflow.Application.Tests/Tasks/Coordinator/TaskExecutionEngineTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Tasks/Coordinator/TaskExecutionEngineTests.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.Guids;
+using BBT.Aether.Results;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Execution.ErrorHandling;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Monitoring;
+using BBT.Workflow.Runtime;
+using BBT.Workflow.Scripting;
+using BBT.Workflow.Tasks.Executors;
+using BBT.Workflow.Tasks.Factory;
+using BBT.Workflow.Tasks.Persistence;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Application.Tests.Tasks.Coordinator;
+
+using BBT.Workflow.Tasks.Coordinator;
+
+/// <summary>
+/// Regression tests for <see cref="TaskExecutionEngine"/> covering the error/fallback path.
+/// Guards issue #807: a task failure resolved by an Ignore boundary must not fault the instance,
+/// and the failure-path completion persist must be fully awaited (no fire-and-forget) so it cannot
+/// race the pipeline's next DbContext write.
+/// </summary>
+public sealed class TaskExecutionEngineTests
+{
+    private readonly ITaskExecutorRegistry _executorRegistry = Substitute.For<ITaskExecutorRegistry>();
+    private readonly ITaskFactory _taskFactory = Substitute.For<ITaskFactory>();
+    private readonly ITaskPersistenceStrategyFactory _persistenceStrategyFactory = Substitute.For<ITaskPersistenceStrategyFactory>();
+    private readonly IGuidGenerator _guidGenerator = Substitute.For<IGuidGenerator>();
+    private readonly IWorkflowMetrics _workflowMetrics = Substitute.For<IWorkflowMetrics>();
+
+    // Real error-handling collaborators so boundary resolution is authentic.
+    private readonly IErrorBoundaryResolver _boundaryResolver = new ErrorBoundaryResolver(NullLogger<ErrorBoundaryResolver>.Instance);
+    private readonly IErrorActionExecutor _actionExecutor = new ErrorActionExecutor(NullLogger<ErrorActionExecutor>.Instance);
+    private readonly IExecutionErrorFactory _errorFactory = new ExecutionErrorFactory(new ErrorNormalizer());
+
+    public TaskExecutionEngineTests()
+    {
+        _guidGenerator.Create().Returns(_ => Guid.NewGuid());
+    }
+
+    private TaskExecutionEngine CreateEngine() => new(
+        _executorRegistry,
+        _taskFactory,
+        _persistenceStrategyFactory,
+        _guidGenerator,
+        _workflowMetrics,
+        _boundaryResolver,
+        _actionExecutor,
+        _errorFactory,
+        NullLogger<TaskExecutionEngine>.Instance);
+
+    private static ScriptContext CreateScriptContext()
+    {
+        var instance = Instance.Create(Guid.NewGuid(), "test-flow", "1.0", "ctx-key");
+        return new ScriptContext.Builder(NullLogger<ScriptContext>.Instance)
+            .SetRuntime(Substitute.For<IRuntimeInfoProvider>())
+            .SetInstance(instance)
+            .Build();
+    }
+
+    private void UsePersistenceStrategy(ITaskPersistenceStrategy strategy)
+    {
+        _persistenceStrategyFactory.GetStrategy(Arg.Any<TaskTrigger>())
+            .Returns(Result<ITaskPersistenceStrategy>.Ok(strategy));
+    }
+
+    /// <summary>
+    /// Issue #807 core regression: on a task failure the completion persist is awaited to
+    /// completion before ExecuteAsync returns. With the previous fire-and-forget (`_ = ...`),
+    /// control returned while the SaveChanges was still in flight, racing the pipeline's next
+    /// DbContext write and tripping EF Core's ConcurrencyDetector.
+    /// </summary>
+    [Fact]
+    public async Task ExecuteAsync_WhenTaskFails_AwaitsFailurePersistBeforeReturning()
+    {
+        // Arrange: reach the failure branch via an executor-not-found result.
+        var task = WorkflowTaskFactory.CreateHttpTask("mock-api");
+        _taskFactory.CreateExecutionTaskAsync(Arg.Any<IReference>(), Arg.Any<CancellationToken>())
+            .Returns(Result<WorkflowTask>.Ok(task));
+        _executorRegistry.GetExecutor(Arg.Any<TaskType>())
+            .Returns(Result<ITaskExecutor>.Fail(new Error("500", "no executor registered")));
+
+        var strategy = new TrackingPersistenceStrategy(completionDelay: TimeSpan.FromMilliseconds(75));
+        UsePersistenceStrategy(strategy);
+
+        var onExecute = OnExecuteTask.Create(1, task, ScriptCode.FromNative(string.Empty));
+        var engine = CreateEngine();
+
+        // Act
+        await engine.ExecuteAsync(onExecute, Guid.NewGuid(), TaskTrigger.OnExecute, CreateScriptContext(), CancellationToken.None);
+
+        // Assert: the failure persist finished before ExecuteAsync returned (no fire-and-forget).
+        strategy.CompletionFinished.ShouldBeTrue(
+            "the failure-path completion persist must be awaited before ExecuteAsync returns");
+        strategy.CompletionCallCount.ShouldBe(1);
+    }
+
+    /// <summary>
+    /// Issue #807 behavioral guard: a code-less exception (no HTTP error code) does not match the
+    /// Retry rule; it lands on the Ignore wildcard, runs zero retries, and the engine returns a
+    /// success result (pipeline continues, instance not faulted).
+    /// </summary>
+    [Fact]
+    public async Task ExecuteAsync_WhenTaskFailsWithNoErrorCode_ResolvesToIgnore_WithZeroRetries()
+    {
+        // Arrange: executor exists but the task fails at execution (mirrors an InputHandler failure,
+        // which surfaces as a Result.Fail with no HTTP status code).
+        var task = WorkflowTaskFactory.CreateHttpTask("mock-api");
+        _taskFactory.CreateExecutionTaskAsync(Arg.Any<IReference>(), Arg.Any<CancellationToken>())
+            .Returns(Result<WorkflowTask>.Ok(task));
+
+        var executor = Substitute.For<ITaskExecutor>();
+        executor.ExecuteAsync(Arg.Any<TaskExecutorContext>(), Arg.Any<CancellationToken>())
+            .Returns(Result<StandardTaskResponse>.Fail(new Error("BusinessRule", "wrong operator cannot reject")));
+        _executorRegistry.GetExecutor(Arg.Any<TaskType>())
+            .Returns(Result<ITaskExecutor>.Ok(executor));
+
+        UsePersistenceStrategy(new TrackingPersistenceStrategy(completionDelay: TimeSpan.Zero));
+
+        // Issue's boundary config: Retry rule for HTTP codes + Ignore wildcard fallback.
+        var errorBoundary = ErrorBoundary.WithRules(
+            new ErrorHandlerRule
+            {
+                Action = ErrorAction.Retry,
+                ErrorCodes = ["409", "500", "503", "504", "429", "408"],
+                Priority = 1,
+                RetryPolicy = new RetryPolicy { MaxRetries = 3, UseJitter = false }
+            },
+            new ErrorHandlerRule
+            {
+                Action = ErrorAction.Ignore,
+                ErrorCodes = ["*"],
+                Priority = 999,
+                LogOnly = true
+            });
+
+        var onExecute = OnExecuteTask.Create(1, task, ScriptCode.FromNative(string.Empty), errorBoundary);
+        var engine = CreateEngine();
+
+        // Act
+        var result = await engine.ExecuteAsync(onExecute, Guid.NewGuid(), TaskTrigger.OnExecute, CreateScriptContext(), CancellationToken.None);
+
+        // Assert: Ignore resolution => pipeline continues (not a hard failure/fault) with zero retries.
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.ShouldNotBeNull();
+        result.Value!.HasFailedTasks.ShouldBeTrue();
+        await executor.Received(1).ExecuteAsync(Arg.Any<TaskExecutorContext>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Test double that records whether the completion persist ran to completion, with an
+    /// optional delay so an un-awaited (fire-and-forget) call is observably incomplete when
+    /// ExecuteAsync returns.
+    /// </summary>
+    private sealed class TrackingPersistenceStrategy(TimeSpan completionDelay) : ITaskPersistenceStrategy
+    {
+        public bool CompletionFinished { get; private set; }
+        public int CompletionCallCount { get; private set; }
+
+        public bool CanHandle(TaskTrigger taskTrigger) => true;
+
+        public Task HandleCreationAsync(InstanceTask instanceTask, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public async Task HandleCompletionAsync(InstanceTask instanceTask, CancellationToken cancellationToken = default)
+        {
+            CompletionCallCount++;
+            if (completionDelay > TimeSpan.Zero)
+                await Task.Delay(completionDelay, cancellationToken);
+            CompletionFinished = true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #807 — an ErrorBoundary fallback-resolution `DbContext` concurrency race that drove instances irreversibly to `Faulted (F)` even when a configured `action=3 (Ignore)` boundary should have failed the transition atomically and kept the instance in its source state.

## Root cause

When a transition `OnExecute` task failed, `TaskExecutionEngine.RecordFailure` fired an **un-awaited** persistence write:

```csharp
_ = strategy.HandleCompletionAsync(instanceTask, cancellationToken); // fire-and-forget
```

That resolves to `instanceTaskRepository.UpdateAsync(..., autoSave: true)` → an immediate `SaveChangesAsync` on the **request-scoped `WorkflowDbContext`**. On the single-task error path (which, unlike parallel task groups, shares the pipeline's `DbContext`), control returned while that `SaveChangesAsync` was still in flight, so the pipeline's next awaited write (e.g. `RunOnExecuteTasksStep`'s instance update) overlapped it and tripped EF Core's `ConcurrencyDetector`:

> "A second operation was started on this context instance before a previous operation completed."

The unhandled `InvalidOperationException` escaped the step and faulted the instance, **overriding** the `Ignore` boundary. The success path already awaited the same persist (`PersistCompletionAsync`); only the failure path fire-and-forgot.

The issue's secondary hypothesis — that a code-less exception wrongly matched the `Retry` rule — was **disproven** during investigation: matching correctly rejects the HTTP-code retry rule and lands on the `["*"]` `Ignore` rule with zero retries. The real problem there was a misleading log that always said "Retry exhausted" even when no retry ran, which is what led to the original misdiagnosis.

## Changes

- **Fix the race:** `RecordFailure` → `async RecordFailureAsync`; the completion persist is now **awaited** inside a `try/catch`, so it cannot race the pipeline's next `DbContext` operation and cannot throw an unhandled exception into the boundary-resolution path. Both call sites in `ExecuteCoreAsync` updated to `await`.
- **Clarify the log:** `HandlePostRetryFailureAsync` now takes the actual attempt count and logs `"No matching Retry rule..."` when zero retries ran (the common no-HTTP-code case) vs. `"Retry exhausted after N attempt(s)..."` when retries actually occurred.

## Tests

New `TaskExecutionEngineTests`:
- **Regression guard** — asserts the failure-path completion persist finishes before `ExecuteAsync` returns. Verified it **fails on the pre-fix fire-and-forget** and **passes after the fix**.
- **Behavioral** — a code-less task failure with the issue's boundary config resolves to `Ignore` with **zero retries** and a non-faulting result.

## Verification

- `dotnet test --filter TaskExecutionEngineTests` → green (2/2).
- Full `BBT.Workflow.Application.Tests` suite: no new failures introduced (the pre-existing failures on `master` are unrelated to task execution — confirmed by running the suite on a clean tree).

## Reviewer notes

Out of scope, noted as follow-ups (not addressed here):
- `TransitionPipeline.MarkInstanceFaultedFromPostCommitAsync` uses the ambient `DbContext` (unlike `MarkInstanceFaultedAsync`, which opens a `RequiresNew` UoW) — a secondary concurrency risk.
- `CompiledBoundaryChain.FindMatch` matches on `error.Code` while `FindMatchExcluding` matches on `error.OriginalCode` — an inconsistency that doesn't change the outcome for wildcard rules but is worth reconciling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure task failure persistence is awaited to avoid DbContext concurrency races and clarify retry vs. ignore behavior in task execution error handling.

Bug Fixes:
- Await task failure persistence to prevent concurrent DbContext operations from throwing and incorrectly faulting workflow instances when an Ignore boundary is configured.
- Differentiate logging messages between exhausted retries and cases where no Retry rule matches to avoid misleading "Retry exhausted" logs.

Tests:
- Add regression tests verifying failure-path completion persistence completes before ExecuteAsync returns and that code-less task failures resolve to Ignore with zero retries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Task execution now waits for failure details to finish saving before returning.
  * Failure handling is more reliable when an error does not include an HTTP status code.
  * Retry reporting now accurately reflects whether retry attempts were performed.
  * Errors encountered while saving failure details are handled without disrupting workflow resolution.

* **Tests**
  * Added coverage for failure persistence timing, fallback handling, and zero-retry scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->