### PR TITLE
Change Interaction

### DIFF
--- a/src/BBT.Workflow.Application/Instances/DTOs/InstanceInteractionOutput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/InstanceInteractionOutput.cs
@@ -4,20 +4,29 @@ namespace BBT.Workflow.Instances;
 
 /// <summary>
 /// Client-workflow-manager interaction directives surfaced on the State (long-poll) function response.
-/// A generic, extensible container: today it carries long-poll termination; future directives are
-/// added here as additional properties rather than at the response root.
+/// A generic, extensible container: today it carries the long-poll directive. It is emitted whenever the
+/// current state declares <c>interaction.longPoll</c> (subject to role grants), regardless of the
+/// <c>terminate</c> value; future directives are added here as additional properties rather than at the
+/// response root.
 /// </summary>
 public sealed class InstanceInteractionOutput
 {
     /// <summary>
     /// When true, the client should terminate its active long-poll request, render the entered-state
-    /// screen, and acknowledge via <see cref="Ack"/>. Set when the entered state declares
-    /// <c>interaction.longPoll.terminate</c> and the caller's role is granted the signal.
+    /// screen, and acknowledge via <see cref="Ack"/>. Reflects the state's <c>interaction.longPoll.terminate</c>
+    /// value — it may be <c>false</c> when the state declares long-poll interaction without termination.
     /// </summary>
     public bool TerminateLongPoll { get; set; }
 
     /// <summary>
-    /// Acknowledge endpoint href. Present when <see cref="TerminateLongPoll"/> is true. POSTing to it
+    /// Acknowledge fallback window in seconds (<c>interaction.longPoll.fallbackTimeoutSeconds</c>, default 60).
+    /// Always present when the state declares <c>interaction.longPoll</c>. When <see cref="TerminateLongPoll"/>
+    /// is true and the client does not acknowledge within this window, a scheduled fallback resumes the pipeline.
+    /// </summary>
+    public int FallbackTimeoutSeconds { get; set; }
+
+    /// <summary>
+    /// Acknowledge endpoint href. Present only when <see cref="TerminateLongPoll"/> is true. POSTing to it
     /// resumes the paused pipeline; if not called, a fallback schedule resumes it automatically.
     /// </summary>
     public AckHref? Ack { get; set; }

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -1080,24 +1080,28 @@ public sealed class InstanceQueryAppService(
                 displayedState = aliasDisplay;
         }
 
-        // Declarative long-poll termination: when the instance is paused on a state that terminates
-        // long polling and the caller's role is granted the signal, tell the client to stop polling,
-        // render the entered-state screen, and acknowledge via the ack href. Role-filtered so only the
-        // intended roles are told to stop. The awaiting instance may be THIS instance (leaf) or a
-        // nested subflow whose signal bubbled up via SubFlowStateInfo — in the subflow case the ack
-        // href is rewritten to THIS level so the client always acknowledges the instance it polls; the
-        // acknowledge endpoint then descends the chain. The two are mutually exclusive (a parent in a
-        // SubFlow state is not itself in a terminate state). Role filtering for the bubbled case was
-        // already applied at the child level (caller role forwarded via headers).
-        var interaction = subFlowStateInfo.Interaction?.TerminateLongPoll == true
+        // Declarative long-poll interaction: emitted whenever the current state declares
+        // interaction.longPoll (subject to role grants), carrying the terminate flag and fallback window.
+        // When terminate is true the client is told to stop polling, render the entered-state screen,
+        // and acknowledge via the ack href. Role-filtered so only the intended roles receive it. The
+        // interaction may originate at THIS instance (leaf) or at a nested subflow whose signal bubbled
+        // up via SubFlowStateInfo — in the subflow case the ack href is rewritten to THIS level so the
+        // client always acknowledges the instance it polls; the acknowledge endpoint then descends the
+        // chain. The two are mutually exclusive (a parent in a SubFlow state does not itself declare
+        // long-poll interaction). Role filtering for the bubbled case was already applied at the child
+        // level (caller role forwarded via headers).
+        var interaction = subFlowStateInfo.Interaction is { } childInteraction
             ? new InstanceInteractionOutput
             {
-                TerminateLongPoll = true,
-                Ack = new AckHref
-                {
-                    Href = urlTemplateBuilder.BuildLongPollAckUrl(
-                        input.Domain, input.Workflow, instance.Id.ToString())
-                }
+                TerminateLongPoll = childInteraction.TerminateLongPoll,
+                FallbackTimeoutSeconds = childInteraction.FallbackTimeoutSeconds,
+                Ack = childInteraction.Ack is not null
+                    ? new AckHref
+                    {
+                        Href = urlTemplateBuilder.BuildLongPollAckUrl(
+                            input.Domain, input.Workflow, instance.Id.ToString())
+                    }
+                    : null
             }
             : await ResolveInteractionAsync(
                 input, instance, currentStateValue, displayedState, cancellationToken);
@@ -1119,9 +1123,11 @@ public sealed class InstanceQueryAppService(
 
     /// <summary>
     /// Resolves the client-workflow-manager interaction directives for the response, or null when none
-    /// apply. Today this is long-poll termination: emitted only on the main-flow current state, when the
-    /// instance is awaiting acknowledge, the state declares <c>interaction.longPoll.terminate</c>, and the
-    /// caller's role is granted by <c>interaction.longPoll.roles</c> (default-allow when no roles configured).
+    /// apply. Today this is the long-poll directive: emitted on the main-flow current state whenever the
+    /// state declares <c>interaction.longPoll</c> and the caller's role is granted by
+    /// <c>interaction.longPoll.roles</c> (default-allow when no roles configured). The <c>terminate</c>
+    /// flag and <c>fallbackTimeoutSeconds</c> are surfaced as configured; the ack href is included only
+    /// when <c>terminate</c> is true (the pipeline pauses awaiting acknowledge in that case).
     /// </summary>
     private async Task<InstanceInteractionOutput?> ResolveInteractionAsync(
         GetInstanceStateInput input,
@@ -1130,7 +1136,7 @@ public sealed class InstanceQueryAppService(
         string? displayedState,
         CancellationToken cancellationToken)
     {
-        if (!instance.IsAwaitingLongPollAck || !currentStateValue.TerminatesLongPollOnEntry)
+        if (currentStateValue.Interaction?.LongPoll is null)
             return null;
 
         // Only signal on the main-flow current state view, not a subflow terminal view.
@@ -1153,12 +1159,18 @@ public sealed class InstanceQueryAppService(
                 return null;
         }
 
-        var ackHref = urlTemplateBuilder.BuildLongPollAckUrl(
-            input.Domain, input.Workflow, instance.Id.ToString());
+        var terminate = currentStateValue.TerminatesLongPollOnEntry;
         return new InstanceInteractionOutput
         {
-            TerminateLongPoll = true,
-            Ack = new AckHref { Href = ackHref }
+            TerminateLongPoll = terminate,
+            FallbackTimeoutSeconds = currentStateValue.LongPollFallbackTimeoutSeconds,
+            Ack = terminate
+                ? new AckHref
+                {
+                    Href = urlTemplateBuilder.BuildLongPollAckUrl(
+                        input.Domain, input.Workflow, instance.Id.ToString())
+                }
+                : null
         };
     }
 

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceStateTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceStateTests.cs
@@ -215,6 +215,7 @@ public class InstanceQueryAppServiceStateTests : IDisposable
         SetupSubFlowGateway(InstanceStatus.Active, "sub-review", new InstanceInteractionOutput
         {
             TerminateLongPoll = true,
+            FallbackTimeoutSeconds = 90,
             Ack = new BBT.Workflow.Shared.AckHref { Href = "/child/longpoll/ack" }
         });
         _urlTemplateBuilder
@@ -226,11 +227,12 @@ public class InstanceQueryAppServiceStateTests : IDisposable
         // Act
         var result = await _service.GetInstanceStateAsync(input, CancellationToken.None);
 
-        // Assert — bubbled up, ack href rewritten to the parent's endpoint
+        // Assert — bubbled up, ack href rewritten to the parent's endpoint, fallback carried through
         result.Result.IsSuccess.ShouldBeTrue();
         var output = result.Result.Value!;
         output.Interaction.ShouldNotBeNull();
         output.Interaction!.TerminateLongPoll.ShouldBeTrue();
+        output.Interaction.FallbackTimeoutSeconds.ShouldBe(90);
         output.Interaction.Ack.ShouldNotBeNull();
         output.Interaction.Ack!.Href.ShouldBe("/parent/longpoll/ack");
     }
@@ -245,6 +247,107 @@ public class InstanceQueryAppServiceStateTests : IDisposable
         var (instance, workflow) = CreateParentWithActiveSubFlow();
         SetupCommonMocks(instance, workflow);
         SetupSubFlowGateway(InstanceStatus.Active, "sub-review");
+
+        var input = CreateInput(instance.Id.ToString());
+
+        // Act
+        var result = await _service.GetInstanceStateAsync(input, CancellationToken.None);
+
+        // Assert
+        result.Result.IsSuccess.ShouldBeTrue();
+        result.Result.Value!.Interaction.ShouldBeNull();
+    }
+
+    /// <summary>
+    /// When the current state declares interaction.longPoll with terminate=true, the interaction block is
+    /// emitted with the terminate flag, the configured fallback window, and the acknowledge href.
+    /// </summary>
+    [Fact]
+    public async Task GetInstanceStateAsync_WhenStateDeclaresLongPollTerminate_EmitsInteractionWithAck()
+    {
+        // Arrange
+        var (instance, workflow) = CreateInstanceWithLongPollState(terminate: true, fallbackSeconds: 45);
+        SetupCommonMocks(instance, workflow);
+        _urlTemplateBuilder
+            .BuildLongPollAckUrl(TestDomain, TestWorkflow, instance.Id.ToString(), Arg.Any<string?>())
+            .Returns("/longpoll/ack");
+
+        var input = CreateInput(instance.Id.ToString());
+
+        // Act
+        var result = await _service.GetInstanceStateAsync(input, CancellationToken.None);
+
+        // Assert
+        result.Result.IsSuccess.ShouldBeTrue();
+        var interaction = result.Result.Value!.Interaction;
+        interaction.ShouldNotBeNull();
+        interaction!.TerminateLongPoll.ShouldBeTrue();
+        interaction.FallbackTimeoutSeconds.ShouldBe(45);
+        interaction.Ack.ShouldNotBeNull();
+        interaction.Ack!.Href.ShouldBe("/longpoll/ack");
+    }
+
+    /// <summary>
+    /// When the current state declares interaction.longPoll with terminate=false, the interaction block is
+    /// still emitted (terminate flag false, fallback window present) but without an acknowledge href.
+    /// </summary>
+    [Fact]
+    public async Task GetInstanceStateAsync_WhenStateDeclaresLongPollWithoutTerminate_EmitsInteractionWithoutAck()
+    {
+        // Arrange
+        var (instance, workflow) = CreateInstanceWithLongPollState(terminate: false, fallbackSeconds: 120);
+        SetupCommonMocks(instance, workflow);
+
+        var input = CreateInput(instance.Id.ToString());
+
+        // Act
+        var result = await _service.GetInstanceStateAsync(input, CancellationToken.None);
+
+        // Assert
+        result.Result.IsSuccess.ShouldBeTrue();
+        var interaction = result.Result.Value!.Interaction;
+        interaction.ShouldNotBeNull();
+        interaction!.TerminateLongPoll.ShouldBeFalse();
+        interaction.FallbackTimeoutSeconds.ShouldBe(120);
+        interaction.Ack.ShouldBeNull();
+    }
+
+    /// <summary>
+    /// When the current state does not declare interaction.longPoll, no interaction block is emitted.
+    /// </summary>
+    [Fact]
+    public async Task GetInstanceStateAsync_WhenStateHasNoLongPollDeclaration_NoInteraction()
+    {
+        // Arrange
+        var instanceId = Guid.NewGuid();
+        var instance = Instance.Create(instanceId, TestWorkflow, TestVersion, "test-key");
+        var state = State.Create(TestState, StateType.Intermediate, StateSubType.None,
+            VersionStrategy.IncreaseMinor.Code);
+        instance.ChangeState(state);
+
+        var workflow = BuildWorkflow(state);
+        SetupCommonMocks(instance, workflow);
+
+        var input = CreateInput(instance.Id.ToString());
+
+        // Act
+        var result = await _service.GetInstanceStateAsync(input, CancellationToken.None);
+
+        // Assert
+        result.Result.IsSuccess.ShouldBeTrue();
+        result.Result.Value!.Interaction.ShouldBeNull();
+    }
+
+    /// <summary>
+    /// When the state declares interaction.longPoll.roles and the caller's role is not granted,
+    /// no interaction block is emitted (role filtering preserved).
+    /// </summary>
+    [Fact]
+    public async Task GetInstanceStateAsync_WhenLongPollRolesDenyCaller_NoInteraction()
+    {
+        // Arrange — role grants present; IsAnyRoleAllowedForGrantsAsync defaults to false (caller not allowed)
+        var (instance, workflow) = CreateInstanceWithLongPollState(terminate: true, fallbackSeconds: 30, withRoles: true);
+        SetupCommonMocks(instance, workflow);
 
         var input = CreateInput(instance.Id.ToString());
 
@@ -895,6 +998,47 @@ public class InstanceQueryAppServiceStateTests : IDisposable
         _instanceQueryGateway
             .GetFunctionWithStateAsync(Arg.Any<GetFunctionWithInstanceInput>(), Arg.Any<CancellationToken>())
             .Returns(ConditionalResult<GetInstanceStateOutput>.Success(subFlowOutput));
+    }
+
+    /// <summary>
+    /// Builds an instance whose current state ("review") declares interaction.longPoll, deserialized from
+    /// JSON since the interaction value objects expose only private (JSON) constructors.
+    /// </summary>
+    private static (Instance instance, Definitions.Workflow workflow) CreateInstanceWithLongPollState(
+        bool terminate, int fallbackSeconds, bool withRoles = false)
+    {
+        var roles = withRoles
+            ? """, "roles": [ { "role": "FullAuthorized", "grant": "allow" } ]"""
+            : "";
+        var terminateLiteral = terminate ? "true" : "false";
+        var json = $$"""
+                   {
+                       "type": "F",
+                       "timeout": null,
+                       "labels": [],
+                       "functions": [],
+                       "features": [],
+                       "states": [
+                           { "key": "review", "stateType": "Intermediate", "transitions": [],
+                             "interaction": { "longPoll": { "terminate": {{terminateLiteral}}, "fallbackTimeoutSeconds": {{fallbackSeconds}}{{roles}} } } }
+                       ],
+                       "sharedTransitions": [],
+                       "extensions": [],
+                       "startTransition": {"key": "start", "from": null, "target": "review", "triggerType": "Manual", "versionStrategy": "Patch", "labels": [], "onExecutionTasks": [], "view": null}
+                   }
+                   """;
+        var options = new System.Text.Json.JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+        };
+        var workflow = System.Text.Json.JsonSerializer.Deserialize<Definitions.Workflow>(json, options)!;
+        workflow.SetReference(new Reference(TestWorkflow, TestDomain, "sys-flows", TestVersion));
+
+        var instance = Instance.Create(Guid.NewGuid(), TestWorkflow, TestVersion, "test-key");
+        var reviewState = workflow.States.First(s => s.Key == "review");
+        instance.ChangeState(reviewState);
+        return (instance, workflow);
     }
 
     private static GetInstanceStateInput CreateInput(string instanceId) => new()


### PR DESCRIPTION
## Summary by Sourcery

Extend long-poll interaction handling so states that declare interaction.longPoll surface a structured interaction directive with terminate flag, fallback window, and optional acknowledge href, including when bubbled from subflows.

New Features:
- Expose a long-poll interaction directive on instance state responses whenever the current state declares interaction.longPoll, carrying terminate, fallback timeout, and optional acknowledge href.

Enhancements:
- Propagate long-poll fallback timeout from subflow interactions to the parent instance while conditionally rewriting the acknowledge href only when present.
- Document the expanded semantics of instance interaction outputs, including non-terminating long-poll interactions and the fallback timeout field.

Tests:
- Add coverage for long-poll interaction emission for terminating and non-terminating states, absence of interaction when no long-poll is declared or roles deny access, and propagation of fallback timeout from subflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fallback timeout information to long-poll interactions.
  * Long-poll directives now appear whenever declared by the current state, with configurable termination behavior.
  * Acknowledge links are provided only when long-poll termination is enabled.
  * Role-based access continues to control whether interactions are included.

* **Bug Fixes**
  * Improved propagation of long-poll settings from nested workflow states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->