### PR TITLE
v0.0.70

### DIFF
--- a/monitoring/BBT.Workflow.Monitor.Application/Instances/MonitorInstanceQueryService.cs
+++ b/monitoring/BBT.Workflow.Monitor.Application/Instances/MonitorInstanceQueryService.cs
@@ -7,6 +7,7 @@ using BBT.Workflow;
 using BBT.Workflow.Caching;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Definitions.GraphQL;
+using BBT.Workflow.Definitions.Schemas;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Monitor.Common.DTOs;
 using BBT.Workflow.Monitor.Instances.DTOs;
@@ -62,6 +63,7 @@ public sealed class MonitorInstanceQueryService(
                 input.GroupBy,
                 input.Aggregations,
                 input.Sort,
+                null,
                 ct);
 
             if (result.Groups is { Count: > 0 })

--- a/src/BBT.Workflow.Application/Execution/Transitions/Strategy/AsyncTransitionStrategy.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Strategy/AsyncTransitionStrategy.cs
@@ -145,26 +145,27 @@ public sealed class AsyncTransitionStrategy(
 
                 if (!ctx.Directives.IsInternalResume)
                 {
-                    if (isReserved)
-                    {
-                        // Reserved transitions are accepted while the instance is Busy by design.
-                        await instanceBusyManager.MarkBusyWithPropagationAsync(ctx.Instance.Id, cancellationToken);
-                    }
-                    else
-                    {
-                        // Explicit Busy admission guard: with the accept lock scoped away from the
-                        // execution lock, an in-flight transition no longer blocks this key — reject
-                        // here so a normal transition cannot be accepted while another is queued/running.
-                        var busyOutcome = await instanceBusyManager.TryMarkBusyWithPropagationAsync(
-                            ctx.Instance.Id, cancellationToken);
-                        if (busyOutcome == BusyMarkOutcome.AlreadyBusy)
-                        {
-                            logger.AsyncTransitionRejectedInstanceBusy(ctx.TransitionKey, ctx.InstanceId);
-                            lockScopeResult = Result<TransitionExecutionContext>.Fail(
-                                WorkflowErrors.InstanceBusy(ctx.InstanceId, ctx.TransitionKey));
-                            return;
-                        }
-                    }
+                    await instanceBusyManager.MarkBusyWithPropagationAsync(ctx.Instance.Id, cancellationToken);
+                    // if (isReserved)
+                    // {
+                    //     // Reserved transitions are accepted while the instance is Busy by design.
+                    //     await instanceBusyManager.MarkBusyWithPropagationAsync(ctx.Instance.Id, cancellationToken);
+                    // }
+                    // else
+                    // {
+                    //     // Explicit Busy admission guard: with the accept lock scoped away from the
+                    //     // execution lock, an in-flight transition no longer blocks this key — reject
+                    //     // here so a normal transition cannot be accepted while another is queued/running.
+                    //     var busyOutcome = await instanceBusyManager.TryMarkBusyWithPropagationAsync(
+                    //         ctx.Instance.Id, cancellationToken);
+                    //     if (busyOutcome == BusyMarkOutcome.AlreadyBusy)
+                    //     {
+                    //         logger.AsyncTransitionRejectedInstanceBusy(ctx.TransitionKey, ctx.InstanceId);
+                    //         lockScopeResult = Result<TransitionExecutionContext>.Fail(
+                    //             WorkflowErrors.InstanceBusy(ctx.InstanceId, ctx.TransitionKey));
+                    //         return;
+                    //     }
+                    // }
                 }
 
                 var enqueueResult = await EnqueueAndSaveJobAsync(context, ctx, activity, cancellationToken);

--- a/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceCommandAppService.cs
@@ -728,7 +728,7 @@ public sealed class InstanceCommandAppService(
             // Workflow output mapping bypasses the standard envelope, but NEVER for subflow
             // instances: correlation forward (sub start) and subflow transitions rely on the
             // standard model, so output is ignored even when configured.
-            if (!instance.IsSubItem)
+            if (!instance.IsSubFlow)
             {
                 var outputResult = await workflowOutputMappingService.ApplyAsync(workflow, scriptContext, cancellationToken);
                 if (outputResult.IsSuccess && outputResult.Value is { } wo)

--- a/src/BBT.Workflow.Application/Tasks/Coordinator/TaskExecutionEngine.cs
+++ b/src/BBT.Workflow.Application/Tasks/Coordinator/TaskExecutionEngine.cs
@@ -180,6 +180,7 @@ public sealed class TaskExecutionEngine : ITaskExecutionEngine
                 onExecuteTask,
                 boundaryChain,
                 totalStopwatch.ElapsedMilliseconds,
+                attempt,
                 cancellationToken);
         }
         catch (Exception ex)
@@ -203,6 +204,7 @@ public sealed class TaskExecutionEngine : ITaskExecutionEngine
     /// <param name="onExecuteTask">The task definition that failed.</param>
     /// <param name="boundaryChain">The compiled boundary chain for resolution.</param>
     /// <param name="totalDurationMs">Total execution duration including retries.</param>
+    /// <param name="attemptsMade">Number of retry attempts actually performed (0 when no Retry rule matched).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The execution result with appropriate boundary action.</returns>
     private async Task<Result<TasksExecutionResult>> HandlePostRetryFailureAsync(
@@ -210,6 +212,7 @@ public sealed class TaskExecutionEngine : ITaskExecutionEngine
         OnExecuteTask onExecuteTask,
         CompiledBoundaryChain boundaryChain,
         long totalDurationMs,
+        int attemptsMade,
         CancellationToken cancellationToken)
     {
         var taskKey = onExecuteTask.Task.Key;
@@ -233,9 +236,18 @@ public sealed class TaskExecutionEngine : ITaskExecutionEngine
                 failedResult.Error, taskKey, "Unknown", totalDurationMs);
         }
 
-        _logger.LogWarning(
-            "Retry exhausted for task {TaskKey}. Resolving fallback boundary action (excluding Retry). Error: {Error}",
-            taskKey, executionError.ErrorMessage);
+        if (attemptsMade > 0)
+        {
+            _logger.LogWarning(
+                "Retry exhausted for task {TaskKey} after {Attempts} attempt(s). Resolving fallback boundary action (excluding Retry). Error: {Error}",
+                taskKey, attemptsMade, executionError.ErrorMessage);
+        }
+        else
+        {
+            _logger.LogWarning(
+                "No matching Retry rule for task {TaskKey}. Resolving fallback boundary action. Error: {Error}",
+                taskKey, executionError.ErrorMessage);
+        }
 
         // Resolve boundary for fallback actions - EXCLUDE Retry since it's already exhausted
         var resolution = _boundaryResolver.ResolveExcluding(
@@ -417,7 +429,14 @@ public sealed class TaskExecutionEngine : ITaskExecutionEngine
     /// <summary>
     /// Records task failure metrics and persists the failure.
     /// </summary>
-    private void RecordFailure(
+    /// <remarks>
+    /// The completion persist is awaited (not fire-and-forget) so its SaveChanges cannot race the
+    /// pipeline's next write on the shared request-scoped DbContext, which previously tripped EF Core's
+    /// ConcurrencyDetector and faulted the instance even when an Ignore boundary should have handled the
+    /// failure (issue #807). Persistence errors are caught and logged so recording a failure never throws
+    /// an unhandled exception into the boundary-resolution path.
+    /// </remarks>
+    private async Task RecordFailureAsync(
         InstanceTask instanceTask,
         ITaskPersistenceStrategy? strategy,
         string taskType,
@@ -430,7 +449,15 @@ public sealed class TaskExecutionEngine : ITaskExecutionEngine
 
         if (strategy != null)
         {
-            _ = strategy.HandleCompletionAsync(instanceTask, cancellationToken);
+            try
+            {
+                await strategy.HandleCompletionAsync(instanceTask, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "Failed to persist task failure for {TaskKey}", instanceTask.TaskId);
+            }
         }
 
         _workflowMetrics.RecordTaskFailed(taskType, workflowKey, stopwatch.Elapsed.TotalSeconds);
@@ -519,7 +546,7 @@ public sealed class TaskExecutionEngine : ITaskExecutionEngine
         if (!executorResult.IsSuccess)
         {
             stopwatch.Stop();
-            RecordFailure(instanceTask, persistenceStrategy, taskTypeStr, workflowKey, stopwatch,
+            await RecordFailureAsync(instanceTask, persistenceStrategy, taskTypeStr, workflowKey, stopwatch,
                 executorResult.Error.Message, cancellationToken);
 
             var infraError = _errorFactory.CreateFromError(
@@ -559,7 +586,7 @@ public sealed class TaskExecutionEngine : ITaskExecutionEngine
         // 9. Handle infrastructure error - return without boundary resolution (not retriable)
         if (!executeResult.IsSuccess)
         {
-            RecordFailure(instanceTask, persistenceStrategy, taskTypeStr, workflowKey, stopwatch,
+            await RecordFailureAsync(instanceTask, persistenceStrategy, taskTypeStr, workflowKey, stopwatch,
                 executeResult.Error.Message ?? "Unknown infrastructure error", cancellationToken);
 
             var infraError = _errorFactory.CreateFromError(

--- a/src/BBT.Workflow.Application/Tasks/Coordinator/TaskExecutionEngine.cs
+++ b/src/BBT.Workflow.Application/Tasks/Coordinator/TaskExecutionEngine.cs
@@ -453,7 +453,7 @@ public sealed class TaskExecutionEngine : ITaskExecutionEngine
             {
                 await strategy.HandleCompletionAsync(instanceTask, cancellationToken);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 _logger.LogError(ex,
                     "Failed to persist task failure for {TaskKey}", instanceTask.TaskId);

--- a/test/BBT.Workflow.Application.Tests/Tasks/Coordinator/TaskExecutionEngineTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Tasks/Coordinator/TaskExecutionEngineTests.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.Guids;
+using BBT.Aether.Results;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Execution.ErrorHandling;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Monitoring;
+using BBT.Workflow.Runtime;
+using BBT.Workflow.Scripting;
+using BBT.Workflow.Tasks.Executors;
+using BBT.Workflow.Tasks.Factory;
+using BBT.Workflow.Tasks.Persistence;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Application.Tests.Tasks.Coordinator;
+
+using BBT.Workflow.Tasks.Coordinator;
+
+/// <summary>
+/// Regression tests for <see cref="TaskExecutionEngine"/> covering the error/fallback path.
+/// Guards issue #807: a task failure resolved by an Ignore boundary must not fault the instance,
+/// and the failure-path completion persist must be fully awaited (no fire-and-forget) so it cannot
+/// race the pipeline's next DbContext write.
+/// </summary>
+public sealed class TaskExecutionEngineTests
+{
+    private readonly ITaskExecutorRegistry _executorRegistry = Substitute.For<ITaskExecutorRegistry>();
+    private readonly ITaskFactory _taskFactory = Substitute.For<ITaskFactory>();
+    private readonly ITaskPersistenceStrategyFactory _persistenceStrategyFactory = Substitute.For<ITaskPersistenceStrategyFactory>();
+    private readonly IGuidGenerator _guidGenerator = Substitute.For<IGuidGenerator>();
+    private readonly IWorkflowMetrics _workflowMetrics = Substitute.For<IWorkflowMetrics>();
+
+    // Real error-handling collaborators so boundary resolution is authentic.
+    private readonly IErrorBoundaryResolver _boundaryResolver = new ErrorBoundaryResolver(NullLogger<ErrorBoundaryResolver>.Instance);
+    private readonly IErrorActionExecutor _actionExecutor = new ErrorActionExecutor(NullLogger<ErrorActionExecutor>.Instance);
+    private readonly IExecutionErrorFactory _errorFactory = new ExecutionErrorFactory(new ErrorNormalizer());
+
+    public TaskExecutionEngineTests()
+    {
+        _guidGenerator.Create().Returns(_ => Guid.NewGuid());
+    }
+
+    private TaskExecutionEngine CreateEngine() => new(
+        _executorRegistry,
+        _taskFactory,
+        _persistenceStrategyFactory,
+        _guidGenerator,
+        _workflowMetrics,
+        _boundaryResolver,
+        _actionExecutor,
+        _errorFactory,
+        NullLogger<TaskExecutionEngine>.Instance);
+
+    private static ScriptContext CreateScriptContext()
+    {
+        var instance = Instance.Create(Guid.NewGuid(), "test-flow", "1.0", "ctx-key");
+        return new ScriptContext.Builder(NullLogger<ScriptContext>.Instance)
+            .SetRuntime(Substitute.For<IRuntimeInfoProvider>())
+            .SetInstance(instance)
+            .Build();
+    }
+
+    private void UsePersistenceStrategy(ITaskPersistenceStrategy strategy)
+    {
+        _persistenceStrategyFactory.GetStrategy(Arg.Any<TaskTrigger>())
+            .Returns(Result<ITaskPersistenceStrategy>.Ok(strategy));
+    }
+
+    /// <summary>
+    /// Issue #807 core regression: on a task failure the completion persist is awaited to
+    /// completion before ExecuteAsync returns. With the previous fire-and-forget (`_ = ...`),
+    /// control returned while the SaveChanges was still in flight, racing the pipeline's next
+    /// DbContext write and tripping EF Core's ConcurrencyDetector.
+    /// </summary>
+    [Fact]
+    public async Task ExecuteAsync_WhenTaskFails_AwaitsFailurePersistBeforeReturning()
+    {
+        // Arrange: reach the failure branch via an executor-not-found result.
+        var task = WorkflowTaskFactory.CreateHttpTask("mock-api");
+        _taskFactory.CreateExecutionTaskAsync(Arg.Any<IReference>(), Arg.Any<CancellationToken>())
+            .Returns(Result<WorkflowTask>.Ok(task));
+        _executorRegistry.GetExecutor(Arg.Any<TaskType>())
+            .Returns(Result<ITaskExecutor>.Fail(new Error("500", "no executor registered")));
+
+        var strategy = new TrackingPersistenceStrategy(completionDelay: TimeSpan.FromMilliseconds(75));
+        UsePersistenceStrategy(strategy);
+
+        var onExecute = OnExecuteTask.Create(1, task, ScriptCode.FromNative(string.Empty));
+        var engine = CreateEngine();
+
+        // Act
+        await engine.ExecuteAsync(onExecute, Guid.NewGuid(), TaskTrigger.OnExecute, CreateScriptContext(), CancellationToken.None);
+
+        // Assert: the failure persist finished before ExecuteAsync returned (no fire-and-forget).
+        strategy.CompletionFinished.ShouldBeTrue(
+            "the failure-path completion persist must be awaited before ExecuteAsync returns");
+        strategy.CompletionCallCount.ShouldBe(1);
+    }
+
+    /// <summary>
+    /// Issue #807 behavioral guard: a code-less exception (no HTTP error code) does not match the
+    /// Retry rule; it lands on the Ignore wildcard, runs zero retries, and the engine returns a
+    /// success result (pipeline continues, instance not faulted).
+    /// </summary>
+    [Fact]
+    public async Task ExecuteAsync_WhenTaskFailsWithNoErrorCode_ResolvesToIgnore_WithZeroRetries()
+    {
+        // Arrange: executor exists but the task fails at execution (mirrors an InputHandler failure,
+        // which surfaces as a Result.Fail with no HTTP status code).
+        var task = WorkflowTaskFactory.CreateHttpTask("mock-api");
+        _taskFactory.CreateExecutionTaskAsync(Arg.Any<IReference>(), Arg.Any<CancellationToken>())
+            .Returns(Result<WorkflowTask>.Ok(task));
+
+        var executor = Substitute.For<ITaskExecutor>();
+        executor.ExecuteAsync(Arg.Any<TaskExecutorContext>(), Arg.Any<CancellationToken>())
+            .Returns(Result<StandardTaskResponse>.Fail(new Error("BusinessRule", "wrong operator cannot reject")));
+        _executorRegistry.GetExecutor(Arg.Any<TaskType>())
+            .Returns(Result<ITaskExecutor>.Ok(executor));
+
+        UsePersistenceStrategy(new TrackingPersistenceStrategy(completionDelay: TimeSpan.Zero));
+
+        // Issue's boundary config: Retry rule for HTTP codes + Ignore wildcard fallback.
+        var errorBoundary = ErrorBoundary.WithRules(
+            new ErrorHandlerRule
+            {
+                Action = ErrorAction.Retry,
+                ErrorCodes = ["409", "500", "503", "504", "429", "408"],
+                Priority = 1,
+                RetryPolicy = new RetryPolicy { MaxRetries = 3, UseJitter = false }
+            },
+            new ErrorHandlerRule
+            {
+                Action = ErrorAction.Ignore,
+                ErrorCodes = ["*"],
+                Priority = 999,
+                LogOnly = true
+            });
+
+        var onExecute = OnExecuteTask.Create(1, task, ScriptCode.FromNative(string.Empty), errorBoundary);
+        var engine = CreateEngine();
+
+        // Act
+        var result = await engine.ExecuteAsync(onExecute, Guid.NewGuid(), TaskTrigger.OnExecute, CreateScriptContext(), CancellationToken.None);
+
+        // Assert: Ignore resolution => pipeline continues (not a hard failure/fault) with zero retries.
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.ShouldNotBeNull();
+        result.Value!.HasFailedTasks.ShouldBeTrue();
+        await executor.Received(1).ExecuteAsync(Arg.Any<TaskExecutorContext>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Test double that records whether the completion persist ran to completion, with an
+    /// optional delay so an un-awaited (fire-and-forget) call is observably incomplete when
+    /// ExecuteAsync returns.
+    /// </summary>
+    private sealed class TrackingPersistenceStrategy(TimeSpan completionDelay) : ITaskPersistenceStrategy
+    {
+        public bool CompletionFinished { get; private set; }
+        public int CompletionCallCount { get; private set; }
+
+        public bool CanHandle(TaskTrigger taskTrigger) => true;
+
+        public Task HandleCreationAsync(InstanceTask instanceTask, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public async Task HandleCompletionAsync(InstanceTask instanceTask, CancellationToken cancellationToken = default)
+        {
+            CompletionCallCount++;
+            if (completionDelay > TimeSpan.Zero)
+                await Task.Delay(completionDelay, cancellationToken);
+            CompletionFinished = true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

Strengthen task failure handling and monitoring behavior, simplify async transition busy-marking, and adjust instance output enrichment and monitoring queries.

Bug Fixes:
- Ensure task failure persistence is fully awaited and does not race subsequent DbContext writes, preventing instances from being faulted when an Ignore boundary should handle the error (issue #807).
- Correct subflow output enrichment by using the proper subflow flag so workflow output is not applied to subflow instances.
- Adjust monitor instance queries to pass the new schema parameter required by the aggregation service.

Enhancements:
- Improve retry failure logging with distinct messages for exhausted retries versus no matching retry rule, including the number of attempts when applicable.
- Simplify async transition busy-marking semantics by always marking instances busy for non-internal resumes.
- Add regression tests around TaskExecutionEngine error and fallback paths to ensure failure persistence is awaited and Ignore boundaries prevent instance faults.

Tests:
- Add TaskExecutionEngine regression tests covering failure persistence awaiting and Ignore boundary behavior to guard against issue #807.