### PR TITLE
feat: add full form-urlencoded payload support

### DIFF
--- a/docs/contracts/form-url-encoded-payloads.md
+++ b/docs/contracts/form-url-encoded-payloads.md
@@ -142,6 +142,7 @@ Invalid or ambiguous shapes return HTTP 400 with a model-binding error. Rejected
 - Unindexed arrays of objects: `items[][name]=A`
 - Negative indices: `items[-1]=A`
 - Sparse indices: `items[1]=B` without `items[0]`
+- Array indices above the supported maximum (1024): `items[1025]=A`
 - Scalar/container collisions: `value=x&value[name]=y`
 - JSON object or array embedded as a scalar value
 

--- a/docs/contracts/form-url-encoded-payloads.md
+++ b/docs/contracts/form-url-encoded-payloads.md
@@ -1,0 +1,149 @@
+# Form URL-Encoded Payloads
+
+The public Orchestration API accepts `application/x-www-form-urlencoded` in addition to
+`application/json` on these endpoint groups:
+
+- Workflow instance start
+- Workflow instance transition
+- Domain function invocation
+- Instance function invocation
+
+The form body is converted to a JSON object before the existing payload-mode and workflow
+pipelines run. Execution-service endpoints, multipart forms, and file uploads are not included.
+
+## Standard payload
+
+A standard payload contains the vNext envelope fields `key`, `stage`, `tags`, and `attributes`.
+Use bracket paths for nested attributes:
+
+```bash
+curl -X POST \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  --data-urlencode 'key=50044086191232280074134' \
+  --data-urlencode 'stage=Initial' \
+  --data-urlencode 'tags[]=retail' \
+  --data-urlencode 'attributes[customer][name]=Ali' \
+  --data-urlencode 'attributes[customer][age]=30' \
+  'https://host/api/v1/acme/workflows/onboarding/instances/start'
+```
+
+This produces the same payload shape as:
+
+```json
+{
+  "key": "50044086191232280074134",
+  "stage": "Initial",
+  "tags": ["retail"],
+  "attributes": {
+    "customer": {
+      "name": "Ali",
+      "age": 30
+    }
+  }
+}
+```
+
+The envelope fields `key`, `stage`, and each `tags` element always remain strings, including
+numeric-looking values. Their names follow the same case-insensitive model-binding behavior as
+JSON when `x-vnext-payload-mode: standard` is supplied.
+
+## Raw payload
+
+When the form has no top-level `attributes` field, it is treated as a raw payload and the whole
+object is passed through the existing raw-payload normalization:
+
+```text
+amount=100&approved=true&currency=TRY
+```
+
+Equivalent JSON:
+
+```json
+{
+  "amount": 100,
+  "approved": true,
+  "currency": "TRY"
+}
+```
+
+## Scalar types
+
+Raw leaves and values below `attributes` use JSON-scalar rules:
+
+| Form value | JSON value |
+|---|---|
+| `30` | number `30` |
+| `1.25` | number `1.25` |
+| `true` / `false` | boolean |
+| `null` | null |
+| `"00123"` | string `"00123"` |
+| `Ali` | string `"Ali"` |
+
+Quote a numeric-, boolean-, or null-looking value as a JSON string when its string type must be
+preserved. URL-encode the quotes when constructing the request manually; for example,
+`code=%2200123%22` represents `code="00123"`.
+
+JSON objects and arrays are not accepted inside one scalar form value. Use bracket paths instead.
+
+## Objects and arrays
+
+Nested object:
+
+```text
+attributes[customer][ownerUserId]="2321321"
+```
+
+Scalar arrays can use trailing brackets or a repeated key:
+
+```text
+tags[]=a&tags[]=b
+tags=a&tags=b
+```
+
+Because `tags` is a known standard-envelope array, a single `tags=a` field is normalized to
+`"tags": ["a"]` as well.
+
+Arrays of objects require contiguous numeric indices. The fields may arrive in any order:
+
+```text
+attributes[items][1][name]=B&attributes[items][0][name]=A
+```
+
+Equivalent JSON:
+
+```json
+{
+  "attributes": {
+    "items": [
+      { "name": "A" },
+      { "name": "B" }
+    ]
+  }
+}
+```
+
+## Payload-mode override
+
+The existing `x-vnext-payload-mode` header has the same precedence for form and JSON bodies:
+
+- `x-vnext-payload-mode: standard` forces standard envelope handling.
+- `x-vnext-payload-mode: raw` forces raw handling.
+- Without the header, a top-level lowercase `attributes` path selects standard mode; otherwise the
+  payload is raw.
+
+Use the standard override when sending a standard envelope without an `attributes` field, such as
+an input containing only `key`.
+
+## Rejected forms
+
+Invalid or ambiguous shapes return HTTP 400 with a model-binding error. Rejected examples include:
+
+- Unclosed or malformed brackets: `attributes[name=value`
+- Unindexed arrays of objects: `items[][name]=A`
+- Negative indices: `items[-1]=A`
+- Sparse indices: `items[1]=B` without `items[0]`
+- Scalar/container collisions: `value=x&value[name]=y`
+- JSON object or array embedded as a scalar value
+
+Use numeric indices for arrays of objects and ensure every index from zero through the highest
+index is present.

--- a/docs/superpowers/plans/2026-07-20-form-urlencoded-json-parity.md
+++ b/docs/superpowers/plans/2026-07-20-form-urlencoded-json-parity.md
@@ -1,0 +1,278 @@
+# Form URL-Encoded JSON Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
+
+**Goal:** Make Orchestration Start, Transition, and Function endpoints accept form-urlencoded bodies with deterministic JSON typing, safe bracket paths, unchanged JSON behavior, and accurate API metadata.
+
+**Architecture:** Keep normalization in `FormUrlEncodedJsonElementInputFormatter`, but split key parsing, tree insertion, and scalar conversion into focused private helpers. Register the formatter through Orchestration-specific MVC options, then verify common MVC binding plus the real controller action metadata through the Orchestration assembly.
+
+**Tech Stack:** .NET 10, ASP.NET Core MVC input formatters, System.Text.Json, xUnit, Shouldly, Microsoft.AspNetCore.TestHost.
+
+## Global Constraints
+
+- Existing `application/json` binding behavior must remain unchanged.
+- Form support is enabled only in the Orchestration host.
+- Standard envelope `key`, `stage`, and `tags` values remain strings.
+- Raw payload leaves and values below `attributes` use JSON-scalar literal semantics.
+- Ambiguous or malformed paths return HTTP 400 instead of silently overwriting data.
+- Do not add a third-party query-string parser.
+
+---
+
+### Task 1: Typed and collision-safe bracket normalization
+
+**Files:**
+- Modify: `test/BBT.Workflow.Application.Tests/HttpApi/FormUrlEncodedJsonElementInputFormatterTests.cs`
+- Modify: `src/BBT.Workflow.HttpApi.Shared/Formatters/FormUrlEncodedJsonElementInputFormatter.cs`
+
+**Interfaces:**
+- Consumes: ASP.NET Core `IFormCollection` and request header `x-vnext-payload-mode`.
+- Produces: `JsonElement` on success or an MVC model-state formatter failure on invalid form shape.
+
+- [x] **Step 1: Add failing scalar-contract tests**
+
+Add focused tests asserting:
+
+```csharp
+[Theory]
+[InlineData("age=30", "age", JsonValueKind.Number)]
+[InlineData("active=true", "active", JsonValueKind.True)]
+[InlineData("value=null", "value", JsonValueKind.Null)]
+public async Task ReadRequestBodyAsync_RawJsonLiteral_UsesJsonType(
+    string body, string property, JsonValueKind expectedKind)
+{
+    var element = await ReadElementAsync(new(), body);
+    element.GetProperty(property).ValueKind.ShouldBe(expectedKind);
+}
+
+[Fact]
+public async Task ReadRequestBodyAsync_QuotedScalar_PreservesString()
+{
+    var element = await ReadElementAsync(new(), "code=%2200123%22");
+    element.GetProperty("code").GetString().ShouldBe("00123");
+}
+```
+
+Extend `BuildContext`/`ReadElementAsync` with an optional payload-mode header. Add standard-mode assertions proving numeric-looking `key`, `stage`, and `tags[]` remain strings while `attributes[age]` becomes a number.
+
+- [x] **Step 2: Run the scalar tests and verify RED**
+
+Run:
+
+```bash
+dotnet test test/BBT.Workflow.Application.Tests/BBT.Workflow.Application.Tests.csproj \
+  --filter 'FullyQualifiedName~FormUrlEncodedJsonElementInputFormatterTests' --no-restore
+```
+
+Expected: new number/boolean/null assertions fail because the formatter currently emits every leaf with `WriteStringValue`.
+
+- [x] **Step 3: Add failing bracket-path and error tests**
+
+Add tests for:
+
+```text
+items[0][name]=A&items[1][name]=B      -> [{"name":"A"},{"name":"B"}]
+items[][name]=A                         -> formatter failure
+items[1][name]=A                        -> formatter failure (sparse index)
+a=x&a[b]=y                              -> formatter failure (scalar/object collision)
+a[b                                     -> formatter failure (malformed bracket)
+items[-1]=A                             -> formatter failure (negative index)
+```
+
+The failure helper must assert `result.HasError` and a non-empty `ModelState` error message.
+
+- [x] **Step 4: Run the bracket tests and verify RED**
+
+Run the same filtered command. Expected: indexed arrays are emitted as objects and invalid forms currently succeed or lose data.
+
+- [x] **Step 5: Implement the minimal typed path tree**
+
+Replace the `List<string>` plus global `appendToArray` parser with typed path segments:
+
+```csharp
+private abstract record PathSegment;
+private sealed record PropertySegment(string Name) : PathSegment;
+private sealed record IndexSegment(int Index) : PathSegment;
+private sealed record AppendSegment : PathSegment;
+```
+
+Parse a property root followed by bracketed property names, non-negative numeric indices, or a trailing empty append segment. Reject trailing characters, empty roots, negative indices, and non-trailing append segments. Insert into dictionary/list nodes while requiring contiguous indices and rejecting any scalar/container type collision.
+
+Resolve payload mode from `x-vnext-payload-mode`, falling back to presence of a top-level `attributes` property. Convert leaves with this rule:
+
+```csharp
+private static object? ParseScalar(string value, bool preserveString)
+{
+    if (preserveString)
+        return value;
+
+    try
+    {
+        using var document = JsonDocument.Parse(value);
+        return document.RootElement.ValueKind switch
+        {
+            JsonValueKind.String => document.RootElement.GetString(),
+            JsonValueKind.Number or JsonValueKind.True or JsonValueKind.False or JsonValueKind.Null
+                => document.RootElement.Clone(),
+            _ => throw new FormUrlEncodedPathException("Object and array scalar values are not supported.")
+        };
+    }
+    catch (JsonException)
+    {
+        return value;
+    }
+}
+```
+
+Preserve strings for the standard envelope paths `key`, `stage`, and `tags`; apply literal conversion below `attributes` or to every raw-payload leaf. On a path exception, add its message to `context.ModelState` and return `InputFormatterResult.Failure()`.
+
+- [x] **Step 6: Run formatter tests and verify GREEN**
+
+Run the filtered formatter command. Expected: all formatter tests pass.
+
+### Task 2: Scope registration to Orchestration
+
+**Files:**
+- Modify: `src/BBT.Workflow.HttpApi.Shared/Microsoft/Extensions/DependencyInjection/WorkflowApiBaseServiceCollectionExtensions.cs`
+- Modify: `orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Microsoft/Extensions/DependencyInjection/OrchestrationApiServiceCollectionExtensions.cs`
+- Modify: `orchestration/BBT.Workflow.Orchestration.HttpApi.Host/BBT.Workflow.Orchestration.HttpApi.Host.csproj`
+- Modify: `test/BBT.Workflow.Application.Tests/BBT.Workflow.Application.Tests.csproj`
+- Create: `test/BBT.Workflow.Application.Tests/HttpApi/FormUrlEncodedFormatterRegistrationTests.cs`
+
+**Interfaces:**
+- Produces: Orchestration-specific `IConfigureOptions<MvcOptions>` registration.
+- Ensures: shared `AddAspNetCoreModules` does not add the formatter.
+
+- [x] **Step 1: Add failing registration tests**
+
+Add a project reference from Application.Tests to the Orchestration host and expose Orchestration internals to the test assembly. Test shared registration separately from a small internal Orchestration registration extension:
+
+```csharp
+sharedOptions.InputFormatters.ShouldNotContain(x =>
+    x is FormUrlEncodedJsonElementInputFormatter);
+
+orchestrationOptions.InputFormatters.ShouldContain(x =>
+    x is FormUrlEncodedJsonElementInputFormatter);
+```
+
+- [x] **Step 2: Run registration tests and verify RED**
+
+Run:
+
+```bash
+dotnet test test/BBT.Workflow.Application.Tests/BBT.Workflow.Application.Tests.csproj \
+  --filter 'FullyQualifiedName~FormUrlEncodedFormatterRegistrationTests'
+```
+
+Expected: shared registration contains the formatter and no Orchestration-only registration exists.
+
+- [x] **Step 3: Move the registration**
+
+Restore the shared call to `services.AddControllers()` and add an internal Orchestration helper:
+
+```csharp
+internal static IServiceCollection AddFormUrlEncodedJsonElementInput(this IServiceCollection services)
+{
+    services.Configure<MvcOptions>(options =>
+        options.InputFormatters.Insert(0, new FormUrlEncodedJsonElementInputFormatter()));
+    return services;
+}
+```
+
+Call it from `AddOrchestrationApiModule` immediately after `AddAspNetCoreModules(configuration)`.
+
+- [x] **Step 4: Run registration and formatter tests and verify GREEN**
+
+Run both filtered test classes. Expected: all pass.
+
+### Task 3: Verify MVC binding and real endpoint API metadata
+
+**Files:**
+- Modify: `test/BBT.Workflow.Application.Tests/BBT.Workflow.Application.Tests.csproj`
+- Create: `test/BBT.Workflow.Application.Tests/HttpApi/FormUrlEncodedMvcContractTests.cs`
+
+**Interfaces:**
+- Consumes: actual `InstanceController` and `FunctionController` action descriptors.
+- Produces: regression proof for body binding and advertised request formats.
+
+- [x] **Step 1: Add TestHost dependency and failing MVC contract tests**
+
+Add `Microsoft.AspNetCore.TestHost` using `$(MicrosoftPackageVersion)`. Build a minimal `WebApplication` with a probe `[ApiController]` action binding `[FromBody] JsonElement?`, register the Orchestration formatter, and assert:
+
+```csharp
+using var form = new FormUrlEncodedContent(new Dictionary<string, string>
+{
+    ["attributes[age]"] = "30"
+});
+var formResponse = await client.PostAsync("/probe", form);
+formResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+var jsonResponse = await client.PostAsJsonAsync("/probe", new { attributes = new { age = 30 } });
+jsonResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+```
+
+Add invalid-form HTTP tests expecting 400.
+
+- [x] **Step 2: Add failing actual-action metadata tests**
+
+Register the real Orchestration controller assembly as an MVC application part, obtain `IApiDescriptionGroupCollectionProvider`, and locate:
+
+```text
+InstanceController.StartAsync
+InstanceController.TransitionAsync
+FunctionController.InvokeDomainFunctionAsync
+FunctionController.InvokeInstanceFunctionAsync
+```
+
+For every HTTP method/action description, assert request formats contain both `application/json` and `application/x-www-form-urlencoded`.
+
+- [x] **Step 3: Run MVC contract tests and verify RED**
+
+Run the filtered MVC class. Expected: form binding or action metadata assertions fail until Orchestration registration and formatter behavior are active in the test application.
+
+- [x] **Step 4: Implement only the test-host/API metadata wiring needed for GREEN**
+
+Reuse the production Orchestration registration helper. Do not duplicate formatter configuration in tests. If ApiExplorer requires API-version services, register the same `AddAetherApiVersioning(apiTitle: "vNext API")` call used by production.
+
+- [x] **Step 5: Run MVC contract tests and verify GREEN**
+
+Run the filtered MVC command. Expected: form, JSON regression, invalid-form 400, and all four action metadata assertions pass.
+
+### Task 4: Publish the form contract and run verification
+
+**Files:**
+- Create: `docs/contracts/form-url-encoded-payloads.md`
+- Modify: `src/BBT.Workflow.HttpApi.Shared/Formatters/FormUrlEncodedJsonElementInputFormatter.cs`
+
+**Interfaces:**
+- Produces: user-facing syntax, typing, payload-mode, and rejection documentation.
+
+- [x] **Step 1: Write the contract documentation**
+
+Document curl-style examples for standard and raw payloads, the JSON-literal/string rules, indexed arrays, header overrides, and rejected ambiguous inputs. Link the formatter XML remarks to `docs/contracts/form-url-encoded-payloads.md`.
+
+- [x] **Step 2: Run targeted verification**
+
+Run:
+
+```bash
+dotnet test test/BBT.Workflow.Application.Tests/BBT.Workflow.Application.Tests.csproj \
+  --filter 'FullyQualifiedName~FormUrlEncoded' --no-restore
+git diff --check
+```
+
+Expected: all form-urlencoded tests pass and diff check returns no output.
+
+- [x] **Step 3: Run the relevant full project**
+
+Run:
+
+```bash
+dotnet test test/BBT.Workflow.Application.Tests/BBT.Workflow.Application.Tests.csproj --no-restore
+```
+
+Expected: no new failures compared with the observed baseline. Report baseline failures separately if the project remains non-green.
+
+- [x] **Step 4: Review final scope**
+
+Run `git status --short` and `git diff --stat origin/master...HEAD` plus the working-tree diff. Confirm no Execution controller behavior changed and unrelated user changes remain intact.

--- a/docs/superpowers/specs/2026-07-20-form-urlencoded-json-parity-design.md
+++ b/docs/superpowers/specs/2026-07-20-form-urlencoded-json-parity-design.md
@@ -1,0 +1,66 @@
+# Form URL-Encoded JSON Parity Design
+
+## Context
+
+Issue #825 adds `application/x-www-form-urlencoded` request-body support to the public Orchestration endpoints for workflow start, transition execution, and function invocation. These endpoints already bind `application/json` bodies as `JsonElement?`; form input must therefore be normalized into the same JSON tree before the existing payload-mode and application pipelines run.
+
+The implementation must preserve existing JSON behavior, remain scoped to the Orchestration host, expose the additional media type through OpenAPI, and reject ambiguous form shapes instead of silently losing or changing data.
+
+## Form-to-JSON Contract
+
+Form keys use bracket paths:
+
+- `attributes[customer][name]=Ali` produces nested JSON objects.
+- `tags[]=a&tags[]=b` and repeated `tags=a&tags=b` produce scalar arrays.
+- `items[0][name]=A&items[1][name]=B` produces an indexed array of objects.
+- Empty brackets are supported only for a trailing scalar-array segment. Ambiguous object-array input such as `items[][name]=A` is rejected with HTTP 400; callers must use numeric indices.
+- Malformed brackets, negative or sparse indices, mixed object/array use at the same path, and scalar/container collisions are rejected with HTTP 400 and a clear model-binding error.
+
+Scalar values use JSON-literal semantics in payload data:
+
+- `30`, `1.25`, `true`, `false`, and `null` become their corresponding JSON value types.
+- A JSON-quoted value such as `"00123"` becomes the string `00123`.
+- Text that is not a valid JSON scalar literal, such as `Ali` or `Initial`, remains a JSON string.
+- JSON objects and arrays are not accepted as scalar field values; structural data must use bracket paths. This avoids two competing representations for the same path.
+
+For a standard payload, the envelope fields `key`, `stage`, and every `tags` element remain strings regardless of whether their text resembles a JSON literal. Values below `attributes` use JSON-literal semantics. For a raw payload, all leaves use JSON-literal semantics. Payload mode is resolved consistently with the existing controller behavior: `x-vnext-payload-mode` overrides auto-detection, otherwise a top-level `attributes` field selects standard mode and its absence selects raw mode.
+
+## Architecture
+
+`FormUrlEncodedJsonElementInputFormatter` remains in `BBT.Workflow.HttpApi.Shared` because it is an HTTP formatting component, but it is registered only from `AddOrchestrationApiModule`. Shared `AddAspNetCoreModules` continues to configure JSON and controllers without enabling form binding in Execution, Monitor, Inbox, or Outbox hosts.
+
+The formatter is divided into three responsibilities:
+
+1. Parse each form key into typed property, numeric-index, or trailing-append path segments.
+2. Insert each form value into a mutable object/array tree while detecting malformed, ambiguous, sparse, or colliding paths.
+3. Write the validated tree as JSON, applying envelope-aware scalar conversion based on the resolved payload mode.
+
+Parsing failures are added to MVC model state and returned as formatter failures so `[ApiController]` produces a normal HTTP 400 response. No partially normalized payload is passed downstream.
+
+## OpenAPI and Documentation
+
+Orchestration MVC options advertise `application/x-www-form-urlencoded` for `JsonElement` and `JsonElement?` bodies. ApiExplorer/OpenAPI tests verify that Start, Transition, domain Function, and instance Function operations retain `application/json` and add the form media type.
+
+A public contract document under `docs/contracts` records supported key syntax, scalar typing, payload-mode interaction, examples, and rejected ambiguous forms. XML comments point to the same rules but are not treated as the user-facing documentation.
+
+## Testing
+
+Tests follow red-green TDD and cover:
+
+- JSON scalar typing for numbers, booleans, null, quoted strings, and ordinary text.
+- Preservation of standard envelope strings, including a numeric-looking large `key` and numeric-looking tags.
+- Nested objects, repeated scalar arrays, trailing `[]` arrays, and indexed arrays of objects.
+- Clear failures for malformed brackets, unindexed object arrays, sparse/negative indices, and scalar/container conflicts.
+- `standard`, `raw`, and auto-detected payload modes.
+- MVC registration being present in Orchestration and absent from shared/Execution registration.
+- Actual MVC body binding for form input and regression binding for `application/json`.
+- ApiExplorer/OpenAPI request media types for all Start, Transition, and Function endpoint groups.
+
+Targeted formatter, MVC, and OpenAPI tests must pass. The relevant test project is also run in full; unrelated baseline failures are reported separately rather than attributed to this feature.
+
+## Non-Goals
+
+- Multipart form data and file uploads are not supported.
+- PHP-style unindexed arrays of objects are not inferred.
+- Schema-driven coercion is not performed inside the formatter.
+- Execution-service endpoints do not gain form-urlencoded support.

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/BBT.Workflow.Orchestration.HttpApi.Host.csproj
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/BBT.Workflow.Orchestration.HttpApi.Host.csproj
@@ -17,4 +17,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\BBT.Workflow.HttpApi.Shared\BBT.Workflow.HttpApi.Shared.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="BBT.Workflow.Application.Tests" />
+  </ItemGroup>
 </Project>

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Microsoft/Extensions/DependencyInjection/OrchestrationApiServiceCollectionExtensions.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Microsoft/Extensions/DependencyInjection/OrchestrationApiServiceCollectionExtensions.cs
@@ -1,9 +1,11 @@
 using BBT.Workflow.Caching;
 using BBT.Workflow.Controllers.Instances;
+using BBT.Workflow.Formatters;
 using BBT.Workflow.HostedServices;
 using BBT.Workflow.HttpApi.Shared.HealthChecks;
 using BBT.Workflow.Orchestration.Services;
 using HealthChecks.NpgSql;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
@@ -30,6 +32,7 @@ public static class OrchestrationApiServiceCollectionExtensions
             .AddApplicationModule()
             .AddInfrastructureModule(configuration) // Infrastructure manages its own dependencies including URL templates
             .AddAspNetCoreModules(configuration)
+            .AddFormUrlEncodedJsonElementInput()
             .AddResultResilience(configuration)
             .AddDaprClients()
             .AddEventBus(configuration)
@@ -50,6 +53,17 @@ public static class OrchestrationApiServiceCollectionExtensions
             .AddHostedServices()
             .AddAppHealthChecks()
             .AddOrchestrationDbHealthCheck(configuration);
+        return services;
+    }
+
+    /// <summary>
+    /// Enables form-urlencoded binding only for the public Orchestration API. Other hosts share
+    /// <c>AddAspNetCoreModules</c> but must not expose this additional request media type.
+    /// </summary>
+    internal static IServiceCollection AddFormUrlEncodedJsonElementInput(this IServiceCollection services)
+    {
+        services.Configure<MvcOptions>(options =>
+            options.InputFormatters.Insert(0, new FormUrlEncodedJsonElementInputFormatter()));
         return services;
     }
 

--- a/src/BBT.Workflow.HttpApi.Shared/Formatters/FormUrlEncodedJsonElementInputFormatter.cs
+++ b/src/BBT.Workflow.HttpApi.Shared/Formatters/FormUrlEncodedJsonElementInputFormatter.cs
@@ -1,0 +1,488 @@
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.Net.Http.Headers;
+
+namespace BBT.Workflow.Formatters;
+
+/// <summary>
+/// Converts <c>application/x-www-form-urlencoded</c> request bodies to the
+/// <see cref="JsonElement"/> shape consumed by Orchestration endpoints.
+/// </summary>
+/// <remarks>
+/// Supports nested bracket paths, trailing scalar arrays, and indexed object arrays. Ambiguous
+/// or malformed paths are returned as model-binding failures instead of being silently rewritten.
+/// Payload leaves follow JSON-scalar semantics; standard envelope fields remain strings.
+/// See <c>docs/contracts/form-url-encoded-payloads.md</c> for the public request contract.
+/// </remarks>
+public sealed class FormUrlEncodedJsonElementInputFormatter : TextInputFormatter
+{
+    private const string PayloadModeHeader = "x-vnext-payload-mode";
+
+    public FormUrlEncodedJsonElementInputFormatter()
+    {
+        SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("application/x-www-form-urlencoded"));
+        SupportedEncodings.Add(Encoding.UTF8);
+        SupportedEncodings.Add(Encoding.Unicode);
+    }
+
+    protected override bool CanReadType(Type type)
+        => type == typeof(JsonElement) || type == typeof(JsonElement?);
+
+    public override async Task<InputFormatterResult> ReadRequestBodyAsync(
+        InputFormatterContext context,
+        Encoding encoding)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(encoding);
+
+        try
+        {
+            var request = context.HttpContext.Request;
+            var form = await request.ReadFormAsync(request.HttpContext.RequestAborted);
+            var fields = ParseFields(form);
+            var standardPayload = IsStandardPayload(request, fields);
+            var root = new ObjectNode();
+
+            foreach (var field in fields)
+            {
+                foreach (var rawValue in field.Values)
+                {
+                    var path = standardPayload
+                        ? NormalizeStandardEnvelopePath(field.Path)
+                        : field.Path;
+                    var preserveString = standardPayload && IsStandardEnvelopePath(path);
+                    var value = ParseScalar(rawValue ?? string.Empty, preserveString);
+                    Insert(root, path, value, field.OriginalKey);
+                }
+            }
+
+            ValidateComplete(root);
+
+            using var buffer = new MemoryStream();
+            using (var writer = new Utf8JsonWriter(buffer))
+            {
+                WriteNode(writer, root);
+            }
+
+            using var document = JsonDocument.Parse(buffer.ToArray());
+            return InputFormatterResult.Success(document.RootElement.Clone());
+        }
+        catch (FormUrlEncodedInputException exception)
+        {
+            context.ModelState.TryAddModelError(context.ModelName, exception.Message);
+            return await InputFormatterResult.FailureAsync();
+        }
+    }
+
+    private static List<ParsedField> ParseFields(IFormCollection form)
+    {
+        var fields = new List<ParsedField>(form.Count);
+        foreach (var field in form)
+        {
+            fields.Add(new ParsedField(field.Key, ParsePath(field.Key), field.Value));
+        }
+
+        return fields;
+    }
+
+    private static IReadOnlyList<PathSegment> ParsePath(string key)
+    {
+        if (string.IsNullOrEmpty(key))
+        {
+            throw InvalidPath(key, "The form key cannot be empty.");
+        }
+
+        var firstBracket = key.IndexOf('[');
+        var rootLength = firstBracket < 0 ? key.Length : firstBracket;
+        var root = key[..rootLength];
+        if (root.Length == 0 || root.Contains(']'))
+        {
+            throw InvalidPath(key, "The root property is malformed.");
+        }
+
+        var segments = new List<PathSegment> { new PropertySegment(root) };
+        var position = rootLength;
+        while (position < key.Length)
+        {
+            if (key[position] != '[')
+            {
+                throw InvalidPath(key, "Unexpected characters follow a bracket segment.");
+            }
+
+            var close = key.IndexOf(']', position + 1);
+            if (close < 0)
+            {
+                throw InvalidPath(key, "A bracket segment is not closed.");
+            }
+
+            var inner = key[(position + 1)..close];
+            if (inner.Contains('[') || inner.Contains(']'))
+            {
+                throw InvalidPath(key, "A bracket segment is malformed.");
+            }
+
+            if (inner.Length == 0)
+            {
+                if (close != key.Length - 1)
+                {
+                    throw InvalidPath(key, "Empty brackets are supported only for trailing scalar arrays.");
+                }
+
+                segments.Add(new AppendSegment());
+            }
+            else if (inner[0] == '-' && inner[1..].All(char.IsDigit))
+            {
+                throw InvalidPath(key, "Array indices cannot be negative.");
+            }
+            else if (inner.All(char.IsDigit))
+            {
+                if (!int.TryParse(inner, NumberStyles.None, CultureInfo.InvariantCulture, out var index))
+                {
+                    throw InvalidPath(key, "The array index is too large.");
+                }
+
+                segments.Add(new IndexSegment(index));
+            }
+            else
+            {
+                segments.Add(new PropertySegment(inner));
+            }
+
+            position = close + 1;
+        }
+
+        return segments;
+    }
+
+    private static bool IsStandardPayload(HttpRequest request, IReadOnlyList<ParsedField> fields)
+    {
+        if (request.Headers.TryGetValue(PayloadModeHeader, out var mode))
+        {
+            return !string.Equals(mode.ToString(), "raw", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return fields.Any(field =>
+            field.Path[0] is PropertySegment { Name: "attributes" });
+    }
+
+    private static bool IsStandardEnvelopePath(IReadOnlyList<PathSegment> path)
+        => path[0] is PropertySegment property &&
+           (property.Name.Equals("key", StringComparison.OrdinalIgnoreCase) ||
+            property.Name.Equals("stage", StringComparison.OrdinalIgnoreCase) ||
+            property.Name.Equals("tags", StringComparison.OrdinalIgnoreCase));
+
+    private static IReadOnlyList<PathSegment> NormalizeStandardEnvelopePath(
+        IReadOnlyList<PathSegment> path)
+    {
+        if (path.Count == 1 &&
+            path[0] is PropertySegment property &&
+            property.Name.Equals("tags", StringComparison.OrdinalIgnoreCase))
+        {
+            return [property, new AppendSegment()];
+        }
+
+        return path;
+    }
+
+    private static ScalarNode ParseScalar(string value, bool preserveString)
+    {
+        if (preserveString)
+        {
+            return new ScalarNode(value);
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(value);
+            return document.RootElement.ValueKind switch
+            {
+                JsonValueKind.String => new ScalarNode(document.RootElement.GetString()),
+                JsonValueKind.Number or JsonValueKind.True or JsonValueKind.False
+                    => new ScalarNode(document.RootElement.Clone()),
+                JsonValueKind.Null => new ScalarNode(null),
+                _ => throw new FormUrlEncodedInputException(
+                    "JSON objects and arrays are not supported as scalar form values; use bracket paths.")
+            };
+        }
+        catch (JsonException)
+        {
+            return new ScalarNode(value);
+        }
+    }
+
+    private static void Insert(
+        ObjectNode root,
+        IReadOnlyList<PathSegment> path,
+        ScalarNode value,
+        string originalKey)
+        => InsertIntoObject(root, path, 0, value, originalKey);
+
+    private static void InsertIntoObject(
+        ObjectNode current,
+        IReadOnlyList<PathSegment> path,
+        int position,
+        ScalarNode value,
+        string originalKey)
+    {
+        if (path[position] is not PropertySegment property)
+        {
+            throw InvalidPath(originalKey, "An object path requires a property segment.");
+        }
+
+        if (position == path.Count - 1)
+        {
+            AddScalar(current.Properties, property.Name, value, originalKey);
+            return;
+        }
+
+        var expected = CreateContainer(path[position + 1]);
+        if (!current.Properties.TryGetValue(property.Name, out var child))
+        {
+            child = expected;
+            current.Properties.Add(property.Name, child);
+        }
+        else if (child.GetType() != expected.GetType())
+        {
+            throw Collision(originalKey, property.Name);
+        }
+
+        InsertIntoNode(child, path, position + 1, value, originalKey);
+    }
+
+    private static void InsertIntoNode(
+        Node current,
+        IReadOnlyList<PathSegment> path,
+        int position,
+        ScalarNode value,
+        string originalKey)
+    {
+        switch (current)
+        {
+            case ObjectNode obj:
+                InsertIntoObject(obj, path, position, value, originalKey);
+                break;
+            case ArrayNode array:
+                InsertIntoArray(array, path, position, value, originalKey);
+                break;
+            case ScalarCollectionNode collection when path[position] is AppendSegment && position == path.Count - 1:
+                collection.Values.Add(value);
+                break;
+            default:
+                throw Collision(originalKey, originalKey);
+        }
+    }
+
+    private static void InsertIntoArray(
+        ArrayNode current,
+        IReadOnlyList<PathSegment> path,
+        int position,
+        ScalarNode value,
+        string originalKey)
+    {
+        if (path[position] is not IndexSegment indexSegment)
+        {
+            throw InvalidPath(originalKey, "An indexed array requires a numeric index.");
+        }
+
+        while (current.Items.Count < indexSegment.Index)
+        {
+            current.Items.Add(MissingNode.Instance);
+        }
+
+        if (position == path.Count - 1)
+        {
+            if (indexSegment.Index == current.Items.Count)
+            {
+                current.Items.Add(value);
+                return;
+            }
+
+            current.Items[indexSegment.Index] = current.Items[indexSegment.Index] is MissingNode
+                ? value
+                : PromoteScalar(current.Items[indexSegment.Index], value, originalKey);
+            return;
+        }
+
+        var expected = CreateContainer(path[position + 1]);
+        Node child;
+        if (indexSegment.Index == current.Items.Count)
+        {
+            child = expected;
+            current.Items.Add(child);
+        }
+        else
+        {
+            child = current.Items[indexSegment.Index];
+            if (child is MissingNode)
+            {
+                child = expected;
+                current.Items[indexSegment.Index] = child;
+            }
+            else if (child.GetType() != expected.GetType())
+            {
+                throw Collision(originalKey, indexSegment.Index.ToString(CultureInfo.InvariantCulture));
+            }
+        }
+
+        InsertIntoNode(child, path, position + 1, value, originalKey);
+    }
+
+    private static Node CreateContainer(PathSegment next)
+        => next switch
+        {
+            PropertySegment => new ObjectNode(),
+            IndexSegment => new ArrayNode(),
+            AppendSegment => new ScalarCollectionNode(),
+            _ => throw new InvalidOperationException($"Unknown path segment {next.GetType().Name}.")
+        };
+
+    private static void AddScalar(
+        Dictionary<string, Node> properties,
+        string key,
+        ScalarNode value,
+        string originalKey)
+    {
+        if (!properties.TryGetValue(key, out var existing))
+        {
+            properties.Add(key, value);
+            return;
+        }
+
+        properties[key] = PromoteScalar(existing, value, originalKey);
+    }
+
+    private static Node PromoteScalar(Node existing, ScalarNode value, string originalKey)
+    {
+        switch (existing)
+        {
+            case ScalarNode scalar:
+                return new ScalarCollectionNode { Values = { scalar, value } };
+            case ScalarCollectionNode collection:
+                collection.Values.Add(value);
+                return collection;
+            default:
+                throw Collision(originalKey, originalKey);
+        }
+    }
+
+    private static void WriteNode(Utf8JsonWriter writer, Node node)
+    {
+        switch (node)
+        {
+            case ObjectNode obj:
+                writer.WriteStartObject();
+                foreach (var (key, value) in obj.Properties)
+                {
+                    writer.WritePropertyName(key);
+                    WriteNode(writer, value);
+                }
+
+                writer.WriteEndObject();
+                break;
+            case ArrayNode array:
+                writer.WriteStartArray();
+                foreach (var value in array.Items)
+                {
+                    WriteNode(writer, value);
+                }
+
+                writer.WriteEndArray();
+                break;
+            case ScalarCollectionNode collection:
+                writer.WriteStartArray();
+                foreach (var value in collection.Values)
+                {
+                    WriteNode(writer, value);
+                }
+
+                writer.WriteEndArray();
+                break;
+            case ScalarNode { Value: JsonElement element }:
+                element.WriteTo(writer);
+                break;
+            case ScalarNode { Value: string text }:
+                writer.WriteStringValue(text);
+                break;
+            case ScalarNode:
+                writer.WriteNullValue();
+                break;
+            default:
+                throw new InvalidOperationException($"Unknown form node {node.GetType().Name}.");
+        }
+    }
+
+    private static void ValidateComplete(Node node)
+    {
+        switch (node)
+        {
+            case ObjectNode obj:
+                foreach (var child in obj.Properties.Values)
+                {
+                    ValidateComplete(child);
+                }
+
+                break;
+            case ArrayNode array when array.Items.Any(item => item is MissingNode):
+                throw new FormUrlEncodedInputException("Sparse array indices are not supported.");
+            case ArrayNode array:
+                foreach (var child in array.Items)
+                {
+                    ValidateComplete(child);
+                }
+
+                break;
+        }
+    }
+
+    private static FormUrlEncodedInputException InvalidPath(string key, string reason)
+        => new($"Invalid form key '{key}': {reason}");
+
+    private static FormUrlEncodedInputException Collision(string key, string segment)
+        => InvalidPath(key, $"The path segment '{segment}' conflicts with an existing scalar or container.");
+
+    private sealed record ParsedField(
+        string OriginalKey,
+        IReadOnlyList<PathSegment> Path,
+        IReadOnlyList<string?> Values);
+
+    private abstract record PathSegment;
+    private sealed record PropertySegment(string Name) : PathSegment;
+    private sealed record IndexSegment(int Index) : PathSegment;
+    private sealed record AppendSegment : PathSegment;
+
+    private abstract class Node;
+
+    private sealed class ObjectNode : Node
+    {
+        public Dictionary<string, Node> Properties { get; } = new(StringComparer.Ordinal);
+    }
+
+    private sealed class ArrayNode : Node
+    {
+        public List<Node> Items { get; } = [];
+    }
+
+    private sealed class ScalarCollectionNode : Node
+    {
+        public List<ScalarNode> Values { get; } = [];
+    }
+
+    private sealed class ScalarNode(object? value) : Node
+    {
+        public object? Value { get; } = value;
+    }
+
+    private sealed class MissingNode : Node
+    {
+        public static MissingNode Instance { get; } = new();
+
+        private MissingNode()
+        {
+        }
+    }
+
+    private sealed class FormUrlEncodedInputException(string message) : Exception(message);
+}

--- a/src/BBT.Workflow.HttpApi.Shared/Formatters/FormUrlEncodedJsonElementInputFormatter.cs
+++ b/src/BBT.Workflow.HttpApi.Shared/Formatters/FormUrlEncodedJsonElementInputFormatter.cs
@@ -21,6 +21,14 @@ public sealed class FormUrlEncodedJsonElementInputFormatter : TextInputFormatter
 {
     private const string PayloadModeHeader = "x-vnext-payload-mode";
 
+    /// <summary>
+    /// Upper bound for a bracket array index. Arrays must use contiguous indices and cannot exceed
+    /// this size, so any index above the limit is guaranteed invalid. Rejecting it during parsing
+    /// prevents an attacker from forcing large intermediate allocations (e.g. <c>items[2000000000]=1</c>)
+    /// before the sparse-array validation would reject it.
+    /// </summary>
+    private const int MaxArrayIndex = 1024;
+
     public FormUrlEncodedJsonElementInputFormatter()
     {
         SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("application/x-www-form-urlencoded"));
@@ -142,6 +150,13 @@ public sealed class FormUrlEncodedJsonElementInputFormatter : TextInputFormatter
                 if (!int.TryParse(inner, NumberStyles.None, CultureInfo.InvariantCulture, out var index))
                 {
                     throw InvalidPath(key, "The array index is too large.");
+                }
+
+                if (index > MaxArrayIndex)
+                {
+                    throw InvalidPath(
+                        key,
+                        $"The array index exceeds the maximum supported value ({MaxArrayIndex}).");
                 }
 
                 segments.Add(new IndexSegment(index));
@@ -271,7 +286,7 @@ public sealed class FormUrlEncodedJsonElementInputFormatter : TextInputFormatter
                 collection.Values.Add(value);
                 break;
             default:
-                throw Collision(originalKey, originalKey);
+                throw Collision(originalKey, path[position].ToString());
         }
     }
 

--- a/test/BBT.Workflow.Application.Tests/BBT.Workflow.Application.Tests.csproj
+++ b/test/BBT.Workflow.Application.Tests/BBT.Workflow.Application.Tests.csproj
@@ -10,12 +10,14 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkPackageVersion)" />
+        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftPackageVersion)" />
     </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\..\src\BBT.Workflow.Application\BBT.Workflow.Application.csproj" />
       <ProjectReference Include="..\..\src\BBT.Workflow.Execution\BBT.Workflow.Execution.csproj" />
       <ProjectReference Include="..\..\src\BBT.Workflow.HttpApi.Shared\BBT.Workflow.HttpApi.Shared.csproj" />
+      <ProjectReference Include="..\..\orchestration\BBT.Workflow.Orchestration.HttpApi.Host\BBT.Workflow.Orchestration.HttpApi.Host.csproj" />
       <ProjectReference Include="..\BBT.Workflow.Domain.Tests\BBT.Workflow.Domain.Tests.csproj" />
     </ItemGroup>
 

--- a/test/BBT.Workflow.Application.Tests/Functions/FunctionAppServiceScopeTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Functions/FunctionAppServiceScopeTests.cs
@@ -239,7 +239,7 @@ public sealed class FunctionAppServiceScopeTests : IDisposable
         // On a hit the tasks are not executed and nothing is written back.
         await _taskCoordinator.DidNotReceive().ExecuteAsync(
             Arg.Any<IEnumerable<OnExecuteTask>>(), Arg.Any<Guid?>(), Arg.Any<TaskTrigger>(),
-            Arg.Any<ScriptContext>(), Arg.Any<CancellationToken>());
+            Arg.Any<TaskExecutionOrigin>(), Arg.Any<ScriptContext>(), Arg.Any<CancellationToken>());
         await _cacheGateway.DidNotReceive().SetAsync(
             Arg.Any<string>(), Arg.Any<object?>(), Arg.Any<int?>(), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<TaskTraceContext>(), Arg.Any<CancellationToken>());
@@ -262,7 +262,7 @@ public sealed class FunctionAppServiceScopeTests : IDisposable
         result.IsSuccess.ShouldBeTrue();
         await _taskCoordinator.Received(1).ExecuteAsync(
             Arg.Any<IEnumerable<OnExecuteTask>>(), Arg.Any<Guid?>(), Arg.Any<TaskTrigger>(),
-            Arg.Any<ScriptContext>(), Arg.Any<CancellationToken>());
+            Arg.Any<TaskExecutionOrigin>(), Arg.Any<ScriptContext>(), Arg.Any<CancellationToken>());
         await _cacheGateway.Received(1).SetAsync(
             "fn:test", Arg.Any<object?>(), Arg.Any<int?>(), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<TaskTraceContext>(), Arg.Any<CancellationToken>());

--- a/test/BBT.Workflow.Application.Tests/HttpApi/FormUrlEncodedFormatterRegistrationTests.cs
+++ b/test/BBT.Workflow.Application.Tests/HttpApi/FormUrlEncodedFormatterRegistrationTests.cs
@@ -1,0 +1,43 @@
+using System.Reflection;
+using BBT.Workflow.Formatters;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Application.Tests.HttpApi;
+
+public sealed class FormUrlEncodedFormatterRegistrationTests
+{
+    [Fact]
+    public void AddAspNetCoreModules_DoesNotRegisterFormFormatterForEveryHost()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder().Build();
+
+        services.AddAspNetCoreModules(configuration);
+
+        var options = services.BuildServiceProvider().GetRequiredService<IOptions<MvcOptions>>().Value;
+        options.InputFormatters.ShouldNotContain(formatter =>
+            formatter is FormUrlEncodedJsonElementInputFormatter);
+    }
+
+    [Fact]
+    public void OrchestrationRegistration_AddsFormFormatter()
+    {
+        var services = new ServiceCollection();
+        services.AddControllers();
+        var registrationMethod = typeof(OrchestrationApiServiceCollectionExtensions).GetMethod(
+            "AddFormUrlEncodedJsonElementInput",
+            BindingFlags.Static | BindingFlags.NonPublic);
+
+        registrationMethod.ShouldNotBeNull();
+        registrationMethod!.Invoke(null, [services]);
+
+        var options = services.BuildServiceProvider().GetRequiredService<IOptions<MvcOptions>>().Value;
+        options.InputFormatters.ShouldContain(formatter =>
+            formatter is FormUrlEncodedJsonElementInputFormatter);
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/HttpApi/FormUrlEncodedJsonElementInputFormatterTests.cs
+++ b/test/BBT.Workflow.Application.Tests/HttpApi/FormUrlEncodedJsonElementInputFormatterTests.cs
@@ -1,0 +1,329 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using BBT.Workflow.Formatters;
+using BBT.Workflow.Instances;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Application.Tests.HttpApi;
+
+/// <summary>
+/// Unit tests for <see cref="FormUrlEncodedJsonElementInputFormatter"/>: it accepts
+/// <c>application/x-www-form-urlencoded</c> bodies, projects them into a <see cref="JsonElement"/>
+/// (supporting bracket-notation nesting and arrays, with string leaf values), and leaves
+/// <c>application/json</c> to the default formatter.
+/// </summary>
+public class FormUrlEncodedJsonElementInputFormatterTests
+{
+    private const string FormContentType = "application/x-www-form-urlencoded";
+
+    private static readonly EmptyModelMetadataProvider MetadataProvider = new();
+
+    private static InputFormatterContext BuildContext(
+        string? contentType,
+        string body,
+        Type modelType,
+        string? payloadMode = null)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.ContentType = contentType;
+        if (payloadMode is not null)
+        {
+            httpContext.Request.Headers["x-vnext-payload-mode"] = payloadMode;
+        }
+
+        var bytes = Encoding.UTF8.GetBytes(body);
+        httpContext.Request.Body = new MemoryStream(bytes);
+        httpContext.Request.ContentLength = bytes.Length;
+
+        var metadata = MetadataProvider.GetMetadataForType(modelType);
+
+        return new InputFormatterContext(
+            httpContext,
+            modelName: string.Empty,
+            modelState: new ModelStateDictionary(),
+            metadata: metadata,
+            readerFactory: (stream, encoding) => new StreamReader(stream, encoding),
+            treatEmptyInputAsDefaultValue: true);
+    }
+
+    private static async Task<JsonElement> ReadElementAsync(
+        FormUrlEncodedJsonElementInputFormatter formatter,
+        string body,
+        string? payloadMode = null)
+    {
+        var context = BuildContext(FormContentType, body, typeof(JsonElement?), payloadMode);
+        var result = await formatter.ReadRequestBodyAsync(context, Encoding.UTF8);
+        result.HasError.ShouldBeFalse();
+        result.Model.ShouldNotBeNull();
+        return (JsonElement)result.Model!;
+    }
+
+    [Fact]
+    public void CanRead_FormUrlEncodedContentType_ReturnsTrue()
+    {
+        var formatter = new FormUrlEncodedJsonElementInputFormatter();
+        var context = BuildContext(FormContentType, "a=1", typeof(JsonElement?));
+
+        formatter.CanRead(context).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void CanRead_JsonContentType_ReturnsFalse()
+    {
+        var formatter = new FormUrlEncodedJsonElementInputFormatter();
+        var context = BuildContext("application/json", "{}", typeof(JsonElement?));
+
+        formatter.CanRead(context).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ReadRequestBodyAsync_RawFlatFields_ProjectsJsonLiteralAndStringLeaves()
+    {
+        var formatter = new FormUrlEncodedJsonElementInputFormatter();
+
+        var element = await ReadElementAsync(formatter, "amount=100&currency=TRY");
+
+        element.ValueKind.ShouldBe(JsonValueKind.Object);
+        element.GetProperty("amount").ValueKind.ShouldBe(JsonValueKind.Number);
+        element.GetProperty("amount").GetInt32().ShouldBe(100);
+        element.GetProperty("currency").GetString().ShouldBe("TRY");
+    }
+
+    [Theory]
+    [InlineData("age=30", "age", JsonValueKind.Number)]
+    [InlineData("active=true", "active", JsonValueKind.True)]
+    [InlineData("active=false", "active", JsonValueKind.False)]
+    [InlineData("value=null", "value", JsonValueKind.Null)]
+    public async Task ReadRequestBodyAsync_RawJsonLiteral_UsesJsonType(
+        string body,
+        string property,
+        JsonValueKind expectedKind)
+    {
+        var element = await ReadElementAsync(new FormUrlEncodedJsonElementInputFormatter(), body);
+
+        element.GetProperty(property).ValueKind.ShouldBe(expectedKind);
+    }
+
+    [Fact]
+    public async Task ReadRequestBodyAsync_QuotedScalar_PreservesString()
+    {
+        var element = await ReadElementAsync(
+            new FormUrlEncodedJsonElementInputFormatter(),
+            "code=%2200123%22");
+
+        element.GetProperty("code").ValueKind.ShouldBe(JsonValueKind.String);
+        element.GetProperty("code").GetString().ShouldBe("00123");
+    }
+
+    [Fact]
+    public async Task ReadRequestBodyAsync_LargeNumericKey_PreservedAsString()
+    {
+        var formatter = new FormUrlEncodedJsonElementInputFormatter();
+
+        var element = await ReadElementAsync(
+            formatter,
+            "key=50044086191232280074134",
+            payloadMode: "standard");
+
+        element.GetProperty("key").ValueKind.ShouldBe(JsonValueKind.String);
+        element.GetProperty("key").GetString().ShouldBe("50044086191232280074134");
+    }
+
+    [Fact]
+    public async Task ReadRequestBodyAsync_StandardEnvelope_PreservesEnvelopeStringsAndTypesAttributes()
+    {
+        var element = await ReadElementAsync(
+            new FormUrlEncodedJsonElementInputFormatter(),
+            "key=50044086191232280074134&stage=123&tags[]=1&attributes[age]=30",
+            payloadMode: "standard");
+
+        element.GetProperty("key").ValueKind.ShouldBe(JsonValueKind.String);
+        element.GetProperty("stage").ValueKind.ShouldBe(JsonValueKind.String);
+        element.GetProperty("tags")[0].ValueKind.ShouldBe(JsonValueKind.String);
+        element.GetProperty("attributes").GetProperty("age").ValueKind.ShouldBe(JsonValueKind.Number);
+    }
+
+    [Fact]
+    public async Task ReadRequestBodyAsync_StandardEnvelope_PreservesEnvelopeStringsCaseInsensitively()
+    {
+        var element = await ReadElementAsync(
+            new FormUrlEncodedJsonElementInputFormatter(),
+            "Key=50044086191232280074134&Stage=123&Tags[]=1&Attributes[age]=30",
+            payloadMode: "standard");
+
+        element.GetProperty("Key").ValueKind.ShouldBe(JsonValueKind.String);
+        element.GetProperty("Stage").ValueKind.ShouldBe(JsonValueKind.String);
+        element.GetProperty("Tags")[0].ValueKind.ShouldBe(JsonValueKind.String);
+        element.GetProperty("Attributes").GetProperty("age").ValueKind.ShouldBe(JsonValueKind.Number);
+    }
+
+    [Fact]
+    public async Task ReadRequestBodyAsync_BracketNotation_BuildsNestedObject()
+    {
+        var formatter = new FormUrlEncodedJsonElementInputFormatter();
+
+        // attributes[session]=... & attributes[customer][ownerUserId]=...
+        var element = await ReadElementAsync(
+            formatter,
+            "attributes[session]=423432&attributes[customer][ownerUserId]=2321321");
+
+        var attributes = element.GetProperty("attributes");
+        attributes.ValueKind.ShouldBe(JsonValueKind.Object);
+        attributes.GetProperty("session").GetInt32().ShouldBe(423432);
+        attributes.GetProperty("customer").GetProperty("ownerUserId").GetInt32().ShouldBe(2321321);
+    }
+
+    [Fact]
+    public async Task ReadRequestBodyAsync_RepeatedKey_ProjectsToJsonArray()
+    {
+        var formatter = new FormUrlEncodedJsonElementInputFormatter();
+
+        var element = await ReadElementAsync(formatter, "tags=a&tags=b");
+
+        var tags = element.GetProperty("tags");
+        tags.ValueKind.ShouldBe(JsonValueKind.Array);
+        tags.GetArrayLength().ShouldBe(2);
+        tags[0].GetString().ShouldBe("a");
+        tags[1].GetString().ShouldBe("b");
+    }
+
+    [Fact]
+    public async Task ReadRequestBodyAsync_EmptyBracketNotation_ProjectsToJsonArray()
+    {
+        var formatter = new FormUrlEncodedJsonElementInputFormatter();
+
+        var element = await ReadElementAsync(formatter, "tags[]=a&tags[]=b");
+
+        var tags = element.GetProperty("tags");
+        tags.ValueKind.ShouldBe(JsonValueKind.Array);
+        tags.GetArrayLength().ShouldBe(2);
+        tags[0].GetString().ShouldBe("a");
+        tags[1].GetString().ShouldBe("b");
+    }
+
+    [Fact]
+    public async Task ReadRequestBodyAsync_IndexedObjectArray_BuildsJsonArray()
+    {
+        var element = await ReadElementAsync(
+            new FormUrlEncodedJsonElementInputFormatter(),
+            "items[0][name]=A&items[1][name]=B");
+
+        var items = element.GetProperty("items");
+        items.ValueKind.ShouldBe(JsonValueKind.Array);
+        items[0].GetProperty("name").GetString().ShouldBe("A");
+        items[1].GetProperty("name").GetString().ShouldBe("B");
+    }
+
+    [Fact]
+    public async Task ReadRequestBodyAsync_CompleteOutOfOrderIndexedArray_BuildsJsonArray()
+    {
+        var element = await ReadElementAsync(
+            new FormUrlEncodedJsonElementInputFormatter(),
+            "items[1][name]=B&items[0][name]=A");
+
+        var items = element.GetProperty("items");
+        items[0].GetProperty("name").GetString().ShouldBe("A");
+        items[1].GetProperty("name").GetString().ShouldBe("B");
+    }
+
+    [Theory]
+    [InlineData("items[][name]=A")]
+    [InlineData("items[1][name]=A")]
+    [InlineData("a=x&a[b]=y")]
+    [InlineData("a[b=x")]
+    [InlineData("items[-1]=A")]
+    [InlineData("payload=%7B%22x%22%3A1%7D")]
+    public async Task ReadRequestBodyAsync_InvalidOrAmbiguousShape_ReturnsFormatterFailure(string body)
+    {
+        var formatter = new FormUrlEncodedJsonElementInputFormatter();
+        var context = BuildContext(FormContentType, body, typeof(JsonElement?));
+
+        var result = await formatter.ReadRequestBodyAsync(context, Encoding.UTF8);
+
+        result.HasError.ShouldBeTrue();
+        context.ModelState.IsValid.ShouldBeFalse();
+        context.ModelState.ErrorCount.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task ReadRequestBodyAsync_EmptyBody_ProjectsToEmptyJsonObject()
+    {
+        var formatter = new FormUrlEncodedJsonElementInputFormatter();
+
+        var element = await ReadElementAsync(formatter, string.Empty);
+
+        element.ValueKind.ShouldBe(JsonValueKind.Object);
+        element.EnumerateObject().MoveNext().ShouldBeFalse();
+    }
+
+    // ---- Model-binding parity with JSON. TransitionDataInput mirrors CreateInstanceDto exactly
+    //      (Key/Tags/Attributes/Stage), so it stands in for both the Start and Transition payloads.
+
+    [Fact]
+    public async Task ProjectedElement_StandardModelWithNestedAttributes_DeserializesIntoDto()
+    {
+        var formatter = new FormUrlEncodedJsonElementInputFormatter();
+
+        // Mirrors the reported payload sent as form-urlencoded bracket notation.
+        var body = "key=50044086191232280074134&stage=Initial"
+                   + "&attributes[session]=423432"
+                   + "&attributes[customer][ownerUserId]=2321321";
+
+        var element = await ReadElementAsync(formatter, body);
+        var dto = JsonSerializer.Deserialize<TransitionDataInput>(element, JsonSerializerOptions.Web);
+
+        dto.ShouldNotBeNull();
+        dto!.Key.ShouldBe("50044086191232280074134");
+        dto.Stage.ShouldBe("Initial");
+        dto.Attributes!.Value.GetProperty("session").GetInt32().ShouldBe(423432);
+        dto.Attributes!.Value.GetProperty("customer").GetProperty("ownerUserId").GetInt32().ShouldBe(2321321);
+    }
+
+    [Fact]
+    public async Task ProjectedElement_ModelTags_DeserializeIntoStringArray()
+    {
+        var formatter = new FormUrlEncodedJsonElementInputFormatter();
+
+        var element = await ReadElementAsync(formatter, "key=k1&tags[]=a&tags[]=b");
+        var dto = JsonSerializer.Deserialize<TransitionDataInput>(element, JsonSerializerOptions.Web);
+
+        dto.ShouldNotBeNull();
+        dto!.Key.ShouldBe("k1");
+        dto.Tags.ShouldBe(new[] { "a", "b" });
+    }
+
+    [Fact]
+    public async Task ProjectedElement_ModelSingleTag_DeserializesIntoSingleElementStringArray()
+    {
+        var formatter = new FormUrlEncodedJsonElementInputFormatter();
+
+        var element = await ReadElementAsync(
+            formatter,
+            "key=k1&tags=a&attributes[name]=Ali");
+        var dto = JsonSerializer.Deserialize<TransitionDataInput>(element, JsonSerializerOptions.Web);
+
+        dto.ShouldNotBeNull();
+        dto!.Tags.ShouldBe(new[] { "a" });
+    }
+
+    [Fact]
+    public async Task ProjectedElement_FreeFormPayload_UsableAsAttributesBody()
+    {
+        var formatter = new FormUrlEncodedJsonElementInputFormatter();
+
+        var element = await ReadElementAsync(formatter, "amount=100&currency=TRY");
+
+        // No top-level "attributes" ⇒ free-form ⇒ controller wraps the whole body as Attributes.
+        element.TryGetProperty("attributes", out _).ShouldBeFalse();
+        var dto = new TransitionDataInput(element);
+        dto.Attributes!.Value.GetProperty("amount").GetInt32().ShouldBe(100);
+        dto.Attributes!.Value.GetProperty("currency").GetString().ShouldBe("TRY");
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/HttpApi/FormUrlEncodedJsonElementInputFormatterTests.cs
+++ b/test/BBT.Workflow.Application.Tests/HttpApi/FormUrlEncodedJsonElementInputFormatterTests.cs
@@ -239,6 +239,8 @@ public class FormUrlEncodedJsonElementInputFormatterTests
     [InlineData("a=x&a[b]=y")]
     [InlineData("a[b=x")]
     [InlineData("items[-1]=A")]
+    [InlineData("items[1025]=A")] // index above MaxArrayIndex — rejected at parse, no padding allocation
+    [InlineData("items[2000000000]=A")] // guards against large sparse-array memory allocation
     [InlineData("payload=%7B%22x%22%3A1%7D")]
     public async Task ReadRequestBodyAsync_InvalidOrAmbiguousShape_ReturnsFormatterFailure(string body)
     {

--- a/test/BBT.Workflow.Application.Tests/HttpApi/FormUrlEncodedMvcContractTests.cs
+++ b/test/BBT.Workflow.Application.Tests/HttpApi/FormUrlEncodedMvcContractTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using BBT.Workflow.Controllers.Instances;
+using BBT.Workflow.Orchestration.Controllers.Instances;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Application.Tests.HttpApi;
+
+public sealed class FormUrlEncodedMvcContractTests
+{
+    [Fact]
+    public async Task MvcBinding_FormAndJsonBodies_ProduceEquivalentTypedPayloads()
+    {
+        await using var app = await StartProbeApplicationAsync();
+        var client = app.GetTestClient();
+        using var form = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["attributes[age]"] = "30",
+            ["attributes[active]"] = "true"
+        });
+
+        var formResponse = await client.PostAsync("/_tests/form-payload", form);
+        var jsonResponse = await client.PostAsJsonAsync(
+            "/_tests/form-payload",
+            new { attributes = new { age = 30, active = true } });
+
+        formResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+        jsonResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var formJson = JsonDocument.Parse(await formResponse.Content.ReadAsStringAsync());
+        var jsonJson = JsonDocument.Parse(await jsonResponse.Content.ReadAsStringAsync());
+        JsonElement.DeepEquals(formJson.RootElement, jsonJson.RootElement).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task MvcBinding_AmbiguousFormPath_ReturnsBadRequest()
+    {
+        await using var app = await StartProbeApplicationAsync();
+        var client = app.GetTestClient();
+        using var content = new StringContent(
+            "items[][name]=A",
+            Encoding.UTF8,
+            "application/x-www-form-urlencoded");
+
+        var response = await client.PostAsync("/_tests/form-payload", content);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        var responseBody = await response.Content.ReadAsStringAsync();
+        responseBody.ShouldContain("Empty brackets are supported only for trailing scalar arrays.");
+    }
+
+    [Theory]
+    [InlineData(nameof(InstanceController), nameof(InstanceController.StartAsync))]
+    [InlineData(nameof(InstanceController), nameof(InstanceController.TransitionAsync))]
+    [InlineData(nameof(FunctionController), nameof(FunctionController.InvokeDomainFunctionAsync))]
+    [InlineData(nameof(FunctionController), nameof(FunctionController.InvokeInstanceFunctionAsync))]
+    public async Task ApiMetadata_JsonElementEndpoints_AdvertiseJsonAndForm(
+        string controllerName,
+        string actionName)
+    {
+        var mvcActionName = actionName.EndsWith("Async", StringComparison.Ordinal)
+            ? actionName[..^"Async".Length]
+            : actionName;
+        var builder = WebApplication.CreateBuilder();
+        builder.Services.AddEndpointsApiExplorer();
+        builder.Services.AddAetherApiVersioning(apiTitle: "vNext API");
+        builder.Services.AddControllers()
+            .AddApplicationPart(typeof(InstanceController).Assembly);
+        builder.Services.AddFormUrlEncodedJsonElementInput();
+        await using var app = builder.Build();
+
+        var descriptions = app.Services
+            .GetRequiredService<IApiDescriptionGroupCollectionProvider>()
+            .ApiDescriptionGroups.Items
+            .SelectMany(group => group.Items)
+            .Where(description =>
+            {
+                var action = description.ActionDescriptor as ControllerActionDescriptor;
+                return action?.ControllerName == controllerName.Replace("Controller", string.Empty) &&
+                       action.ActionName == mvcActionName;
+            })
+            .ToArray();
+
+        descriptions.ShouldNotBeEmpty();
+        foreach (var description in descriptions)
+        {
+            var mediaTypes = description.SupportedRequestFormats
+                .Select(format => format.MediaType)
+                .ToArray();
+            mediaTypes.ShouldContain("application/json");
+            mediaTypes.ShouldContain("application/x-www-form-urlencoded");
+        }
+    }
+
+    private static async Task<WebApplication> StartProbeApplicationAsync()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddControllers()
+            .AddApplicationPart(typeof(FormPayloadProbeController).Assembly);
+        builder.Services.AddFormUrlEncodedJsonElementInput();
+        var app = builder.Build();
+        app.MapControllers();
+        await app.StartAsync();
+        return app;
+    }
+}
+
+[ApiController]
+[Route("_tests/form-payload")]
+public sealed class FormPayloadProbeController : ControllerBase
+{
+    [HttpPost]
+    public IActionResult Post([FromBody] JsonElement? body)
+        => Ok(body);
+}


### PR DESCRIPTION
## Summary

- add JSON-compatible `application/x-www-form-urlencoded` binding for Orchestration Start, Transition, and Function endpoints
- preserve string semantics for standard envelope fields while typing raw payload and `attributes` values as JSON scalars
- support nested objects, repeated/trailing scalar arrays, and indexed object arrays
- reject malformed, sparse, or structurally ambiguous form paths with `400 Bad Request`
- scope the formatter registration to the Orchestration host
- document the public form payload contract and add formatter, MVC, registration, and ApiDescription coverage

## Why

The previous formatter emitted every form value as a JSON string and could silently mis-shape or drop complex array data. This prevented form submissions from reaching JSON parity and caused strict JSON-schema validation to behave differently depending on content type.

## Impact

Clients can submit equivalent JSON and form-urlencoded payloads to the supported Orchestration endpoints. Numeric, boolean, and null literals retain their JSON types, while quoted values and standard envelope fields remain strings.

Closes #825.

## Validation

- `dotnet test test/BBT.Workflow.Application.Tests/BBT.Workflow.Application.Tests.csproj --filter 'FullyQualifiedName~FormUrlEncoded' --no-restore`
  - 35 passed, 0 failed
- `git diff --cached --check` before commit
  - passed
- Full Application test project:
  - 749 passed, 27 failed, 8 skipped
  - the same 27 unrelated baseline failures were present before this change

## Summary by Sourcery

Add a scoped form-urlencoded-to-JSON input formatter for Orchestration APIs, ensuring JSON-type parity, strict path validation, and documented contract, with supporting MVC registration and test coverage.

New Features:
- Introduce a custom application/x-www-form-urlencoded input formatter that projects form data into JsonElement payloads with JSON-scalar semantics.

Enhancements:
- Scope form-urlencoded formatter registration to the Orchestration host without affecting other ASP.NET Core modules.
- Ensure Orchestration endpoints advertise both JSON and form-urlencoded media types via MVC API metadata.

Documentation:
- Document the form-urlencoded payload contract, including supported key patterns, typing rules, payload modes, and rejection cases.
- Add internal design and implementation plan documents for achieving JSON parity for form-urlencoded payloads.

Tests:
- Add unit tests for the new form-urlencoded input formatter covering scalar typing, nested objects, arrays, and error cases.
- Add tests verifying formatter registration is limited to Orchestration and that MVC binding and ApiExplorer metadata behave as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Orchestration API endpoints now support `application/x-www-form-urlencoded` request bodies.
  * Form data supports nested objects, arrays, typed scalar values, and standard or raw payload modes.
  * Invalid or ambiguous form structures return clear HTTP 400 responses.
  * API metadata now advertises both JSON and form-encoded request formats for supported endpoints.

* **Documentation**
  * Added comprehensive guidance covering form payload structure, typing, overrides, validation rules, and supported endpoint scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->