### PR TITLE
feat: user-controlled Content-Type, 202 Accepted for async ops, and clearer script errors

### DIFF
--- a/docs/runtime/script-context-and-engine.md
+++ b/docs/runtime/script-context-and-engine.md
@@ -40,6 +40,39 @@ entire runtime. Side effects should remain explicit through approved helpers.
 - Script mutations not applied back to transition context will not affect instance data.
 - Long-running or side-effect-heavy scripts can make synchronous transitions slow.
 
+## Pitfalls
+
+### `dynamic` values inside anonymous types
+
+`ScriptContext.Body` (and property accesses on it, e.g. `context.Body?.kkbScore`) is
+`dynamic`. Feeding a `dynamic` value into an **anonymous type initializer** turns the
+`new { … }` into a runtime (DLR) construction and leaves the anonymous type as an *open
+generic*, which cannot be instantiated:
+
+```csharp
+// ❌ throws: Cannot create an instance of <>f__AnonymousType0`1[<creditBureau>j__TPar]
+//    because Type.ContainsGenericParameters is true.
+Data = new { creditBureau = new { kkbScore = result?.kkbScore } };
+```
+
+Fix it by keeping initializer values statically typed, or by not using anonymous types:
+
+```csharp
+// ✅ cast each dynamic leaf to a concrete type / object
+Data = new { creditBureau = new { kkbScore = (object?)result?.kkbScore } };
+
+// ✅ or build with the ScriptBase helpers (no anonymous types)
+var creditBureau = CreateObject();
+SetProperty(creditBureau, "kkbScore", result?.kkbScore);
+var data = CreateObject();
+SetProperty(data, "creditBureau", creditBureau);
+Data = data;
+```
+
+When the runtime detects this specific failure it rewrites the error message with this
+guidance (`ScriptDiagnostics.Explain`), so the surfaced error points at the fix instead of
+the raw DLR text.
+
 ## Observability
 
 Scripts can log through approved helper functions. Pipeline telemetry should identify the

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionResponseActionResultMapper.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionResponseActionResultMapper.cs
@@ -1,29 +1,13 @@
 using BBT.Aether.AspNetCore.Results;
 using BBT.Aether.Results;
 using BBT.Workflow.Functions;
+using BBT.Workflow.Orchestration.Controllers;
 using Microsoft.AspNetCore.Mvc;
 
 namespace BBT.Workflow.Controllers.Instances;
 
 internal static class FunctionResponseActionResultMapper
 {
-    private static readonly HashSet<string> RestrictedResponseHeaders = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "connection",
-        "content-length",
-        "content-type",         // ObjectResult negotiates this via output formatters
-        "date",                 // server writes its own
-        "host",                 // upstream internal hostname must not leak
-        "keep-alive",
-        "proxy-authenticate",
-        "proxy-authorization",
-        "server",               // orchestrator sets its own Server header
-        "te",
-        "trailer",
-        "transfer-encoding",
-        "upgrade"
-    };
-
     public static IActionResult ToActionResult(
         Result<FunctionResponseOutput> result,
         HttpContext httpContext)
@@ -32,25 +16,14 @@ internal static class FunctionResponseActionResultMapper
             return result.ToActionResult(httpContext);
 
         var output = result.Value!;
-        ApplyHeaders(output, httpContext);
+        ResponseOutputWriter.ApplyHeaders(output.Headers, httpContext);
 
-        return new ObjectResult(output.Data)
+        var objectResult = new ObjectResult(output.Data)
         {
             StatusCode = output.StatusCode ?? StatusCodes.Status200OK
         };
-    }
+        objectResult.ContentTypes.Add(ResponseOutputWriter.ResolveContentType(output.Headers));
 
-    private static void ApplyHeaders(FunctionResponseOutput output, HttpContext httpContext)
-    {
-        if (output.Headers is null || output.Headers.Count == 0)
-            return;
-
-        foreach (var (key, value) in output.Headers)
-        {
-            if (RestrictedResponseHeaders.Contains(key))
-                continue;
-
-            httpContext.Response.Headers[key] = value;
-        }
+        return objectResult;
     }
 }

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
@@ -43,12 +43,14 @@ public sealed class InstanceController(
     /// <summary>
     /// Starts a new workflow instance.
     /// </summary>
-    /// <response code="200">Instance started successfully</response>
+    /// <response code="200">Instance started synchronously (sync=true)</response>
+    /// <response code="202">Instance accepted for durable background processing (sync=false)</response>
     /// <response code="400">Validation failed</response>
     /// <response code="404">Workflow or state not found</response>
     /// <response code="409">Instance with same key already exists</response>
     [HttpPost("{domain}/workflows/{workflow}/instances/start")]
     [ProducesResponseType(typeof(StartInstanceOutput), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(StartInstanceOutput), StatusCodes.Status202Accepted)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
@@ -95,7 +97,7 @@ public sealed class InstanceController(
         }
 
         var result = await commandAppService.StartAsync(input, cancellationToken);
-        return InstanceResponseActionResultMapper.ToActionResult(result, HttpContext);
+        return InstanceResponseActionResultMapper.ToActionResult(result, HttpContext, async: !sync);
     }
 
     [ApiExplorerSettings(IgnoreApi = true)]
@@ -335,7 +337,8 @@ public sealed class InstanceController(
     /// <summary>
     /// Executes a transition on a workflow instance.
     /// </summary>
-    /// <response code="200">Transition executed successfully</response>
+    /// <response code="200">Transition executed synchronously (sync=true)</response>
+    /// <response code="202">Transition accepted for durable background processing (sync=false)</response>
     /// <response code="400">Validation or state transition rule failed</response>
     /// <response code="403">Transition not authorized for current context</response>
     /// <response code="404">Instance, workflow, or transition not found</response>
@@ -343,6 +346,7 @@ public sealed class InstanceController(
     /// <response code="503">Service temporarily unavailable</response>
     [HttpPatch("{domain}/workflows/{workflow}/instances/{instance}/transitions/{transitionKey}")]
     [ProducesResponseType(typeof(TransitionOutput), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(TransitionOutput), StatusCodes.Status202Accepted)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
@@ -392,7 +396,7 @@ public sealed class InstanceController(
             input,
             cancellationToken);
 
-        return InstanceResponseActionResultMapper.ToActionResult(result, HttpContext);
+        return InstanceResponseActionResultMapper.ToActionResult(result, HttpContext, async: !sync);
     }
 
     /// <summary>

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceResponseActionResultMapper.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceResponseActionResultMapper.cs
@@ -14,51 +14,39 @@ namespace BBT.Workflow.Orchestration.Controllers.Instances;
 /// </summary>
 internal static class InstanceResponseActionResultMapper
 {
-    private static readonly HashSet<string> RestrictedResponseHeaders = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "connection",
-        "content-length",
-        "content-type",         // ObjectResult negotiates this via output formatters
-        "date",                 // server writes its own
-        "host",                 // upstream internal hostname must not leak
-        "keep-alive",
-        "proxy-authenticate",
-        "proxy-authorization",
-        "server",               // orchestrator sets its own Server header
-        "te",
-        "trailer",
-        "transfer-encoding",
-        "upgrade"
-    };
-
-    internal static IActionResult ToActionResult<T>(Result<T> result, HttpContext httpContext)
+    /// <remarks>
+    /// When <paramref name="async"/> is <c>true</c> the request runs durably in the background
+    /// (<c>sync=false</c>): a successful result is returned as <c>202 Accepted</c> instead of
+    /// <c>200 OK</c>, since the work has been accepted for processing rather than completed.
+    /// Ignored for the custom output-response path (where the author sets the status explicitly)
+    /// and for error results.
+    /// </remarks>
+    internal static IActionResult ToActionResult<T>(Result<T> result, HttpContext httpContext, bool async = false)
         where T : InstanceOutputBase
     {
         if (result.IsSuccess && result.Value is { HasOutputResponse: true } output)
         {
-            ApplyHeaders(output.OutputHeaders, httpContext);
+            ResponseOutputWriter.ApplyHeaders(output.OutputHeaders, httpContext);
 
             // OutputData may be null → empty body with the configured/default status code.
-            return new ObjectResult(output.OutputData)
+            var objectResult = new ObjectResult(output.OutputData)
             {
                 StatusCode = output.OutputStatusCode ?? StatusCodes.Status200OK
             };
+            objectResult.ContentTypes.Add(ResponseOutputWriter.ResolveContentType(output.OutputHeaders));
+
+            return objectResult;
         }
 
-        return WorkflowResultActionResultMapper.ToActionResult(result, httpContext);
-    }
+        var actionResult = WorkflowResultActionResultMapper.ToActionResult(result, httpContext);
 
-    private static void ApplyHeaders(Dictionary<string, string>? headers, HttpContext httpContext)
-    {
-        if (headers is null || headers.Count == 0)
-            return;
-
-        foreach (var (key, value) in headers)
+        // Durable (sync=false) success → 202 Accepted: the work is queued, not finished.
+        if (async && result.IsSuccess &&
+            actionResult is ObjectResult { StatusCode: null or StatusCodes.Status200OK } acceptedResult)
         {
-            if (RestrictedResponseHeaders.Contains(key))
-                continue;
-
-            httpContext.Response.Headers[key] = value;
+            acceptedResult.StatusCode = StatusCodes.Status202Accepted;
         }
+
+        return actionResult;
     }
 }

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/ResponseOutputWriter.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/ResponseOutputWriter.cs
@@ -25,13 +25,13 @@ internal static class ResponseOutputWriter
     {
         "connection",
         "content-length",
-        ContentTypeHeader,      // applied via ObjectResult.ContentTypes, never as a raw header
-        "date",                 // server writes its own
-        "host",                 // upstream internal hostname must not leak
+        ContentTypeHeader, // applied via ObjectResult.ContentTypes, never as a raw header
+        "date", // server writes its own
+        "host", // upstream internal hostname must not leak
         "keep-alive",
         "proxy-authenticate",
         "proxy-authorization",
-        "server",               // orchestrator sets its own Server header
+        "server", // orchestrator sets its own Server header
         "te",
         "trailer",
         "transfer-encoding",
@@ -48,7 +48,7 @@ internal static class ResponseOutputWriter
 
         foreach (var (key, value) in headers)
         {
-            if (RestrictedResponseHeaders.Contains(key))
+            if (string.IsNullOrWhiteSpace(key) || RestrictedResponseHeaders.Contains(key))
                 continue;
 
             httpContext.Response.Headers[key] = value;
@@ -68,7 +68,7 @@ internal static class ResponseOutputWriter
                 if (string.Equals(key, ContentTypeHeader, StringComparison.OrdinalIgnoreCase) &&
                     !string.IsNullOrWhiteSpace(value))
                 {
-                    return value;
+                    return value.Trim();
                 }
             }
         }

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/ResponseOutputWriter.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/ResponseOutputWriter.cs
@@ -1,0 +1,78 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace BBT.Workflow.Orchestration.Controllers;
+
+/// <summary>
+/// Shared response-shaping logic for the function and instance output mappers. Copies
+/// author-supplied response headers onto the outgoing response while excluding hop-by-hop /
+/// server-owned headers, and resolves the response Content-Type.
+/// </summary>
+/// <remarks>
+/// <c>content-type</c> is intentionally not written as a raw header — it is applied through
+/// <see cref="ObjectResult.ContentTypes"/> so the exact media-type string is preserved (no
+/// implicit <c>charset</c> suffix). When the author does not supply one, it defaults to
+/// <c>application/json</c>. Functions act as a BFF layer, so authors may set a custom
+/// Content-Type for integration scenarios.
+/// </remarks>
+internal static class ResponseOutputWriter
+{
+    /// <summary>Default response media type when the author does not set <c>content-type</c>.</summary>
+    private const string DefaultContentType = "application/json";
+
+    private const string ContentTypeHeader = "content-type";
+
+    private static readonly HashSet<string> RestrictedResponseHeaders = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "connection",
+        "content-length",
+        ContentTypeHeader,      // applied via ObjectResult.ContentTypes, never as a raw header
+        "date",                 // server writes its own
+        "host",                 // upstream internal hostname must not leak
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "server",               // orchestrator sets its own Server header
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "upgrade"
+    };
+
+    /// <summary>
+    /// Copies author-supplied headers onto the response, skipping restricted headers.
+    /// </summary>
+    public static void ApplyHeaders(IReadOnlyDictionary<string, string>? headers, HttpContext httpContext)
+    {
+        if (headers is null || headers.Count == 0)
+            return;
+
+        foreach (var (key, value) in headers)
+        {
+            if (RestrictedResponseHeaders.Contains(key))
+                continue;
+
+            httpContext.Response.Headers[key] = value;
+        }
+    }
+
+    /// <summary>
+    /// Resolves the response Content-Type from author-supplied headers (case-insensitive),
+    /// falling back to <c>application/json</c> when absent or empty.
+    /// </summary>
+    public static string ResolveContentType(IReadOnlyDictionary<string, string>? headers)
+    {
+        if (headers is not null)
+        {
+            foreach (var (key, value) in headers)
+            {
+                if (string.Equals(key, ContentTypeHeader, StringComparison.OrdinalIgnoreCase) &&
+                    !string.IsNullOrWhiteSpace(value))
+                {
+                    return value;
+                }
+            }
+        }
+
+        return DefaultContentType;
+    }
+}

--- a/src/BBT.Workflow.Application/Functions/FunctionAppService.cs
+++ b/src/BBT.Workflow.Application/Functions/FunctionAppService.cs
@@ -417,7 +417,7 @@ public sealed class FunctionAppService(
 
                 return Result<FunctionResponseOutput>.Fail(Error.Failure(
                     WorkflowErrorCodes.ExtensionExecutionFailed,
-                    $"Function '{function.Key}' output ScriptMapping failed: {ex.Message}"));
+                    $"Function '{function.Key}' output ScriptMapping failed: {ScriptDiagnostics.Explain(ex)}"));
             }
         }
 

--- a/src/BBT.Workflow.Application/Scripting/ScriptDiagnostics.cs
+++ b/src/BBT.Workflow.Application/Scripting/ScriptDiagnostics.cs
@@ -40,7 +40,7 @@ public static class ScriptDiagnostics
     {
         for (var current = exception; current is not null; current = current.InnerException)
         {
-            if (current.Message.Contains(OpenGenericAnonymousMarker, StringComparison.Ordinal))
+            if (current.Message?.Contains(OpenGenericAnonymousMarker, StringComparison.Ordinal) == true)
                 return true;
         }
 

--- a/src/BBT.Workflow.Application/Scripting/ScriptDiagnostics.cs
+++ b/src/BBT.Workflow.Application/Scripting/ScriptDiagnostics.cs
@@ -1,0 +1,49 @@
+namespace BBT.Workflow.Scripting;
+
+/// <summary>
+/// Enriches raw script-execution exceptions with actionable guidance before they are
+/// surfaced in a <c>Result</c> error message. Keeps executor catch-sites free of
+/// diagnostic heuristics — they simply call <see cref="Explain"/> in place of
+/// <c>ex.Message</c>.
+/// </summary>
+public static class ScriptDiagnostics
+{
+    // Thrown by the runtime when a dynamic value is used inside an anonymous-type
+    // initializer, leaving the anonymous type as an open generic
+    // (e.g. "Cannot create an instance of <>f__AnonymousType0`1[...] because
+    //  Type.ContainsGenericParameters is true.").
+    private const string OpenGenericAnonymousMarker = "ContainsGenericParameters";
+
+    private const string DynamicAnonymousGuidance =
+        "A script built its response with a 'dynamic' value (e.g. from context.Body) inside an " +
+        "anonymous type 'new { ... }', which leaves the anonymous type as an open generic and cannot " +
+        "be instantiated. Cast dynamic values to concrete types or 'object' " +
+        "(e.g. (object?)result?.value), or build the object with CreateObject()/SetProperty()/" +
+        "ToDictionary() or a Dictionary<string, object?>.";
+
+    /// <summary>
+    /// Returns an actionable message for known script-authoring pitfalls, or the original
+    /// <see cref="System.Exception.Message"/> when the exception is not recognized.
+    /// </summary>
+    /// <param name="exception">The exception thrown while compiling or running a script mapping.</param>
+    public static string Explain(Exception exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+
+        if (MatchesOpenGenericAnonymous(exception))
+            return $"{DynamicAnonymousGuidance} Original error: {exception.Message}";
+
+        return exception.Message;
+    }
+
+    private static bool MatchesOpenGenericAnonymous(Exception exception)
+    {
+        for (var current = exception; current is not null; current = current.InnerException)
+        {
+            if (current.Message.Contains(OpenGenericAnonymousMarker, StringComparison.Ordinal))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/src/BBT.Workflow.Application/SubFlow/Services/SubflowOutputMappingService.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubflowOutputMappingService.cs
@@ -85,7 +85,7 @@ public sealed class SubflowOutputMappingService(
             logger.SubFlowOutputMappingFailed(ex, parentInstance.Id);
             return Result.Fail(WorkflowErrors.SubFlowOutputMappingFailed(
                 parentInstance.Id,
-                ex.Message,
+                ScriptDiagnostics.Explain(ex),
                 stackTrace: ex.ToString()));
         }
     }

--- a/src/BBT.Workflow.Application/Tasks/Executors/Cache/CacheAsideTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Cache/CacheAsideTaskExecutor.cs
@@ -68,7 +68,7 @@ public sealed class CacheAsideTaskExecutor : TaskExecutorBase<CacheAsideTask>
                 return await scriptRunner.InputHandler(task, context.ScriptContext);
             }, cancellationToken, ex => Error.Failure(
                 WorkflowErrorCodes.TaskExecution,
-                $"CacheAside task input handler failed: {ex.Message}"));
+                $"CacheAside task input handler failed: {ScriptDiagnostics.Explain(ex)}"));
 
             if (!result.IsSuccess)
             {
@@ -179,6 +179,6 @@ public sealed class CacheAsideTaskExecutor : TaskExecutorBase<CacheAsideTask>
             return outputResponse.Data;
         }, cancellationToken, ex => Error.Failure(
             WorkflowErrorCodes.TaskExecution,
-            $"CacheAside task source mapping failed: {ex.Message}"));
+            $"CacheAside task source mapping failed: {ScriptDiagnostics.Explain(ex)}"));
     }
 }

--- a/src/BBT.Workflow.Application/Tasks/Executors/Dapr/DaprBindingTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Dapr/DaprBindingTaskExecutor.cs
@@ -56,7 +56,7 @@ public sealed class DaprBindingTaskExecutor : TaskExecutorBase<DaprBindingTask>
             return await scriptRunner.InputHandler(task, context.ScriptContext);
         }, cancellationToken, ex => Error.Failure(
             WorkflowErrorCodes.TaskExecution,
-            $"DaprBinding task input handler failed: {ex.Message}"));
+            $"DaprBinding task input handler failed: {ScriptDiagnostics.Explain(ex)}"));
 
         if (!result.IsSuccess)
         {
@@ -134,7 +134,7 @@ public sealed class DaprBindingTaskExecutor : TaskExecutorBase<DaprBindingTask>
             return outputResponse.Data;
         }, cancellationToken, ex => Error.Failure(
             WorkflowErrorCodes.TaskExecution,
-            $"DaprBinding task output handler failed: {ex.Message}"));
+            $"DaprBinding task output handler failed: {ScriptDiagnostics.Explain(ex)}"));
 
         if (!result.IsSuccess)
         {

--- a/src/BBT.Workflow.Application/Tasks/Executors/Dapr/DaprHttpEndpointTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Dapr/DaprHttpEndpointTaskExecutor.cs
@@ -56,7 +56,7 @@ public sealed class DaprHttpEndpointTaskExecutor : TaskExecutorBase<DaprHttpEndp
             return await scriptRunner.InputHandler(task, context.ScriptContext);
         }, cancellationToken, ex => Error.Failure(
             WorkflowErrorCodes.TaskExecution,
-            $"DaprHttpEndpoint task input handler failed: {ex.Message}"));
+            $"DaprHttpEndpoint task input handler failed: {ScriptDiagnostics.Explain(ex)}"));
 
         if (!result.IsSuccess)
         {
@@ -134,7 +134,7 @@ public sealed class DaprHttpEndpointTaskExecutor : TaskExecutorBase<DaprHttpEndp
             return outputResponse.Data;
         }, cancellationToken, ex => Error.Failure(
             WorkflowErrorCodes.TaskExecution,
-            $"DaprHttpEndpoint task output handler failed: {ex.Message}"));
+            $"DaprHttpEndpoint task output handler failed: {ScriptDiagnostics.Explain(ex)}"));
 
         if (!result.IsSuccess)
         {

--- a/src/BBT.Workflow.Application/Tasks/Executors/Dapr/DaprPubSubTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Dapr/DaprPubSubTaskExecutor.cs
@@ -56,7 +56,7 @@ public sealed class DaprPubSubTaskExecutor : TaskExecutorBase<DaprPubSubTask>
             return await scriptRunner.InputHandler(task, context.ScriptContext);
         }, cancellationToken, ex => Error.Failure(
             WorkflowErrorCodes.TaskExecution,
-            $"DaprPubSub task input handler failed: {ex.Message}"));
+            $"DaprPubSub task input handler failed: {ScriptDiagnostics.Explain(ex)}"));
 
         if (!result.IsSuccess)
         {
@@ -134,7 +134,7 @@ public sealed class DaprPubSubTaskExecutor : TaskExecutorBase<DaprPubSubTask>
             return outputResponse.Data;
         }, cancellationToken, ex => Error.Failure(
             WorkflowErrorCodes.TaskExecution,
-            $"DaprPubSub task output handler failed: {ex.Message}"));
+            $"DaprPubSub task output handler failed: {ScriptDiagnostics.Explain(ex)}"));
 
         if (!result.IsSuccess)
         {

--- a/src/BBT.Workflow.Application/Tasks/Executors/Dapr/DaprServiceTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Dapr/DaprServiceTaskExecutor.cs
@@ -56,7 +56,7 @@ public sealed class DaprServiceTaskExecutor : TaskExecutorBase<DaprServiceTask>
             return await scriptRunner.InputHandler(task, context.ScriptContext);
         }, cancellationToken, ex => Error.Failure(
             WorkflowErrorCodes.TaskExecution,
-            $"DaprService task input handler failed: {ex.Message}"));
+            $"DaprService task input handler failed: {ScriptDiagnostics.Explain(ex)}"));
 
         if (!result.IsSuccess)
         {
@@ -134,7 +134,7 @@ public sealed class DaprServiceTaskExecutor : TaskExecutorBase<DaprServiceTask>
             return outputResponse.Data;
         }, cancellationToken, ex => Error.Failure(
             WorkflowErrorCodes.TaskExecution,
-            $"DaprService task output handler failed: {ex.Message}"));
+            $"DaprService task output handler failed: {ScriptDiagnostics.Explain(ex)}"));
 
         if (!result.IsSuccess)
         {

--- a/src/BBT.Workflow.Application/Tasks/Executors/Dapr/StateStoreTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Dapr/StateStoreTaskExecutor.cs
@@ -56,7 +56,7 @@ public sealed class StateStoreTaskExecutor : TaskExecutorBase<StateStoreTask>
             return await scriptRunner.InputHandler(task, context.ScriptContext);
         }, cancellationToken, ex => Error.Failure(
             WorkflowErrorCodes.TaskExecution,
-            $"StateStore task input handler failed: {ex.Message}"));
+            $"StateStore task input handler failed: {ScriptDiagnostics.Explain(ex)}"));
 
         if (!result.IsSuccess)
         {
@@ -134,7 +134,7 @@ public sealed class StateStoreTaskExecutor : TaskExecutorBase<StateStoreTask>
             return outputResponse.Data;
         }, cancellationToken, ex => Error.Failure(
             WorkflowErrorCodes.TaskExecution,
-            $"StateStore task output handler failed: {ex.Message}"));
+            $"StateStore task output handler failed: {ScriptDiagnostics.Explain(ex)}"));
 
         if (!result.IsSuccess)
         {

--- a/src/BBT.Workflow.Application/Tasks/Executors/Http/HttpTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Http/HttpTaskExecutor.cs
@@ -55,7 +55,7 @@ public sealed class HttpTaskExecutor : TaskExecutorBase<HttpTask>
             return await scriptRunner.InputHandler(task, context.ScriptContext);
         }, cancellationToken, ex => Error.Failure(
             WorkflowErrorCodes.TaskExecution,
-            $"Http task input handler failed: {ex.Message}"));
+            $"Http task input handler failed: {ScriptDiagnostics.Explain(ex)}"));
 
         if (!result.IsSuccess)
         {
@@ -134,7 +134,7 @@ public sealed class HttpTaskExecutor : TaskExecutorBase<HttpTask>
             return outputResponse.Data;
         }, cancellationToken, ex => Error.Failure(
             WorkflowErrorCodes.TaskExecution,
-            $"Http task output handler failed: {ex.Message}"));
+            $"Http task output handler failed: {ScriptDiagnostics.Explain(ex)}"));
 
         if (!result.IsSuccess)
         {

--- a/src/BBT.Workflow.Application/Tasks/Executors/Http/SoapTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Http/SoapTaskExecutor.cs
@@ -51,7 +51,7 @@ public sealed class SoapTaskExecutor : TaskExecutorBase<SoapTask>
             return await scriptRunner.InputHandler(task, context.ScriptContext);
         }, cancellationToken, ex => Error.Failure(
             WorkflowErrorCodes.TaskExecution,
-            $"Soap task input handler failed: {ex.Message}"));
+            $"Soap task input handler failed: {ScriptDiagnostics.Explain(ex)}"));
 
         if (!result.IsSuccess)
         {
@@ -129,7 +129,7 @@ public sealed class SoapTaskExecutor : TaskExecutorBase<SoapTask>
             return outputResponse.Data;
         }, cancellationToken, ex => Error.Failure(
             WorkflowErrorCodes.TaskExecution,
-            $"Soap task output handler failed: {ex.Message}"));
+            $"Soap task output handler failed: {ScriptDiagnostics.Explain(ex)}"));
 
         if (!result.IsSuccess)
         {

--- a/src/BBT.Workflow.Application/Tasks/Executors/Script/ScriptTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Script/ScriptTaskExecutor.cs
@@ -53,7 +53,7 @@ public sealed class ScriptTaskExecutor : TaskExecutorBase<ScriptTask>
             return await scriptRunner.InputHandler(task, context.ScriptContext);
         }, cancellationToken, ex => Error.Failure(
             WorkflowErrorCodes.TaskExecution,
-            $"Script input handler failed: {ex.Message}"));
+            $"Script input handler failed: {ScriptDiagnostics.Explain(ex)}"));
 
         if (!result.IsSuccess)
         {
@@ -96,7 +96,7 @@ public sealed class ScriptTaskExecutor : TaskExecutorBase<ScriptTask>
                 taskType: TaskType.ToString());
         }, cancellationToken, ex => Error.Failure(
             WorkflowErrorCodes.TaskExecution,
-            $"Script output handler failed: {ex.Message}"));
+            $"Script output handler failed: {ScriptDiagnostics.Explain(ex)}"));
 
         if (!result.IsSuccess)
         {

--- a/src/BBT.Workflow.Application/Tasks/Executors/Trigger/TriggerTaskExecutorBase.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Trigger/TriggerTaskExecutorBase.cs
@@ -65,7 +65,7 @@ public abstract class TriggerTaskExecutorBase<TTask>(
             return await scriptRunner.InputHandler(task, context.ScriptContext);
         }, cancellationToken, ex => Error.Failure(
             WorkflowErrorCodes.TaskExecution,
-            $"Input handler failed for {TaskType}: {ex.Message}"));
+            $"Input handler failed for {TaskType}: {ScriptDiagnostics.Explain(ex)}"));
 
         if (!result.IsSuccess)
         {
@@ -106,7 +106,7 @@ public abstract class TriggerTaskExecutorBase<TTask>(
             return outputResponse.Data;
         }, cancellationToken, ex => Error.Failure(
             WorkflowErrorCodes.TaskExecution,
-            $"Output handler failed for {TaskType}: {ex.Message}"));
+            $"Output handler failed for {TaskType}: {ScriptDiagnostics.Explain(ex)}"));
 
         if (!result.IsSuccess)
         {

--- a/test/BBT.Workflow.Application.Tests/Functions/FunctionResponseActionResultMapperTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Functions/FunctionResponseActionResultMapperTests.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using BBT.Aether.Results;
+using BBT.Workflow.Controllers.Instances;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Functions;
+
+public sealed class FunctionResponseActionResultMapperTests
+{
+    [Fact]
+    public void ToActionResult_WithoutContentTypeHeader_DefaultsToApplicationJson()
+    {
+        var result = Result<FunctionResponseOutput>.Ok(new FunctionResponseOutput
+        {
+            Data = new { a = 1 }
+        });
+
+        var actionResult = FunctionResponseActionResultMapper.ToActionResult(result, new DefaultHttpContext());
+
+        var objectResult = actionResult.ShouldBeOfType<ObjectResult>();
+        objectResult.ContentTypes.ShouldContain("application/json");
+        objectResult.ContentTypes.ShouldNotContain("application/json; charset=utf-8");
+    }
+
+    [Fact]
+    public void ToActionResult_WithUserContentType_UsesUserValueCaseInsensitively()
+    {
+        var result = Result<FunctionResponseOutput>.Ok(new FunctionResponseOutput
+        {
+            Data = "<root/>",
+            Headers = new Dictionary<string, string>
+            {
+                ["Content-Type"] = "application/xml"
+            }
+        });
+
+        var httpContext = new DefaultHttpContext();
+        var actionResult = FunctionResponseActionResultMapper.ToActionResult(result, httpContext);
+
+        var objectResult = actionResult.ShouldBeOfType<ObjectResult>();
+        objectResult.ContentTypes.ShouldContain("application/xml");
+        // content-type must not be duplicated as a raw response header.
+        httpContext.Response.Headers.ContainsKey("Content-Type").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ToActionResult_WithNonRestrictedHeader_WritesRawHeader()
+    {
+        var result = Result<FunctionResponseOutput>.Ok(new FunctionResponseOutput
+        {
+            Data = new { a = 1 },
+            Headers = new Dictionary<string, string>
+            {
+                ["X-Correlation-Id"] = "abc-123"
+            }
+        });
+
+        var httpContext = new DefaultHttpContext();
+        FunctionResponseActionResultMapper.ToActionResult(result, httpContext);
+
+        httpContext.Response.Headers["X-Correlation-Id"].ToString().ShouldBe("abc-123");
+    }
+
+    [Fact]
+    public void ToActionResult_HonorsStatusCode()
+    {
+        var result = Result<FunctionResponseOutput>.Ok(new FunctionResponseOutput
+        {
+            Data = new { a = 1 },
+            StatusCode = StatusCodes.Status201Created
+        });
+
+        var actionResult = FunctionResponseActionResultMapper.ToActionResult(result, new DefaultHttpContext());
+
+        actionResult.ShouldBeOfType<ObjectResult>().StatusCode.ShouldBe(StatusCodes.Status201Created);
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/HttpApi/Results/InstanceResponseActionResultMapperTests.cs
+++ b/test/BBT.Workflow.Application.Tests/HttpApi/Results/InstanceResponseActionResultMapperTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
+using BBT.Aether.Results;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Validation;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Orchestration.Controllers.Instances;
+
+public sealed class InstanceResponseActionResultMapperTests
+{
+    private static Result<StartInstanceOutput> SuccessResult() =>
+        Result<StartInstanceOutput>.Ok(new StartInstanceOutput
+        {
+            Id = Guid.NewGuid(),
+            Key = "instance-1",
+            Status = InstanceStatus.Busy
+        });
+
+    [Fact]
+    public void ToActionResult_AsyncSuccess_Returns202Accepted()
+    {
+        var actionResult = InstanceResponseActionResultMapper.ToActionResult(
+            SuccessResult(), new DefaultHttpContext(), async: true);
+
+        actionResult.ShouldBeAssignableTo<ObjectResult>()!.StatusCode.ShouldBe(StatusCodes.Status202Accepted);
+    }
+
+    [Fact]
+    public void ToActionResult_SyncSuccess_KeepsOkStatus()
+    {
+        var actionResult = InstanceResponseActionResultMapper.ToActionResult(
+            SuccessResult(), new DefaultHttpContext(), async: false);
+
+        var objectResult = actionResult.ShouldBeAssignableTo<ObjectResult>()!;
+        (objectResult.StatusCode is null or StatusCodes.Status200OK).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ToActionResult_AsyncFailure_PreservesErrorStatus()
+    {
+        // Schema-validation failures are mapped to a 400 ObjectResult by
+        // WorkflowResultActionResultMapper itself (no Aether/DI problem-result path),
+        // which makes this a DI-free way to assert the async flag never touches errors.
+        var actionResult = InstanceResponseActionResultMapper.ToActionResult(
+            SchemaValidationFailure(), new DefaultHttpContext(), async: true);
+
+        var objectResult = actionResult.ShouldBeAssignableTo<ObjectResult>()!;
+        objectResult.StatusCode.ShouldBe(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public void ToActionResult_AsyncCustomOutputResponse_UsesScriptStatusNot202()
+    {
+        var result = Result<StartInstanceOutput>.Ok(new StartInstanceOutput
+        {
+            Id = Guid.NewGuid(),
+            HasOutputResponse = true,
+            OutputData = new { ok = true },
+            OutputStatusCode = StatusCodes.Status201Created
+        });
+
+        var actionResult = InstanceResponseActionResultMapper.ToActionResult(
+            result, new DefaultHttpContext(), async: true);
+
+        actionResult.ShouldBeAssignableTo<ObjectResult>()!.StatusCode.ShouldBe(StatusCodes.Status201Created);
+    }
+
+    private static Result<StartInstanceOutput> SchemaValidationFailure()
+    {
+        var details = new SchemaValidationProblemDetails(
+            "en-US",
+            [
+                new SchemaValidationErrorDetail(
+                    Path: "customer.identityNumber",
+                    Keyword: "minLength",
+                    Code: "schema.minLength",
+                    Message: "identityNumber too short.",
+                    Label: "Identity Number",
+                    SchemaPath: "/properties/customer/properties/identityNumber/minLength",
+                    Parameters: JsonSerializer.Deserialize<Dictionary<string, JsonElement>>("""{"minLength":11}""")!)
+            ]);
+
+        var error = Error.Validation(
+                WorkflowErrorCodes.ValidationErrors,
+                "JSON schema validation failed",
+                new List<ValidationResult> { new("identityNumber too short.", ["customer.identityNumber"]) })
+            with
+            {
+                Detail = JsonSerializer.Serialize(details)
+            };
+
+        return Result<StartInstanceOutput>.Fail(error);
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/Scripting/ScriptDiagnosticsTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Scripting/ScriptDiagnosticsTests.cs
@@ -1,0 +1,44 @@
+using System;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Scripting;
+
+public sealed class ScriptDiagnosticsTests
+{
+    [Fact]
+    public void Explain_OpenGenericAnonymousType_ReturnsActionableGuidance()
+    {
+        var ex = new ArgumentException(
+            "Cannot create an instance of <>f__AnonymousType0`1[<creditBureau>j__TPar] " +
+            "because Type.ContainsGenericParameters is true.");
+
+        var message = ScriptDiagnostics.Explain(ex);
+
+        message.ShouldContain("CreateObject()");
+        message.ShouldContain("(object?)");
+        message.ShouldContain("Original error:");
+        message.ShouldContain(ex.Message);
+    }
+
+    [Fact]
+    public void Explain_MarkerInInnerException_IsDetected()
+    {
+        var inner = new InvalidOperationException("... Type.ContainsGenericParameters is true.");
+        var ex = new InvalidOperationException("Script output handler failed", inner);
+
+        var message = ScriptDiagnostics.Explain(ex);
+
+        message.ShouldContain("anonymous type");
+    }
+
+    [Fact]
+    public void Explain_UnrelatedException_ReturnsOriginalMessageUnchanged()
+    {
+        var ex = new InvalidOperationException("Something else went wrong");
+
+        var message = ScriptDiagnostics.Explain(ex);
+
+        message.ShouldBe("Something else went wrong");
+    }
+}


### PR DESCRIPTION
## Overview

Three related changes to the orchestration host and script engine.

### 1. User-controlled `Content-Type` (#819)
Functions act as a BFF layer, so authors need to set the response `Content-Type` for integration scenarios. `content-type` was previously stripped from output-script response headers, so responses were always the negotiated `application/json; charset=utf-8`.

- Lifts the restriction: the author-supplied `content-type` is now honored.
- Routed through `ObjectResult.ContentTypes` (exact media-type string, no `charset` suffix).
- Defaults to **`application/json`** when the author does not set one.
- Applied to both `FunctionResponseActionResultMapper` and the sibling `InstanceResponseActionResultMapper`, via a new shared `ResponseOutputWriter` helper.

### 2. `202 Accepted` for async Instance Start & Transition
When `sync=false` the pipeline runs durably in the background and the response returns immediately with `{ id, status }`. Returning `200 OK` was semantically wrong.

- Start and Transition now return **`202 Accepted`** on async success.
- `sync=true` (200), error results (400/403/404/409/503), and the custom output-response path are **unchanged**.
- Keyed off the request flag (`async: !sync`), not the resulting instance status — correctly covers the idempotent "already exists" path.

### 3. Clearer error for `dynamic` inside anonymous types
A ScriptMapping building `ScriptResponse.Data` from `context.Body` (dynamic) via a nested anonymous type — `new { a = new { b = ctx.Body?.x } }` — crashes with the cryptic:
`Cannot create an instance of <>f__AnonymousType0`1[...] because Type.ContainsGenericParameters is true.`

The dynamic value turns the `new {}` into a runtime (DLR) construction that leaves the anonymous type as an open generic. The throw originates **inside the compiled script**, so it can't be executed transparently.

- New `ScriptDiagnostics.Explain(ex)` detects this failure (walks inner exceptions) and rewrites the surfaced message with actionable guidance (cast to `object`/concrete, or use `CreateObject()`/`SetProperty()`/`ToDictionary()`); otherwise returns the original message.
- Wired into every script-handler error site (Script/Http/Soap/CacheAside/StateStore/Dapr×5/Trigger executors, plus subflow and function output-mapping paths).

## Reviewer notes
- **Content-Type limitation:** if an author sets a media type no registered formatter can produce for the payload (e.g. `text/csv` with an object), ASP.NET returns `406` — inherent to formatter negotiation, out of scope here.
- **Script fix is author-side:** change 3 improves the *error message*; the actual fix for a crashing script is to avoid `dynamic` in anonymous initializers (documented in `docs/runtime/script-context-and-engine.md`).
- `WorkflowOutputMappingService` intentionally not touched — it swallows the exception as a non-blocking fallback and already logs the full exception.

## Tests
- New unit tests: `FunctionResponseActionResultMapperTests`, `InstanceResponseActionResultMapperTests`, `ScriptDiagnosticsTests` — all pass.
- Affected projects build with 0 errors.
- Pre-existing unrelated failures (`InstanceQueryAppService*`, `ViewGetContentAsTyped*`, `ScriptCodeModelTests…Ref_Encoding`) fail identically on a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Allow function and instance outputs to control HTTP response Content-Type and adjust status codes for async instance operations, while improving script error messaging for dynamic values in anonymous types.

New Features:
- Support author-defined Content-Type on function and instance output responses with a sensible application/json default.
- Return 202 Accepted for asynchronous instance start and transition requests when work is queued in the background.

Enhancements:
- Centralize response header and Content-Type handling in a shared ResponseOutputWriter to avoid duplication and enforce header restrictions.
- Provide clearer, actionable diagnostics for script mapping failures involving dynamic values in anonymous type initializers, and surface them across all script execution paths.

Documentation:
- Document the pitfall of using dynamic values inside anonymous type initializers in scripts and recommend safer patterns.

Tests:
- Add unit tests for function and instance response mappers, including Content-Type and async status behavior, and for ScriptDiagnostics guidance behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Asynchronous instance starts and transitions now return HTTP 202 Accepted when processing is queued.
  * Custom response headers and content types are applied more consistently, with JSON as the default content type.

* **Bug Fixes**
  * Script failures now provide clearer, actionable diagnostics, including guidance for anonymous-type and dynamic-value issues.

* **Documentation**
  * Added guidance on diagnosing and resolving dynamic values used in anonymous type initializers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->