### PR TITLE
fix(subflow): keep sync subflow completion synchronous via chain-reentrant locks

### DIFF
--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/TransitionPipeline.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/TransitionPipeline.cs
@@ -110,6 +110,11 @@ public class TransitionPipeline
                     WorkflowErrors.InstanceLockConflict(context.InstanceId));
             }
 
+            // Mark the reserved key as held by this chain so nested acquisitions of the same
+            // key (deeper sync subflow callbacks) resolve reentrantly. AsyncLocal-scoped:
+            // expires automatically when this method returns.
+            ChainLockRegistry.Register(reservedKey);
+
             // A durable S8 checkpoint always belongs to the interrupted MAIN transition.
             // Reserved transitions (cancel/exit/update-data/timeout/long-poll ack) must never
             // resume from a foreign checkpoint — clear it in-memory so the executor builds
@@ -137,6 +142,12 @@ public class TransitionPipeline
             return Result<TransitionExecutionContext>.Fail(
                 WorkflowErrors.InstanceLockConflict(context.InstanceId));
         }
+
+        // Mark the chain lock key as held by this chain so a sync subflow completion callback
+        // running inside the post-commit phase can acquire the parent's terminal lock
+        // reentrantly instead of falling back to async Inbox delivery. AsyncLocal-scoped:
+        // expires automatically when this method returns.
+        ChainLockRegistry.Register(context.LockKey);
 
         // 4) Mark instance Busy immediately after lock acquisition
         await _busyMarker.MarkBusyAsync(context.InstanceId, cancellationToken);

--- a/src/BBT.Workflow.Domain/Execution/Transitions/Pipeline/ChainLockRegistry.cs
+++ b/src/BBT.Workflow.Domain/Execution/Transitions/Pipeline/ChainLockRegistry.cs
@@ -1,0 +1,36 @@
+using System.Collections.Immutable;
+
+namespace BBT.Workflow.Execution.Pipeline;
+
+/// <summary>
+/// Tracks the transition lock keys held by the current logical execution chain.
+/// Enables chain-reentrant lock acquisition: when a nested operation (e.g. a sync subflow
+/// completion callback running inside the parent's post-commit phase) needs a lock key that
+/// is already held higher up in the same async call chain, it can proceed without
+/// re-acquiring — mutual exclusion is already provided by the outer holder.
+/// Registrations are AsyncLocal-scoped: they flow into awaited child calls and
+/// automatically disappear when the registering async method returns.
+/// </summary>
+public static class ChainLockRegistry
+{
+    private static readonly AsyncLocal<ImmutableHashSet<string>?> HeldKeys = new();
+
+    /// <summary>
+    /// Registers a lock key as held by the current execution chain.
+    /// Call only after the distributed lock has actually been acquired, from the method
+    /// whose lexical scope owns the lock (the registration is visible to awaited callees
+    /// and expires when that method returns).
+    /// </summary>
+    /// <param name="lockKey">The acquired lock key.</param>
+    public static void Register(string lockKey)
+    {
+        HeldKeys.Value = (HeldKeys.Value ?? ImmutableHashSet.Create<string>(StringComparer.Ordinal))
+            .Add(lockKey);
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when the given lock key is already held by the current execution chain.
+    /// </summary>
+    /// <param name="lockKey">The lock key to check.</param>
+    public static bool IsHeld(string lockKey) => HeldKeys.Value?.Contains(lockKey) == true;
+}

--- a/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
@@ -1350,6 +1350,19 @@ public static partial class WorkflowLogs
         string transitionKey);
 
     /// <summary>
+    /// Logs when a lock acquisition is satisfied reentrantly because the current execution
+    /// chain already holds the same key (e.g. sync subflow completion inside the parent's
+    /// post-commit phase).
+    /// </summary>
+    [LoggerMessage(
+        EventId = 40123,
+        Level = LogLevel.Debug,
+        Message = "Transition lock {LockKey} already held by the current execution chain; acquired reentrantly")]
+    public static partial void TransitionLockReentrantAcquired(
+        this ILogger logger,
+        string lockKey);
+
+    /// <summary>
     /// Logs when the chain lock lease could not be extended between chained transitions;
     /// the chain stops instead of continuing without a held lease.
     /// </summary>

--- a/src/BBT.Workflow.Infrastructure/Execution/Locks/TransitionLockScopeFactory.cs
+++ b/src/BBT.Workflow.Infrastructure/Execution/Locks/TransitionLockScopeFactory.cs
@@ -32,6 +32,16 @@ public sealed class TransitionLockScopeFactory(
         string lockKey,
         CancellationToken cancellationToken = default)
     {
+        // Chain-reentrant acquisition: when this exact key is already held higher up in the
+        // same async call chain (e.g. a sync subflow completion callback running inside the
+        // parent pipeline's post-commit phase), the outer holder already provides mutual
+        // exclusion — and the provider (SET NX) would reject the re-acquire anyway.
+        if (ChainLockRegistry.IsHeld(lockKey))
+        {
+            logger.TransitionLockReentrantAcquired(lockKey);
+            return TransitionLockScope.Reentrant(lockKey);
+        }
+
         var handle = await distributedLockService.TryAcquireLockAsync(
             lockKey,
             _leaseSeconds,
@@ -73,10 +83,10 @@ internal sealed class TransitionLockScope : ITransitionLockScope
         _logger = logger;
     }
 
-    private TransitionLockScope(string lockKey)
+    private TransitionLockScope(string lockKey, bool isAcquired)
     {
         LockKey = lockKey;
-        IsAcquired = false;
+        IsAcquired = isAcquired;
         _handle = null;
         _leaseSeconds = 0;
         _logger = null!;
@@ -91,7 +101,9 @@ internal sealed class TransitionLockScope : ITransitionLockScope
     /// <inheritdoc />
     public async Task<bool> ExtendAsync(CancellationToken cancellationToken = default)
     {
-        if (_handle is null) return false;
+        // A reentrant scope has no handle of its own; the outer holder owns the lease
+        // (sized upfront to cover the chain budget), so report extension as succeeded.
+        if (_handle is null) return IsAcquired;
 
         var extended = await _handle.ExtendAsync(_leaseSeconds, cancellationToken);
 
@@ -113,5 +125,11 @@ internal sealed class TransitionLockScope : ITransitionLockScope
         }
     }
 
-    internal static TransitionLockScope NotAcquired(string lockKey) => new(lockKey);
+    internal static TransitionLockScope NotAcquired(string lockKey) => new(lockKey, isAcquired: false);
+
+    /// <summary>
+    /// Creates an acquired scope without an underlying handle for a key the current execution
+    /// chain already holds. Disposal is a no-op so the outer holder's lock is never released.
+    /// </summary>
+    internal static TransitionLockScope Reentrant(string lockKey) => new(lockKey, isAcquired: true);
 }

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/TransitionPipelineTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/TransitionPipelineTests.cs
@@ -189,6 +189,73 @@ public class TransitionPipelineTests
     }
 
     [Fact]
+    public async Task RunAsync_ShouldRegisterChainLockKeyForPostCommitExecution()
+    {
+        // The sync subflow completion callback runs inside the post-commit phase and needs to
+        // see the parent chain lock as held-by-own-chain (reentrant) instead of failing acquisition.
+        var context = CreateTransitionExecutionContext();
+        var workflowContext = CreateWorkflowExecutionContext(context);
+
+        SetupContextFactory(context);
+        SetupStepsToSucceed();
+        context.Directives.EnqueuePostCommit(Substitute.For<IPostCommitJob>());
+
+        bool? heldDuringPostCommit = null;
+        _mockPostCommitExecutor.ExecuteAsync(
+            Arg.Any<IReadOnlyList<IPostCommitJob>>(),
+            Arg.Any<TransitionExecutionContext>(),
+            Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                heldDuringPostCommit = ChainLockRegistry.IsHeld(context.LockKey);
+                return PostCommitResult.Ok();
+            });
+
+        var result = await _pipeline.RunAsync(workflowContext, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        heldDuringPostCommit.ShouldBe(true);
+        // The registration must not leak out of the pipeline run.
+        ChainLockRegistry.IsHeld(context.LockKey).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenReservedTransition_ShouldRegisterOwnLockKeyForPostCommitExecution()
+    {
+        var context = CreateTransitionExecutionContext("cancel");
+        var workflowContext = CreateWorkflowExecutionContext(context);
+        var expectedOwnKey = context.LockKey + ":reserved";
+
+        SetupContextFactory(context);
+        SetupStepsToSucceed();
+        context.Directives.EnqueuePostCommit(Substitute.For<IPostCommitJob>());
+
+        _mockReservedResolver
+            .IsReserved(Arg.Any<TransitionExecutionContext>())
+            .Returns(true);
+
+        bool? ownKeyHeld = null;
+        bool? mainKeyHeld = null;
+        _mockPostCommitExecutor.ExecuteAsync(
+            Arg.Any<IReadOnlyList<IPostCommitJob>>(),
+            Arg.Any<TransitionExecutionContext>(),
+            Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                ownKeyHeld = ChainLockRegistry.IsHeld(expectedOwnKey);
+                mainKeyHeld = ChainLockRegistry.IsHeld(context.LockKey);
+                return PostCommitResult.Ok();
+            });
+
+        var result = await _pipeline.RunAsync(workflowContext, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        ownKeyHeld.ShouldBe(true);
+        // The reserved path holds only its own type-specific key, never the main flow key.
+        mainKeyHeld.ShouldBe(false);
+    }
+
+    [Fact]
     public async Task RunAsync_ShouldMarkBusyImmediatelyAfterLockAcquisition()
     {
         // Arrange

--- a/test/BBT.Workflow.Domain.Tests/Execution/Transitions/Pipeline/ChainLockRegistryTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Execution/Transitions/Pipeline/ChainLockRegistryTests.cs
@@ -1,0 +1,91 @@
+using System.Threading.Tasks;
+using BBT.Workflow.Execution.Pipeline;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Execution.Transitions.Pipeline;
+
+/// <summary>
+/// Unit tests for <see cref="ChainLockRegistry"/> async-flow scoping semantics.
+/// </summary>
+public class ChainLockRegistryTests : DomainTestBase<DomainEntryPoint>
+{
+    [Fact]
+    public void IsHeld_WithoutRegistration_ShouldReturnFalse()
+    {
+        ChainLockRegistry.IsHeld("vnext:bank:flow:none").ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task Register_ShouldBeVisibleToNestedAsyncCalls()
+    {
+        const string key = "vnext:bank:parent-flow:instance-1";
+
+        ChainLockRegistry.Register(key);
+
+        (await NestedIsHeldAsync(key)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Register_InsideChildAsyncMethod_ShouldNotLeakToCaller()
+    {
+        const string key = "vnext:bank:parent-flow:instance-2";
+
+        await RegisterInChildScopeAsync(key);
+
+        ChainLockRegistry.IsHeld(key).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task Register_ShouldIsolateParallelExecutionFlows()
+    {
+        const string keyA = "vnext:bank:parent-flow:flow-a";
+        const string keyB = "vnext:bank:parent-flow:flow-b";
+
+        var flowA = Task.Run(async () =>
+        {
+            ChainLockRegistry.Register(keyA);
+            await Task.Yield();
+            return (SeesOwn: ChainLockRegistry.IsHeld(keyA), SeesOther: ChainLockRegistry.IsHeld(keyB));
+        });
+        var flowB = Task.Run(async () =>
+        {
+            ChainLockRegistry.Register(keyB);
+            await Task.Yield();
+            return (SeesOwn: ChainLockRegistry.IsHeld(keyB), SeesOther: ChainLockRegistry.IsHeld(keyA));
+        });
+
+        var results = await Task.WhenAll(flowA, flowB);
+
+        results[0].SeesOwn.ShouldBeTrue();
+        results[0].SeesOther.ShouldBeFalse();
+        results[1].SeesOwn.ShouldBeTrue();
+        results[1].SeesOther.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task Register_MultipleKeysInSameChain_ShouldAllBeHeld()
+    {
+        const string outerKey = "vnext:bank:parent-flow:outer";
+        const string innerKey = "vnext:bank:child-flow:inner";
+
+        ChainLockRegistry.Register(outerKey);
+        ChainLockRegistry.Register(innerKey);
+
+        (await NestedIsHeldAsync(outerKey)).ShouldBeTrue();
+        (await NestedIsHeldAsync(innerKey)).ShouldBeTrue();
+    }
+
+    private static async Task<bool> NestedIsHeldAsync(string key)
+    {
+        await Task.Yield();
+        return ChainLockRegistry.IsHeld(key);
+    }
+
+    private static async Task RegisterInChildScopeAsync(string key)
+    {
+        await Task.Yield();
+        ChainLockRegistry.Register(key);
+        ChainLockRegistry.IsHeld(key).ShouldBeTrue();
+    }
+}

--- a/test/BBT.Workflow.Infrastructure.Tests/Execution/Locks/TransitionLockScopeFactoryTests.cs
+++ b/test/BBT.Workflow.Infrastructure.Tests/Execution/Locks/TransitionLockScopeFactoryTests.cs
@@ -1,0 +1,101 @@
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.DistributedLock;
+using BBT.Workflow.BackgroundJobs.Options;
+using BBT.Workflow.Execution.Pipeline;
+using BBT.Workflow.Infrastructure.Execution.Locks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Execution.Locks;
+
+/// <summary>
+/// Unit tests for <see cref="TransitionLockScopeFactory"/> — distributed acquisition
+/// and chain-reentrant acquisition via <see cref="ChainLockRegistry"/>.
+/// </summary>
+public sealed class TransitionLockScopeFactoryTests
+{
+    private readonly IDistributedLockService _lockService = Substitute.For<IDistributedLockService>();
+
+    private TransitionLockScopeFactory CreateFactory() => new(
+        _lockService,
+        Options.Create(new WorkflowExecutionOptions()),
+        Substitute.For<ILogger<TransitionLockScopeFactory>>());
+
+    [Fact]
+    public async Task AcquireAsync_WhenKeyNotHeldByChain_ShouldDelegateToDistributedLockService()
+    {
+        const string key = "vnext:bank:parent-flow:delegate";
+        var handle = Substitute.For<IDistributedLockHandle>();
+        _lockService.TryAcquireLockAsync(key, Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(handle);
+
+        await using var scope = await CreateFactory().AcquireAsync(key);
+
+        scope.IsAcquired.ShouldBeTrue();
+        scope.LockKey.ShouldBe(key);
+        await _lockService.Received(1)
+            .TryAcquireLockAsync(key, Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task AcquireAsync_WhenKeyNotHeldAndServiceReturnsNull_ShouldReturnNotAcquired()
+    {
+        const string key = "vnext:bank:parent-flow:contended";
+        _lockService.TryAcquireLockAsync(key, Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns((IDistributedLockHandle?)null);
+
+        await using var scope = await CreateFactory().AcquireAsync(key);
+
+        scope.IsAcquired.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task AcquireAsync_WhenChainAlreadyHoldsKey_ShouldReturnReentrantScopeWithoutDistributedAcquire()
+    {
+        // Simulates the sync subflow completion callback: the parent pipeline higher up in
+        // this async chain already holds the parent lock, so re-acquisition must succeed
+        // without touching the distributed lock service (which would reject same-key acquire).
+        const string key = "vnext:bank:parent-flow:reentrant";
+        ChainLockRegistry.Register(key);
+        _lockService.TryAcquireLockAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns((IDistributedLockHandle?)null);
+
+        await using var scope = await CreateFactory().AcquireAsync(key);
+
+        scope.IsAcquired.ShouldBeTrue();
+        scope.LockKey.ShouldBe(key);
+        await _lockService.DidNotReceive()
+            .TryAcquireLockAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task AcquireAsync_ReentrantScope_ShouldReportExtendAsSucceeded()
+    {
+        // The outer holder owns the real lease; a reentrant scope must not abort chains
+        // that opt into between-hop lease extension.
+        const string key = "vnext:bank:parent-flow:reentrant-extend";
+        ChainLockRegistry.Register(key);
+
+        await using var scope = await CreateFactory().AcquireAsync(key);
+
+        (await scope.ExtendAsync()).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task AcquireAsync_ReentrantScope_DisposeShouldNotReleaseOuterLock()
+    {
+        const string key = "vnext:bank:parent-flow:reentrant-dispose";
+        ChainLockRegistry.Register(key);
+
+        var scope = await CreateFactory().AcquireAsync(key);
+        await scope.DisposeAsync();
+
+        // No handle was created, so nothing may be released on the lock service.
+        await _lockService.DidNotReceive()
+            .TryAcquireLockAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes sync=true chains where a subflow's completion behaved asynchronously: the parent's still-held chain lock blocked the completion callback's terminal-lock acquisition, so the hook failed silently (`DurablePostCommit`) and the parent resume fell back to the Outbox → Inbox path. Sync requests returned `Busy` and the parent settled later.
- Introduces **chain-reentrant lock acquisition**: an `AsyncLocal`-scoped `ChainLockRegistry` tracks lock keys held by the current execution chain; re-acquiring a chain-held key returns a handle-less reentrant scope instead of failing. Mutual exclusion is still provided by the outer holder — concurrent chains and Inbox processing are unaffected.
- Nested completion, fault, and cancellation callbacks now run inline within the sync request; the late Inbox event no-ops via the existing duplicate-correlation guard.

## Root Cause
`TransitionPipeline` executes post-commit jobs (`StartSubflowJob` / `ForwardToSubflowJob`) **inside** the request-scoped chain lock (`vnext:{domain}:{flow}:{instanceId}`). When the subflow completed synchronously inside that call chain, `SubflowCompletionService.CompletionAsync` tried to acquire the **same key** as the parent's terminal lock. The Dapr/Redis provider (`SET NX`) rejects re-acquire, so the completion hook always failed with `SubItemTerminalLockNotAcquired` and completion degraded to async Inbox delivery — defeating the sync caller-mode propagation added in 1d8d913b. The reserved own-lock design (`ReservedTransitionResolver`) already anticipated "sync subflow resume inside the parent's post-commit phase"; the terminal-lock re-acquisition was the only missing piece.

## Changes
- `src/BBT.Workflow.Domain/Execution/Transitions/Pipeline/ChainLockRegistry.cs` — new `AsyncLocal` registry; registrations flow into awaited callees and expire automatically when the registering method returns.
- `src/BBT.Workflow.Application/Execution/Transitions/Pipeline/TransitionPipeline.cs` — registers the chain lock key (normal path) and reserved own-lock key after acquisition.
- `src/BBT.Workflow.Infrastructure/Execution/Locks/TransitionLockScopeFactory.cs` — returns an acquired, handle-less `Reentrant` scope for chain-held keys; disposal never releases the outer lock; `ExtendAsync` reports success (outer lease is sized for the chain budget).
- `src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs` — `TransitionLockReentrantAcquired` (EventId 40123, Debug).
- 12 new tests: `ChainLockRegistryTests` (async-flow scoping/isolation), `TransitionLockScopeFactoryTests` (reentrant vs delegated acquisition), `TransitionPipelineTests` (keys registered during post-commit, no leak after the run).

## Test Plan
- [x] New tests written first and observed failing (TDD), then passing after the fix
- [x] Full test suites compared against a clean master baseline — pre-existing failure counts unchanged (Domain 154, Application 27, Infrastructure 11), zero regressions; Monitor suite fully green
- [x] `dotnet build vnext.sln` — 0 errors, no new warnings in touched files
- [ ] Manual verification: sync=true start of a flow with an auto-completing subflow should now return the settled (e.g. `Completed`) status; logs should show `acquired reentrantly` (Debug) instead of `Parent terminal lock ... could not be acquired for Completed outcome`

## Notes
- Semantics are strictly additive: a key is treated as held only when the **same async call chain** registered it. Genuinely contended acquisitions (another request/worker holding the lock) still fail fast and retain the Inbox retry path.
- If the outer lease expires mid-chain the reentrant assumption mirrors the outer chain's existing exposure — no new failure mode is introduced.
- Follow-up candidate: an end-to-end integration test (real infra) asserting the sync response reflects the settled parent status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure synchronous subflow completions remain fully inline by introducing chain-reentrant lock tracking and acquisition for transition locks.

New Features:
- Add an AsyncLocal-scoped ChainLockRegistry to track lock keys held by the current execution chain and enable chain-reentrant lock acquisition.

Bug Fixes:
- Prevent synchronous subflow completion callbacks from failing terminal lock acquisition and degrading to asynchronous Inbox delivery, so sync flows return settled statuses instead of Busy.

Enhancements:
- Update TransitionLockScopeFactory to return reentrant lock scopes that treat chain-held keys as acquired without re-acquiring the distributed lock and to report lease extension success for these scopes.
- Register main and reserved transition lock keys within TransitionPipeline so post-commit callbacks can resolve reentrantly against already-held locks.
- Add debug-level logging for reentrant transition lock acquisition to aid observability of sync subflow behavior.

Tests:
- Add ChainLockRegistry unit tests to validate async-flow scoping and isolation semantics.
- Add TransitionLockScopeFactory unit tests covering delegated versus reentrant acquisition, lease extension, and disposal behavior.
- Extend TransitionPipeline tests to verify chain and reserved lock keys are registered during post-commit execution and do not leak beyond the pipeline run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow transition handling when nested callbacks reacquire a lock already held by the same execution chain.
  * Prevented duplicate distributed lock acquisition and ensured reentrant locks remain valid through extension and cleanup.
  * Ensured lock ownership tracking is isolated to the active execution flow and does not leak after completion.

* **Tests**
  * Added coverage for normal and reserved transitions, nested asynchronous execution, parallel flows, and reentrant lock lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->