### PR TITLE
Fix GetInstance invoker encoding and error handling

### DIFF
--- a/src/BBT.Workflow.Application/Tasks/Executors/Trigger/GetInstanceTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Trigger/GetInstanceTaskExecutor.cs
@@ -168,55 +168,71 @@ public sealed class GetInstanceTaskExecutor : TriggerTaskExecutorBase<GetInstanc
         CancellationToken cancellationToken)
     {
         Logger.LogDebug("Using RemoteInvokerService for GetInstance task {TaskKey}", task.Key);
-
-        // Create envelope from task using TaskBindingMapper
-        var envelopeResult = TaskBindingMapper.CreateEnvelope(task);
-        if (!envelopeResult.IsSuccess)
+        try
         {
-            Logger.TaskEnvelopeCreationFailed(
+            // Create envelope from task using TaskBindingMapper
+            var envelopeResult = TaskBindingMapper.CreateEnvelope(task);
+            if (!envelopeResult.IsSuccess)
+            {
+                Logger.TaskEnvelopeCreationFailed(
+                    task.Key,
+                    TaskType.ToString(),
+                    context.ScriptContext?.Instance?.Id ?? Guid.Empty,
+                    envelopeResult.Error.Message ?? "Failed to create envelope");
+                return Result<TaskInvocationResult>.Fail(envelopeResult.Error);
+            }
+
+            // Enrich binding with runtime context (endpoint, headers, resolved instance)
+            var enrichResult = await EnrichBindingAsync(
+                envelopeResult.Value!,
+                task.TriggerDomain,
+                task.UseDapr,
+                instanceIdentifier,
+                cancellationToken);
+
+            if (!enrichResult.IsSuccess)
+            {
+                Logger.TaskRemoteExecutionFailed(
+                    task.Key,
+                    TaskType.ToString(),
+                    context.ScriptContext?.Instance?.Id ?? Guid.Empty,
+                    enrichResult.Error.Message ?? "Failed to resolve endpoint");
+                return Result<TaskInvocationResult>.Fail(enrichResult.Error);
+            }
+
+            var traceContext = RemoteInvoker.CreateTraceContext(context.ScriptContext);
+            var result = await RemoteInvoker.InvokeAsync(
+                TaskTypes.GetInstance,
                 task.Key,
-                TaskType.ToString(),
-                context.ScriptContext?.Instance?.Id ?? Guid.Empty,
-                envelopeResult.Error.Message ?? "Failed to create envelope");
-            return Result<TaskInvocationResult>.Fail(envelopeResult.Error);
+                enrichResult.Value!,
+                traceContext,
+                cancellationToken);
+
+            if (!result.IsSuccess)
+            {
+                Logger.TaskRemoteExecutionFailed(
+                    task.Key,
+                    TaskType.ToString(),
+                    context.ScriptContext?.Instance?.Id ?? Guid.Empty,
+                    result.Error.Message ?? "Unknown error");
+            }
+
+            return result;
         }
-
-        // Enrich binding with runtime context (endpoint, headers, resolved instance)
-        var enrichResult = await EnrichBindingAsync(
-            envelopeResult.Value!,
-            task.TriggerDomain,
-            task.UseDapr,
-            instanceIdentifier,
-            cancellationToken);
-
-        if (!enrichResult.IsSuccess)
+        catch (Exception ex)
         {
             Logger.TaskRemoteExecutionFailed(
                 task.Key,
                 TaskType.ToString(),
                 context.ScriptContext?.Instance?.Id ?? Guid.Empty,
-                enrichResult.Error.Message ?? "Failed to resolve endpoint");
-            return Result<TaskInvocationResult>.Fail(enrichResult.Error);
+                ex.Message);
+
+            return Result<TaskInvocationResult>.Fail(
+                Error.Failure(
+                    WorkflowErrorCodes.TaskExecution,
+                    $"GetInstance remote execution failed: {ex.Message}",
+                    detail: ex.GetType().Name));
         }
-
-        var traceContext = RemoteInvoker.CreateTraceContext(context.ScriptContext);
-        var result = await RemoteInvoker.InvokeAsync(
-            TaskTypes.GetInstance,
-            task.Key,
-            enrichResult.Value!,
-            traceContext,
-            cancellationToken);
-
-        if (!result.IsSuccess)
-        {
-            Logger.TaskRemoteExecutionFailed(
-                task.Key,
-                TaskType.ToString(),
-                context.ScriptContext?.Instance?.Id ?? Guid.Empty,
-                result.Error.Message ?? "Unknown error");
-        }
-
-        return result;
     }
 
     private async Task<Result<TaskEnvelope>> EnrichBindingAsync(

--- a/src/BBT.Workflow.Execution/Invokers/GetInstanceRemoteInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/GetInstanceRemoteInvoker.cs
@@ -215,12 +215,22 @@ public sealed class GetInstanceRemoteInvoker : ITaskInvoker<GetInstanceBinding>
 
     private static string BuildPath(GetInstanceBinding binding)
     {
-        var path = $"/api/v1/{binding.Domain}/workflows/{binding.Workflow}/instances/{binding.Instance}";
+        var domain = Uri.EscapeDataString(binding.Domain);
+        var workflow = Uri.EscapeDataString(binding.Workflow);
+        var instance = Uri.EscapeDataString(binding.Instance);
+        var path = $"/api/v1/{domain}/workflows/{workflow}/instances/{instance}";
 
         if (binding.Extensions is { Length: > 0 })
         {
-            var extensionsParam = string.Join("&", binding.Extensions.Where(e => !string.IsNullOrEmpty(e)).Select(e => $"extensions={Uri.EscapeDataString(e)}"));
-            path += $"?{extensionsParam}";
+            var validExtensions = binding.Extensions
+                .Where(e => !string.IsNullOrEmpty(e))
+                .Select(e => $"extensions={Uri.EscapeDataString(e)}")
+                .ToList();
+
+            if (validExtensions.Count > 0)
+            {
+                path += $"?{string.Join("&", validExtensions)}";
+            }
         }
 
         return path;


### PR DESCRIPTION
Wrap GetInstance task execution in try/catch and improve logging/return values for remote invocation failures. Ensure TaskEnvelope creation/enrichment errors are logged and returned, and exceptions produce a WorkflowErrorCodes.TaskExecution failure with type detail. Also make GetInstanceRemoteInvoker build safe URLs by URI-escaping domain/workflow/instance segments and only appending non-empty extensions as query parameters to avoid malformed requests.

## Summary by Sourcery

Improve robustness and URL safety of remote GetInstance task invocation.

Bug Fixes:
- Return failures when TaskEnvelope creation or binding enrichment fail during remote GetInstance execution instead of proceeding with invalid state.
- Handle exceptions during remote GetInstance invocation by logging them and surfacing a TaskExecution workflow error with exception type detail.
- Build GetInstance remote invoker URLs using URI-escaped path segments and only include non-empty extensions as query parameters to avoid malformed requests.