### PR TITLE
fix(subflow): load instance data for output mapping; use ExecutionKey index for task lookup

### DIFF
--- a/src/BBT.Workflow.Application/SubFlow/Services/SubflowCompletionService.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubflowCompletionService.cs
@@ -96,7 +96,9 @@ public sealed class SubflowCompletionService(
 
                     await using var correlationUow = uowManager.Begin(
                         new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew });
-                    parentInstance = await instanceRepository.FindWithAllCorrelationsAsync(completedInput.InstanceId, cancellationToken);
+                    // Data must be loaded here: output mapping appends a new data version via
+                    // Instance.AddData, whose version/IsLatest math reads the in-memory data list.
+                    parentInstance = await instanceRepository.FindWithAllCorrelationsAndDataAsync(completedInput.InstanceId, cancellationToken);
 
                     if (parentInstance == null)
                     {

--- a/src/BBT.Workflow.Application/SubFlow/Services/SubflowFaultService.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubflowFaultService.cs
@@ -87,7 +87,9 @@ public sealed class SubflowFaultService(
 
                     await using var uow = uowManager.Begin(
                         new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew });
-                    parentInstance = await instanceRepository.FindWithAllCorrelationsAsync(
+                    // Data must be loaded here: output mapping appends a new data version via
+                    // Instance.AddData, whose version/IsLatest math reads the in-memory data list.
+                    parentInstance = await instanceRepository.FindWithAllCorrelationsAndDataAsync(
                         input.InstanceId, cancellationToken);
 
                     if (parentInstance == null)

--- a/src/BBT.Workflow.Domain/Instances/IInstanceRepository.cs
+++ b/src/BBT.Workflow.Domain/Instances/IInstanceRepository.cs
@@ -144,6 +144,20 @@ public interface IInstanceRepository : IRepository<Instance, Guid>
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Finds an instance including ALL child correlations (completed and active) AND instance data
+    /// as a tracked entity. Required by subflow terminal handlers that run output mapping:
+    /// <c>Instance.AddData</c> derives the next version and moves the <c>IsLatest</c> flag from the
+    /// in-memory data list, so merging onto an aggregate loaded without data would restart
+    /// versioning at the default version and leave duplicate latest rows.
+    /// </summary>
+    /// <param name="instanceId">The instance identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The instance with all correlations and data, or null when not found.</returns>
+    Task<Instance?> FindWithAllCorrelationsAndDataAsync(
+        Guid instanceId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Returns active instances with Human state subtype.
     /// Includes DataList for JSON data extraction.
     /// </summary>

--- a/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceRepository.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceRepository.cs
@@ -164,6 +164,20 @@ public sealed class EfCoreInstanceRepository(
             .FirstOrDefaultAsync(i => i.Id == instanceId, cancellationToken);
     }
 
+    /// <inheritdoc />
+    public async Task<Instance?> FindWithAllCorrelationsAndDataAsync(
+        Guid instanceId,
+        CancellationToken cancellationToken = default)
+    {
+        var dbSet = await GetDbSetAsync();
+        var instance = await IncludeListData(dbSet.AsQueryable())
+            .Include(i => i.ChildCorrelations)
+            .AsSplitQuery()
+            .FirstOrDefaultAsync(i => i.Id == instanceId, cancellationToken);
+
+        return MarkIfPartiallyLoaded(instance);
+    }
+
     /// <summary>
     /// Inserts a new instance and automatically records metrics
     /// </summary>

--- a/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceTaskRepository.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceTaskRepository.cs
@@ -27,12 +27,20 @@ public class EfCoreInstanceTaskRepository(
     {
         var dbSet = await GetDbSetAsync();
         var executionKey = InstanceTask.CreateExecutionKey(transitionId, taskId);
+
+        // ExecutionKey is the deterministic hash of (TransitionId, TaskId), so any row matching
+        // the pair either carries exactly this key or a NULL key (row created before the
+        // ExecutionKey migration). Filtering on the key lets the planner resolve the common case
+        // through UX_InstanceTasks_ExecutionKey as a point lookup; the OR arm keeps legacy rows
+        // reachable via the (TransitionId, ...) prefix of the covering index.
         return await dbSet
+            .Where(task => task.ExecutionKey == executionKey ||
+                           (task.TransitionId == transitionId &&
+                            task.TaskId == taskId &&
+                            task.ExecutionKey == null))
             .OrderByDescending(task => task.ExecutionKey == executionKey)
             .ThenByDescending(task => task.StartedAt)
-            .FirstOrDefaultAsync(
-                task => task.TransitionId == transitionId && task.TaskId == taskId,
-                cancellationToken);
+            .FirstOrDefaultAsync(cancellationToken);
     }
 
     /// <summary>

--- a/test/BBT.Workflow.Application.Tests/SubFlow/SubflowCompletionServiceTests.cs
+++ b/test/BBT.Workflow.Application.Tests/SubFlow/SubflowCompletionServiceTests.cs
@@ -137,7 +137,7 @@ public sealed class SubflowCompletionServiceTests
         parent.SetEffectiveState("child-active");
         var completedAt = DateTime.UtcNow.AddMinutes(-1);
         _instanceRepository
-            .Setup(x => x.FindWithAllCorrelationsAsync(parent.Id, It.IsAny<CancellationToken>()))
+            .Setup(x => x.FindWithAllCorrelationsAndDataAsync(parent.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(parent);
         _instanceRepository
             .Setup(x => x.UpdateAsync(parent, true, It.IsAny<CancellationToken>()))
@@ -171,7 +171,7 @@ public sealed class SubflowCompletionServiceTests
         parent.SetEffectiveState("terminal-parent");
         var completedAt = DateTime.UtcNow.AddMinutes(-1);
         _instanceRepository
-            .Setup(x => x.FindWithAllCorrelationsAsync(parent.Id, It.IsAny<CancellationToken>()))
+            .Setup(x => x.FindWithAllCorrelationsAndDataAsync(parent.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(parent);
         _instanceRepository
             .Setup(x => x.UpdateAsync(parent, true, It.IsAny<CancellationToken>()))
@@ -201,7 +201,7 @@ public sealed class SubflowCompletionServiceTests
         var parent = CreateParentInstance(out var subInstanceId, SubFlowType.SubFlow);
         parent.Complete("bank");
         _instanceRepository
-            .Setup(x => x.FindWithAllCorrelationsAsync(parent.Id, It.IsAny<CancellationToken>()))
+            .Setup(x => x.FindWithAllCorrelationsAndDataAsync(parent.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(parent);
 
         await CreateService().CompletionAsync(CreateInput(parent.Id, subInstanceId));
@@ -223,7 +223,7 @@ public sealed class SubflowCompletionServiceTests
         typeof(Instance).GetProperty(nameof(Instance.Status))!
             .SetValue(parent, InstanceStatus.Passive);
         _instanceRepository
-            .Setup(x => x.FindWithAllCorrelationsAsync(parent.Id, It.IsAny<CancellationToken>()))
+            .Setup(x => x.FindWithAllCorrelationsAndDataAsync(parent.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(parent);
 
         await CreateService().CompletionAsync(CreateInput(parent.Id, subInstanceId));
@@ -246,7 +246,7 @@ public sealed class SubflowCompletionServiceTests
         parent.SetEffectiveState("terminal-parent");
         var completedAt = DateTime.UtcNow.AddMinutes(-1);
         _instanceRepository
-            .Setup(x => x.FindWithAllCorrelationsAsync(parent.Id, It.IsAny<CancellationToken>()))
+            .Setup(x => x.FindWithAllCorrelationsAndDataAsync(parent.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(parent);
         _instanceRepository
             .Setup(x => x.UpdateAsync(parent, true, It.IsAny<CancellationToken>()))
@@ -274,7 +274,7 @@ public sealed class SubflowCompletionServiceTests
         var input = CreateInput(parentInstance.Id, subInstanceId);
 
         _instanceRepository
-            .Setup(x => x.FindWithAllCorrelationsAsync(parentInstance.Id, It.IsAny<CancellationToken>()))
+            .Setup(x => x.FindWithAllCorrelationsAndDataAsync(parentInstance.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(parentInstance);
         _instanceRepository
             .Setup(x => x.UpdateAsync(parentInstance, true, It.IsAny<CancellationToken>()))
@@ -309,7 +309,7 @@ public sealed class SubflowCompletionServiceTests
         var parentWorkflow = WorkflowFactory.CreateDefault("parent-flow", "bank", "1.0.0");
 
         _instanceRepository
-            .Setup(x => x.FindWithAllCorrelationsAsync(parentInstance.Id, It.IsAny<CancellationToken>()))
+            .Setup(x => x.FindWithAllCorrelationsAndDataAsync(parentInstance.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(parentInstance);
         _instanceRepository
             .Setup(x => x.UpdateAsync(parentInstance, true, It.IsAny<CancellationToken>()))
@@ -353,7 +353,7 @@ public sealed class SubflowCompletionServiceTests
         var parentWorkflow = WorkflowFactory.CreateDefault("parent-flow", "bank", "1.0.0");
 
         _instanceRepository
-            .Setup(x => x.FindWithAllCorrelationsAsync(parentInstance.Id, It.IsAny<CancellationToken>()))
+            .Setup(x => x.FindWithAllCorrelationsAndDataAsync(parentInstance.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(parentInstance);
         _instanceRepository
             .Setup(x => x.UpdateAsync(parentInstance, true, It.IsAny<CancellationToken>()))
@@ -392,9 +392,12 @@ public sealed class SubflowCompletionServiceTests
 
         var reloaded = CloneParentWithCompletedCorrelation(parentInstance, subInstanceId);
         _instanceRepository
-            .SetupSequence(x => x.FindWithAllCorrelationsAsync(
+            .Setup(x => x.FindWithAllCorrelationsAndDataAsync(
                 parentInstance.Id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(parentInstance)
+            .ReturnsAsync(parentInstance);
+        _instanceRepository
+            .Setup(x => x.FindWithAllCorrelationsAsync(
+                parentInstance.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(reloaded);
         _instanceRepository
             .Setup(x => x.UpdateAsync(It.IsAny<Instance>(), true, It.IsAny<CancellationToken>()))
@@ -418,8 +421,11 @@ public sealed class SubflowCompletionServiceTests
             () => CreateService().CompletionAsync(input, CancellationToken.None));
 
         _instanceRepository.Verify(
+            x => x.FindWithAllCorrelationsAndDataAsync(parentInstance.Id, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _instanceRepository.Verify(
             x => x.FindWithAllCorrelationsAsync(parentInstance.Id, It.IsAny<CancellationToken>()),
-            Times.Exactly(2));
+            Times.Once);
         reloaded.FindCorrelationBySubInstanceId(subInstanceId)!.IsCompleted.ShouldBeFalse();
         _instanceRepository.Verify(
             x => x.UpdateAsync(reloaded, true, It.IsAny<CancellationToken>()),
@@ -444,9 +450,13 @@ public sealed class SubflowCompletionServiceTests
             .ReturnsAsync(_lockScope.Object);
         var loadCall = 0;
         _instanceRepository
+            .Setup(x => x.FindWithAllCorrelationsAndDataAsync(parent.Id, It.IsAny<CancellationToken>()))
+            .Callback(() => order.Add($"load-{++loadCall}"))
+            .ReturnsAsync(parent);
+        _instanceRepository
             .Setup(x => x.FindWithAllCorrelationsAsync(parent.Id, It.IsAny<CancellationToken>()))
             .Callback(() => order.Add($"load-{++loadCall}"))
-            .ReturnsAsync(() => loadCall == 1 ? parent : terminalReload);
+            .ReturnsAsync(terminalReload);
         _instanceRepository
             .Setup(x => x.UpdateAsync(It.IsAny<Instance>(), true, It.IsAny<CancellationToken>()))
             .ReturnsAsync((Instance instance, bool _, CancellationToken _) => instance);
@@ -480,8 +490,10 @@ public sealed class SubflowCompletionServiceTests
         var input = CreateInput(parent.Id, subInstanceId);
         var workflow = WorkflowFactory.CreateDefault("parent-flow", "bank", "1.0.0");
         _instanceRepository
-            .SetupSequence(x => x.FindWithAllCorrelationsAsync(parent.Id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(parent)
+            .Setup(x => x.FindWithAllCorrelationsAndDataAsync(parent.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(parent);
+        _instanceRepository
+            .Setup(x => x.FindWithAllCorrelationsAsync(parent.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync((Instance?)null);
         _instanceRepository
             .Setup(x => x.UpdateAsync(It.IsAny<Instance>(), true, It.IsAny<CancellationToken>()))
@@ -503,8 +515,10 @@ public sealed class SubflowCompletionServiceTests
 
         actual.ShouldBeSameAs(expected);
         parent.FindCorrelationBySubInstanceId(subInstanceId)!.IsCompleted.ShouldBeTrue();
+        _instanceRepository.Verify(x => x.FindWithAllCorrelationsAndDataAsync(
+            parent.Id, CancellationToken.None), Times.Once);
         _instanceRepository.Verify(x => x.FindWithAllCorrelationsAsync(
-            parent.Id, CancellationToken.None), Times.Exactly(2));
+            parent.Id, CancellationToken.None), Times.Once);
         VerifyRevertFailureLogged();
     }
 
@@ -534,7 +548,7 @@ public sealed class SubflowCompletionServiceTests
     {
         var parentWorkflow = WorkflowFactory.CreateDefault("parent-flow", "bank", "1.0.0");
         _instanceRepository
-            .Setup(x => x.FindWithAllCorrelationsAsync(parent.Id, It.IsAny<CancellationToken>()))
+            .Setup(x => x.FindWithAllCorrelationsAndDataAsync(parent.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(parent);
         _instanceRepository
             .Setup(x => x.UpdateAsync(parent, true, It.IsAny<CancellationToken>()))
@@ -558,8 +572,11 @@ public sealed class SubflowCompletionServiceTests
     private void VerifyNoMappingOrResume()
     {
         _instanceRepository.Verify(
-            x => x.FindWithAllCorrelationsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            x => x.FindWithAllCorrelationsAndDataAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
             Times.Once);
+        _instanceRepository.Verify(
+            x => x.FindWithAllCorrelationsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
         _instanceRepository.Verify(
             x => x.FindAsync(It.IsAny<Guid>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
             Times.Never);

--- a/test/BBT.Workflow.Application.Tests/SubFlow/SubflowFaultServiceTests.cs
+++ b/test/BBT.Workflow.Application.Tests/SubFlow/SubflowFaultServiceTests.cs
@@ -281,18 +281,17 @@ public sealed class SubflowFaultServiceTests
         var reloaded = CloneParentWithCompletedCorrelation(parentInstance, subInstanceId);
         _instanceRepository
             .Setup(x => x.FindWithAllCorrelationsAsync(parentInstance.Id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(parentInstance);
-        _instanceRepository
-            .SetupSequence(x => x.FindWithAllCorrelationsAsync(parentInstance.Id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(parentInstance)
             .ReturnsAsync(reloaded);
 
         await Should.ThrowAsync<SubflowCompletionException>(
             () => CreateService().FaultAsync(input, CancellationToken.None));
 
         _instanceRepository.Verify(
+            x => x.FindWithAllCorrelationsAndDataAsync(parentInstance.Id, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _instanceRepository.Verify(
             x => x.FindWithAllCorrelationsAsync(parentInstance.Id, It.IsAny<CancellationToken>()),
-            Times.Exactly(2));
+            Times.Once);
         reloaded.FindCorrelationBySubInstanceId(subInstanceId)!.IsCompleted.ShouldBeFalse();
         _instanceRepository.Verify(
             x => x.UpdateAsync(reloaded, true, It.IsAny<CancellationToken>()),
@@ -317,9 +316,13 @@ public sealed class SubflowFaultServiceTests
             .ReturnsAsync(_lockScope.Object);
         var loadCall = 0;
         _instanceRepository
+            .Setup(x => x.FindWithAllCorrelationsAndDataAsync(parent.Id, It.IsAny<CancellationToken>()))
+            .Callback(() => order.Add($"load-{++loadCall}"))
+            .ReturnsAsync(parent);
+        _instanceRepository
             .Setup(x => x.FindWithAllCorrelationsAsync(parent.Id, It.IsAny<CancellationToken>()))
             .Callback(() => order.Add($"load-{++loadCall}"))
-            .ReturnsAsync(() => loadCall == 1 ? parent : terminalReload);
+            .ReturnsAsync(terminalReload);
         _instanceRepository
             .Setup(x => x.UpdateAsync(It.IsAny<Instance>(), true, It.IsAny<CancellationToken>()))
             .ReturnsAsync((Instance instance, bool _, CancellationToken _) => instance);
@@ -683,6 +686,11 @@ public sealed class SubflowFaultServiceTests
 
     private void SetupParentInstance(Instance parentInstance)
     {
+        // Main load (correlations + data) and compensation reload (correlations only)
+        // both resolve to the same entity unless a test overrides the revert path.
+        _instanceRepository
+            .Setup(x => x.FindWithAllCorrelationsAndDataAsync(parentInstance.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(parentInstance);
         _instanceRepository
             .Setup(x => x.FindWithAllCorrelationsAsync(parentInstance.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(parentInstance);


### PR DESCRIPTION
## Summary
- `SubflowCompletionService` / `SubflowFaultService` loaded the parent instance via `FindWithAllCorrelationsAsync`, which does not include `DataList`. Output mapping then called `Instance.AddData` on an empty in-memory data list, restarting versioning at the default version and leaving duplicate `IsLatest` rows next to the existing history.
- Adds `FindWithAllCorrelationsAndDataAsync` (all correlations + instance data, latest-only aware, split query, marked partially loaded) and uses it for the two main loads that run output mapping. Revert/cancel paths keep the lean correlations-only load per the include-discipline rule.
- Rewrites `FindByTransitionAndTaskAsync` to filter on the deterministic `ExecutionKey` first, so the per-task idempotency check in `StandardTaskPersistenceStrategy` resolves as a point lookup on `UX_InstanceTasks_ExecutionKey` instead of scanning the transition's rows; an OR arm keeps pre-migration NULL-key rows reachable via the covering index prefix. Result set and ordering semantics are unchanged, no new index or migration needed.

## Changes
- `src/BBT.Workflow.Domain/Instances/IInstanceRepository.cs` — new `FindWithAllCorrelationsAndDataAsync` contract
- `src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceRepository.cs` — implementation (correlations + `IncludeListData`, `AsSplitQuery`, `MarkIfPartiallyLoaded`)
- `src/BBT.Workflow.Application/SubFlow/Services/SubflowCompletionService.cs`, `SubflowFaultService.cs` — main loads switched to the data-including method
- `src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceTaskRepository.cs` — ExecutionKey-first task journal lookup
- `test/BBT.Workflow.Application.Tests/SubFlow/*` — mocks split between main load (with data) and compensation reload (correlations only), so tests now pin the two include strategies

## Test Plan
- [x] `dotnet test --filter "FullyQualifiedName~SubFlow"` — 95/95 passed
- [x] `dotnet test --filter "FullyQualifiedName~TaskPersistence"` — 13/13 passed
- [x] Full Application/Infrastructure suites diffed against a stashed master baseline — failure lists identical (no regressions introduced)

## Notes
- Under legacy full-history loading the completion/fault main load now pulls the full `DataList`; under `LatestOnlyInstanceLoading` it is a single extra row (the full-merge model keeps the latest row self-sufficient for `AddData` version/sequence math).
- The legacy `ExecutionKey IS NULL` OR arm only matters for transitions that were in flight before the 20260715 `InstanceTaskExecutionJournalKey` migration; it can be dropped later to reduce the query to a pure unique-key lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure subflow completion and fault handlers load parent instances with correlations and data for output mapping, and optimize instance task lookup using the deterministic execution key.

New Features:
- Add repository API to load an instance with all child correlations and associated data for subflow terminal handling.

Bug Fixes:
- Prevent duplicate latest data versions by avoiding output mapping on instances loaded without DataList.
- Ensure subflow completion and fault services use the data-inclusive instance load when performing output mapping.

Enhancements:
- Optimize FindByTransitionAndTaskAsync to perform execution-key-first lookups while preserving result semantics.
- Adjust subflow application tests to distinguish between main data-inclusive loads and lean compensation reloads, asserting correct repository usage patterns.

Tests:
- Update subflow completion and fault service tests to cover the new correlations-and-data load path and verify compensation reload behavior separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subflow completion and fault handling by loading parent workflow data and correlations together.
  * Ensured output mapping preserves data versioning and latest-value behavior.
  * Improved instance-task lookup reliability for both current and legacy records.
  * Prioritized exact execution matches while retaining compatibility with older task records.

* **Tests**
  * Updated completion and fault-handling coverage for revised parent-instance loading and resume/revert scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->