### PR TITLE
feat(tasks): add GetInstanceTask trigger task type (#806)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ describe the stable mental model, boundaries, failure modes, and change-safety r
 8. Read [Long-Poll Termination on State Entry](domain/long-poll-termination.md) before changing State-function long-poll behavior or the pipeline pause/resume path.
 9. Read [Event-Driven Workflows](domain/event-driven-workflows.md) before wiring external events into workflows or transitions (event mappings, Dapr subscriptions, correlation).
 10. Read [Instance Filtering and Queries](runtime/instance-filtering-and-queries.md) before writing instance queries in mapping scripts (fluent `InstanceQuery`, operator reference, `GetInstancesTask` vs `DaprServiceTask`, migration from hand-written GraphQL filters).
+11. Read [GetInstance Task](runtime/get-instance-task.md) when a mapping needs a single instance's metadata **and** data in one call (task type `18`, local/remote response parity).
 
 ## Documentation Rules
 

--- a/docs/runtime/get-instance-task.md
+++ b/docs/runtime/get-instance-task.md
@@ -1,0 +1,83 @@
+# GetInstance Task
+
+`GetInstanceTask` (type `"18"`) is a trigger task that retrieves a **full single-instance
+projection** — metadata **and** data — for a workflow instance. It is the task-level equivalent of:
+
+```
+GET /api/v1/{domain}/workflows/{workflow}/instances/{instance}
+```
+
+It complements the two existing instance-query tasks:
+
+| Task | Type | Returns | Endpoint |
+|------|------|---------|----------|
+| `GetInstancesTask` | 15 | Paged/grouped list | `GET .../instances` |
+| `GetInstanceDataTask` | 13 | Data (attributes) only | `GET .../instances/{instance}/data` |
+| **`GetInstanceTask`** | **18** | **Full projection (metadata + attributes)** | `GET .../instances/{instance}` |
+
+## When to use
+
+Use `GetInstanceTask` when a mapping needs both the instance **metadata** (state, status, audit,
+duration, incident info) and its **attributes** in a single call — for example, to branch on the
+target instance's `status`/`currentState` while also reading its data.
+
+If you only need the attributes, prefer `GetInstanceDataTask` (lighter payload).
+
+## Response shape (local == remote)
+
+The response exposed to the script context is a `GetInstanceOutput`:
+
+```jsonc
+{
+  "id": "d2d65771-5595-44aa-b0e5-630353d87a80",
+  "key": "...",
+  "flow": "...",
+  "domain": "...",
+  "flowVersion": "...",
+  "eTag": "\"...\"",
+  "tags": [],
+  "metadata": {
+    "currentState": "...",
+    "effectiveState": "...",
+    "status": "A",
+    "createdAt": "...",
+    "modifiedAt": "...",
+    "incident": { /* present only when the instance has incidents */ }
+  },
+  "attributes": { /* instance data */ },
+  "extensions": { /* present only when extensions requested */ }
+}
+```
+
+Same-domain execution runs in-process through `IInstanceQueryGateway.GetInstanceAsync`; cross-domain
+execution calls the same REST endpoint on the target domain (HTTP or Dapr). **Both paths surface the
+identical `GetInstanceOutput` template**, so a single mapping works regardless of where the target
+instance lives. `304 Not Modified` (ETag) is handled the same as `GetInstanceDataTask`.
+
+## Definition example
+
+```jsonc
+{
+  "key": "load-account",
+  "type": "18",
+  "domain": "core",
+  "flow": "account-opening",
+  "instanceId": "d2d65771-5595-44aa-b0e5-630353d87a80",
+  // or: "key": "some-business-key"
+  "extensions": [],
+  "useDapr": false,
+  "validateSsl": true,
+  "timeoutSeconds": 30
+}
+```
+
+Either `instanceId` (GUID) or `key` (business key) must be supplied; `instanceId` takes precedence.
+
+## Mapping example
+
+```csharp
+// OutputHandler mapping — reads the StandardTaskResponse
+var response = context.GetTaskResponse("load-account");
+var status = response.Data.metadata.status;      // "A", "C", "F", ...
+var amount = response.Data.attributes.amount;     // instance data
+```

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/appsettings.json
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/appsettings.json
@@ -181,6 +181,7 @@
       "DaprServiceTask",
       "DirectTriggerTask",
       "GetInstanceDataTask",
+      "GetInstanceTask",
       "HttpTask",
       "HumanTask",
       "NotificationTask",

--- a/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/TaskServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/TaskServiceCollectionExtensions.cs
@@ -112,6 +112,7 @@ public static class TaskServiceCollectionExtensions
         services.AddTaskExecutor<DirectTriggerTaskExecutor>();
         services.AddTaskExecutor<GetInstanceDataTaskExecutor>();
         services.AddTaskExecutor<GetInstancesTaskExecutor>();
+        services.AddTaskExecutor<GetInstanceTaskExecutor>();
 
         return services;
     }

--- a/src/BBT.Workflow.Application/Tasks/Executors/Core/TaskExecutorBase.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Core/TaskExecutorBase.cs
@@ -256,6 +256,7 @@ public abstract class TaskExecutorBase<TTask>(ILogger logger) : ITaskExecutor
         DirectTriggerTask directTrigger => directTrigger.AcceptedStatusCodes,
         GetInstancesTask getInstances => getInstances.AcceptedStatusCodes,
         GetInstanceDataTask getInstanceData => getInstanceData.AcceptedStatusCodes,
+        GetInstanceTask getInstance => getInstance.AcceptedStatusCodes,
         StartTask startTask => startTask.AcceptedStatusCodes,
         SubProcessTask subProcess => subProcess.AcceptedStatusCodes,
         _ => null

--- a/src/BBT.Workflow.Application/Tasks/Executors/Trigger/GetInstanceTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Trigger/GetInstanceTaskExecutor.cs
@@ -1,0 +1,274 @@
+using System.Text.Json;
+using BBT.Aether.Results;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Discovery;
+using BBT.Workflow.Execution;
+using BBT.Workflow.Execution.Bindings;
+using BBT.Workflow.Gateway;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Logging;
+using BBT.Workflow.Runtime;
+using BBT.Workflow.Scripting;
+using BBT.Workflow.Tasks.Mapping;
+using Microsoft.Extensions.Logging;
+
+namespace BBT.Workflow.Tasks.Executors;
+
+/// <summary>
+/// Executor for GetInstance tasks that retrieve a full instance projection (metadata + data)
+/// from workflow instances. Domain-aware: uses the local IInstanceQueryGateway for the same domain,
+/// RemoteInvokerService for cross-domain execution. Both paths surface an identical
+/// <see cref="GetInstanceOutput"/> shape to the script context.
+/// </summary>
+public sealed class GetInstanceTaskExecutor : TriggerTaskExecutorBase<GetInstanceTask>
+{
+    private readonly IInstanceQueryGateway _instanceQueryGateway;
+    private readonly IDomainDiscoveryResolver _endpointResolver;
+
+    /// <summary>
+    /// Initializes a new instance of GetInstanceTaskExecutor.
+    /// </summary>
+    public GetInstanceTaskExecutor(
+        IScriptEngine scriptEngine,
+        IRuntimeInfoProvider runtimeInfoProvider,
+        IRemoteInvokerService remoteInvoker,
+        IInstanceQueryGateway instanceQueryGateway,
+        IDomainDiscoveryResolver endpointResolver,
+        ILogger<GetInstanceTaskExecutor> logger)
+        : base(scriptEngine, runtimeInfoProvider, remoteInvoker, logger)
+    {
+        _instanceQueryGateway = instanceQueryGateway;
+        _endpointResolver = endpointResolver;
+    }
+
+    /// <inheritdoc />
+    public override TaskType TaskType => TaskType.GetInstance;
+
+    /// <inheritdoc />
+    protected override string GetTargetDomain(GetInstanceTask task) => task.TriggerDomain;
+
+    /// <inheritdoc />
+    protected override async Task<Result<TaskInvocationResult>> InvokeAsync(
+        GetInstanceTask task,
+        TaskExecutorContext context,
+        CancellationToken cancellationToken)
+    {
+        // Resolve instance identifier
+        var instanceIdResult = ResolveInstanceIdentifier(task);
+        if (!instanceIdResult.IsSuccess)
+        {
+            Logger.TaskInstanceResolutionFailed(
+                task.Key,
+                TaskType.ToString(),
+                context.ScriptContext?.Instance?.Id ?? Guid.Empty,
+                instanceIdResult.Error.Message ?? "Unknown error");
+            return Result<TaskInvocationResult>.Fail(instanceIdResult.Error);
+        }
+
+        var instanceIdentifier = instanceIdResult.Value!;
+        var isSameDomain = IsSameDomain(task);
+
+        Logger.LogDebug(
+            "GetInstance task {TaskKey} targeting domain {TargetDomain}, instance {InstanceId}, same domain: {IsSameDomain}",
+            task.Key, task.TriggerDomain, instanceIdentifier, isSameDomain);
+
+        if (isSameDomain)
+        {
+            return await ExecuteLocalAsync(task, instanceIdentifier, context, cancellationToken);
+        }
+
+        return await ExecuteRemoteAsync(task, instanceIdentifier, context, cancellationToken);
+    }
+
+    private static Result<string> ResolveInstanceIdentifier(GetInstanceTask task)
+    {
+        if (!string.IsNullOrEmpty(task.Identifier))
+        {
+            return Result<string>.Ok(task.Identifier);
+        }
+
+        return Result<string>.Fail(Error.Validation(
+            WorkflowErrorCodes.TaskExecution,
+            "GetInstance task requires either instanceId or key to be specified"));
+    }
+
+    private async Task<Result<TaskInvocationResult>> ExecuteLocalAsync(
+        GetInstanceTask task,
+        string instanceIdentifier,
+        TaskExecutorContext context,
+        CancellationToken cancellationToken)
+    {
+        Logger.LogDebug("Using local IInstanceQueryGateway for GetInstance task {TaskKey}", task.Key);
+
+        try
+        {
+            var headers = ConvertTaskHeadersToDictionary(task.Headers);
+
+            var input = new GetInstanceInput
+            {
+                Domain = task.TriggerDomain,
+                Workflow = task.TriggerFlow,
+                Instance = instanceIdentifier,
+                Extensions = task.Extensions,
+                Headers = headers
+            };
+
+            var result = await _instanceQueryGateway.GetInstanceAsync(input, cancellationToken);
+            if (!result.Result.IsSuccess)
+            {
+                Logger.TaskLocalExecutionFailed(
+                    task.Key,
+                    TaskType.ToString(),
+                    instanceIdentifier,
+                    result.Result.Error.Message ?? "GetInstance failed");
+                return Result<TaskInvocationResult>.Ok(TaskInvocationResult.Failure(
+                    error: result.Result.Error.Message ?? "GetInstance failed",
+                    statusCode: MapErrorToStatusCode(result.Result.Error),
+                    taskType: TaskType.ToString()));
+            }
+
+            // Handle not modified (304) scenario
+            if (result.IsNotModified)
+            {
+                return Result<TaskInvocationResult>.Ok(TaskInvocationResult.Success(
+                    data: null,
+                    statusCode: 304,
+                    taskType: TaskType.ToString(),
+                    metadata: new Dictionary<string, object>
+                    {
+                        ["NotModified"] = true
+                    }));
+            }
+
+            return Result<TaskInvocationResult>.Ok(TaskInvocationResult.Success(
+                data: result.Result.Value,
+                statusCode: 200,
+                taskType: TaskType.ToString()));
+        }
+        catch (Exception ex)
+        {
+            Logger.TaskLocalExecutionFailed(
+                task.Key,
+                TaskType.ToString(),
+                instanceIdentifier,
+                ex.Message);
+
+            return Result<TaskInvocationResult>.Fail(
+                Error.Failure(
+                    WorkflowErrorCodes.TaskExecution,
+                    $"GetInstance execution failed: {ex.Message}",
+                    detail: ex.GetType().Name));
+        }
+    }
+
+    private async Task<Result<TaskInvocationResult>> ExecuteRemoteAsync(
+        GetInstanceTask task,
+        string instanceIdentifier,
+        TaskExecutorContext context,
+        CancellationToken cancellationToken)
+    {
+        Logger.LogDebug("Using RemoteInvokerService for GetInstance task {TaskKey}", task.Key);
+
+        // Create envelope from task using TaskBindingMapper
+        var envelopeResult = TaskBindingMapper.CreateEnvelope(task);
+        if (!envelopeResult.IsSuccess)
+        {
+            Logger.TaskEnvelopeCreationFailed(
+                task.Key,
+                TaskType.ToString(),
+                context.ScriptContext?.Instance?.Id ?? Guid.Empty,
+                envelopeResult.Error.Message ?? "Failed to create envelope");
+            return Result<TaskInvocationResult>.Fail(envelopeResult.Error);
+        }
+
+        // Enrich binding with runtime context (endpoint, headers, resolved instance)
+        var enrichResult = await EnrichBindingAsync(
+            envelopeResult.Value!,
+            task.TriggerDomain,
+            task.UseDapr,
+            instanceIdentifier,
+            cancellationToken);
+
+        if (!enrichResult.IsSuccess)
+        {
+            Logger.TaskRemoteExecutionFailed(
+                task.Key,
+                TaskType.ToString(),
+                context.ScriptContext?.Instance?.Id ?? Guid.Empty,
+                enrichResult.Error.Message ?? "Failed to resolve endpoint");
+            return Result<TaskInvocationResult>.Fail(enrichResult.Error);
+        }
+
+        var traceContext = RemoteInvoker.CreateTraceContext(context.ScriptContext);
+        var result = await RemoteInvoker.InvokeAsync(
+            TaskTypes.GetInstance,
+            task.Key,
+            enrichResult.Value!,
+            traceContext,
+            cancellationToken);
+
+        if (!result.IsSuccess)
+        {
+            Logger.TaskRemoteExecutionFailed(
+                task.Key,
+                TaskType.ToString(),
+                context.ScriptContext?.Instance?.Id ?? Guid.Empty,
+                result.Error.Message ?? "Unknown error");
+        }
+
+        return result;
+    }
+
+    private async Task<Result<TaskEnvelope>> EnrichBindingAsync(
+        TaskEnvelope envelope,
+        string targetDomain,
+        bool useDapr,
+        string instanceIdentifier,
+        CancellationToken cancellationToken)
+    {
+        // Deserialize binding
+        var binding = envelope.Binding.Deserialize<GetInstanceBinding>();
+        if (binding == null)
+        {
+            return Result<TaskEnvelope>.Fail(Error.Failure(
+                WorkflowErrorCodes.TaskBindingMappingFailed,
+                "Failed to deserialize GetInstanceBinding"));
+        }
+
+        // Resolve endpoint
+        var preferredKind = useDapr ? EndpointKind.Dapr : EndpointKind.Url;
+        var endpointResult = await _endpointResolver.GetEndpointAsync(
+            targetDomain, preferredKind, cancellationToken);
+
+        if (!endpointResult.IsSuccess)
+        {
+            return Result<TaskEnvelope>.Fail(endpointResult.Error);
+        }
+
+        var endpoint = endpointResult.Value!;
+
+        // Create enriched binding with runtime context
+        var enrichedBinding = new GetInstanceBinding
+        {
+            Domain = binding.Domain,
+            Workflow = binding.Workflow,
+            Instance = instanceIdentifier,
+            Extensions = binding.Extensions,
+            ETag = binding.ETag,
+            UseDapr = binding.UseDapr,
+            ValidateSSL = binding.ValidateSSL,
+            TimeoutSeconds = binding.TimeoutSeconds,
+            Headers = binding.Headers,
+            BaseUrl = endpoint.BaseUrl.ToString(),
+            DaprAppId = endpoint.DaprAppId,
+            AcceptedStatusCodes = binding.AcceptedStatusCodes
+        };
+
+        return Result.Ok(new TaskEnvelope
+        {
+            TaskType = envelope.TaskType,
+            TaskKey = envelope.TaskKey,
+            Binding = JsonSerializer.SerializeToElement(enrichedBinding)
+        });
+    }
+}

--- a/src/BBT.Workflow.Application/Tasks/Factory/PooledTaskFactory.cs
+++ b/src/BBT.Workflow.Application/Tasks/Factory/PooledTaskFactory.cs
@@ -210,6 +210,9 @@ public static class PoolableTaskRegistry
         RegisterPoolableTask<SubProcessTask>(
             SubProcessTask.CreateEmpty,
             (source, target) => ((SubProcessTask)target).CopyFromInternal((SubProcessTask)source));
+        RegisterPoolableTask<GetInstanceTask>(
+            GetInstanceTask.CreateEmpty,
+            (source, target) => ((GetInstanceTask)target).CopyFromInternal((GetInstanceTask)source));
     }
 
     public static void RegisterPoolableTask<T>(

--- a/src/BBT.Workflow.Application/Tasks/Mapping/TaskBindingMapper.cs
+++ b/src/BBT.Workflow.Application/Tasks/Mapping/TaskBindingMapper.cs
@@ -53,7 +53,8 @@ public static class TaskBindingMapper
                 SubProcessTask subProcessTask => (TaskTypes.SubProcess, (object)MapSubProcessTask(subProcessTask)),
                 GetInstancesTask getInstancesTask => (TaskTypes.GetInstances, (object)MapGetInstancesTask(getInstancesTask)),
                 GetInstanceDataTask getDataTask => (TaskTypes.GetInstanceData, (object)MapGetInstanceDataTask(getDataTask)),
-                
+                GetInstanceTask getInstanceTask => (TaskTypes.GetInstance, (object)MapGetInstanceTask(getInstanceTask)),
+
                 // Note: DirectTriggerTask and SubProcessTask require runtime context (InstanceId, Correlation)
                 // and should use ITriggerTaskRemoteExecutor directly with pre-built bindings
                 _ => throw new NotSupportedException($"Task type {task.GetType().Name} is not supported for remote execution")
@@ -167,6 +168,24 @@ public static class TaskBindingMapper
     /// Note: Instance is resolved at runtime, this provides a basic mapping.
     /// </summary>
     private static GetInstanceDataBinding MapGetInstanceDataTask(GetInstanceDataTask task) => new()
+    {
+        Domain = task.TriggerDomain,
+        Workflow = task.TriggerFlow,
+        Instance = task.Identifier ?? string.Empty,
+        Extensions = task.Extensions,
+        ValidateSSL = task.ValidateSSL,
+        UseDapr = task.UseDapr,
+        Headers = task.Headers?.GetRawText(),
+        TimeoutSeconds = task.TimeoutSeconds,
+        ETag = null,
+        AcceptedStatusCodes = task.AcceptedStatusCodes
+    };
+
+    /// <summary>
+    /// Maps GetInstanceTask to GetInstanceBinding.
+    /// Note: Instance is resolved at runtime, this provides a basic mapping.
+    /// </summary>
+    private static GetInstanceBinding MapGetInstanceTask(GetInstanceTask task) => new()
     {
         Domain = task.TriggerDomain,
         Workflow = task.TriggerFlow,

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/GetInstanceTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/GetInstanceTask.cs
@@ -1,0 +1,307 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace BBT.Workflow.Definitions;
+
+/// <summary>
+/// Get Instance Task Definition - Retrieves a full workflow instance projection (metadata + data)
+/// from a workflow instance. Task-level equivalent of
+/// <c>GET /api/v1/{domain}/workflows/{workflow}/instances/{instance}</c>.
+/// </summary>
+public sealed class GetInstanceTask : WorkflowTask
+{
+    private GetInstanceTask()
+    {
+    }
+
+    [JsonConstructor]
+    private GetInstanceTask(JsonElement config) : base(config)
+    {
+        Type = ((int)TaskType.GetInstance).ToString();
+    }
+
+    /// <summary>
+    /// Domain of the target workflow
+    /// </summary>
+    public string TriggerDomain { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Flow name of the target workflow
+    /// </summary>
+    public string TriggerFlow { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Flow key of the target workflow (optional)
+    /// </summary>
+    public string? TriggerKey { get; private set; }
+
+    /// <summary>
+    /// InstanceId of the target workflow (optional)
+    /// </summary>
+    public Guid? TriggerInstanceId { get; private set; }
+
+    /// <summary>
+    /// Extensions to request for data enrichment (optional)
+    /// </summary>
+    public string[]? Extensions { get; private set; }
+
+    /// <summary>
+    /// Whether to use Dapr service invocation instead of direct HTTP
+    /// </summary>
+    public bool UseDapr { get; private set; } = false;
+
+    /// <summary>
+    /// Whether to validate SSL certificates
+    /// </summary>
+    public bool ValidateSSL { get; private set; } = true;
+
+    /// <summary>
+    /// Headers
+    /// </summary>
+    public JsonElement? Headers { get; private set; }
+
+    /// <summary>
+    /// Timeout seconds
+    /// </summary>
+    public int TimeoutSeconds { get; private set; } = 30;
+
+    /// <summary>
+    /// HTTP status codes that are treated as successful even when they are error codes (e.g. 403, 404).
+    /// Supports exact codes ("403") and alias patterns ("4xx", "40x", "5xx", "50x").
+    /// When a response status code matches any entry, the task is considered successful
+    /// and the ErrorBoundary is not triggered.
+    /// </summary>
+    public IReadOnlyList<string>? AcceptedStatusCodes { get; private set; }
+
+    public string? Identifier => TriggerInstanceId.HasValue ? TriggerInstanceId.Value.ToString() : TriggerKey;
+
+    public void SetInstance(string? instanceId)
+    {
+        if (!instanceId.IsNullOrWhiteSpace())
+        {
+            if (Guid.TryParse(instanceId, out var guid))
+            {
+                TriggerInstanceId = guid;
+            }
+            else
+            {
+                TriggerKey = instanceId;
+            }
+        }
+        else
+        {
+            TriggerInstanceId = null;
+        }
+    }
+
+    public void SetKey(string? key)
+    {
+        TriggerKey = key;
+    }
+
+    public void SetDomain(string domain)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(domain, nameof(domain));
+        TriggerDomain = domain;
+    }
+
+    public void SetFlow(string flow)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(flow, nameof(flow));
+        TriggerFlow = flow;
+    }
+
+    public void SetExtensions(string[] extensions)
+    {
+        Extensions = extensions;
+    }
+
+    public void SetUseDapr(bool useDapr)
+    {
+        UseDapr = useDapr;
+    }
+
+    public void SetValidateSSL(bool validateSSL)
+    {
+        ValidateSSL = validateSSL;
+    }
+
+    public void SetHeaders(Dictionary<string, string?> headers)
+    {
+        Headers = JsonSerializer.SerializeToElement(headers);
+    }
+
+    /// <summary>
+    /// Adds or updates a single header by key. If the key already exists, its value is overwritten.
+    /// </summary>
+    /// <param name="key">The header key. Must not be null or whitespace.</param>
+    /// <param name="value">The header value; can be null.</param>
+    public void AddHeader(string key, string? value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        var d = TaskHeadersHelper.ToMutableDictionary(Headers);
+        d[key] = value;
+        Headers = TaskHeadersHelper.FromDictionary(d);
+    }
+
+    /// <summary>
+    /// Removes a header by key. Does nothing if the key does not exist.
+    /// </summary>
+    /// <param name="key">The header key to remove. Must not be null or whitespace.</param>
+    public void RemoveHeader(string key)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        var d = TaskHeadersHelper.ToMutableDictionary(Headers);
+        d.Remove(key);
+        Headers = TaskHeadersHelper.FromDictionary(d);
+    }
+
+    /// <summary>
+    /// Internal property setters for object pooling
+    /// </summary>
+    internal void SetTriggerDomainInternal(string triggerDomain) => TriggerDomain = triggerDomain;
+    internal void SetTriggerFlowInternal(string triggerFlow) => TriggerFlow = triggerFlow;
+    internal void SetTriggerKeyInternal(string? triggerKey) => TriggerKey = triggerKey;
+    internal void SetTriggerInstanceIdInternal(Guid? triggerInstanceId) => TriggerInstanceId = triggerInstanceId;
+    internal void SetExtensionsInternal(string[]? extensions) => Extensions = extensions;
+    internal void SetUseDaprInternal(bool useDapr) => UseDapr = useDapr;
+    internal void SetValidateSSLInternal(bool validateSSL) => ValidateSSL = validateSSL;
+    internal void SetHeadersInternal(JsonElement? headers) => Headers = headers;
+    internal void SetTimeoutSecondsInternal(int timeoutSeconds) => TimeoutSeconds = timeoutSeconds;
+    internal void SetAcceptedStatusCodesInternal(IReadOnlyList<string>? codes) => AcceptedStatusCodes = codes;
+
+    protected override void Configure(JsonElement config)
+    {
+        base.Configure(config);
+
+        if (config.TryGetProperty("domain", out var triggerDomainElement))
+            TriggerDomain = triggerDomainElement.GetString() ?? throw new ArgumentException($"Property 'domain' is required for GetInstanceTask (Key={Key}).", nameof(config));
+
+        if (config.TryGetProperty("flow", out var triggerFlowElement))
+            TriggerFlow = triggerFlowElement.GetString() ?? throw new ArgumentException($"Property 'flow' is required for GetInstanceTask (Key={Key}).", nameof(config));
+
+        if (config.TryGetProperty("key", out var keyElement))
+            TriggerKey = keyElement.GetString();
+
+        if (config.TryGetProperty("instanceId", out var instanceIdElement))
+            TriggerInstanceId = instanceIdElement.TryGetGuid(out var instanceId) ? instanceId : null;
+
+        if (config.TryGetProperty("extensions", out var extensionsElement) && extensionsElement.ValueKind == JsonValueKind.Array)
+        {
+            var extensionsList = new List<string>();
+            foreach (var item in extensionsElement.EnumerateArray())
+            {
+                var ext = item.GetString();
+                if (!string.IsNullOrWhiteSpace(ext))
+                    extensionsList.Add(ext);
+            }
+            Extensions = extensionsList.Count > 0 ? extensionsList.ToArray() : null;
+        }
+
+        if (config.TryGetProperty("useDapr", out var useDaprElement))
+            UseDapr = useDaprElement.GetBoolean();
+
+        if (config.TryGetProperty("validateSsl", out var validateSslElement))
+            ValidateSSL = validateSslElement.GetBoolean();
+
+        if (config.TryGetProperty("headers", out var headersElement))
+        {
+            var headers = headersElement.GetRawText();
+            Headers = string.IsNullOrWhiteSpace(headers) ? null : headersElement;
+        }
+
+        if (config.TryGetProperty("timeoutSeconds", out var timeoutSeconds))
+            TimeoutSeconds = timeoutSeconds.GetInt32();
+
+        if (config.TryGetProperty("acceptedStatusCodes", out var acceptedCodesElement) &&
+            acceptedCodesElement.ValueKind == JsonValueKind.Array)
+        {
+            var codes = acceptedCodesElement.EnumerateArray()
+                .Select(e => e.GetString())
+                .Where(s => !string.IsNullOrWhiteSpace(s))
+                .Select(s => s!)
+                .ToList();
+            AcceptedStatusCodes = codes.Count > 0 ? codes : null;
+        }
+    }
+
+    public static GetInstanceTask Create(JsonElement config)
+    {
+        return new GetInstanceTask(config);
+    }
+
+    /// <summary>
+    /// Creates a deep copy of the current GetInstanceTask instance.
+    /// </summary>
+    public override WorkflowTask Clone()
+    {
+        return CloneTyped();
+    }
+
+    /// <summary>
+    /// Creates a typed deep copy of the current GetInstanceTask instance.
+    /// </summary>
+    public GetInstanceTask CloneTyped()
+    {
+        var cloned = new GetInstanceTask();
+        CopyBaseTo(cloned);
+
+        cloned.TriggerDomain = TriggerDomain;
+        cloned.TriggerFlow = TriggerFlow;
+        cloned.TriggerKey = TriggerKey;
+        cloned.TriggerInstanceId = TriggerInstanceId;
+        cloned.Extensions = Extensions;
+        cloned.UseDapr = UseDapr;
+        cloned.ValidateSSL = ValidateSSL;
+        cloned.Headers = Headers;
+        cloned.TimeoutSeconds = TimeoutSeconds;
+        cloned.AcceptedStatusCodes = AcceptedStatusCodes;
+
+        return cloned;
+    }
+
+    /// <summary>
+    /// Internal method for object pooling - copies all properties efficiently
+    /// </summary>
+    /// <param name="source">Source task to copy from</param>
+    public void CopyFromInternal(GetInstanceTask source)
+    {
+        source.CopyBaseToInternal(this);
+        SetTriggerDomainInternal(source.TriggerDomain);
+        SetTriggerFlowInternal(source.TriggerFlow);
+        SetTriggerKeyInternal(source.TriggerKey);
+        SetTriggerInstanceIdInternal(source.TriggerInstanceId);
+        SetExtensionsInternal(source.Extensions);
+        SetUseDaprInternal(source.UseDapr);
+        SetValidateSSLInternal(source.ValidateSSL);
+        SetHeadersInternal(source.Headers);
+        SetTimeoutSecondsInternal(source.TimeoutSeconds);
+        SetAcceptedStatusCodesInternal(source.AcceptedStatusCodes);
+    }
+
+    /// <summary>
+    /// Resets the task instance to a clean state for object pooling
+    /// </summary>
+    public override void Reset()
+    {
+        base.Reset();
+        TriggerDomain = string.Empty;
+        TriggerFlow = string.Empty;
+        TriggerKey = null;
+        TriggerInstanceId = null;
+        Extensions = null;
+        UseDapr = false;
+        ValidateSSL = true;
+        Headers = null;
+        TimeoutSeconds = 30;
+        AcceptedStatusCodes = null;
+    }
+
+    /// <summary>
+    /// Creates a new instance for object pooling - internal use only
+    /// </summary>
+    public static GetInstanceTask CreateEmpty()
+    {
+        return new GetInstanceTask();
+    }
+}

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/TaskEnums.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/TaskEnums.cs
@@ -24,7 +24,8 @@ public enum TaskType
     SubProcess = 14,
     GetInstances = 15,
     Soap = 16,
-    StateStore = 17
+    StateStore = 17,
+    GetInstance = 18
 }
 
 /// <summary>

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/WorkflowTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/WorkflowTask.cs
@@ -24,6 +24,7 @@ namespace BBT.Workflow.Definitions;
 [JsonDerivedType(typeof(GetInstancesTask), typeDiscriminator: "15")]
 [JsonDerivedType(typeof(SoapTask), typeDiscriminator: "16")]
 [JsonDerivedType(typeof(StateStoreTask), typeDiscriminator: "17")]
+[JsonDerivedType(typeof(GetInstanceTask), typeDiscriminator: "18")]
 public abstract class WorkflowTask : IDomainEntity, ITaskReference, IReferenceSetter, ITaskClonable
 {
     protected WorkflowTask()

--- a/src/BBT.Workflow.Execution.Abstractions/Bindings/GetInstanceBinding.cs
+++ b/src/BBT.Workflow.Execution.Abstractions/Bindings/GetInstanceBinding.cs
@@ -1,0 +1,69 @@
+namespace BBT.Workflow.Execution.Bindings;
+
+/// <summary>
+/// Binding configuration for GetInstance task execution.
+/// Used to retrieve a full instance projection (metadata + data) from a remote domain.
+/// </summary>
+public sealed class GetInstanceBinding
+{
+    /// <summary>
+    /// Target domain where the workflow instance resides.
+    /// </summary>
+    public required string Domain { get; init; }
+
+    /// <summary>
+    /// Target workflow key.
+    /// </summary>
+    public required string Workflow { get; init; }
+
+    /// <summary>
+    /// Target instance ID (can be Guid string or key).
+    /// </summary>
+    public required string Instance { get; init; }
+
+    /// <summary>
+    /// Optional extensions to include in the response.
+    /// </summary>
+    public string[]? Extensions { get; init; }
+
+    /// <summary>
+    /// Optional ETag for conditional request.
+    /// </summary>
+    public string? ETag { get; init; }
+
+    /// <summary>
+    /// Whether to use Dapr service invocation instead of direct HTTP.
+    /// </summary>
+    public bool UseDapr { get; init; } = false;
+
+    /// <summary>
+    /// Whether to validate SSL certificates.
+    /// </summary>
+    public bool ValidateSSL { get; init; } = true;
+
+    /// <summary>
+    /// Request headers as JSON string.
+    /// </summary>
+    public string? Headers { get; init; }
+
+    /// <summary>
+    /// Timeout seconds for HTTP requests.
+    /// </summary>
+    public int TimeoutSeconds { get; init; } = 30;
+
+    /// <summary>
+    /// Resolved base URL for HTTP requests.
+    /// </summary>
+    public string? BaseUrl { get; init; }
+
+    /// <summary>
+    /// Dapr application ID for service invocation.
+    /// </summary>
+    public string? DaprAppId { get; init; }
+
+    /// <summary>
+    /// HTTP status codes that should be treated as successful task invocation results.
+    /// Supports exact codes such as "400" and wildcard patterns such as "4xx".
+    /// </summary>
+    public IReadOnlyList<string>? AcceptedStatusCodes { get; init; }
+}

--- a/src/BBT.Workflow.Execution.Abstractions/TaskTypes.cs
+++ b/src/BBT.Workflow.Execution.Abstractions/TaskTypes.cs
@@ -23,5 +23,6 @@ public static class TaskTypes
     public const string SubProcess = "subprocess";
     public const string GetInstanceData = "getinstancedata";
     public const string GetInstances = "getinstances";
+    public const string GetInstance = "getinstance";
 }
 

--- a/src/BBT.Workflow.Execution/Invokers/GetInstanceRemoteInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/GetInstanceRemoteInvoker.cs
@@ -1,0 +1,310 @@
+using System.Diagnostics;
+using System.Text.Json;
+using BBT.Workflow.Execution.Bindings;
+using BBT.Workflow.Execution.Metrics;
+using Dapr.Client;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace BBT.Workflow.Execution.Invokers;
+
+/// <summary>
+/// Remote invoker for GetInstance tasks.
+/// Supports both Dapr service invocation and direct HTTP calls.
+/// Used for cross-domain full instance (metadata + data) retrieval.
+/// </summary>
+public sealed class GetInstanceRemoteInvoker : ITaskInvoker<GetInstanceBinding>
+{
+    private readonly DaprClient _daprClient;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<GetInstanceRemoteInvoker> _logger;
+    private readonly ITaskMetrics _metrics;
+    private readonly string _orchestrationAppId;
+
+    public GetInstanceRemoteInvoker(
+        DaprClient daprClient,
+        IHttpClientFactory httpClientFactory,
+        IConfiguration configuration,
+        ILogger<GetInstanceRemoteInvoker> logger,
+        ITaskMetrics? metrics = null)
+    {
+        _daprClient = daprClient;
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+        _metrics = metrics ?? NullTaskMetrics.Instance;
+        _orchestrationAppId = configuration["OrchestrationApi:AppId"] ?? "vnext-app";
+    }
+
+    /// <inheritdoc />
+    public string TaskType => TaskTypes.GetInstance;
+
+    /// <inheritdoc />
+    public Type BindingType => typeof(GetInstanceBinding);
+
+    /// <inheritdoc />
+    public async Task<TaskInvocationResult> InvokeAsync(
+        TaskDescriptor<GetInstanceBinding> descriptor,
+        CancellationToken cancellationToken = default)
+    {
+        return await ExecuteAsync(descriptor.TaskKey, descriptor.Binding, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<TaskInvocationResult> InvokeAsync(
+        string? taskKey,
+        JsonElement binding,
+        CancellationToken cancellationToken = default)
+    {
+        var typedBinding = binding.Deserialize<GetInstanceBinding>()
+            ?? throw new InvalidOperationException("Failed to deserialize GetInstanceBinding");
+
+        return await ExecuteAsync(taskKey, typedBinding, cancellationToken);
+    }
+
+    private async Task<TaskInvocationResult> ExecuteAsync(
+        string? taskKey,
+        GetInstanceBinding binding,
+        CancellationToken cancellationToken)
+    {
+        // Route to Dapr or HttpClient based on binding
+        if (binding.UseDapr && !string.IsNullOrEmpty(binding.DaprAppId))
+        {
+            return await ExecuteWithDaprAsync(taskKey, binding, cancellationToken);
+        }
+
+        return await ExecuteWithHttpClientAsync(taskKey, binding, cancellationToken);
+    }
+
+    private async Task<TaskInvocationResult> ExecuteWithDaprAsync(
+        string? taskKey,
+        GetInstanceBinding binding,
+        CancellationToken cancellationToken)
+    {
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            var appId = binding.DaprAppId ?? _orchestrationAppId;
+            var request = CreateDaprRequest(binding, appId);
+
+            using var response = await _daprClient.InvokeMethodWithResponseAsync(request, cancellationToken);
+            stopwatch.Stop();
+
+            return await ProcessResponseAsync(binding, response, stopwatch.ElapsedMilliseconds, cancellationToken);
+        }
+        catch (TaskCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            stopwatch.Stop();
+            _metrics.RecordTaskExecution(TaskType, "cancelled");
+            _logger.LogWarning("GetInstance Dapr invocation was cancelled for task {TaskKey}: {Domain}/{Workflow}/{Instance}",
+                taskKey, binding.Domain, binding.Workflow, binding.Instance);
+
+            return TaskInvocationResult.Failure(
+                error: "GetInstance remote invocation was cancelled",
+                executionDurationMs: stopwatch.ElapsedMilliseconds,
+                taskType: TaskType,
+                metadata: CreateMetadata(binding, cancelled: true));
+        }
+        catch (Exception ex)
+        {
+            stopwatch.Stop();
+            _metrics.RecordTaskExecution(TaskType, "failure");
+            _logger.LogError(ex, "GetInstance Dapr invocation failed for task {TaskKey}: {Domain}/{Workflow}/{Instance}",
+                taskKey, binding.Domain, binding.Workflow, binding.Instance);
+
+            return TaskInvocationResult.Failure(
+                error: ex.Message,
+                executionDurationMs: stopwatch.ElapsedMilliseconds,
+                taskType: TaskType,
+                metadata: CreateMetadata(binding, exceptionType: ex.GetType().Name));
+        }
+    }
+
+    private async Task<TaskInvocationResult> ExecuteWithHttpClientAsync(
+        string? taskKey,
+        GetInstanceBinding binding,
+        CancellationToken cancellationToken)
+    {
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            var httpClient = CreateHttpClient(binding, taskKey);
+            var request = CreateHttpRequest(binding);
+
+            using var response = await httpClient.SendAsync(request, cancellationToken);
+            stopwatch.Stop();
+
+            return await ProcessResponseAsync(binding, response, stopwatch.ElapsedMilliseconds, cancellationToken);
+        }
+        catch (TaskCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            stopwatch.Stop();
+            _metrics.RecordTaskExecution(TaskType, "cancelled");
+            _logger.LogWarning("GetInstance HTTP invocation was cancelled for task {TaskKey}: {Domain}/{Workflow}/{Instance}",
+                taskKey, binding.Domain, binding.Workflow, binding.Instance);
+
+            return TaskInvocationResult.Failure(
+                error: "GetInstance remote invocation was cancelled",
+                executionDurationMs: stopwatch.ElapsedMilliseconds,
+                taskType: TaskType,
+                metadata: CreateMetadata(binding, cancelled: true));
+        }
+        catch (HttpRequestException ex)
+        {
+            stopwatch.Stop();
+            _metrics.RecordTaskExecution(TaskType, "failure");
+            _logger.LogError(ex, "GetInstance HTTP invocation failed for task {TaskKey}: {Domain}/{Workflow}/{Instance}",
+                taskKey, binding.Domain, binding.Workflow, binding.Instance);
+
+            return TaskInvocationResult.Failure(
+                error: ex.Message,
+                executionDurationMs: stopwatch.ElapsedMilliseconds,
+                taskType: TaskType,
+                metadata: CreateMetadata(binding, exceptionType: ex.GetType().Name));
+        }
+        catch (Exception ex)
+        {
+            stopwatch.Stop();
+            _metrics.RecordTaskExecution(TaskType, "failure");
+            _logger.LogError(ex, "GetInstance HTTP invocation failed for task {TaskKey}: {Domain}/{Workflow}/{Instance}",
+                taskKey, binding.Domain, binding.Workflow, binding.Instance);
+
+            return TaskInvocationResult.Failure(
+                error: ex.Message,
+                executionDurationMs: stopwatch.ElapsedMilliseconds,
+                taskType: TaskType,
+                metadata: CreateMetadata(binding, exceptionType: ex.GetType().Name));
+        }
+    }
+
+    private async Task<TaskInvocationResult> ProcessResponseAsync(
+        GetInstanceBinding binding,
+        HttpResponseMessage response,
+        long executionDurationMs,
+        CancellationToken cancellationToken)
+    {
+        var responseHeaders = InvokerHelpers.MergeHeaders(response.Headers, response.Content.Headers);
+        var content = await response.ReadDecompressedContentAsync(cancellationToken);
+        var responseData = InvokerHelpers.TryParseJson(content);
+        var metadata = CreateMetadata(binding, reasonPhrase: response.ReasonPhrase);
+        var isSuccess = response.IsSuccessStatusCode
+            || AcceptedStatusCodeMatcher.IsAccepted((int)response.StatusCode, binding.AcceptedStatusCodes);
+
+        _metrics.RecordTaskExecution(TaskType, isSuccess ? "success" : "failure");
+
+        return isSuccess
+            ? TaskInvocationResult.Success(
+                data: responseData,
+                body: content,
+                statusCode: (int)response.StatusCode,
+                executionDurationMs: executionDurationMs,
+                taskType: TaskType,
+                headers: responseHeaders,
+                metadata: metadata)
+            : TaskInvocationResult.Failure(
+                error: $"HTTP {(int)response.StatusCode}: {response.ReasonPhrase}",
+                statusCode: (int)response.StatusCode,
+                body: content,
+                executionDurationMs: executionDurationMs,
+                taskType: TaskType,
+                headers: responseHeaders,
+                data: responseData,
+                metadata: metadata);
+    }
+
+    private static string BuildPath(GetInstanceBinding binding)
+    {
+        var path = $"/api/v1/{binding.Domain}/workflows/{binding.Workflow}/instances/{binding.Instance}";
+
+        if (binding.Extensions is { Length: > 0 })
+        {
+            var extensionsParam = string.Join("&", binding.Extensions.Where(e => !string.IsNullOrEmpty(e)).Select(e => $"extensions={Uri.EscapeDataString(e)}"));
+            path += $"?{extensionsParam}";
+        }
+
+        return path;
+    }
+
+    private HttpRequestMessage CreateDaprRequest(GetInstanceBinding binding, string appId)
+    {
+        var path = BuildPath(binding);
+
+        var request = _daprClient.CreateInvokeMethodRequest(
+            HttpMethod.Get,
+            appId,
+            path);
+
+        if (!string.IsNullOrEmpty(binding.ETag))
+        {
+            request.Headers.TryAddWithoutValidation("If-None-Match", binding.ETag);
+        }
+
+        return request;
+    }
+
+    private HttpRequestMessage CreateHttpRequest(GetInstanceBinding binding)
+    {
+        var path = BuildPath(binding);
+
+        if (string.IsNullOrEmpty(binding.BaseUrl))
+            throw new InvalidOperationException("BaseUrl is required for HTTP execution");
+
+        var baseUrl = binding.BaseUrl.TrimEnd('/') + "/";
+        var requestUri = new Uri(new Uri(baseUrl), path.TrimStart('/'));
+
+        var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+        if (!string.IsNullOrEmpty(binding.ETag))
+        {
+            request.Headers.TryAddWithoutValidation("If-None-Match", binding.ETag);
+        }
+
+        return request;
+    }
+
+    private Dictionary<string, object> CreateMetadata(
+        GetInstanceBinding binding,
+        bool cancelled = false,
+        string? reasonPhrase = null,
+        string? exceptionType = null)
+    {
+        var metadata = new Dictionary<string, object>
+        {
+            ["Domain"] = binding.Domain,
+            ["Workflow"] = binding.Workflow,
+            ["Instance"] = binding.Instance,
+            ["OrchestrationAppId"] = _orchestrationAppId
+        };
+
+        if (cancelled)
+            metadata["Cancelled"] = true;
+
+        if (!string.IsNullOrEmpty(reasonPhrase))
+            metadata["ReasonPhrase"] = reasonPhrase;
+
+        if (!string.IsNullOrEmpty(exceptionType))
+            metadata["ExceptionType"] = exceptionType;
+
+        return metadata;
+    }
+
+    private HttpClient CreateHttpClient(GetInstanceBinding binding, string? taskKey)
+    {
+        var clientName = binding.ValidateSSL
+            ? WorkflowHttpClientNames.Default
+            : WorkflowHttpClientNames.NoSslValidation;
+
+        if (!binding.ValidateSSL)
+        {
+            _logger.LogDebug(
+                "SSL certificate validation is disabled for {TaskType} task {TaskKey}",
+                TaskType, taskKey);
+        }
+
+        var client = _httpClientFactory.CreateClient(clientName);
+        client.Timeout = TimeSpan.FromSeconds(binding.TimeoutSeconds);
+
+        return client;
+    }
+}

--- a/src/BBT.Workflow.Execution/Microsoft/Extensions/DependencyInjection/ExecutionServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Execution/Microsoft/Extensions/DependencyInjection/ExecutionServiceCollectionExtensions.cs
@@ -60,6 +60,7 @@ public static class ExecutionServiceCollectionExtensions
         services.AddSingleton<ITaskInvoker, SubProcessRemoteInvoker>();
         services.AddSingleton<ITaskInvoker, GetInstanceDataRemoteInvoker>();
         services.AddSingleton<ITaskInvoker, GetInstancesRemoteInvoker>();
+        services.AddSingleton<ITaskInvoker, GetInstanceRemoteInvoker>();
         
         return services;
     }

--- a/test/BBT.Workflow.Application.Tests/Tasks/Executors/GetInstanceTaskExecutorTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Tasks/Executors/GetInstanceTaskExecutorTests.cs
@@ -1,0 +1,226 @@
+using System;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.Results;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Discovery;
+using BBT.Workflow.Gateway;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Runtime;
+using BBT.Workflow.Scripting;
+using BBT.Workflow.Tasks;
+using BBT.Workflow.Tasks.Executors;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Application.Tests.Tasks.Executors;
+
+public sealed class GetInstanceTaskExecutorTests
+{
+    private const string LocalDomain = "test-domain";
+    private const string RemoteDomain = "other-domain";
+
+    private static TaskExecutorContext CreateContext(GetInstanceTask task)
+    {
+        var onExecute = OnExecuteTask.Create(1, task, ScriptCode.FromNative(string.Empty));
+        var instance = Instance.Create(Guid.NewGuid(), "test-flow", "1.0", "ctx-key");
+        var scriptContext = new ScriptContext.Builder(NullLogger<ScriptContext>.Instance)
+            .SetRuntime(Substitute.For<IRuntimeInfoProvider>())
+            .SetInstance(instance)
+            .Build();
+
+        return new TaskExecutorContext(task, onExecute, scriptContext, null, TaskTrigger.OnExecute);
+    }
+
+    private static GetInstanceTaskExecutor CreateExecutor(
+        IInstanceQueryGateway gateway,
+        IRuntimeInfoProvider runtime,
+        IRemoteInvokerService? remoteInvoker = null,
+        IDomainDiscoveryResolver? endpointResolver = null)
+        => new(
+            Substitute.For<IScriptEngine>(),
+            runtime,
+            remoteInvoker ?? Substitute.For<IRemoteInvokerService>(),
+            gateway,
+            endpointResolver ?? Substitute.For<IDomainDiscoveryResolver>(),
+            NullLogger<GetInstanceTaskExecutor>.Instance);
+
+    private static GetInstanceOutput SampleOutput() => new()
+    {
+        Id = Guid.Parse("d2d65771-5595-44aa-b0e5-630353d87a80"),
+        Key = "inst-key",
+        Flow = "test-flow",
+        Domain = LocalDomain,
+        FlowVersion = "1.0.0",
+        Metadata = new InstanceMetadataDto
+        {
+            CurrentState = "review",
+            Status = InstanceStatus.Active,
+            CreatedAt = new DateTime(2026, 07, 20, 0, 0, 0, DateTimeKind.Utc)
+        },
+        Attributes = JsonSerializer.SerializeToElement(new { amount = 100, currency = "TRY" })
+    };
+
+    [Fact]
+    public async Task ExecuteAsync_SameDomain_ReturnsFullInstanceOutput_ViaLocalGateway()
+    {
+        var task = WorkflowTaskFactory.CreateGetInstanceTask(domain: LocalDomain, flow: "test-flow", key: "inst-key");
+
+        var gateway = Substitute.For<IInstanceQueryGateway>();
+        gateway.GetInstanceAsync(Arg.Any<GetInstanceInput>(), Arg.Any<CancellationToken>())
+            .Returns(ConditionalResult<GetInstanceOutput>.Success(SampleOutput()));
+
+        var runtime = Substitute.For<IRuntimeInfoProvider>();
+        runtime.Domain.Returns(LocalDomain);
+
+        var remoteInvoker = Substitute.For<IRemoteInvokerService>();
+        var executor = CreateExecutor(gateway, runtime, remoteInvoker);
+
+        var result = await executor.ExecuteAsync(CreateContext(task), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.IsSuccess.ShouldBeTrue();
+        result.Value.StatusCode.ShouldBe(200);
+
+        // Local path: gateway used, remote invoker not touched.
+        await gateway.Received(1).GetInstanceAsync(Arg.Any<GetInstanceInput>(), Arg.Any<CancellationToken>());
+        await remoteInvoker.DidNotReceive().InvokeAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TaskEnvelope>(),
+            Arg.Any<TaskTraceContext>(), Arg.Any<CancellationToken>());
+
+        var json = JsonSerializer.Serialize((object?)result.Value.Data, JsonSerializerConstants.JsonOptions);
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("key").GetString().ShouldBe("inst-key");
+        doc.RootElement.GetProperty("metadata").GetProperty("status").GetString().ShouldNotBeNull();
+        doc.RootElement.GetProperty("attributes").GetProperty("amount").GetInt32().ShouldBe(100);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SameDomain_WhenNotModified_Returns304()
+    {
+        var task = WorkflowTaskFactory.CreateGetInstanceTask(domain: LocalDomain, flow: "test-flow");
+
+        var gateway = Substitute.For<IInstanceQueryGateway>();
+        gateway.GetInstanceAsync(Arg.Any<GetInstanceInput>(), Arg.Any<CancellationToken>())
+            .Returns(ConditionalResult<GetInstanceOutput>.NotModified());
+
+        var runtime = Substitute.For<IRuntimeInfoProvider>();
+        runtime.Domain.Returns(LocalDomain);
+
+        var executor = CreateExecutor(gateway, runtime);
+
+        var result = await executor.ExecuteAsync(CreateContext(task), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.StatusCode.ShouldBe(304);
+        result.Value.Metadata!["NotModified"].ShouldBe(true);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SameDomain_WhenGatewayFails_ReturnsFailureResponse()
+    {
+        var task = WorkflowTaskFactory.CreateGetInstanceTask(domain: LocalDomain, flow: "test-flow");
+
+        var gateway = Substitute.For<IInstanceQueryGateway>();
+        gateway.GetInstanceAsync(Arg.Any<GetInstanceInput>(), Arg.Any<CancellationToken>())
+            .Returns(ConditionalResult<GetInstanceOutput>.Fail(
+                Error.NotFound(WorkflowErrorCodes.TaskExecution, "instance not found")));
+
+        var runtime = Substitute.For<IRuntimeInfoProvider>();
+        runtime.Domain.Returns(LocalDomain);
+
+        var executor = CreateExecutor(gateway, runtime);
+
+        var result = await executor.ExecuteAsync(CreateContext(task), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.IsSuccess.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CrossDomain_UsesRemoteInvoker_NotGateway()
+    {
+        var task = WorkflowTaskFactory.CreateGetInstanceTask(domain: RemoteDomain, flow: "test-flow", key: "inst-key");
+
+        var gateway = Substitute.For<IInstanceQueryGateway>();
+
+        var runtime = Substitute.For<IRuntimeInfoProvider>();
+        runtime.Domain.Returns(LocalDomain); // current domain differs from target => remote
+
+        var endpointResolver = Substitute.For<IDomainDiscoveryResolver>();
+        endpointResolver.GetEndpointAsync(Arg.Any<string>(), Arg.Any<EndpointKind>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok(new DiscoveryEndpoint(EndpointKind.Url, new Uri("https://other-domain.local"), null)));
+
+        var remoteBody = JsonSerializer.SerializeToElement(SampleOutput(), JsonSerializerConstants.JsonOptions);
+        var remoteInvoker = Substitute.For<IRemoteInvokerService>();
+        remoteInvoker.InvokeAsync(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TaskEnvelope>(),
+                Arg.Any<TaskTraceContext>(), Arg.Any<CancellationToken>())
+            .Returns(Result<TaskInvocationResult>.Ok(TaskInvocationResult.Success(
+                data: remoteBody, statusCode: 200, taskType: BBT.Workflow.Execution.TaskTypes.GetInstance)));
+
+        var executor = CreateExecutor(gateway, runtime, remoteInvoker, endpointResolver);
+
+        var result = await executor.ExecuteAsync(CreateContext(task), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.IsSuccess.ShouldBeTrue();
+
+        await remoteInvoker.Received(1).InvokeAsync(
+            BBT.Workflow.Execution.TaskTypes.GetInstance, Arg.Any<string>(), Arg.Any<TaskEnvelope>(),
+            Arg.Any<TaskTraceContext>(), Arg.Any<CancellationToken>());
+        await gateway.DidNotReceive().GetInstanceAsync(Arg.Any<GetInstanceInput>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Core requirement of the feature: same-domain (local gateway) and cross-domain (remote HTTP)
+    /// execution must expose an identical response template to the script context, so authors can
+    /// write one mapping regardless of where the target instance lives.
+    /// </summary>
+    [Fact]
+    public async Task ExecuteAsync_LocalAndRemote_ProduceIdenticalResponseShape()
+    {
+        var output = SampleOutput();
+        var expectedJson = JsonSerializer.Serialize(output, JsonSerializerConstants.JsonOptions);
+
+        // --- Local ---
+        var localGateway = Substitute.For<IInstanceQueryGateway>();
+        localGateway.GetInstanceAsync(Arg.Any<GetInstanceInput>(), Arg.Any<CancellationToken>())
+            .Returns(ConditionalResult<GetInstanceOutput>.Success(output));
+        var localRuntime = Substitute.For<IRuntimeInfoProvider>();
+        localRuntime.Domain.Returns(LocalDomain);
+        var localExecutor = CreateExecutor(localGateway, localRuntime);
+        var localTask = WorkflowTaskFactory.CreateGetInstanceTask(domain: LocalDomain, flow: "test-flow", key: "inst-key");
+        var localResult = await localExecutor.ExecuteAsync(CreateContext(localTask), CancellationToken.None);
+
+        // --- Remote --- (HTTP body is the serialized GetInstanceOutput from the same endpoint)
+        var remoteRuntime = Substitute.For<IRuntimeInfoProvider>();
+        remoteRuntime.Domain.Returns(LocalDomain);
+        var endpointResolver = Substitute.For<IDomainDiscoveryResolver>();
+        endpointResolver.GetEndpointAsync(Arg.Any<string>(), Arg.Any<EndpointKind>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok(new DiscoveryEndpoint(EndpointKind.Url, new Uri("https://other-domain.local"), null)));
+        var remoteBody = JsonSerializer.SerializeToElement(output, JsonSerializerConstants.JsonOptions);
+        var remoteInvoker = Substitute.For<IRemoteInvokerService>();
+        remoteInvoker.InvokeAsync(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TaskEnvelope>(),
+                Arg.Any<TaskTraceContext>(), Arg.Any<CancellationToken>())
+            .Returns(Result<TaskInvocationResult>.Ok(TaskInvocationResult.Success(
+                data: remoteBody, statusCode: 200, taskType: BBT.Workflow.Execution.TaskTypes.GetInstance)));
+        var remoteExecutor = CreateExecutor(Substitute.For<IInstanceQueryGateway>(), remoteRuntime, remoteInvoker, endpointResolver);
+        var remoteTask = WorkflowTaskFactory.CreateGetInstanceTask(domain: RemoteDomain, flow: "test-flow", key: "inst-key");
+        var remoteResult = await remoteExecutor.ExecuteAsync(CreateContext(remoteTask), CancellationToken.None);
+
+        localResult.IsSuccess.ShouldBeTrue();
+        remoteResult.IsSuccess.ShouldBeTrue();
+
+        var localJson = JsonSerializer.Serialize((object?)localResult.Value!.Data, JsonSerializerConstants.JsonOptions);
+        var remoteJson = JsonSerializer.Serialize((object?)remoteResult.Value!.Data, JsonSerializerConstants.JsonOptions);
+
+        localJson.ShouldBe(expectedJson);
+        remoteJson.ShouldBe(expectedJson);
+        localJson.ShouldBe(remoteJson);
+    }
+}

--- a/test/BBT.Workflow.Domain.Tests/Factories/WorkflowTaskFactory.cs
+++ b/test/BBT.Workflow.Domain.Tests/Factories/WorkflowTaskFactory.cs
@@ -72,4 +72,30 @@ public static class WorkflowTaskFactory
         task.SetReference(new Reference(name, domain, "sys-tasks", "1.0.0"));
         return task;
     }
+
+    public static GetInstanceTask CreateGetInstanceTask(
+        string name = "get-instance",
+        string domain = "test-domain",
+        string flow = "test-flow",
+        string? key = "inst-key",
+        string? instanceId = null,
+        bool useDapr = false)
+    {
+        var keyJson = key != null ? $@"""key"": ""{key}""," : "";
+        var instanceIdJson = instanceId != null ? $@"""instanceId"": ""{instanceId}""," : "";
+
+        var config = $@"{{
+            ""key"": ""{name}"",
+            ""type"": ""18"",
+            ""domain"": ""{domain}"",
+            ""flow"": ""{flow}"",
+            {keyJson}
+            {instanceIdJson}
+            ""useDapr"": {useDapr.ToString().ToLowerInvariant()}
+        }}";
+
+        var task = GetInstanceTask.Create(config.ToJsonElement());
+        task.SetReference(new Reference(name, domain, "sys-tasks", "1.0.0"));
+        return task;
+    }
 }


### PR DESCRIPTION
## What

Adds **`GetInstanceTask`** (task type `18`) — a trigger task that returns a **full single-instance projection** (metadata + attributes) for a workflow instance. It is the task-level equivalent of:

```
GET /api/v1/{domain}/workflows/{workflow}/instances/{instance}
```

It completes the instance-query task family:

| Task | Type | Returns | Endpoint |
|------|------|---------|----------|
| `GetInstancesTask` | 15 | Paged/grouped list | `.../instances` |
| `GetInstanceDataTask` | 13 | Data (attributes) only | `.../instances/{instance}/data` |
| **`GetInstanceTask`** | **18** | **Metadata + attributes** | `.../instances/{instance}` |

Closes #806.

## Why

Authors could list instances or read a single instance's *data*, but there was no first-class task returning the **full** single-instance view (`GetInstanceOutput`: identity + `Metadata` + `Attributes` + `Extensions`). This task lets a mapping reach both metadata (state/status/audit/incident) and data in one call.

## How

Modeled on the existing `GetInstanceDataTask` chain (Option B — bespoke binding + remote invoker), so the new task has literal structural parity with the rest of the TriggerTask family:

- **Local (same domain):** `IInstanceQueryGateway.GetInstanceAsync` in-process (no HTTP hop).
- **Remote (cross domain):** `TaskBindingMapper` → `GetInstanceBinding` → `GetInstanceRemoteInvoker` calling the same REST endpoint (HTTP/Dapr). `BuildPath` is identical to `GetInstanceDataRemoteInvoker` minus the `/data` suffix.

### Response-shape parity (the key requirement)
Local returns `GetInstanceOutput`; remote calls the endpoint that serializes the same `GetInstanceOutput`. Both are wrapped identically into `StandardTaskResponse` for the script context, so a single mapping works regardless of where the instance lives. `304 Not Modified` (ETag) is handled the same as `GetInstanceDataTask`.

## Files

**New:** `GetInstanceTask`, `GetInstanceBinding`, `GetInstanceTaskExecutor`, `GetInstanceRemoteInvoker`, executor tests, `docs/runtime/get-instance-task.md`.

**Wiring:** `TaskType` enum (`GetInstance = 18`), `WorkflowTask` `JsonDerivedType "18"`, `TaskTypes` constant, executor DI, remote invoker DI, `PooledTaskFactory`, `TaskBindingMapper` case + mapper, `TaskExecutorBase` accepted-status-codes, appsettings pooling list, test factory helper.

## Tests

5 new executor tests, all passing:
- same-domain returns full output via gateway
- 304 Not Modified
- gateway failure → failure response
- cross-domain uses remote invoker (not gateway)
- **local vs remote produce byte-identical response `Data`** (parity)

Full solution builds with 0 errors. The wider `Application.Tests` suite has 26 pre-existing failures unrelated to this change (verified by running the suite on the clean branch base — identical 26 failures; this PR only adds 5 passing tests).

## Reviewer notes

- `vnext-meta/component-registry.json` is currently empty `{}`, and the task `type` JSON schema lives in the external `@burgan-tech/vnext-*` packages, so no in-repo schema change is required beyond the (opt-in, currently disabled) pooling list entry.
- Either `instanceId` (GUID) or `key` (business key) resolves the target; `instanceId` takes precedence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a new GetInstance trigger task type that returns the full workflow instance projection, with supporting bindings, executors, remote invoker, configuration wiring, and documentation.

New Features:
- Introduce GetInstanceTask (type 18) to retrieve a full single-instance projection including metadata and attributes via trigger tasks.
- Add GetInstanceBinding and GetInstanceRemoteInvoker to support cross-domain GetInstanceTask execution over HTTP or Dapr.

Enhancements:
- Wire GetInstanceTask through task type enums, pooled task factory, task executors, task invokers, and binding mapper to integrate with the existing trigger task infrastructure.
- Extend TaskExecutorBase to honor AcceptedStatusCodes for GetInstanceTask responses, aligning behavior with other trigger tasks.

Documentation:
- Add runtime documentation for GetInstanceTask and reference it from the main README to guide usage when both metadata and data are needed in one call.

Tests:
- Add factory helper and executor test suite for GetInstanceTask covering same-domain, cross-domain, error, 304 Not Modified, and local/remote response parity scenarios.