### PR TITLE
perf: fingerprint ETag and distributed response cache for instance functions (state, data, master, schema)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ describe the stable mental model, boundaries, failure modes, and change-safety r
 6. Read [API and Service Contracts](contracts/api-and-service-contracts.md) before changing HTTP or Dapr-facing contracts.
 7. Read [JSON Validation](contracts/json-validation.md) before changing schema validation errors.
 8. Read [Long-Poll Termination on State Entry](domain/long-poll-termination.md) before changing State-function long-poll behavior or the pipeline pause/resume path.
-9. Read [State and Data Function Cache and Fingerprint ETag](runtime/state-function-cache-and-etag.md) before changing the state/data functions' ETag, caching, or 304 behavior (includes the workflow-level `functionCache.ttlSeconds` contract).
+9. Read [Instance Function Cache and Fingerprint ETag](runtime/state-function-cache-and-etag.md) before changing the state/data/master/schema functions' ETag, caching, or 304 behavior (includes the workflow-level `functionCache.ttlSeconds` contract).
 10. Read [Event-Driven Workflows](domain/event-driven-workflows.md) before wiring external events into workflows or transitions (event mappings, Dapr subscriptions, correlation).
 11. Read [Instance Filtering and Queries](runtime/instance-filtering-and-queries.md) before writing instance queries in mapping scripts (fluent `InstanceQuery`, operator reference, `GetInstancesTask` vs `DaprServiceTask`, migration from hand-written GraphQL filters).
 12. Read [GetInstance Task](runtime/get-instance-task.md) when a mapping needs a single instance's metadata **and** data in one call (task type `18`, local/remote response parity).

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,9 +28,10 @@ describe the stable mental model, boundaries, failure modes, and change-safety r
 6. Read [API and Service Contracts](contracts/api-and-service-contracts.md) before changing HTTP or Dapr-facing contracts.
 7. Read [JSON Validation](contracts/json-validation.md) before changing schema validation errors.
 8. Read [Long-Poll Termination on State Entry](domain/long-poll-termination.md) before changing State-function long-poll behavior or the pipeline pause/resume path.
-9. Read [Event-Driven Workflows](domain/event-driven-workflows.md) before wiring external events into workflows or transitions (event mappings, Dapr subscriptions, correlation).
-10. Read [Instance Filtering and Queries](runtime/instance-filtering-and-queries.md) before writing instance queries in mapping scripts (fluent `InstanceQuery`, operator reference, `GetInstancesTask` vs `DaprServiceTask`, migration from hand-written GraphQL filters).
-11. Read [GetInstance Task](runtime/get-instance-task.md) when a mapping needs a single instance's metadata **and** data in one call (task type `18`, local/remote response parity).
+9. Read [State Function Cache and Fingerprint ETag](runtime/state-function-cache-and-etag.md) before changing the state function's ETag, caching, or 304 behavior.
+10. Read [Event-Driven Workflows](domain/event-driven-workflows.md) before wiring external events into workflows or transitions (event mappings, Dapr subscriptions, correlation).
+11. Read [Instance Filtering and Queries](runtime/instance-filtering-and-queries.md) before writing instance queries in mapping scripts (fluent `InstanceQuery`, operator reference, `GetInstancesTask` vs `DaprServiceTask`, migration from hand-written GraphQL filters).
+12. Read [GetInstance Task](runtime/get-instance-task.md) when a mapping needs a single instance's metadata **and** data in one call (task type `18`, local/remote response parity).
 
 ## Documentation Rules
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ describe the stable mental model, boundaries, failure modes, and change-safety r
 6. Read [API and Service Contracts](contracts/api-and-service-contracts.md) before changing HTTP or Dapr-facing contracts.
 7. Read [JSON Validation](contracts/json-validation.md) before changing schema validation errors.
 8. Read [Long-Poll Termination on State Entry](domain/long-poll-termination.md) before changing State-function long-poll behavior or the pipeline pause/resume path.
-9. Read [State Function Cache and Fingerprint ETag](runtime/state-function-cache-and-etag.md) before changing the state function's ETag, caching, or 304 behavior.
+9. Read [State and Data Function Cache and Fingerprint ETag](runtime/state-function-cache-and-etag.md) before changing the state/data functions' ETag, caching, or 304 behavior (includes the workflow-level `functionCache.ttlSeconds` contract).
 10. Read [Event-Driven Workflows](domain/event-driven-workflows.md) before wiring external events into workflows or transitions (event mappings, Dapr subscriptions, correlation).
 11. Read [Instance Filtering and Queries](runtime/instance-filtering-and-queries.md) before writing instance queries in mapping scripts (fluent `InstanceQuery`, operator reference, `GetInstancesTask` vs `DaprServiceTask`, migration from hand-written GraphQL filters).
 12. Read [GetInstance Task](runtime/get-instance-task.md) when a mapping needs a single instance's metadata **and** data in one call (task type `18`, local/remote response parity).

--- a/docs/runtime/state-function-cache-and-etag.md
+++ b/docs/runtime/state-function-cache-and-etag.md
@@ -1,4 +1,4 @@
-# State and Data Function Cache and Fingerprint ETag
+# Instance Function Cache and Fingerprint ETag (state, data, master, schema)
 
 ## Purpose
 
@@ -168,6 +168,38 @@ extension output call without `If-None-Match` and always get a freshly computed 
 Similarly, state-dependent `queryRoles` outcomes are only re-evaluated when data or flow
 version changes (transitions usually write data, which re-triggers everything).
 
+## Master and schema functions
+
+Both return a resolved schema document (`GetSchemaOutput`) — the flow-level master schema for
+`master`, the transition's schema for `schema` — and share one cache service
+(`IInstanceSchemaFunctionCache`) and, by user decision, the data-centric change signal:
+
+```
+master etag = h(instanceId | latestDataEtag | flowVersion | callerHash)
+schema etag = h(instanceId | latestDataEtag | effectiveState | flowVersion | callerHash | transitionKey)
+master key  = master-fn:{domain}:{workflow}:{instance}:{callerHash}
+schema key  = schema-fn:{domain}:{workflow}:{instance}:{callerHash}:{transitionKey}
+callerHash  = h(roles | actor identity | culture | version)   # no extensions dimension
+```
+
+- `effectiveState` is only in the **schema** material: transition resolution
+  (`ResolveTransition(transitionKey, currentState)`) is state-dependent, and
+  `EffectiveState == CurrentState` whenever no active subflow exists.
+- **Active subflow → full bypass** (both functions forward to the subflow's own function via
+  the gateway). The subflow's body-embedded `ETag` is nulled on the forwarded response — it
+  belongs to a different resource. Subflow calls never carry `If-None-Match` (the remote
+  master/schema calls strip it from forwarded headers, like the state path).
+- Only **successful** outcomes are cached (missing transition key, unresolvable transition,
+  or missing schema reference are never written).
+- A validated hit short-circuits fully (no aggregate load); the queryRoles gate is skipped on
+  hits with the same justification as state/data — and note the master function's gate,
+  previously disabled by a commented-out block, is now enabled (consistent with schema).
+- Accepted staleness: republishing a schema component under the same version does not move the
+  ETag (same class as a flow redeploy); data writes over-invalidate master/schema (harmless
+  rebuilds, never staleness).
+- Observability: shared EventIds 20420-20425 with a `{Function}` parameter
+  (`InstanceSchemaFunctionCache*`), component types `master-fn` / `schema-fn`.
+
 ## Configuration
 
 ```json
@@ -207,9 +239,10 @@ function cache entries; the single value covers all built-in functions of the wo
 | 20404 | `StateFunctionCacheError` | Cache operation failed; degraded to miss |
 | 20405 | `StateFunctionEtagNotModified` | 304 answered from the fingerprint alone |
 | 20410-20414 | `DataFunctionCache*` / `DataFunctionEtagNotModified` | Data-function counterparts of the above |
+| 20420-20425 | `InstanceSchemaFunctionCache*` | Master/schema counterparts (shared quintet + subflow bypass, `{Function}` = master/schema) |
 
 Cache operations are traced under the `BBT.Workflow.Cache` activity source
-(component types `state-fn` and `data-fn`).
+(component types `state-fn`, `data-fn`, `master-fn`, `schema-fn`).
 
 ## Key implementation files
 

--- a/docs/runtime/state-function-cache-and-etag.md
+++ b/docs/runtime/state-function-cache-and-etag.md
@@ -1,0 +1,155 @@
+# State Function Cache and Fingerprint ETag
+
+## Purpose
+
+The state function (`GET .../functions/state`, long-polling) is the hottest read path in the
+runtime: clients poll it continuously with `If-None-Match` until the instance reaches a terminal
+status. Rebuilding the full response on every poll (aggregate load, authorization gate, role
+filtering, canonical-JSON hashing) is wasteful because the answer only changes when the
+instance's state or status changes.
+
+The runtime therefore derives the ETag from a **state fingerprint** instead of the response
+body, and backs it with a distributed response cache. The fingerprint is loaded by a
+single-row projection query (the *light DB query*), so the dominant poll cycle is answered
+without touching the aggregate, the cache, or the response builder.
+
+## Request flow
+
+```mermaid
+flowchart TB
+    A["GET /functions/state<br/>(long-poll, If-None-Match)"] --> B["Light DB query<br/>(single-row fingerprint projection)"]
+    B --> C{Active subflow?}
+    C -- yes --> S["Live evaluation<br/>(cache bypass, live ETag)"]
+    C -- no --> D["Compute ETag<br/>(fingerprint + caller hash)"]
+    D --> E{If-None-Match matches?}
+    E -- yes --> R304["304 Not Modified<br/>(no cache access, no build)"]
+    E -- no --> F["Redis cache GET<br/>(entry.Etag == etag?)"]
+    F -- match --> R200C["200 from cache<br/>(no aggregate load)"]
+    F -- "miss / stale" --> G["Full build<br/>(aggregate + auth + role filtering)"]
+    G --> H["Cache SET (TTL 60s)"]
+    H --> R200["200 + ETag"]
+```
+
+Edge cases not shown: when the fingerprint query finds no instance, the full path runs and
+produces the proper error (404). When `StateFunctionCache:Enabled` is `false`, the left column
+is skipped entirely, but the ETag is still computed with the same formula inside the full
+build — toggling the flag never changes ETag semantics.
+
+## The three structures
+
+### Light DB query (fingerprint)
+
+`IInstanceRepository.GetStateFingerprintAsync(identifier)` projects one row — no includes, no
+aggregate materialization:
+
+```
+SELECT Id, Key, EffectiveState, Status, FlowVersion,
+       EXISTS(active SubFlow correlation) AS HasActiveSubFlow
+```
+
+- Identifier resolution mirrors `FindByIdentifierAsReadOnlyAsync`: id first, then the most
+  recent row by key (`ORDER BY CreatedAt DESC`).
+- `HasActiveSubFlow` translates to an `EXISTS` subquery served by the partial index
+  `IX_InstancesCorrelations_ActiveBlockingSubFlow` (`ParentInstanceId WHERE IsCompleted = false
+  AND SubFlowType = 'S'`) — a single B-tree probe, not a correlation load.
+- `EffectiveState` (not `CurrentState`) is used because subflow state changes are propagated
+  upward into the parent's `EffectiveState` column.
+
+### ETag
+
+Computed by `IStateFunctionCache.ComputeEtag` — a deterministic SHA-256 hash (32 hex chars):
+
+```
+etag = h(instanceId | effectiveState | status | flowVersion | callerHash)
+```
+
+- **Deterministic across pods**: any instance of the service computes the same ETag for the
+  same fingerprint, so 304 works with an empty cache (after TTL expiry, Redis flush, or
+  failover).
+- **`callerHash` is inside the hash**: the response is authorization- and localization-scoped,
+  so a caller switching role, actor, or culture must never receive a false 304.
+- **Subflow variant**: when an active subflow exists, the response content comes from a live
+  subflow call, so the displayed state and status are folded into the hash:
+  `h(... | displayedState | displayedStatus)`. The parent row alone cannot see
+  subflow-internal Busy/Active flips (`PropagateEffectiveStateToParent` updates only
+  `EffectiveState`, never `Status`, and is asynchronous via the Inbox worker).
+- The ETag intentionally does **not** track instance-data-only changes: the state function
+  signals state/status transitions, not data versions. `X-Entity-ETag` served from cache may
+  lag data-only updates until the next state/status change (accepted by design — the data
+  function is the authority for data freshness).
+
+### Distributed cache
+
+`IStateFunctionCache` over Aether `IDistributedCacheService` (Redis):
+
+```
+key   = state-fn:{domain}:{workflow}:{instance}:{callerHash}
+value = { Etag, EntityEtag, Output }          # full role-scoped response body
+TTL   = StateFunctionCache:TtlSeconds         # default 60s = client long-poll timeout
+callerHash = h(role | roles | actor identity | culture | extensions | version)
+```
+
+- The cache serves only callers **without** a current ETag (first poll, evicted client state).
+  Validation on a hit is a single ETag equality check — state, status, version, and caller
+  scope are all inside the hash, so a matching entry is guaranteed fresh.
+- Actor identity participates because `$InstanceStarter`/`$PreviousUser` pseudo-roles are
+  matched against `ICurrentUser`; culture participates because state alias labels are
+  localized.
+- Cache failures never fail a request: read errors degrade to a miss, write errors are
+  swallowed (`StateFunctionCacheError`, EventId 20404).
+- The authorization gate (`IsInstanceQueryAllowedAsync`) is skipped on a validated hit by
+  design: the key pins the caller, the fingerprint pins the instance facts the gate depends on.
+
+## Subflow behavior
+
+Instances with an open SubFlow correlation bypass both the 304 fast path and the cache — the
+response is composed from a live call to the subflow's own state function
+(`IInstanceQueryGateway`, in-process for same-domain, HTTP/Dapr for cross-domain). That call
+benefits from the *subflow side's* own fingerprint cache: the subflow service answers it from
+its Redis entry or fingerprint fast path like any other state request. Nothing is ever written
+to the parent's cache while the correlation is open.
+
+**The subflow call always returns a body — a 304 from the subflow is impossible by contract.**
+The parent needs the subflow response to compose its own; it never sends `If-None-Match`
+downstream. The in-process gateway maps only the typed `input.IfNoneMatch` (never set for this
+call), and the remote path (`RemoteInstanceQueryAppService.GetFunctionWithStateAsync`)
+explicitly strips `If-None-Match` from the forwarded caller headers — the caller's ETag belongs
+to a different resource (the parent), and a false 304 would leave the composer with no body.
+
+## Configuration
+
+```json
+"StateFunctionCache": {
+  "Enabled": true,
+  "TtlSeconds": 60
+}
+```
+
+Orchestration host `appsettings.json`. `Enabled=false` is the kill switch (full evaluation on
+every poll); `TtlSeconds` bounds only the residual staleness of parts not covered by the
+fingerprint (e.g. `X-Entity-ETag`) — state/status changes are detected on every request via
+the projection query.
+
+## Observability
+
+| EventId | Name | When |
+| --- | --- | --- |
+| 20400 | `StateFunctionCacheHit` | Cached response served (ETag equality validated) |
+| 20401 | `StateFunctionCacheMiss` | No entry for the caller scope |
+| 20402 | `StateFunctionCacheInvalidated` | Entry ETag no longer matches the current fingerprint ETag |
+| 20403 | `StateFunctionCacheBypassedForSubFlow` | Active subflow — live evaluation |
+| 20404 | `StateFunctionCacheError` | Cache operation failed; degraded to miss |
+| 20405 | `StateFunctionEtagNotModified` | 304 answered from the fingerprint alone |
+
+Cache operations are traced under the `BBT.Workflow.Cache` activity source
+(component type `state-fn`).
+
+## Key implementation files
+
+| Concern | File |
+| --- | --- |
+| Flow orchestration | `src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs` (`GetInstanceStateAsync`, `TryServeStateFromFingerprintAsync`) |
+| ETag + cache | `src/BBT.Workflow.Application/Instances/Caching/StateFunctionCache.cs` |
+| Fingerprint record | `src/BBT.Workflow.Domain/Instances/InstanceStateFingerprint.cs` |
+| Projection query | `src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceRepository.cs` (`GetStateFingerprintAsync`) |
+| Options | `src/BBT.Workflow.Application/Instances/Caching/StateFunctionCacheOptions.cs` |

--- a/docs/runtime/state-function-cache-and-etag.md
+++ b/docs/runtime/state-function-cache-and-etag.md
@@ -1,4 +1,4 @@
-# State Function Cache and Fingerprint ETag
+# State and Data Function Cache and Fingerprint ETag
 
 ## Purpose
 
@@ -116,19 +116,85 @@ call), and the remote path (`RemoteInstanceQueryAppService.GetFunctionWithStateA
 explicitly strips `If-None-Match` from the forwarded caller headers — the caller's ETag belongs
 to a different resource (the parent), and a false 304 would leave the composer with no body.
 
+## Data function
+
+The data function (`GET .../instances/{instance}/data` and `functions/data`) uses the same
+mechanism with a data-centric material — the design principle is that the data function
+signals **data change points**, not state or extension flux:
+
+```
+etag = h(instanceId | latestDataEtag | flowVersion | callerHash)
+key  = data-fn:{domain}:{workflow}:{instance}:{callerHash}
+callerHash = h(roles | actor identity | culture | version)   # extensions deliberately EXCLUDED
+```
+
+- **Change signal is `InstanceData.ETag`** of the IsLatest row — a fresh ULID on every
+  latest-line data write. It is read index-only via `UX_InstancesData_Instance_IsLatest`
+  (ETag is in the INCLUDE list) by `IInstanceRepository.GetDataFingerprintAsync`.
+- **`flowVersion` is in the material** because a flow migration can change `x-roles` field
+  filtering and extension definitions without a data write.
+- **Extensions are outside the key and the ETag.** The ETag signals the data change point
+  only; requests differing only in the requested extension list share one key and one ETag.
+- **Latest-data requests only.** Pinned-version requests (`?version=X`) bypass the fast path
+  and the cache: a write into an *older* version line (`AddDataWithVersion`) creates a new row
+  without touching the IsLatest row's ETag, so the latest-based material cannot see it. On the
+  full path, pinned requests hash the **resolved** row's ETag instead — correct, because a
+  write into that line produces a new row with a new ULID.
+- **No subflow bypass**: the data body is always the parent's own `FindData` result; an active
+  subflow only contributes extension output — which is never cached (below).
+- A 304 answered from the fingerprint skips the aggregate load, the authorization gate, field
+  filtering **and the extension run** — including always-on Global extensions, which are the
+  most expensive part of a data read.
+
+**The cache stores pure instance data — extension output is never cached:**
+
+- An entry holds only the caller-scoped, field-filtered `Data` payload.
+- A validated entry does **not** short-circuit the request: it feeds the **data portion** of
+  the build (skipping the x-roles field filtering step — which may evaluate dynamic role
+  scripts) while the extension pipeline **always runs fresh** against the raw instance data.
+  This holds for every 200: whether or not the caller requested extensions, data comes from
+  the cache when valid and extension output is never stale.
+- Every latest-data 200 with a resolved data row warms the cache (data-only entry), including
+  responses that carried extension output.
+- Responses with no resolved data row are never cached.
+- The heavy wins remain on the 304 fast path (no aggregate, no auth, no filtering, no
+  extension run — including always-on Global extensions); the body cache additionally removes
+  the field-filtering cost from every 200.
+
+Accepted staleness (by design — "the critical thing is the data change point"): the ETag does
+not track extension output, so an ETag-holding client receives 304 until the next data write
+or flow migration even if extension output changed in the meantime; clients that need fresh
+extension output call without `If-None-Match` and always get a freshly computed response.
+Similarly, state-dependent `queryRoles` outcomes are only re-evaluated when data or flow
+version changes (transitions usually write data, which re-triggers everything).
+
 ## Configuration
 
 ```json
 "StateFunctionCache": {
   "Enabled": true,
   "TtlSeconds": 60
+},
+"InstanceFunctionCache": {
+  "Enabled": true,
+  "DefaultTtlSeconds": 60
 }
 ```
 
 Orchestration host `appsettings.json`. `Enabled=false` is the kill switch (full evaluation on
-every poll); `TtlSeconds` bounds only the residual staleness of parts not covered by the
-fingerprint (e.g. `X-Entity-ETag`) — state/status changes are detected on every request via
-the projection query.
+every request); TTL bounds only the residual staleness of parts not covered by the fingerprint
+— fingerprint-covered changes are detected on every request via the projection query.
+
+**Workflow-author TTL** (data/view/schema family — not the state function): the flow
+definition may declare
+
+```json
+"functionCache": { "ttlSeconds": 120 }
+```
+
+(`Definitions.FunctionCacheDefinition`, bound to `Workflow.FunctionCache`). When present and
+positive it overrides `InstanceFunctionCache:DefaultTtlSeconds` for that workflow's built-in
+function cache entries; the single value covers all built-in functions of the workflow.
 
 ## Observability
 
@@ -140,9 +206,10 @@ the projection query.
 | 20403 | `StateFunctionCacheBypassedForSubFlow` | Active subflow — live evaluation |
 | 20404 | `StateFunctionCacheError` | Cache operation failed; degraded to miss |
 | 20405 | `StateFunctionEtagNotModified` | 304 answered from the fingerprint alone |
+| 20410-20414 | `DataFunctionCache*` / `DataFunctionEtagNotModified` | Data-function counterparts of the above |
 
 Cache operations are traced under the `BBT.Workflow.Cache` activity source
-(component type `state-fn`).
+(component types `state-fn` and `data-fn`).
 
 ## Key implementation files
 

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/MasterFunctionHandler.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/MasterFunctionHandler.cs
@@ -1,6 +1,7 @@
 using BBT.Aether.AspNetCore.Results;
 using BBT.Workflow.CurrentUser;
 using BBT.Workflow.Definitions.Functions;
+using BBT.Workflow.Domain.Shared;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Instances.DTOs;
 using Microsoft.AspNetCore.Mvc;
@@ -10,6 +11,7 @@ namespace BBT.Workflow.Controllers.Instances;
 /// <summary>
 /// Handles the <c>master</c> system function. Returns the flow-level master schema the instance is
 /// bound to, forwarding to the active subflow instance when one is present.
+/// Supports conditional GET (304 Not Modified) and sets the ETag response header.
 /// </summary>
 public sealed class MasterFunctionHandler(
     IInstanceQueryAppService queryAppService) : IInstanceFunctionHandler
@@ -25,6 +27,7 @@ public sealed class MasterFunctionHandler(
             Workflow = request.Workflow,
             Instance = request.Instance,
             Version = request.Parameters?.Version,
+            IfNoneMatch = request.IfNoneMatch,
             Headers = request.Headers,
             QueryParameters = request.QueryParameters,
             Roles = request.CurrentUser.ResolveCallerRoles(request.Headers),
@@ -32,6 +35,12 @@ public sealed class MasterFunctionHandler(
 
         var result = await queryAppService.GetMasterAsync(input, cancellationToken);
 
-        return result.ToActionResult(request.HttpContext);
+        if (result.Result is { IsSuccess: true, Value: { } value } && !string.IsNullOrEmpty(value.ETag))
+            request.HttpContext.Response.Headers[HeadersConstants.ETag] = value.ETag;
+
+        if (result.IsNotModified)
+            return new StatusCodeResult(304);
+
+        return result.Result.ToActionResult(request.HttpContext);
     }
 }

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/SchemaFunctionHandler.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/SchemaFunctionHandler.cs
@@ -1,6 +1,7 @@
 using BBT.Aether.AspNetCore.Results;
 using BBT.Workflow.CurrentUser;
 using BBT.Workflow.Definitions.Functions;
+using BBT.Workflow.Domain.Shared;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Instances.DTOs;
 using Microsoft.AspNetCore.Mvc;
@@ -9,6 +10,7 @@ namespace BBT.Workflow.Controllers.Instances;
 
 /// <summary>
 /// Handles the <c>schema</c> system function.
+/// Supports conditional GET (304 Not Modified) and sets the ETag response header.
 /// </summary>
 public sealed class SchemaFunctionHandler(
     IInstanceQueryAppService queryAppService) : IInstanceFunctionHandler
@@ -24,6 +26,7 @@ public sealed class SchemaFunctionHandler(
             Workflow = request.Workflow,
             Instance = request.Instance,
             Version = request.Parameters.Version,
+            IfNoneMatch = request.IfNoneMatch,
             Headers = request.Headers,
             QueryParameters = request.QueryParameters,
             Roles = request.CurrentUser.ResolveCallerRoles(request.Headers),
@@ -34,6 +37,12 @@ public sealed class SchemaFunctionHandler(
             request.Parameters.TransitionKey,
             cancellationToken);
 
-        return result.ToActionResult(request.HttpContext);
+        if (result.Result is { IsSuccess: true, Value: { } value } && !string.IsNullOrEmpty(value.ETag))
+            request.HttpContext.Response.Headers[HeadersConstants.ETag] = value.ETag;
+
+        if (result.IsNotModified)
+            return new StatusCodeResult(304);
+
+        return result.Result.ToActionResult(request.HttpContext);
     }
 }

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/appsettings.json
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/appsettings.json
@@ -277,6 +277,10 @@
       "EnforceMasterSchemaFiltering": true
     }
   },
+  "StateFunctionCache": {
+    "Enabled": true,
+    "TtlSeconds": 60
+  },
   "Dapr": {
     "Notification": {
       "BindingPrefix": "vnext-notification",

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/appsettings.json
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/appsettings.json
@@ -281,6 +281,10 @@
     "Enabled": true,
     "TtlSeconds": 60
   },
+  "InstanceFunctionCache": {
+    "Enabled": true,
+    "DefaultTtlSeconds": 60
+  },
   "Dapr": {
     "Notification": {
       "BindingPrefix": "vnext-notification",

--- a/src/BBT.Workflow.Application/Instances/Caching/CallerScopeHash.cs
+++ b/src/BBT.Workflow.Application/Instances/Caching/CallerScopeHash.cs
@@ -1,0 +1,51 @@
+using System.Security.Cryptography;
+using System.Text;
+using BBT.Aether.Users;
+
+namespace BBT.Workflow.Instances.Caching;
+
+/// <summary>
+/// Shared caller-scope hashing for the built-in instance function caches. The scope covers
+/// role/roles, the current actor identity ($InstanceStarter/$PreviousUser pseudo-roles are
+/// matched against ICurrentUser — see TransitionAuthorizationManager, so two callers with
+/// identical role headers can receive different responses), the resolved culture (localized
+/// labels), requested extensions and the requested version. Folding this hash into cache
+/// keys and ETags guarantees a caller switching role, actor, or culture never receives
+/// another scope's cached answer or a false 304.
+/// </summary>
+internal static class CallerScopeHash
+{
+    /// <summary>
+    /// Length of the caller-scope hash (hex chars of the SHA-256 digest).
+    /// </summary>
+    internal const int Length = 16;
+
+    internal static string Compute(
+        ICurrentUser currentUser,
+        string? role,
+        IReadOnlyList<string>? roles,
+        string[]? extensions,
+        IReadOnlyDictionary<string, string?>? headers,
+        string? version)
+    {
+        var sortedRoles = roles is { Count: > 0 }
+            ? string.Join(',', roles.Order(StringComparer.Ordinal))
+            : string.Empty;
+        var sortedExtensions = extensions is { Length: > 0 }
+            ? string.Join(',', extensions.Order(StringComparer.Ordinal))
+            : string.Empty;
+        var culture = LanguageResolver.ResolveCulture(headers);
+
+        var callerScope = string.Join('|',
+            role ?? string.Empty,
+            sortedRoles,
+            currentUser.Id ?? string.Empty,
+            currentUser.ActorUserName ?? string.Empty,
+            culture,
+            sortedExtensions,
+            version ?? string.Empty);
+
+        return Convert.ToHexStringLower(
+            SHA256.HashData(Encoding.UTF8.GetBytes(callerScope)))[..Length];
+    }
+}

--- a/src/BBT.Workflow.Application/Instances/Caching/DataFunctionCache.cs
+++ b/src/BBT.Workflow.Application/Instances/Caching/DataFunctionCache.cs
@@ -1,0 +1,108 @@
+using System.Security.Cryptography;
+using System.Text;
+using BBT.Aether.DistributedCache;
+using BBT.Aether.Users;
+using BBT.Workflow.Caching;
+using BBT.Workflow.Logging;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace BBT.Workflow.Instances.Caching;
+
+/// <summary>
+/// Distributed-cache implementation of <see cref="IDataFunctionCache"/> backed by
+/// <see cref="IDistributedCacheService"/>. Entry TTL is resolved per workflow by the caller
+/// (flow definition's <c>functionCache.ttlSeconds</c>, falling back to
+/// <see cref="InstanceFunctionCacheOptions.DefaultTtlSeconds"/>); data freshness within the
+/// TTL is guaranteed by the fingerprint-ETag validation, not by this store.
+/// All cache failures degrade to a miss — a broken cache must never fail a data request.
+/// </summary>
+public sealed class DataFunctionCache(
+    IDistributedCacheService cache,
+    ICurrentUser currentUser,
+    IOptions<InstanceFunctionCacheOptions> options,
+    ILogger<DataFunctionCache> logger) : IDataFunctionCache
+{
+    private const string ComponentType = "data-fn";
+    private const string KeyPrefix = "data-fn:";
+
+    /// <summary>
+    /// Length of the fingerprint ETag (hex chars of the SHA-256 digest — 128 bits).
+    /// </summary>
+    private const int EtagLength = 32;
+
+    /// <inheritdoc />
+    public bool Enabled => options.Value.Enabled;
+
+    /// <inheritdoc />
+    public int ResolveTtlSeconds(Definitions.FunctionCacheDefinition? functionCache) =>
+        functionCache?.TtlSeconds is > 0 ? functionCache.TtlSeconds.Value : options.Value.DefaultTtlSeconds;
+
+    /// <inheritdoc />
+    public string BuildKey(GetInstanceDataInput input) =>
+        $"{KeyPrefix}{input.Domain}:{input.Workflow}:{input.Instance}:{BuildCallerHash(input)}";
+
+    /// <inheritdoc />
+    public string ComputeEtag(GetInstanceDataInput input, InstanceDataFingerprint fingerprint)
+    {
+        var material = string.Join('|',
+            fingerprint.Id,
+            fingerprint.LatestDataEtag ?? string.Empty,
+            fingerprint.FlowVersion ?? string.Empty,
+            BuildCallerHash(input));
+
+        return Convert.ToHexStringLower(
+            SHA256.HashData(Encoding.UTF8.GetBytes(material)))[..EtagLength];
+    }
+
+    // Extensions are deliberately EXCLUDED from the caller scope: the ETag tracks the data
+    // change point only (extension flux never moves it), and requests differing only in the
+    // requested extension list share one key/ETag — the body cache serves extensionless
+    // requests, extension-carrying requests are always rebuilt fresh.
+    private string BuildCallerHash(GetInstanceDataInput input) =>
+        CallerScopeHash.Compute(currentUser, role: null, input.Roles, extensions: null, input.Headers, input.Version);
+
+    /// <inheritdoc />
+    public async Task<DataFunctionCacheEntry?> GetAsync(string key, CancellationToken cancellationToken = default)
+    {
+        using var activity = CacheActivityHelper.StartActivity(
+            CacheActivityHelper.OperationGet, key, ComponentType);
+
+        try
+        {
+            var entry = await cache.GetAsync<DataFunctionCacheEntry>(key, cancellationToken);
+            CacheActivityHelper.SetCacheHit(activity, entry is not null);
+            return entry;
+        }
+        catch (Exception ex)
+        {
+            CacheActivityHelper.SetError(activity, ex);
+            logger.DataFunctionCacheError(ex, CacheActivityHelper.OperationGet, key);
+            return null;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task SetAsync(string key, DataFunctionCacheEntry entry, int ttlSeconds, CancellationToken cancellationToken = default)
+    {
+        using var activity = CacheActivityHelper.StartActivity(
+            CacheActivityHelper.OperationSet, key, ComponentType);
+
+        try
+        {
+            await cache.SetAsync(
+                key,
+                entry,
+                new DistributedCacheEntryOptions
+                {
+                    AbsoluteExpiration = DateTimeOffset.UtcNow.AddSeconds(ttlSeconds)
+                },
+                cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            CacheActivityHelper.SetError(activity, ex);
+            logger.DataFunctionCacheError(ex, CacheActivityHelper.OperationSet, key);
+        }
+    }
+}

--- a/src/BBT.Workflow.Application/Instances/Caching/DataFunctionCacheEntry.cs
+++ b/src/BBT.Workflow.Application/Instances/Caching/DataFunctionCacheEntry.cs
@@ -1,0 +1,30 @@
+using System.Text.Json;
+
+namespace BBT.Workflow.Instances.Caching;
+
+/// <summary>
+/// Distributed-cache envelope for the DATA portion of a data-function response. Stores ONLY
+/// the caller-scoped, field-filtered instance data — never extension output: a validated
+/// entry supplies the response's Data (skipping the x-roles filtering step) while extensions
+/// are always computed fresh on the build path. Validation on a hit is a single ETag equality
+/// check: the current ETag is recomputed from the lightweight data fingerprint, so a matching
+/// entry is guaranteed to reflect the instance's current latest-data version and flow version.
+/// </summary>
+public sealed class DataFunctionCacheEntry
+{
+    /// <summary>
+    /// Unquoted fingerprint ETag the response was built under
+    /// (hash of instance id + latest data ETag + flow version + caller scope).
+    /// </summary>
+    public string Etag { get; set; } = string.Empty;
+
+    /// <summary>
+    /// ETag of the instance-data row the response was built from (X-Entity-ETag header value).
+    /// </summary>
+    public string EntityEtag { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The caller-scoped (x-roles filtered) instance data payload.
+    /// </summary>
+    public JsonElement? Data { get; set; }
+}

--- a/src/BBT.Workflow.Application/Instances/Caching/IDataFunctionCache.cs
+++ b/src/BBT.Workflow.Application/Instances/Caching/IDataFunctionCache.cs
@@ -1,0 +1,55 @@
+namespace BBT.Workflow.Instances.Caching;
+
+/// <summary>
+/// Distributed cache and fingerprint-ETag calculator for data-function responses. Keys and
+/// ETags are scoped to the instance identifier and the caller context (roles, actor, culture,
+/// requested data version) because the response is authorization-filtered (x-roles).
+/// Extensions are deliberately OUTSIDE the scope: the ETag tracks the data change point only,
+/// the cache stores pure instance data (a validated entry feeds the build path's Data portion
+/// regardless of whether extensions were requested), and extension output is always computed
+/// fresh. Only latest-data requests use the cache — a pinned-version body can change without
+/// moving the latest row's ETag (older-line writes). Implementations must never let a cache
+/// failure fail the request: read errors are reported as a miss, write errors are swallowed.
+/// </summary>
+public interface IDataFunctionCache
+{
+    /// <summary>
+    /// Whether the cache is enabled (bound from the <c>InstanceFunctionCache</c> configuration
+    /// section). The ETag computation is pure and usable regardless of this flag.
+    /// </summary>
+    bool Enabled { get; }
+
+    /// <summary>
+    /// Builds the cache key for the given request:
+    /// <c>data-fn:{domain}:{workflow}:{instance}:{callerHash}</c>.
+    /// </summary>
+    string BuildKey(GetInstanceDataInput input);
+
+    /// <summary>
+    /// Computes the deterministic fingerprint ETag:
+    /// hash of (instance id, latest data ETag, flow version, caller scope). Computable from the
+    /// lightweight fingerprint projection alone, so an If-None-Match match can be answered with
+    /// 304 without loading the aggregate, running extensions, or building the response.
+    /// For pinned-version requests the caller passes a fingerprint carrying the resolved row's
+    /// ETag instead of the latest one.
+    /// </summary>
+    string ComputeEtag(GetInstanceDataInput input, InstanceDataFingerprint fingerprint);
+
+    /// <summary>
+    /// Resolves the effective TTL: the workflow author's <c>functionCache.ttlSeconds</c> when
+    /// positive, otherwise the host default (<c>InstanceFunctionCache:DefaultTtlSeconds</c>).
+    /// </summary>
+    int ResolveTtlSeconds(Definitions.FunctionCacheDefinition? functionCache);
+
+    /// <summary>
+    /// Gets the cached entry for the key, or null on miss or cache failure.
+    /// </summary>
+    Task<DataFunctionCacheEntry?> GetAsync(string key, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Stores the entry under the key with the given TTL — resolved by the caller from the
+    /// workflow definition (<c>functionCache.ttlSeconds</c>) falling back to the configured
+    /// default. Failures are swallowed.
+    /// </summary>
+    Task SetAsync(string key, DataFunctionCacheEntry entry, int ttlSeconds, CancellationToken cancellationToken = default);
+}

--- a/src/BBT.Workflow.Application/Instances/Caching/IInstanceSchemaFunctionCache.cs
+++ b/src/BBT.Workflow.Application/Instances/Caching/IInstanceSchemaFunctionCache.cs
@@ -1,0 +1,66 @@
+using BBT.Workflow.Instances.DTOs;
+
+namespace BBT.Workflow.Instances.Caching;
+
+/// <summary>
+/// Distributed cache and fingerprint-ETag calculator serving BOTH the master and the schema
+/// instance functions (they share the <see cref="GetSchemaOutput"/> body shape). Keys and ETags
+/// are scoped to the instance identifier and the caller context (roles, actor, culture,
+/// requested workflow version); the schema function additionally folds the transition key and
+/// the effective state into its scope — transition resolution is state-dependent. The change
+/// signal is the latest instance-data ETag plus the bound flow version, mirroring the data
+/// function. Extensions play no role in these functions. Implementations must never let a
+/// cache failure fail the request: read errors are reported as a miss, write errors are
+/// swallowed.
+/// </summary>
+public interface IInstanceSchemaFunctionCache
+{
+    /// <summary>
+    /// Whether the cache is enabled (bound from the <c>InstanceFunctionCache</c> configuration
+    /// section, shared with the data function). The ETag computation is pure and usable
+    /// regardless of this flag.
+    /// </summary>
+    bool Enabled { get; }
+
+    /// <summary>
+    /// Builds the master-function cache key:
+    /// <c>master-fn:{domain}:{workflow}:{instance}:{callerHash}</c>.
+    /// </summary>
+    string BuildKey(GetMasterInput input);
+
+    /// <summary>
+    /// Builds the schema-function cache key:
+    /// <c>schema-fn:{domain}:{workflow}:{instance}:{callerHash}:{transitionKey}</c>.
+    /// </summary>
+    string BuildKey(GetSchemaInput input, string transitionKey);
+
+    /// <summary>
+    /// Master ETag: hash of (instance id, latest data ETag, flow version, caller scope) —
+    /// the flow-level master schema is state-independent.
+    /// </summary>
+    string ComputeEtag(GetMasterInput input, InstanceDataFingerprint fingerprint);
+
+    /// <summary>
+    /// Schema ETag: hash of (instance id, latest data ETag, effective state, flow version,
+    /// caller scope, transition key) — transition resolution depends on the current state
+    /// (equal to the effective state whenever no active subflow exists, and subflow-active
+    /// instances bypass this cache).
+    /// </summary>
+    string ComputeEtag(GetSchemaInput input, InstanceDataFingerprint fingerprint, string transitionKey);
+
+    /// <summary>
+    /// Resolves the effective TTL: the workflow author's <c>functionCache.ttlSeconds</c> when
+    /// positive, otherwise the host default (<c>InstanceFunctionCache:DefaultTtlSeconds</c>).
+    /// </summary>
+    int ResolveTtlSeconds(Definitions.FunctionCacheDefinition? functionCache);
+
+    /// <summary>
+    /// Gets the cached entry for the key, or null on miss or cache failure.
+    /// </summary>
+    Task<SchemaFunctionCacheEntry?> GetAsync(string key, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Stores the entry under the key with the given TTL. Failures are swallowed.
+    /// </summary>
+    Task SetAsync(string key, SchemaFunctionCacheEntry entry, int ttlSeconds, CancellationToken cancellationToken = default);
+}

--- a/src/BBT.Workflow.Application/Instances/Caching/IStateFunctionCache.cs
+++ b/src/BBT.Workflow.Application/Instances/Caching/IStateFunctionCache.cs
@@ -1,0 +1,53 @@
+namespace BBT.Workflow.Instances.Caching;
+
+/// <summary>
+/// Distributed cache and fingerprint-ETag calculator for state-function (long-poll) responses.
+/// Keys and ETags are scoped to the instance identifier and the caller context (roles, actor,
+/// culture, extensions, version) because the response content is authorization- and
+/// localization-dependent. Implementations must never let a cache failure fail the request:
+/// read errors are reported as a miss, write errors are swallowed.
+/// </summary>
+public interface IStateFunctionCache
+{
+    /// <summary>
+    /// Whether the cache is enabled (bound from the <c>StateFunctionCache</c> configuration section).
+    /// The ETag computation methods are pure and usable regardless of this flag.
+    /// </summary>
+    bool Enabled { get; }
+
+    /// <summary>
+    /// Builds the cache key for the given request:
+    /// <c>state-fn:{domain}:{workflow}:{instance}:{callerHash}</c>. The caller hash covers
+    /// role/roles, the current actor identity ($InstanceStarter/$PreviousUser pseudo-roles are
+    /// actor-dependent), the resolved culture (state alias labels are localized), requested
+    /// extensions and workflow version. A client alternating between id and key for the same
+    /// instance produces two independent entries — accepted, TTL-bounded.
+    /// </summary>
+    string BuildKey(GetInstanceStateInput input);
+
+    /// <summary>
+    /// Computes the deterministic fingerprint ETag for a subflow-free instance:
+    /// hash of (instance id, effective state, status, flow version, caller scope).
+    /// Computable from the lightweight fingerprint projection alone, so an If-None-Match
+    /// match can be answered with 304 without loading the aggregate or building the response.
+    /// The caller scope is part of the hash so a role/culture switch never yields a false 304.
+    /// </summary>
+    string ComputeEtag(GetInstanceStateInput input, InstanceStateFingerprint fingerprint);
+
+    /// <summary>
+    /// Computes the fingerprint ETag for an instance with an active SubFlow. The displayed
+    /// state and status come from the live subflow response and are folded into the hash —
+    /// the parent row's fingerprint alone cannot see subflow-internal Busy/Active flips.
+    /// </summary>
+    string ComputeEtag(GetInstanceStateInput input, InstanceStateFingerprint fingerprint, GetInstanceStateOutput subFlowOutput);
+
+    /// <summary>
+    /// Gets the cached entry for the key, or null on miss or cache failure.
+    /// </summary>
+    Task<StateFunctionCacheEntry?> GetAsync(string key, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Stores the entry under the key with the configured TTL. Failures are swallowed.
+    /// </summary>
+    Task SetAsync(string key, StateFunctionCacheEntry entry, CancellationToken cancellationToken = default);
+}

--- a/src/BBT.Workflow.Application/Instances/Caching/InstanceFunctionCacheOptions.cs
+++ b/src/BBT.Workflow.Application/Instances/Caching/InstanceFunctionCacheOptions.cs
@@ -1,0 +1,28 @@
+namespace BBT.Workflow.Instances.Caching;
+
+/// <summary>
+/// Host-level configuration for the built-in instance function caches (data now; view,
+/// schema, master in later phases). The effective TTL per workflow is author-controlled via
+/// the flow definition's <c>functionCache.ttlSeconds</c>; this section only supplies the
+/// default used when the workflow does not specify one. The state function has its own
+/// section (<see cref="StateFunctionCacheOptions"/>) and is not covered here.
+/// </summary>
+public sealed class InstanceFunctionCacheOptions
+{
+    /// <summary>
+    /// Configuration section name for instance function cache options.
+    /// </summary>
+    public const string SectionName = "InstanceFunctionCache";
+
+    /// <summary>
+    /// Gets or sets whether the built-in instance function caches are enabled.
+    /// Default is true. Disable to force full evaluation on every request (kill switch).
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the default cache entry TTL in seconds, used when the workflow
+    /// definition does not declare <c>functionCache.ttlSeconds</c>. Default is 60.
+    /// </summary>
+    public int DefaultTtlSeconds { get; set; } = 60;
+}

--- a/src/BBT.Workflow.Application/Instances/Caching/InstanceSchemaFunctionCache.cs
+++ b/src/BBT.Workflow.Application/Instances/Caching/InstanceSchemaFunctionCache.cs
@@ -1,0 +1,125 @@
+using System.Security.Cryptography;
+using System.Text;
+using BBT.Aether.DistributedCache;
+using BBT.Aether.Users;
+using BBT.Workflow.Caching;
+using BBT.Workflow.Instances.DTOs;
+using BBT.Workflow.Logging;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace BBT.Workflow.Instances.Caching;
+
+/// <summary>
+/// Distributed-cache implementation of <see cref="IInstanceSchemaFunctionCache"/> backed by
+/// <see cref="IDistributedCacheService"/>, serving both the master and the schema functions.
+/// Entry TTL is resolved per workflow by the caller (flow definition's
+/// <c>functionCache.ttlSeconds</c>, falling back to
+/// <see cref="InstanceFunctionCacheOptions.DefaultTtlSeconds"/>). All cache failures degrade
+/// to a miss — a broken cache must never fail a request.
+/// </summary>
+public sealed class InstanceSchemaFunctionCache(
+    IDistributedCacheService cache,
+    ICurrentUser currentUser,
+    IOptions<InstanceFunctionCacheOptions> options,
+    ILogger<InstanceSchemaFunctionCache> logger) : IInstanceSchemaFunctionCache
+{
+    internal const string MasterKeyPrefix = "master-fn:";
+    internal const string SchemaKeyPrefix = "schema-fn:";
+
+    /// <summary>
+    /// Length of the fingerprint ETag (hex chars of the SHA-256 digest — 128 bits).
+    /// </summary>
+    private const int EtagLength = 32;
+
+    /// <inheritdoc />
+    public bool Enabled => options.Value.Enabled;
+
+    /// <inheritdoc />
+    public int ResolveTtlSeconds(Definitions.FunctionCacheDefinition? functionCache) =>
+        functionCache?.TtlSeconds is > 0 ? functionCache.TtlSeconds.Value : options.Value.DefaultTtlSeconds;
+
+    /// <inheritdoc />
+    public string BuildKey(GetMasterInput input) =>
+        $"{MasterKeyPrefix}{input.Domain}:{input.Workflow}:{input.Instance}:{BuildCallerHash(input.Roles, input.Headers, input.Version)}";
+
+    /// <inheritdoc />
+    public string BuildKey(GetSchemaInput input, string transitionKey) =>
+        $"{SchemaKeyPrefix}{input.Domain}:{input.Workflow}:{input.Instance}:{BuildCallerHash(input.Roles, input.Headers, input.Version)}:{transitionKey}";
+
+    /// <inheritdoc />
+    public string ComputeEtag(GetMasterInput input, InstanceDataFingerprint fingerprint) =>
+        HashEtag(string.Join('|',
+            fingerprint.Id,
+            fingerprint.LatestDataEtag ?? string.Empty,
+            fingerprint.FlowVersion ?? string.Empty,
+            BuildCallerHash(input.Roles, input.Headers, input.Version)));
+
+    /// <inheritdoc />
+    public string ComputeEtag(GetSchemaInput input, InstanceDataFingerprint fingerprint, string transitionKey) =>
+        HashEtag(string.Join('|',
+            fingerprint.Id,
+            fingerprint.LatestDataEtag ?? string.Empty,
+            fingerprint.EffectiveState ?? string.Empty,
+            fingerprint.FlowVersion ?? string.Empty,
+            BuildCallerHash(input.Roles, input.Headers, input.Version),
+            transitionKey));
+
+    // Extensions play no role in the master/schema functions — the caller scope is
+    // roles + actor identity + culture + requested workflow version only.
+    private string BuildCallerHash(
+        IReadOnlyList<string>? roles,
+        IReadOnlyDictionary<string, string?>? headers,
+        string? version) =>
+        CallerScopeHash.Compute(currentUser, role: null, roles, extensions: null, headers, version);
+
+    private static string HashEtag(string material) =>
+        Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(material)))[..EtagLength];
+
+    /// <inheritdoc />
+    public async Task<SchemaFunctionCacheEntry?> GetAsync(string key, CancellationToken cancellationToken = default)
+    {
+        using var activity = CacheActivityHelper.StartActivity(
+            CacheActivityHelper.OperationGet, key, ComponentTypeOf(key));
+
+        try
+        {
+            var entry = await cache.GetAsync<SchemaFunctionCacheEntry>(key, cancellationToken);
+            CacheActivityHelper.SetCacheHit(activity, entry is not null);
+            return entry;
+        }
+        catch (Exception ex)
+        {
+            CacheActivityHelper.SetError(activity, ex);
+            logger.InstanceSchemaFunctionCacheError(ex, ComponentTypeOf(key), CacheActivityHelper.OperationGet, key);
+            return null;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task SetAsync(string key, SchemaFunctionCacheEntry entry, int ttlSeconds, CancellationToken cancellationToken = default)
+    {
+        using var activity = CacheActivityHelper.StartActivity(
+            CacheActivityHelper.OperationSet, key, ComponentTypeOf(key));
+
+        try
+        {
+            await cache.SetAsync(
+                key,
+                entry,
+                new DistributedCacheEntryOptions
+                {
+                    AbsoluteExpiration = DateTimeOffset.UtcNow.AddSeconds(ttlSeconds)
+                },
+                cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            CacheActivityHelper.SetError(activity, ex);
+            logger.InstanceSchemaFunctionCacheError(ex, ComponentTypeOf(key), CacheActivityHelper.OperationSet, key);
+        }
+    }
+
+    private static string ComponentTypeOf(string key) =>
+        key.StartsWith(MasterKeyPrefix, StringComparison.Ordinal) ? "master-fn" : "schema-fn";
+}

--- a/src/BBT.Workflow.Application/Instances/Caching/SchemaFunctionCacheEntry.cs
+++ b/src/BBT.Workflow.Application/Instances/Caching/SchemaFunctionCacheEntry.cs
@@ -1,0 +1,23 @@
+using BBT.Workflow.Instances.DTOs;
+
+namespace BBT.Workflow.Instances.Caching;
+
+/// <summary>
+/// Distributed-cache envelope for a master- or schema-function response. Stores the resolved
+/// schema document output together with the fingerprint ETag it was built under. Validation on
+/// a hit is a single ETag equality check against the ETag recomputed from the lightweight data
+/// fingerprint. There is no entity ETag — schema documents are definition components, not
+/// instance-data rows.
+/// </summary>
+public sealed class SchemaFunctionCacheEntry
+{
+    /// <summary>
+    /// Unquoted fingerprint ETag the response was built under.
+    /// </summary>
+    public string Etag { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The fully built schema response for the caller scope encoded in the cache key.
+    /// </summary>
+    public GetSchemaOutput Output { get; set; } = new();
+}

--- a/src/BBT.Workflow.Application/Instances/Caching/StateFunctionCache.cs
+++ b/src/BBT.Workflow.Application/Instances/Caching/StateFunctionCache.cs
@@ -26,11 +26,6 @@ public sealed class StateFunctionCache(
     private const string KeyPrefix = "state-fn:";
 
     /// <summary>
-    /// Length of the caller-scope hash segment in the cache key (hex chars of the SHA-256 digest).
-    /// </summary>
-    private const int CallerHashLength = 16;
-
-    /// <summary>
     /// Length of the fingerprint ETag (hex chars of the SHA-256 digest — 128 bits).
     /// </summary>
     private const int EtagLength = 32;
@@ -70,34 +65,8 @@ public sealed class StateFunctionCache(
             SHA256.HashData(Encoding.UTF8.GetBytes(material)))[..EtagLength];
     }
 
-    /// <summary>
-    /// Hashes the caller scope: role/roles, actor identity ($InstanceStarter/$PreviousUser
-    /// pseudo-roles are matched against ICurrentUser — see TransitionAuthorizationManager, so two
-    /// callers with identical role headers can receive different transition lists), resolved
-    /// culture (state alias labels are localized), requested extensions and workflow version.
-    /// </summary>
-    private string BuildCallerHash(GetInstanceStateInput input)
-    {
-        var roles = input.Roles is { Count: > 0 }
-            ? string.Join(',', input.Roles.Order(StringComparer.Ordinal))
-            : string.Empty;
-        var extensions = input.Extensions is { Length: > 0 }
-            ? string.Join(',', input.Extensions.Order(StringComparer.Ordinal))
-            : string.Empty;
-        var culture = LanguageResolver.ResolveCulture(input.Headers);
-
-        var callerScope = string.Join('|',
-            input.Role ?? string.Empty,
-            roles,
-            currentUser.Id ?? string.Empty,
-            currentUser.ActorUserName ?? string.Empty,
-            culture,
-            extensions,
-            input.Version ?? string.Empty);
-
-        return Convert.ToHexStringLower(
-            SHA256.HashData(Encoding.UTF8.GetBytes(callerScope)))[..CallerHashLength];
-    }
+    private string BuildCallerHash(GetInstanceStateInput input) =>
+        CallerScopeHash.Compute(currentUser, input.Role, input.Roles, input.Extensions, input.Headers, input.Version);
 
     /// <inheritdoc />
     public async Task<StateFunctionCacheEntry?> GetAsync(string key, CancellationToken cancellationToken = default)

--- a/src/BBT.Workflow.Application/Instances/Caching/StateFunctionCache.cs
+++ b/src/BBT.Workflow.Application/Instances/Caching/StateFunctionCache.cs
@@ -1,0 +1,145 @@
+using System.Security.Cryptography;
+using System.Text;
+using BBT.Aether.DistributedCache;
+using BBT.Aether.Users;
+using BBT.Workflow.Caching;
+using BBT.Workflow.Logging;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace BBT.Workflow.Instances.Caching;
+
+/// <summary>
+/// Distributed-cache implementation of <see cref="IStateFunctionCache"/> backed by
+/// <see cref="IDistributedCacheService"/>. Entries expire after the configured TTL
+/// (default 60s — the client long-poll timeout); state/status freshness within the TTL
+/// is guaranteed by the caller's fingerprint-ETag validation, not by this store.
+/// All cache failures degrade to a miss — a broken cache must never fail a poll request.
+/// </summary>
+public sealed class StateFunctionCache(
+    IDistributedCacheService cache,
+    ICurrentUser currentUser,
+    IOptions<StateFunctionCacheOptions> options,
+    ILogger<StateFunctionCache> logger) : IStateFunctionCache
+{
+    private const string ComponentType = "state-fn";
+    private const string KeyPrefix = "state-fn:";
+
+    /// <summary>
+    /// Length of the caller-scope hash segment in the cache key (hex chars of the SHA-256 digest).
+    /// </summary>
+    private const int CallerHashLength = 16;
+
+    /// <summary>
+    /// Length of the fingerprint ETag (hex chars of the SHA-256 digest — 128 bits).
+    /// </summary>
+    private const int EtagLength = 32;
+
+    /// <inheritdoc />
+    public bool Enabled => options.Value.Enabled;
+
+    /// <inheritdoc />
+    public string BuildKey(GetInstanceStateInput input) =>
+        $"{KeyPrefix}{input.Domain}:{input.Workflow}:{input.Instance}:{BuildCallerHash(input)}";
+
+    /// <inheritdoc />
+    public string ComputeEtag(GetInstanceStateInput input, InstanceStateFingerprint fingerprint) =>
+        ComputeEtagCore(input, fingerprint, displayedState: null, displayedStatus: null);
+
+    /// <inheritdoc />
+    public string ComputeEtag(GetInstanceStateInput input, InstanceStateFingerprint fingerprint,
+        GetInstanceStateOutput subFlowOutput) =>
+        ComputeEtagCore(input, fingerprint, subFlowOutput.State, subFlowOutput.Status?.Code);
+
+    private string ComputeEtagCore(
+        GetInstanceStateInput input,
+        InstanceStateFingerprint fingerprint,
+        string? displayedState,
+        string? displayedStatus)
+    {
+        var material = string.Join('|',
+            fingerprint.Id,
+            fingerprint.EffectiveState ?? string.Empty,
+            fingerprint.Status.Code,
+            fingerprint.FlowVersion ?? string.Empty,
+            BuildCallerHash(input),
+            displayedState ?? string.Empty,
+            displayedStatus ?? string.Empty);
+
+        return Convert.ToHexStringLower(
+            SHA256.HashData(Encoding.UTF8.GetBytes(material)))[..EtagLength];
+    }
+
+    /// <summary>
+    /// Hashes the caller scope: role/roles, actor identity ($InstanceStarter/$PreviousUser
+    /// pseudo-roles are matched against ICurrentUser — see TransitionAuthorizationManager, so two
+    /// callers with identical role headers can receive different transition lists), resolved
+    /// culture (state alias labels are localized), requested extensions and workflow version.
+    /// </summary>
+    private string BuildCallerHash(GetInstanceStateInput input)
+    {
+        var roles = input.Roles is { Count: > 0 }
+            ? string.Join(',', input.Roles.Order(StringComparer.Ordinal))
+            : string.Empty;
+        var extensions = input.Extensions is { Length: > 0 }
+            ? string.Join(',', input.Extensions.Order(StringComparer.Ordinal))
+            : string.Empty;
+        var culture = LanguageResolver.ResolveCulture(input.Headers);
+
+        var callerScope = string.Join('|',
+            input.Role ?? string.Empty,
+            roles,
+            currentUser.Id ?? string.Empty,
+            currentUser.ActorUserName ?? string.Empty,
+            culture,
+            extensions,
+            input.Version ?? string.Empty);
+
+        return Convert.ToHexStringLower(
+            SHA256.HashData(Encoding.UTF8.GetBytes(callerScope)))[..CallerHashLength];
+    }
+
+    /// <inheritdoc />
+    public async Task<StateFunctionCacheEntry?> GetAsync(string key, CancellationToken cancellationToken = default)
+    {
+        using var activity = CacheActivityHelper.StartActivity(
+            CacheActivityHelper.OperationGet, key, ComponentType);
+
+        try
+        {
+            var entry = await cache.GetAsync<StateFunctionCacheEntry>(key, cancellationToken);
+            CacheActivityHelper.SetCacheHit(activity, entry is not null);
+            return entry;
+        }
+        catch (Exception ex)
+        {
+            CacheActivityHelper.SetError(activity, ex);
+            logger.StateFunctionCacheError(ex, CacheActivityHelper.OperationGet, key);
+            return null;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task SetAsync(string key, StateFunctionCacheEntry entry, CancellationToken cancellationToken = default)
+    {
+        using var activity = CacheActivityHelper.StartActivity(
+            CacheActivityHelper.OperationSet, key, ComponentType);
+
+        try
+        {
+            await cache.SetAsync(
+                key,
+                entry,
+                new DistributedCacheEntryOptions
+                {
+                    AbsoluteExpiration = DateTimeOffset.UtcNow.AddSeconds(options.Value.TtlSeconds)
+                },
+                cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            CacheActivityHelper.SetError(activity, ex);
+            logger.StateFunctionCacheError(ex, CacheActivityHelper.OperationSet, key);
+        }
+    }
+}

--- a/src/BBT.Workflow.Application/Instances/Caching/StateFunctionCacheEntry.cs
+++ b/src/BBT.Workflow.Application/Instances/Caching/StateFunctionCacheEntry.cs
@@ -1,0 +1,28 @@
+namespace BBT.Workflow.Instances.Caching;
+
+/// <summary>
+/// Distributed-cache envelope for a state-function response. Stores the fully built,
+/// caller-scoped <see cref="GetInstanceStateOutput"/> together with the fingerprint ETag it
+/// was built under. Validation on a hit is a single ETag equality check: the current ETag is
+/// recomputed from the lightweight fingerprint projection, so a matching entry is guaranteed
+/// to reflect the instance's current effective state, status and flow version.
+/// </summary>
+public sealed class StateFunctionCacheEntry
+{
+    /// <summary>
+    /// Unquoted fingerprint ETag the response was built under
+    /// (hash of instance id + effective state + status + flow version + caller scope).
+    /// </summary>
+    public string Etag { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Entity (instance data) ETag at build time. May lag behind data-only updates until the
+    /// next state/status change — accepted: the state function tracks state/status, not data.
+    /// </summary>
+    public string EntityEtag { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The fully built state-function response for the caller scope encoded in the cache key.
+    /// </summary>
+    public GetInstanceStateOutput Output { get; set; } = new();
+}

--- a/src/BBT.Workflow.Application/Instances/Caching/StateFunctionCacheOptions.cs
+++ b/src/BBT.Workflow.Application/Instances/Caching/StateFunctionCacheOptions.cs
@@ -1,0 +1,30 @@
+namespace BBT.Workflow.Instances.Caching;
+
+/// <summary>
+/// Configuration options for the state-function (long-poll) response cache.
+/// The cache stores the full role-scoped state response together with a validation
+/// fingerprint (effective state + status + flow version); each hit is validated
+/// against the database with a single-row projection query instead of a full
+/// aggregate load and response rebuild.
+/// </summary>
+public sealed class StateFunctionCacheOptions
+{
+    /// <summary>
+    /// Configuration section name for state-function cache options.
+    /// </summary>
+    public const string SectionName = "StateFunctionCache";
+
+    /// <summary>
+    /// Gets or sets whether the state-function response cache is enabled.
+    /// Default is true. Disable to force full evaluation on every poll (kill switch).
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the cache entry TTL in seconds. Default is 60 — the default
+    /// client long-poll timeout. The TTL only bounds residual staleness of parts
+    /// not covered by the fingerprint (e.g. entity data ETag); state/status changes
+    /// are detected on every hit via the fingerprint validation query.
+    /// </summary>
+    public int TtlSeconds { get; set; } = 60;
+}

--- a/src/BBT.Workflow.Application/Instances/DTOs/GetMasterInput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/GetMasterInput.cs
@@ -36,4 +36,9 @@ public sealed class GetMasterInput : IHasDomain
     /// Caller roles, used to enforce state/workflow queryRoles visibility.
     /// </summary>
     public IReadOnlyList<string>? Roles { get; set; }
+
+    /// <summary>
+    /// ETag value for conditional requests (If-None-Match header).
+    /// </summary>
+    public string? IfNoneMatch { get; set; }
 }

--- a/src/BBT.Workflow.Application/Instances/DTOs/GetSchemaInput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/GetSchemaInput.cs
@@ -37,6 +37,11 @@ public sealed class GetSchemaInput: IHasDomain
     /// Caller roles, used to enforce state/workflow queryRoles visibility.
     /// </summary>
     public IReadOnlyList<string>? Roles { get; set; }
+
+    /// <summary>
+    /// ETag value for conditional requests (If-None-Match header).
+    /// </summary>
+    public string? IfNoneMatch { get; set; }
 }
 
 public sealed class GetSchemaOutput
@@ -52,5 +57,21 @@ public sealed class GetSchemaOutput
     public string Type { get; set; }
 
     public JsonElement Schema { get; set; }
+
+    /// <summary>
+    /// Fingerprint ETag (RFC 7232 quoted) for cache validation.
+    /// </summary>
+    public string? ETag
+    {
+        get
+        {
+            if (string.IsNullOrEmpty(_etag))
+                return null;
+            var unquoted = _etag.Replace("\"", "");
+            return $"\"{unquoted}\"";
+        }
+        set => _etag = value;
+    }
+    private string? _etag = string.Empty;
 }
 

--- a/src/BBT.Workflow.Application/Instances/IInstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/IInstanceQueryAppService.cs
@@ -54,9 +54,10 @@ public interface IInstanceQueryAppService : IApplicationService
         CancellationToken cancellationToken = default);
     
     /// <summary>
-    /// Retrieves schema for an instance
+    /// Retrieves schema for an instance. Supports conditional reads (If-None-Match → 304)
+    /// via the fingerprint ETag.
     /// </summary>
-    Task<Result<GetSchemaOutput>> GetSchemaAsync(
+    Task<ConditionalResult<GetSchemaOutput>> GetSchemaAsync(
         GetSchemaInput input,
         string? transitionKey,
         CancellationToken cancellationToken = default);
@@ -71,8 +72,9 @@ public interface IInstanceQueryAppService : IApplicationService
     /// <summary>
     /// Retrieves the flow-level master schema an instance is bound to.
     /// If the instance has an active SubFlow, the request is forwarded to the SubFlow instance.
+    /// Supports conditional reads (If-None-Match → 304) via the fingerprint ETag.
     /// </summary>
-    Task<Result<GetSchemaOutput>> GetMasterAsync(
+    Task<ConditionalResult<GetSchemaOutput>> GetMasterAsync(
         GetMasterInput input,
         CancellationToken cancellationToken = default);
 

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -48,6 +48,7 @@ public sealed class InstanceQueryAppService(
     ICurrentUser currentUser,
     IPaginationLinkGenerator paginationLinkGenerator,
     IOptions<InstanceFilteringOptions> instanceFilteringOptions,
+    Caching.IStateFunctionCache stateFunctionCache,
     ILogger<InstanceQueryAppService> logger)
     : ApplicationService(serviceProvider), IInstanceQueryAppService
 {
@@ -786,6 +787,20 @@ public sealed class InstanceQueryAppService(
     {
         runtimeInfoProvider.Check(input.Domain);
 
+        // Long-poll fast path: the ETag is a deterministic hash of the state fingerprint
+        // (instance id + effective state + status + flow version) plus the caller scope, so an
+        // If-None-Match match can be answered with 304 from a single projection query — no cache
+        // entry, aggregate load or response build needed. The body cache only serves callers
+        // without a current ETag.
+        string? stateCacheKey = null;
+        if (stateFunctionCache.Enabled)
+        {
+            var fastResult = await TryServeStateFromFingerprintAsync(input, cancellationToken);
+            if (fastResult.HasValue)
+                return fastResult.Value;
+            stateCacheKey = stateFunctionCache.BuildKey(input);
+        }
+
         return await GetInstanceByIdOrKeyAsync(input.Instance, cancellationToken)
             .BindAsync(instance =>
                 componentCacheStore.GetFlowAsync(input.Domain, input.Workflow, instance.FlowVersion ?? input.Version, cancellationToken)
@@ -804,15 +819,86 @@ public sealed class InstanceQueryAppService(
                     var output = buildResult.Value!;
                     var entityEtag = data.instance.LatestData?.ETag ?? string.Empty;
                     output.EntityEtag = entityEtag;
-                    var representationEtag = representationEtagService.Generate(output);
 
-                    if (!string.IsNullOrEmpty(input.IfNoneMatch) && representationEtag.MatchesIfNoneMatch(input.IfNoneMatch))
+                    // Same fingerprint-ETag the fast path computes from the projection query.
+                    // Active-subflow responses fold the live displayed state/status into the hash:
+                    // the parent row alone cannot see subflow-internal Busy/Active flips.
+                    var fingerprint = InstanceStateFingerprint.FromInstance(data.instance);
+                    var etag = data.instance.HasActiveSubFlow
+                        ? stateFunctionCache.ComputeEtag(input, fingerprint, output)
+                        : stateFunctionCache.ComputeEtag(input, fingerprint);
+
+                    // Warm the cache before the 304 decision so a Not-Modified outcome still
+                    // stores the entry. Active-subflow responses are built from a live subflow
+                    // call and cannot be validated by the local fingerprint — never cache them.
+                    if (stateCacheKey is not null && !data.instance.HasActiveSubFlow)
+                    {
+                        await stateFunctionCache.SetAsync(stateCacheKey, new Caching.StateFunctionCacheEntry
+                        {
+                            Etag = etag,
+                            EntityEtag = entityEtag,
+                            Output = output
+                        }, cancellationToken);
+                    }
+
+                    if (!string.IsNullOrEmpty(input.IfNoneMatch) && etag.MatchesIfNoneMatch(input.IfNoneMatch))
                         return ConditionalResult<GetInstanceStateOutput>.NotModified();
 
-                    output.ETag = representationEtag;
+                    output.ETag = etag;
                     return ConditionalResult<GetInstanceStateOutput>.Success(output);
                 },
                 onFailure: error => ConditionalResult<GetInstanceStateOutput>.Fail(error));
+    }
+
+    /// <summary>
+    /// Long-poll fast path over the state fingerprint. Loads the lightweight projection, computes
+    /// the deterministic fingerprint ETag and answers: 304 when the caller's If-None-Match matches
+    /// (no cache access, no build), or the cached response when the stored entry carries the same
+    /// ETag. Returns null when the full build path must run: instance not found (proper error
+    /// comes from the full path), active subflow (live evaluation required), cache miss, or a
+    /// stale cache entry.
+    /// </summary>
+    private async Task<ConditionalResult<GetInstanceStateOutput>?> TryServeStateFromFingerprintAsync(
+        GetInstanceStateInput input,
+        CancellationToken cancellationToken)
+    {
+        var fingerprint = await instanceRepository.GetStateFingerprintAsync(input.Instance, cancellationToken);
+        if (fingerprint is null)
+            return null;
+
+        if (fingerprint.HasActiveSubFlow)
+        {
+            logger.StateFunctionCacheBypassedForSubFlow(input.Instance);
+            return null;
+        }
+
+        var etag = stateFunctionCache.ComputeEtag(input, fingerprint);
+
+        if (!string.IsNullOrEmpty(input.IfNoneMatch) && etag.MatchesIfNoneMatch(input.IfNoneMatch))
+        {
+            logger.StateFunctionEtagNotModified(input.Instance, fingerprint.EffectiveState, fingerprint.Status.Code);
+            return ConditionalResult<GetInstanceStateOutput>.NotModified();
+        }
+
+        var entry = await stateFunctionCache.GetAsync(stateFunctionCache.BuildKey(input), cancellationToken);
+        if (entry is null)
+        {
+            logger.StateFunctionCacheMiss(input.Instance);
+            return null;
+        }
+
+        if (!string.Equals(entry.Etag, etag, StringComparison.Ordinal))
+        {
+            logger.StateFunctionCacheInvalidated(input.Instance, entry.Etag, etag);
+            return null;
+        }
+
+        logger.StateFunctionCacheHit(input.Instance, fingerprint.EffectiveState, fingerprint.Status.Code);
+
+        var output = entry.Output;
+        output.EntityEtag = entry.EntityEtag;
+        output.ETag = entry.Etag;
+        return ConditionalResult<GetInstanceStateOutput>.Success(output);
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -50,6 +50,7 @@ public sealed class InstanceQueryAppService(
     IOptions<InstanceFilteringOptions> instanceFilteringOptions,
     Caching.IStateFunctionCache stateFunctionCache,
     Caching.IDataFunctionCache dataFunctionCache,
+    Caching.IInstanceSchemaFunctionCache instanceSchemaFunctionCache,
     ILogger<InstanceQueryAppService> logger)
     : ApplicationService(serviceProvider), IInstanceQueryAppService
 {
@@ -701,7 +702,8 @@ public sealed class InstanceQueryAppService(
                     // one (a write into that version line creates a new row with a new ULID).
                     var etag = dataFunctionCache.ComputeEtag(input, isLatestRequest
                         ? InstanceDataFingerprint.FromInstance(instance)
-                        : new InstanceDataFingerprint(instance.Id, instance.Key, instanceData?.ETag, instance.FlowVersion));
+                        : new InstanceDataFingerprint(instance.Id, instance.Key, instanceData?.ETag,
+                            instance.FlowVersion, instance.EffectiveState, instance.HasActiveSubFlow));
 
                     // Warm the cache before the 304 decision so a Not-Modified outcome still
                     // stores the entry. Only latest-data responses with an existing data row are
@@ -1460,20 +1462,138 @@ public sealed class InstanceQueryAppService(
     /// <param name="transitionKey">Optional transition key to get schema for</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Result containing the schema output or error information</returns>
-    public async Task<Result<GetSchemaOutput>> GetSchemaAsync(
+    public async Task<ConditionalResult<GetSchemaOutput>> GetSchemaAsync(
         GetSchemaInput input,
         string? transitionKey,
         CancellationToken cancellationToken = default)
     {
         runtimeInfoProvider.Check(input.Domain);
 
+        // Fast path: the ETag is a deterministic hash of the data fingerprint (instance id +
+        // latest data ETag + effective state + flow version) plus caller scope and transition
+        // key — transition resolution is state-dependent. An If-None-Match match is answered
+        // with 304 from a single projection query.
+        string? schemaCacheKey = null;
+        if (instanceSchemaFunctionCache.Enabled && !string.IsNullOrEmpty(transitionKey))
+        {
+            var fastResult = await TryServeSchemaFromFingerprintAsync(input, transitionKey, cancellationToken);
+            if (fastResult.HasValue)
+                return fastResult.Value;
+            schemaCacheKey = instanceSchemaFunctionCache.BuildKey(input, transitionKey);
+        }
+
         // Railway chain: Get Instance → Get Workflow → Build Schema Output
         return await GetInstanceByIdOrKeyAsync(input.Instance, cancellationToken)
             .BindAsync(instance =>
                 componentCacheStore.GetFlowAsync(input.Domain, input.Workflow, instance.FlowVersion ?? input.Version, cancellationToken)
                     .MapAsync(workflow => (instance, workflow)))
-            .ThenAsync(data =>
-                BuildSchemaOutputAsync(data.instance, data.workflow, input, transitionKey, cancellationToken));
+            .MatchAsync(
+                onSuccess: async data =>
+                {
+                    var buildResult = await BuildSchemaOutputAsync(data.instance, data.workflow, input, transitionKey, cancellationToken);
+                    if (!buildResult.IsSuccess)
+                        return ConditionalResult<GetSchemaOutput>.Fail(buildResult.Error);
+
+                    return await FinalizeSchemaFunctionResultAsync(
+                        "schema",
+                        buildResult.Value!,
+                        data.instance,
+                        data.workflow,
+                        schemaCacheKey,
+                        instanceSchemaFunctionCache.ComputeEtag(input, InstanceDataFingerprint.FromInstance(data.instance), transitionKey!),
+                        input.IfNoneMatch,
+                        cancellationToken);
+                },
+                onFailure: error => ConditionalResult<GetSchemaOutput>.Fail(error));
+    }
+
+    /// <summary>
+    /// Shared epilogue for the master/schema full paths: subflow-forwarded responses are
+    /// returned as-is (never cached, never 304 — the body came from a live subflow call and
+    /// its embedded ETag must not leak into the parent response); locally resolved responses
+    /// are cached under the fingerprint ETag (warm before the 304 decision) and answered
+    /// conditionally.
+    /// </summary>
+    private async Task<ConditionalResult<GetSchemaOutput>> FinalizeSchemaFunctionResultAsync(
+        string function,
+        GetSchemaOutput output,
+        Instance instance,
+        Definitions.Workflow flow,
+        string? cacheKey,
+        string etag,
+        string? ifNoneMatch,
+        CancellationToken cancellationToken)
+    {
+        if (instance.HasActiveSubFlow)
+        {
+            output.ETag = null;
+            return ConditionalResult<GetSchemaOutput>.Success(output);
+        }
+
+        if (cacheKey is not null)
+        {
+            await instanceSchemaFunctionCache.SetAsync(cacheKey, new Caching.SchemaFunctionCacheEntry
+            {
+                Etag = etag,
+                Output = output
+            }, instanceSchemaFunctionCache.ResolveTtlSeconds(flow.FunctionCache), cancellationToken);
+        }
+
+        if (!string.IsNullOrEmpty(ifNoneMatch) && etag.MatchesIfNoneMatch(ifNoneMatch))
+            return ConditionalResult<GetSchemaOutput>.NotModified();
+
+        output.ETag = etag;
+        return ConditionalResult<GetSchemaOutput>.Success(output);
+    }
+
+    /// <summary>
+    /// Fast path for the schema function over the data fingerprint: 304 when If-None-Match
+    /// matches the fingerprint ETag, cached response when the stored entry carries the same
+    /// ETag. Bypassed entirely when the instance has an active SubFlow (live evaluation).
+    /// Returns null when the full build path must run.
+    /// </summary>
+    private async Task<ConditionalResult<GetSchemaOutput>?> TryServeSchemaFromFingerprintAsync(
+        GetSchemaInput input,
+        string transitionKey,
+        CancellationToken cancellationToken)
+    {
+        var fingerprint = await instanceRepository.GetDataFingerprintAsync(input.Instance, cancellationToken);
+        if (fingerprint is null)
+            return null;
+
+        if (fingerprint.HasActiveSubFlow)
+        {
+            logger.InstanceSchemaFunctionCacheBypassedForSubFlow("schema", input.Instance);
+            return null;
+        }
+
+        var etag = instanceSchemaFunctionCache.ComputeEtag(input, fingerprint, transitionKey);
+
+        if (!string.IsNullOrEmpty(input.IfNoneMatch) && etag.MatchesIfNoneMatch(input.IfNoneMatch))
+        {
+            logger.InstanceSchemaFunctionEtagNotModified("schema", input.Instance);
+            return ConditionalResult<GetSchemaOutput>.NotModified();
+        }
+
+        var entry = await instanceSchemaFunctionCache.GetAsync(
+            instanceSchemaFunctionCache.BuildKey(input, transitionKey), cancellationToken);
+        if (entry is null)
+        {
+            logger.InstanceSchemaFunctionCacheMiss("schema", input.Instance);
+            return null;
+        }
+
+        if (!string.Equals(entry.Etag, etag, StringComparison.Ordinal))
+        {
+            logger.InstanceSchemaFunctionCacheInvalidated("schema", input.Instance, entry.Etag, etag);
+            return null;
+        }
+
+        logger.InstanceSchemaFunctionCacheHit("schema", input.Instance);
+
+        var output = entry.Output;
+        output.ETag = entry.Etag;
+        return ConditionalResult<GetSchemaOutput>.Success(output);
     }
 
     /// <summary>
@@ -1501,19 +1621,97 @@ public sealed class InstanceQueryAppService(
     /// Retrieves the flow-level master schema an instance is bound to.
     /// If the instance has an active SubFlow, forwards the request to the SubFlow instance.
     /// </summary>
-    public async Task<Result<GetSchemaOutput>> GetMasterAsync(
+    public async Task<ConditionalResult<GetSchemaOutput>> GetMasterAsync(
         GetMasterInput input,
         CancellationToken cancellationToken = default)
     {
         runtimeInfoProvider.Check(input.Domain);
+
+        // Fast path: the master ETag is a deterministic hash of the data fingerprint
+        // (instance id + latest data ETag + flow version) plus the caller scope — the
+        // flow-level master schema is state-independent. An If-None-Match match is answered
+        // with 304 from a single projection query.
+        string? masterCacheKey = null;
+        if (instanceSchemaFunctionCache.Enabled)
+        {
+            var fastResult = await TryServeMasterFromFingerprintAsync(input, cancellationToken);
+            if (fastResult.HasValue)
+                return fastResult.Value;
+            masterCacheKey = instanceSchemaFunctionCache.BuildKey(input);
+        }
 
         // Railway chain: Get Instance → Get Workflow → Build Master Schema Output
         return await GetInstanceByIdOrKeyAsync(input.Instance, cancellationToken)
             .BindAsync(instance =>
                 componentCacheStore.GetFlowAsync(input.Domain, input.Workflow, instance.FlowVersion ?? input.Version, cancellationToken)
                     .MapAsync(workflow => (instance, workflow)))
-            .ThenAsync(data =>
-                BuildMasterOutputAsync(data.instance, data.workflow, input, cancellationToken));
+            .MatchAsync(
+                onSuccess: async data =>
+                {
+                    var buildResult = await BuildMasterOutputAsync(data.instance, data.workflow, input, cancellationToken);
+                    if (!buildResult.IsSuccess)
+                        return ConditionalResult<GetSchemaOutput>.Fail(buildResult.Error);
+
+                    return await FinalizeSchemaFunctionResultAsync(
+                        "master",
+                        buildResult.Value!,
+                        data.instance,
+                        data.workflow,
+                        masterCacheKey,
+                        instanceSchemaFunctionCache.ComputeEtag(input, InstanceDataFingerprint.FromInstance(data.instance)),
+                        input.IfNoneMatch,
+                        cancellationToken);
+                },
+                onFailure: error => ConditionalResult<GetSchemaOutput>.Fail(error));
+    }
+
+    /// <summary>
+    /// Fast path for the master function over the data fingerprint: 304 when If-None-Match
+    /// matches the fingerprint ETag, cached response when the stored entry carries the same
+    /// ETag. Bypassed entirely when the instance has an active SubFlow (live evaluation).
+    /// Returns null when the full build path must run.
+    /// </summary>
+    private async Task<ConditionalResult<GetSchemaOutput>?> TryServeMasterFromFingerprintAsync(
+        GetMasterInput input,
+        CancellationToken cancellationToken)
+    {
+        var fingerprint = await instanceRepository.GetDataFingerprintAsync(input.Instance, cancellationToken);
+        if (fingerprint is null)
+            return null;
+
+        if (fingerprint.HasActiveSubFlow)
+        {
+            logger.InstanceSchemaFunctionCacheBypassedForSubFlow("master", input.Instance);
+            return null;
+        }
+
+        var etag = instanceSchemaFunctionCache.ComputeEtag(input, fingerprint);
+
+        if (!string.IsNullOrEmpty(input.IfNoneMatch) && etag.MatchesIfNoneMatch(input.IfNoneMatch))
+        {
+            logger.InstanceSchemaFunctionEtagNotModified("master", input.Instance);
+            return ConditionalResult<GetSchemaOutput>.NotModified();
+        }
+
+        var entry = await instanceSchemaFunctionCache.GetAsync(
+            instanceSchemaFunctionCache.BuildKey(input), cancellationToken);
+        if (entry is null)
+        {
+            logger.InstanceSchemaFunctionCacheMiss("master", input.Instance);
+            return null;
+        }
+
+        if (!string.Equals(entry.Etag, etag, StringComparison.Ordinal))
+        {
+            logger.InstanceSchemaFunctionCacheInvalidated("master", input.Instance, entry.Etag, etag);
+            return null;
+        }
+
+        logger.InstanceSchemaFunctionCacheHit("master", input.Instance);
+
+        var output = entry.Output;
+        output.ETag = entry.Etag;
+        return ConditionalResult<GetSchemaOutput>.Success(output);
     }
 
     /// <summary>
@@ -1526,9 +1724,8 @@ public sealed class InstanceQueryAppService(
         GetMasterInput input,
         CancellationToken cancellationToken)
     {
-        // TODO: Need?
-        // if (!await IsInstanceQueryAllowedAsync(currentWorkflow, instance, input.Roles, input.Headers, input.QueryParameters, cancellationToken))
-        //     return Result<GetSchemaOutput>.Fail(WorkflowErrors.QueryAccessDenied(instance.GetEffectiveState));
+        if (!await IsInstanceQueryAllowedAsync(currentWorkflow, instance, input.Roles, input.Headers, input.QueryParameters, cancellationToken))
+            return Result<GetSchemaOutput>.Fail(WorkflowErrors.QueryAccessDenied(instance.GetEffectiveState));
 
         // Check if there's an active SubFlow - if so, forward the request to SubFlow
         // instance.Subflow returns the first active subflow (Type: S and not completed)

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -49,6 +49,7 @@ public sealed class InstanceQueryAppService(
     IPaginationLinkGenerator paginationLinkGenerator,
     IOptions<InstanceFilteringOptions> instanceFilteringOptions,
     Caching.IStateFunctionCache stateFunctionCache,
+    Caching.IDataFunctionCache dataFunctionCache,
     ILogger<InstanceQueryAppService> logger)
     : ApplicationService(serviceProvider), IInstanceQueryAppService
 {
@@ -601,6 +602,27 @@ public sealed class InstanceQueryAppService(
     {
         runtimeInfoProvider.Check(input.Domain);
 
+        // Fast path for latest-data requests only: the ETag is a deterministic hash of the data
+        // fingerprint (instance id + latest data ETag + flow version) plus the caller scope, so
+        // an If-None-Match match is answered with 304 from a single projection query — no
+        // aggregate load, no extension run, no response build. Pinned-version requests stay on
+        // the full path: an older-line write changes their body without moving the latest ETag.
+        //
+        // A validated cache entry does NOT short-circuit the build: it supplies the DATA portion
+        // (skipping the x-roles field filtering) while extensions are ALWAYS computed fresh —
+        // the cache holds pure instance data, never extension output.
+        var isLatestRequest = InstanceDataVersionComparer.IsRequestingLatest(input.Version);
+        string? dataCacheKey = null;
+        Caching.DataFunctionCacheEntry? validatedEntry = null;
+        if (dataFunctionCache.Enabled && isLatestRequest)
+        {
+            var fastPath = await TryServeDataFromFingerprintAsync(input, cancellationToken);
+            if (fastPath.NotModified.HasValue)
+                return fastPath.NotModified.Value;
+            validatedEntry = fastPath.ValidatedEntry;
+            dataCacheKey = dataFunctionCache.BuildKey(input);
+        }
+
         // Railway chain: Get Instance → Load Flow (using instance.FlowVersion) → Match to ConditionalResult
         return await GetInstanceByIdOrKeyAsync(input.Instance, input.Version, cancellationToken)
             .BindAsync(instance =>
@@ -617,13 +639,21 @@ public sealed class InstanceQueryAppService(
                     var instanceData = instance.FindData(input.Version);
                     var entityEtag = instanceData?.ETag ?? string.Empty;
 
-                    var result = new GetInstanceDataOutput
-                    {
-                        Data = instanceData?.Data.JsonElement
-                    };
+                    var result = new GetInstanceDataOutput();
 
-                    result.Data = await schemaFieldFilterService.ApplyAsync(flow, result.Data, instance, cancellationToken) ??
-                                  result.Data;
+                    // Data portion: reuse the validated cache entry (already field-filtered for
+                    // this caller scope) when available; otherwise filter the resolved row.
+                    // Extensions below always run fresh against the RAW instance data.
+                    if (validatedEntry is not null)
+                    {
+                        result.Data = validatedEntry.Data;
+                    }
+                    else
+                    {
+                        result.Data = instanceData?.Data.JsonElement;
+                        result.Data = await schemaFieldFilterService.ApplyAsync(flow, result.Data, instance, cancellationToken) ??
+                                      result.Data;
+                    }
 
                     // If there's an active SubFlow and extensions are requested, fetch from SubFlow
                     if (instance.Subflow != null)
@@ -665,17 +695,82 @@ public sealed class InstanceQueryAppService(
                     }
 
                     result.EntityEtag = entityEtag;
-                    var representationEtag = representationEtagService.Generate(result);
 
-                    if (!string.IsNullOrEmpty(input.IfNoneMatch) && representationEtag.MatchesIfNoneMatch(input.IfNoneMatch))
+                    // Same fingerprint-ETag the fast path computes from the projection query.
+                    // Pinned-version requests hash the RESOLVED row's ETag instead of the latest
+                    // one (a write into that version line creates a new row with a new ULID).
+                    var etag = dataFunctionCache.ComputeEtag(input, isLatestRequest
+                        ? InstanceDataFingerprint.FromInstance(instance)
+                        : new InstanceDataFingerprint(instance.Id, instance.Key, instanceData?.ETag, instance.FlowVersion));
+
+                    // Warm the cache before the 304 decision so a Not-Modified outcome still
+                    // stores the entry. Only latest-data responses with an existing data row are
+                    // cacheable; the entry holds ONLY the field-filtered data — extension output
+                    // is never cached. No re-write when the data came from a validated entry.
+                    // TTL is workflow-author-controlled with a host default.
+                    if (dataCacheKey is not null && instanceData is not null && validatedEntry is null)
+                    {
+                        await dataFunctionCache.SetAsync(dataCacheKey, new Caching.DataFunctionCacheEntry
+                        {
+                            Etag = etag,
+                            EntityEtag = entityEtag,
+                            Data = result.Data
+                        }, dataFunctionCache.ResolveTtlSeconds(flow.FunctionCache), cancellationToken);
+                    }
+
+                    if (!string.IsNullOrEmpty(input.IfNoneMatch) && etag.MatchesIfNoneMatch(input.IfNoneMatch))
                     {
                         return ConditionalResult<GetInstanceDataOutput>.NotModified();
                     }
 
-                    result.ETag = representationEtag;
+                    result.ETag = etag;
                     return ConditionalResult<GetInstanceDataOutput>.Success(result);
                 },
                 onFailure: ConditionalResult<GetInstanceDataOutput>.Fail);
+    }
+
+    /// <summary>
+    /// Fast path for latest-data requests over the data fingerprint. Loads the lightweight
+    /// projection, computes the deterministic fingerprint ETag and answers 304 when the
+    /// caller's If-None-Match matches (no cache access, no extension run, no build).
+    /// Otherwise consults the body cache and returns the entry whose ETag matches the current
+    /// fingerprint ETag — the build path then reuses its DATA portion (skipping field
+    /// filtering) while always computing extensions fresh. Both results are null when the
+    /// instance was not found (the full path produces the proper error), on a cache miss,
+    /// or when the stored entry is stale.
+    /// </summary>
+    private async Task<(ConditionalResult<GetInstanceDataOutput>? NotModified, Caching.DataFunctionCacheEntry? ValidatedEntry)>
+        TryServeDataFromFingerprintAsync(
+            GetInstanceDataInput input,
+            CancellationToken cancellationToken)
+    {
+        var fingerprint = await instanceRepository.GetDataFingerprintAsync(input.Instance, cancellationToken);
+        if (fingerprint is null)
+            return (null, null);
+
+        var etag = dataFunctionCache.ComputeEtag(input, fingerprint);
+
+        if (!string.IsNullOrEmpty(input.IfNoneMatch) && etag.MatchesIfNoneMatch(input.IfNoneMatch))
+        {
+            logger.DataFunctionEtagNotModified(input.Instance);
+            return (ConditionalResult<GetInstanceDataOutput>.NotModified(), null);
+        }
+
+        var entry = await dataFunctionCache.GetAsync(dataFunctionCache.BuildKey(input), cancellationToken);
+        if (entry is null)
+        {
+            logger.DataFunctionCacheMiss(input.Instance);
+            return (null, null);
+        }
+
+        if (!string.Equals(entry.Etag, etag, StringComparison.Ordinal))
+        {
+            logger.DataFunctionCacheInvalidated(input.Instance, entry.Etag, etag);
+            return (null, null);
+        }
+
+        logger.DataFunctionCacheHit(input.Instance);
+        return (null, entry);
     }
 
     /// Gets the view definition for rule-based view selection.

--- a/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using BBT.Workflow.Definitions;
 using BBT.Workflow.Definitions.CastHandlers;
 using BBT.Workflow.Definitions.Validators;
 using BBT.Workflow.Instances;
+using BBT.Workflow.Instances.Caching;
 using BBT.Workflow.Monitoring;
 using BBT.Workflow.RepresentationEtag;
 using BBT.Workflow.Resilience;
@@ -66,6 +67,9 @@ public static class WorkflowApplicationModuleServiceCollectionExtensions
     {
            services.AddOptions<InstanceFilteringOptions>()
             .BindConfiguration(InstanceFilteringOptions.SectionName);
+        services.AddOptions<StateFunctionCacheOptions>()
+            .BindConfiguration(StateFunctionCacheOptions.SectionName);
+        services.AddScoped<IStateFunctionCache, StateFunctionCache>();
         // Application Services
         services.AddScoped<IDefinitionAppService, DefinitionAppService>();
         services.AddScoped<IInstanceCommandAppService, InstanceCommandAppService>();

--- a/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
@@ -70,6 +70,9 @@ public static class WorkflowApplicationModuleServiceCollectionExtensions
         services.AddOptions<StateFunctionCacheOptions>()
             .BindConfiguration(StateFunctionCacheOptions.SectionName);
         services.AddScoped<IStateFunctionCache, StateFunctionCache>();
+        services.AddOptions<InstanceFunctionCacheOptions>()
+            .BindConfiguration(InstanceFunctionCacheOptions.SectionName);
+        services.AddScoped<IDataFunctionCache, DataFunctionCache>();
         // Application Services
         services.AddScoped<IDefinitionAppService, DefinitionAppService>();
         services.AddScoped<IInstanceCommandAppService, InstanceCommandAppService>();

--- a/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
@@ -73,6 +73,7 @@ public static class WorkflowApplicationModuleServiceCollectionExtensions
         services.AddOptions<InstanceFunctionCacheOptions>()
             .BindConfiguration(InstanceFunctionCacheOptions.SectionName);
         services.AddScoped<IDataFunctionCache, DataFunctionCache>();
+        services.AddScoped<IInstanceSchemaFunctionCache, InstanceSchemaFunctionCache>();
         // Application Services
         services.AddScoped<IDefinitionAppService, DefinitionAppService>();
         services.AddScoped<IInstanceCommandAppService, InstanceCommandAppService>();

--- a/src/BBT.Workflow.Domain/Definitions/FunctionCacheDefinition.cs
+++ b/src/BBT.Workflow.Domain/Definitions/FunctionCacheDefinition.cs
@@ -1,0 +1,29 @@
+using System.Text.Json.Serialization;
+
+namespace BBT.Workflow.Definitions;
+
+/// <summary>
+/// Workflow-author-controlled cache tuning for the built-in instance functions
+/// (data, view, schema, ...). A single TTL covers all of them. The state function is
+/// configured host-side (<c>StateFunctionCache</c> options) and is NOT covered by this object.
+/// JSON shape on the flow definition: <c>"functionCache": { "ttlSeconds": 120 }</c>.
+/// </summary>
+public sealed class FunctionCacheDefinition
+{
+    private FunctionCacheDefinition()
+    {
+    }
+
+    [JsonConstructor]
+    private FunctionCacheDefinition(int? ttlSeconds)
+    {
+        TtlSeconds = ttlSeconds;
+    }
+
+    /// <summary>
+    /// Cache TTL in seconds for this workflow's built-in function responses.
+    /// Null or non-positive falls back to the host default
+    /// (<c>InstanceFunctionCache:DefaultTtlSeconds</c>).
+    /// </summary>
+    public int? TtlSeconds { get; private set; }
+}

--- a/src/BBT.Workflow.Domain/Definitions/Workflow.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Workflow.cs
@@ -107,6 +107,13 @@ public sealed class Workflow : IDomainEntity, IReference, IReferenceSetter, IHas
     public WorkflowTimeout? Timeout { get; private set; }
 
     /// <summary>
+    /// Optional author-controlled cache tuning for the built-in instance functions
+    /// (data, view, schema, ...). Null means host defaults apply.
+    /// </summary>
+    [JsonInclude] [JsonPropertyName("functionCache")]
+    public FunctionCacheDefinition? FunctionCache { get; private set; }
+
+    /// <summary>
     /// Defines the cancellation configuration for this workflow.
     /// When configured, allows the workflow to be canceled via the cancel transition.
     /// </summary>

--- a/src/BBT.Workflow.Domain/Instances/IInstanceRepository.cs
+++ b/src/BBT.Workflow.Domain/Instances/IInstanceRepository.cs
@@ -32,6 +32,16 @@ public interface IInstanceRepository : IRepository<Instance, Guid>
     Task<Instance?> FindByIdentifierSlimAsync(string identifier, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Projects the state-function validation fingerprint (effective state, status, flow version,
+    /// active-subflow flag) for the instance matching the identifier (GUID or key) in a single
+    /// projection query — no includes, no aggregate materialization. Identifier resolution mirrors
+    /// <see cref="FindByIdentifierAsReadOnlyAsync"/> (id first, then most recent row by key).
+    /// Returns null when no instance matches.
+    /// </summary>
+    Task<InstanceStateFingerprint?> GetStateFingerprintAsync(string identifier,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Finds the single non-terminal instance (status Active or Busy) for the given key, or null
     /// if none exists. Terminal rows (Completed/Faulted/Passive) are ignored, so this is the
     /// authoritative "is this key currently in use?" lookup — unlike <see cref="FindByIdentifierAsync"/>,

--- a/src/BBT.Workflow.Domain/Instances/IInstanceRepository.cs
+++ b/src/BBT.Workflow.Domain/Instances/IInstanceRepository.cs
@@ -42,6 +42,16 @@ public interface IInstanceRepository : IRepository<Instance, Guid>
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Projects the data-function validation fingerprint (latest data row's ETag + flow version)
+    /// for the instance matching the identifier (GUID or key) in a single projection query.
+    /// The latest ETag read is an index-only probe (<c>UX_InstancesData_Instance_IsLatest</c>
+    /// includes ETag). Identifier resolution mirrors <see cref="FindByIdentifierAsReadOnlyAsync"/>.
+    /// Returns null when no instance matches.
+    /// </summary>
+    Task<InstanceDataFingerprint?> GetDataFingerprintAsync(string identifier,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Finds the single non-terminal instance (status Active or Busy) for the given key, or null
     /// if none exists. Terminal rows (Completed/Faulted/Passive) are ignored, so this is the
     /// authoritative "is this key currently in use?" lookup — unlike <see cref="FindByIdentifierAsync"/>,

--- a/src/BBT.Workflow.Domain/Instances/InstanceDataFingerprint.cs
+++ b/src/BBT.Workflow.Domain/Instances/InstanceDataFingerprint.cs
@@ -13,11 +13,17 @@ namespace BBT.Workflow.Instances;
 /// <param name="LatestDataEtag">ETag of the IsLatest instance-data row; null when the instance
 /// has no data rows yet.</param>
 /// <param name="FlowVersion">Bound flow version.</param>
+/// <param name="EffectiveState">Externally exposed state column — the schema function's
+/// transition resolution is state-dependent (equals CurrentState when no active subflow).</param>
+/// <param name="HasActiveSubFlow">True when an open SubFlow-type correlation exists. Master and
+/// schema responses are then composed from a live subflow call and must not be served from cache.</param>
 public sealed record InstanceDataFingerprint(
     Guid Id,
     string? Key,
     string? LatestDataEtag,
-    string? FlowVersion)
+    string? FlowVersion,
+    string? EffectiveState,
+    bool HasActiveSubFlow)
 {
     /// <summary>
     /// Builds the fingerprint from an already-loaded aggregate — the full-build path uses this
@@ -27,5 +33,7 @@ public sealed record InstanceDataFingerprint(
         new(instance.Id,
             instance.Key,
             instance.LatestData?.ETag,
-            instance.FlowVersion);
+            instance.FlowVersion,
+            instance.EffectiveState,
+            instance.HasActiveSubFlow);
 }

--- a/src/BBT.Workflow.Domain/Instances/InstanceDataFingerprint.cs
+++ b/src/BBT.Workflow.Domain/Instances/InstanceDataFingerprint.cs
@@ -1,0 +1,31 @@
+namespace BBT.Workflow.Instances;
+
+/// <summary>
+/// Lightweight projection of the columns that determine whether a cached data-function
+/// response is still valid: the latest data row's ETag (a new ULID on every latest-line
+/// data write) plus the bound flow version (a migration can change x-roles field filtering
+/// and extension definitions without a data write). Loaded via a single-row projection —
+/// the latest ETag read is an index-only probe on <c>UX_InstancesData_Instance_IsLatest</c>.
+/// </summary>
+/// <param name="Id">Identifier of the instance row actually resolved for the requested identifier.
+/// Compared inside the ETag hash so a newer row reusing the same key invalidates cached answers.</param>
+/// <param name="Key">Instance business key.</param>
+/// <param name="LatestDataEtag">ETag of the IsLatest instance-data row; null when the instance
+/// has no data rows yet.</param>
+/// <param name="FlowVersion">Bound flow version.</param>
+public sealed record InstanceDataFingerprint(
+    Guid Id,
+    string? Key,
+    string? LatestDataEtag,
+    string? FlowVersion)
+{
+    /// <summary>
+    /// Builds the fingerprint from an already-loaded aggregate — the full-build path uses this
+    /// so its ETag is computed from exactly the same values the projection query would return.
+    /// </summary>
+    public static InstanceDataFingerprint FromInstance(Instance instance) =>
+        new(instance.Id,
+            instance.Key,
+            instance.LatestData?.ETag,
+            instance.FlowVersion);
+}

--- a/src/BBT.Workflow.Domain/Instances/InstanceStateFingerprint.cs
+++ b/src/BBT.Workflow.Domain/Instances/InstanceStateFingerprint.cs
@@ -1,0 +1,36 @@
+namespace BBT.Workflow.Instances;
+
+/// <summary>
+/// Lightweight projection of the instance columns that determine whether a cached
+/// state-function response is still valid. Loaded via a single-row projection query
+/// (no includes) so long-poll validation does not materialize the full aggregate.
+/// </summary>
+/// <param name="Id">Identifier of the instance row actually resolved for the requested identifier.
+/// Compared against the cached entry so a newer row reusing the same key invalidates the cache.</param>
+/// <param name="Key">Instance business key.</param>
+/// <param name="EffectiveState">Externally exposed state column (includes subflow propagation).</param>
+/// <param name="Status">Instance status.</param>
+/// <param name="FlowVersion">Bound flow version; a version migration can change transitions/views
+/// without a state or status change.</param>
+/// <param name="HasActiveSubFlow">True when an open SubFlow-type correlation exists. The state
+/// response is then built from a live subflow call, so it must not be served from cache.</param>
+public sealed record InstanceStateFingerprint(
+    Guid Id,
+    string? Key,
+    string? EffectiveState,
+    InstanceStatus Status,
+    string? FlowVersion,
+    bool HasActiveSubFlow)
+{
+    /// <summary>
+    /// Builds the fingerprint from an already-loaded aggregate — the full-build path uses this
+    /// so its ETag is computed from exactly the same values the projection query would return.
+    /// </summary>
+    public static InstanceStateFingerprint FromInstance(Instance instance) =>
+        new(instance.Id,
+            instance.Key,
+            instance.EffectiveState,
+            instance.Status,
+            instance.FlowVersion,
+            instance.HasActiveSubFlow);
+}

--- a/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
@@ -2443,6 +2443,87 @@ public static partial class WorkflowLogs
 
     #endregion
 
+    #region State Function Cache
+
+    /// <summary>
+    /// Logs when a state-function response is served from cache (fingerprint validated as unchanged).
+    /// </summary>
+    [LoggerMessage(
+        EventId = 20400,
+        Level = LogLevel.Debug,
+        Message = "State function cache hit for instance {Instance} (state {State}, status {Status})")]
+    public static partial void StateFunctionCacheHit(
+        this ILogger logger,
+        string instance,
+        string? state,
+        string status);
+
+    /// <summary>
+    /// Logs when no cached state-function response exists for the caller scope.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 20401,
+        Level = LogLevel.Debug,
+        Message = "State function cache miss for instance {Instance}")]
+    public static partial void StateFunctionCacheMiss(
+        this ILogger logger,
+        string instance);
+
+    /// <summary>
+    /// Logs when a cached state-function response is discarded because its fingerprint ETag
+    /// no longer matches the ETag computed from the current projection.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 20402,
+        Level = LogLevel.Debug,
+        Message = "State function cache invalidated for instance {Instance}: etag {CachedEtag} -> {CurrentEtag}")]
+    public static partial void StateFunctionCacheInvalidated(
+        this ILogger logger,
+        string instance,
+        string? cachedEtag,
+        string currentEtag);
+
+    /// <summary>
+    /// Logs when the cache is bypassed because the instance has an active SubFlow —
+    /// the state response is built from a live subflow call and cannot be validated locally.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 20403,
+        Level = LogLevel.Debug,
+        Message = "State function cache bypassed for instance {Instance}: active SubFlow requires live evaluation")]
+    public static partial void StateFunctionCacheBypassedForSubFlow(
+        this ILogger logger,
+        string instance);
+
+    /// <summary>
+    /// Logs when a state-function cache operation fails; the failure degrades to a miss.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 20404,
+        Level = LogLevel.Warning,
+        Message = "State function cache {Operation} failed for key {CacheKey}; treating as miss")]
+    public static partial void StateFunctionCacheError(
+        this ILogger logger,
+        Exception exception,
+        string operation,
+        string cacheKey);
+
+    /// <summary>
+    /// Logs when the fingerprint ETag matched the caller's If-None-Match and 304 was returned
+    /// directly from the projection query — no cache access, aggregate load or response build.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 20405,
+        Level = LogLevel.Debug,
+        Message = "State function ETag unchanged for instance {Instance} (state {State}, status {Status}); returning 304 from fingerprint")]
+    public static partial void StateFunctionEtagNotModified(
+        this ILogger logger,
+        string instance,
+        string? state,
+        string status);
+
+    #endregion
+
     #region Multi-Channel Notification
 
     /// <summary>

--- a/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
@@ -2590,6 +2590,92 @@ public static partial class WorkflowLogs
 
     #endregion
 
+    #region Master/Schema Function Cache
+
+    // One shared quintet serves both the master and the schema function ({Function} parameter
+    // is "master" or "schema") — they share the cache service and the response body shape.
+
+    /// <summary>
+    /// Logs when a master/schema response is served from cache (fingerprint ETag validated).
+    /// </summary>
+    [LoggerMessage(
+        EventId = 20420,
+        Level = LogLevel.Debug,
+        Message = "{Function} function cache hit for instance {Instance}")]
+    public static partial void InstanceSchemaFunctionCacheHit(
+        this ILogger logger,
+        string function,
+        string instance);
+
+    /// <summary>
+    /// Logs when no cached master/schema response exists for the caller scope.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 20421,
+        Level = LogLevel.Debug,
+        Message = "{Function} function cache miss for instance {Instance}")]
+    public static partial void InstanceSchemaFunctionCacheMiss(
+        this ILogger logger,
+        string function,
+        string instance);
+
+    /// <summary>
+    /// Logs when a cached master/schema response is discarded because its fingerprint ETag
+    /// no longer matches the ETag computed from the current projection.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 20422,
+        Level = LogLevel.Debug,
+        Message = "{Function} function cache invalidated for instance {Instance}: etag {CachedEtag} -> {CurrentEtag}")]
+    public static partial void InstanceSchemaFunctionCacheInvalidated(
+        this ILogger logger,
+        string function,
+        string instance,
+        string? cachedEtag,
+        string currentEtag);
+
+    /// <summary>
+    /// Logs when a master/schema cache operation fails; the failure degrades to a miss.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 20423,
+        Level = LogLevel.Warning,
+        Message = "{Function} function cache {Operation} failed for key {CacheKey}; treating as miss")]
+    public static partial void InstanceSchemaFunctionCacheError(
+        this ILogger logger,
+        Exception exception,
+        string function,
+        string operation,
+        string cacheKey);
+
+    /// <summary>
+    /// Logs when the fingerprint ETag matched the caller's If-None-Match and 304 was returned
+    /// from the projection query — no cache access, aggregate load or response build.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 20424,
+        Level = LogLevel.Debug,
+        Message = "{Function} function ETag unchanged for instance {Instance}; returning 304 from fingerprint")]
+    public static partial void InstanceSchemaFunctionEtagNotModified(
+        this ILogger logger,
+        string function,
+        string instance);
+
+    /// <summary>
+    /// Logs when the fast path and cache are bypassed because the instance has an active
+    /// SubFlow — the master/schema response is composed from a live subflow call.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 20425,
+        Level = LogLevel.Debug,
+        Message = "{Function} function cache bypassed for instance {Instance}: active SubFlow requires live evaluation")]
+    public static partial void InstanceSchemaFunctionCacheBypassedForSubFlow(
+        this ILogger logger,
+        string function,
+        string instance);
+
+    #endregion
+
     #region Multi-Channel Notification
 
     /// <summary>

--- a/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
@@ -2524,6 +2524,72 @@ public static partial class WorkflowLogs
 
     #endregion
 
+    #region Data Function Cache
+
+    /// <summary>
+    /// Logs when a data-function response is served from cache (fingerprint ETag validated).
+    /// </summary>
+    [LoggerMessage(
+        EventId = 20410,
+        Level = LogLevel.Debug,
+        Message = "Data function cache hit for instance {Instance}")]
+    public static partial void DataFunctionCacheHit(
+        this ILogger logger,
+        string instance);
+
+    /// <summary>
+    /// Logs when no cached data-function response exists for the caller scope.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 20411,
+        Level = LogLevel.Debug,
+        Message = "Data function cache miss for instance {Instance}")]
+    public static partial void DataFunctionCacheMiss(
+        this ILogger logger,
+        string instance);
+
+    /// <summary>
+    /// Logs when a cached data-function response is discarded because its fingerprint ETag
+    /// no longer matches the ETag computed from the current projection.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 20412,
+        Level = LogLevel.Debug,
+        Message = "Data function cache invalidated for instance {Instance}: etag {CachedEtag} -> {CurrentEtag}")]
+    public static partial void DataFunctionCacheInvalidated(
+        this ILogger logger,
+        string instance,
+        string? cachedEtag,
+        string currentEtag);
+
+    /// <summary>
+    /// Logs when a data-function cache operation fails; the failure degrades to a miss.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 20413,
+        Level = LogLevel.Warning,
+        Message = "Data function cache {Operation} failed for key {CacheKey}; treating as miss")]
+    public static partial void DataFunctionCacheError(
+        this ILogger logger,
+        Exception exception,
+        string operation,
+        string cacheKey);
+
+    /// <summary>
+    /// Logs when the data fingerprint ETag matched the caller's If-None-Match and 304 was
+    /// returned from the projection query — no cache access, aggregate load, extension run
+    /// or response build.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 20414,
+        Level = LogLevel.Debug,
+        Message = "Data function ETag unchanged for instance {Instance}; returning 304 from fingerprint")]
+    public static partial void DataFunctionEtagNotModified(
+        this ILogger logger,
+        string instance);
+
+    #endregion
+
     #region Multi-Channel Notification
 
     /// <summary>

--- a/src/BBT.Workflow.Infrastructure/Gateway/LocalInstanceQueryGateway.cs
+++ b/src/BBT.Workflow.Infrastructure/Gateway/LocalInstanceQueryGateway.cs
@@ -145,7 +145,10 @@ public sealed class LocalInstanceQueryGateway : IInstanceQueryGateway
                     Instance = input.Instance,
                     Roles = input.Roles
                 };
-                return await queryService.GetSchemaAsync(schemaInput, transitionKey, ct);
+                // Subflow composition path: no If-None-Match is ever sent, so the conditional
+                // result can never be NotModified — unwrap to the plain body result.
+                var conditional = await queryService.GetSchemaAsync(schemaInput, transitionKey, ct);
+                return conditional.Result;
             }, cancellationToken);
     }
 
@@ -190,7 +193,10 @@ public sealed class LocalInstanceQueryGateway : IInstanceQueryGateway
                     QueryParameters = input.QueryParams,
                     Roles = input.Roles
                 };
-                return await queryService.GetMasterAsync(masterInput, ct);
+                // Subflow composition path: no If-None-Match is ever sent, so the conditional
+                // result can never be NotModified — unwrap to the plain body result.
+                var conditional = await queryService.GetMasterAsync(masterInput, ct);
+                return conditional.Result;
             }, cancellationToken);
     }
 }

--- a/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceRepository.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceRepository.cs
@@ -327,6 +327,48 @@ public sealed class EfCoreInstanceRepository(
     }
 
     /// <inheritdoc />
+    public async Task<InstanceStateFingerprint?> GetStateFingerprintAsync(
+        string identifier,
+        CancellationToken cancellationToken = default)
+    {
+        var dbSet = await GetDbSetAsync();
+        return await QueryStateFingerprintAsync(dbSet.AsNoTracking(), identifier, cancellationToken);
+    }
+
+    /// <summary>
+    /// Core state-fingerprint projection over an instance queryable. Internal so integration tests
+    /// can run the exact production query against a real database without composing the repository.
+    /// </summary>
+    internal static async Task<InstanceStateFingerprint?> QueryStateFingerprintAsync(
+        IQueryable<Instance> query,
+        string identifier,
+        CancellationToken cancellationToken)
+    {
+        if (Guid.TryParse(identifier, out var instanceId))
+        {
+            var byId = await ProjectStateFingerprint(query.Where(i => i.Id == instanceId))
+                .FirstOrDefaultAsync(cancellationToken);
+            if (byId is not null)
+                return byId;
+        }
+
+        // Key is not unique across terminal/historical rows; OrderByDescending(CreatedAt)
+        // keeps the fallback deterministic, mirroring FindByIdentifierAsReadOnlyAsync.
+        return await ProjectStateFingerprint(
+                query.Where(i => i.Key == identifier).OrderByDescending(i => i.CreatedAt))
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    private static IQueryable<InstanceStateFingerprint> ProjectStateFingerprint(IQueryable<Instance> query) =>
+        query.Select(i => new InstanceStateFingerprint(
+            i.Id,
+            i.Key,
+            i.EffectiveState,
+            i.Status,
+            i.FlowVersion,
+            i.ChildCorrelations.Any(c => !c.IsCompleted && c.SubFlowType == SubFlowType.SubFlow)));
+
+    /// <inheritdoc />
     public async Task<Instance?> FindByIdentifierWithFullHistoryAsync(string identifier,
         CancellationToken cancellationToken = default)
     {

--- a/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceRepository.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceRepository.cs
@@ -407,7 +407,9 @@ public sealed class EfCoreInstanceRepository(
             i.Id,
             i.Key,
             i.DataList.Where(d => d.IsLatest).Select(d => d.ETag).FirstOrDefault(),
-            i.FlowVersion));
+            i.FlowVersion,
+            i.EffectiveState,
+            i.ChildCorrelations.Any(c => !c.IsCompleted && c.SubFlowType == SubFlowType.SubFlow)));
 
     /// <inheritdoc />
     public async Task<Instance?> FindByIdentifierWithFullHistoryAsync(string identifier,

--- a/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceRepository.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceRepository.cs
@@ -369,6 +369,47 @@ public sealed class EfCoreInstanceRepository(
             i.ChildCorrelations.Any(c => !c.IsCompleted && c.SubFlowType == SubFlowType.SubFlow)));
 
     /// <inheritdoc />
+    public async Task<InstanceDataFingerprint?> GetDataFingerprintAsync(
+        string identifier,
+        CancellationToken cancellationToken = default)
+    {
+        var dbSet = await GetDbSetAsync();
+        return await QueryDataFingerprintAsync(dbSet.AsNoTracking(), identifier, cancellationToken);
+    }
+
+    /// <summary>
+    /// Core data-fingerprint projection over an instance queryable. Internal so integration tests
+    /// can run the exact production query against a real database without composing the repository.
+    /// The latest-data ETag subquery is served index-only by UX_InstancesData_Instance_IsLatest.
+    /// </summary>
+    internal static async Task<InstanceDataFingerprint?> QueryDataFingerprintAsync(
+        IQueryable<Instance> query,
+        string identifier,
+        CancellationToken cancellationToken)
+    {
+        if (Guid.TryParse(identifier, out var instanceId))
+        {
+            var byId = await ProjectDataFingerprint(query.Where(i => i.Id == instanceId))
+                .FirstOrDefaultAsync(cancellationToken);
+            if (byId is not null)
+                return byId;
+        }
+
+        // Key is not unique across terminal/historical rows; OrderByDescending(CreatedAt)
+        // keeps the fallback deterministic, mirroring FindByIdentifierAsReadOnlyAsync.
+        return await ProjectDataFingerprint(
+                query.Where(i => i.Key == identifier).OrderByDescending(i => i.CreatedAt))
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    private static IQueryable<InstanceDataFingerprint> ProjectDataFingerprint(IQueryable<Instance> query) =>
+        query.Select(i => new InstanceDataFingerprint(
+            i.Id,
+            i.Key,
+            i.DataList.Where(d => d.IsLatest).Select(d => d.ETag).FirstOrDefault(),
+            i.FlowVersion));
+
+    /// <inheritdoc />
     public async Task<Instance?> FindByIdentifierWithFullHistoryAsync(string identifier,
         CancellationToken cancellationToken = default)
     {

--- a/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceQueryAppService.cs
@@ -325,7 +325,15 @@ public sealed class RemoteInstanceQueryAppService(
             var requestUri = new Uri(endpoint.BaseUrl, relativePath.TrimStart('/'));
             using var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
             var forwardHeaders = currentUser.ToForwardHeaders();
-            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, input.Headers);
+            // If-None-Match must come only from the typed input.IfNoneMatch below. input.Headers
+            // carries the caller's full header set, and the caller's own If-None-Match (an ETag
+            // for a DIFFERENT resource, e.g. the parent instance in the subflow window) must not
+            // leak into this request — a false 304 here would leave the consumer with no body.
+            CurrentUserForwardHeadersHelper.MergeIntoRequest(
+                requestMessage,
+                forwardHeaders,
+                input.Headers,
+                static header => string.Equals(header, "If-None-Match", StringComparison.OrdinalIgnoreCase));
             if (!string.IsNullOrEmpty(input.IfNoneMatch))
                 requestMessage.Headers.TryAddWithoutValidation("If-None-Match", input.IfNoneMatch);
             var response = await httpClient.SendAsync(requestMessage, cancellationToken);

--- a/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/Remote/RemoteInstanceQueryAppService.cs
@@ -448,7 +448,14 @@ public sealed class RemoteInstanceQueryAppService(
             var requestUri = new Uri(endpoint.BaseUrl, relativePath.TrimStart('/'));
             using var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
             var forwardHeaders = currentUser.ToForwardHeaders();
-            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, input.Headers);
+            // If-None-Match must never be forwarded downstream: this is a subflow composition
+            // call whose caller ETag belongs to a DIFFERENT resource (the parent instance),
+            // and the composer always needs a body.
+            CurrentUserForwardHeadersHelper.MergeIntoRequest(
+                requestMessage,
+                forwardHeaders,
+                input.Headers,
+                static header => string.Equals(header, "If-None-Match", StringComparison.OrdinalIgnoreCase));
             var response = await httpClient.SendAsync(requestMessage, cancellationToken);
 
             // Status code → Result.Fail (per Railway Pattern)
@@ -550,7 +557,14 @@ public sealed class RemoteInstanceQueryAppService(
             var requestUri = new Uri(endpoint.BaseUrl, relativePath.TrimStart('/'));
             using var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
             var forwardHeaders = currentUser.ToForwardHeaders();
-            CurrentUserForwardHeadersHelper.MergeIntoRequest(requestMessage, forwardHeaders, input.Headers);
+            // If-None-Match must never be forwarded downstream: this is a subflow composition
+            // call whose caller ETag belongs to a DIFFERENT resource (the parent instance),
+            // and the composer always needs a body.
+            CurrentUserForwardHeadersHelper.MergeIntoRequest(
+                requestMessage,
+                forwardHeaders,
+                input.Headers,
+                static header => string.Equals(header, "If-None-Match", StringComparison.OrdinalIgnoreCase));
             var response = await httpClient.SendAsync(requestMessage, cancellationToken);
 
             // Status code → Result.Fail (per Railway Pattern)

--- a/test/BBT.Workflow.Application.Tests/Instances/Caching/DataFunctionCacheTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/Caching/DataFunctionCacheTests.cs
@@ -52,7 +52,7 @@ public class DataFunctionCacheTests
 
     private static InstanceDataFingerprint CreateFingerprint() =>
         new(Guid.Parse("22222222-2222-2222-2222-222222222222"), "test-key",
-            "01JD2G4YV0EXAMPLEULID0000A", "1.0.0");
+            "01JD2G4YV0EXAMPLEULID0000A", "1.0.0", "review", HasActiveSubFlow: false);
 
     [Fact]
     public void Options_Defaults_AreEnabledWith60SecondDefaultTtl()

--- a/test/BBT.Workflow.Application.Tests/Instances/Caching/DataFunctionCacheTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/Caching/DataFunctionCacheTests.cs
@@ -1,0 +1,247 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.DistributedCache;
+using BBT.Aether.Users;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Instances.Caching;
+
+/// <summary>
+/// Unit tests for <see cref="DataFunctionCache"/>: cache-key/ETag composition (caller scoping,
+/// data-etag and flow-version sensitivity), workflow-author TTL resolution, failure-degrades-
+/// to-miss behavior, and envelope JSON round-trip including the JsonElement data payload.
+/// </summary>
+public class DataFunctionCacheTests
+{
+    private const string TestDomain = "test-domain";
+    private const string TestWorkflow = "test-flow";
+    private const string TestInstance = "instance-1";
+
+    private readonly IDistributedCacheService _distributedCache = Substitute.For<IDistributedCacheService>();
+    private readonly ICurrentUser _currentUser = Substitute.For<ICurrentUser>();
+
+    private DataFunctionCache CreateSut(InstanceFunctionCacheOptions? options = null) =>
+        new(_distributedCache,
+            _currentUser,
+            Options.Create(options ?? new InstanceFunctionCacheOptions()),
+            Substitute.For<ILogger<DataFunctionCache>>());
+
+    private static GetInstanceDataInput CreateInput(
+        IReadOnlyList<string>? roles = null,
+        string[]? extensions = null,
+        string? version = null,
+        Dictionary<string, string?>? headers = null) => new()
+    {
+        Domain = TestDomain,
+        Workflow = TestWorkflow,
+        Instance = TestInstance,
+        Roles = roles,
+        Extensions = extensions,
+        Version = version,
+        Headers = headers ?? new Dictionary<string, string?>(),
+        QueryParameters = new Dictionary<string, string?>()
+    };
+
+    private static InstanceDataFingerprint CreateFingerprint() =>
+        new(Guid.Parse("22222222-2222-2222-2222-222222222222"), "test-key",
+            "01JD2G4YV0EXAMPLEULID0000A", "1.0.0");
+
+    [Fact]
+    public void Options_Defaults_AreEnabledWith60SecondDefaultTtl()
+    {
+        var options = new InstanceFunctionCacheOptions();
+
+        options.Enabled.ShouldBeTrue();
+        options.DefaultTtlSeconds.ShouldBe(60);
+    }
+
+    [Fact]
+    public void BuildKey_ContainsDomainWorkflowAndInstance()
+    {
+        var key = CreateSut().BuildKey(CreateInput());
+
+        key.ShouldStartWith($"data-fn:{TestDomain}:{TestWorkflow}:{TestInstance}:");
+    }
+
+    [Fact]
+    public void ComputeEtag_IsDeterministicAndRolesOrderInsensitive()
+    {
+        var sut = CreateSut();
+        var fingerprint = CreateFingerprint();
+
+        var etag1 = sut.ComputeEtag(CreateInput(roles: ["b", "a"]), fingerprint);
+        var etag2 = sut.ComputeEtag(CreateInput(roles: ["a", "b"]), fingerprint);
+
+        etag1.ShouldBe(etag2);
+        etag1.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void ComputeEtag_ChangesWithEveryFingerprintComponent()
+    {
+        var sut = CreateSut();
+        var input = CreateInput();
+        var fingerprint = CreateFingerprint();
+        var baseline = sut.ComputeEtag(input, fingerprint);
+
+        sut.ComputeEtag(input, fingerprint with { Id = Guid.NewGuid() }).ShouldNotBe(baseline);
+        sut.ComputeEtag(input, fingerprint with { LatestDataEtag = "01JD2G4YV0OTHERULID000000" }).ShouldNotBe(baseline);
+        sut.ComputeEtag(input, fingerprint with { FlowVersion = "2.0.0" }).ShouldNotBe(baseline);
+    }
+
+    [Fact]
+    public void ComputeEtag_ChangesWithCallerScope()
+    {
+        var sut = CreateSut();
+        var fingerprint = CreateFingerprint();
+
+        _currentUser.ActorUserName.Returns("alice");
+        var aliceEtag = sut.ComputeEtag(CreateInput(), fingerprint);
+
+        _currentUser.ActorUserName.Returns("bob");
+        var bobEtag = sut.ComputeEtag(CreateInput(), fingerprint);
+
+        aliceEtag.ShouldNotBe(bobEtag);
+
+        var withCulture = sut.ComputeEtag(CreateInput(headers: new Dictionary<string, string?>
+        {
+            ["Accept-Language"] = "tr-TR"
+        }), fingerprint);
+        var withVersion = sut.ComputeEtag(CreateInput(version: "1.0.0"), fingerprint);
+
+        withCulture.ShouldNotBe(bobEtag);
+        withVersion.ShouldNotBe(bobEtag);
+    }
+
+    /// <summary>
+    /// Extensions are outside the caller scope: the ETag tracks the data change point and the
+    /// key is shared across extension variants (the body cache only serves extensionless
+    /// requests; extension demand always rebuilds fresh).
+    /// </summary>
+    [Fact]
+    public void ComputeEtagAndBuildKey_IgnoreRequestedExtensions()
+    {
+        var sut = CreateSut();
+        var fingerprint = CreateFingerprint();
+
+        sut.ComputeEtag(CreateInput(extensions: ["ext-a"]), fingerprint)
+            .ShouldBe(sut.ComputeEtag(CreateInput(), fingerprint));
+        sut.BuildKey(CreateInput(extensions: ["ext-a"]))
+            .ShouldBe(sut.BuildKey(CreateInput()));
+    }
+
+    [Fact]
+    public void ResolveTtlSeconds_PrefersWorkflowAuthorValue()
+    {
+        var sut = CreateSut(new InstanceFunctionCacheOptions { DefaultTtlSeconds = 60 });
+
+        sut.ResolveTtlSeconds(FunctionCacheFromJson("""{ "ttlSeconds": 120 }""")).ShouldBe(120);
+        sut.ResolveTtlSeconds(FunctionCacheFromJson("""{ "ttlSeconds": null }""")).ShouldBe(60);
+        sut.ResolveTtlSeconds(FunctionCacheFromJson("""{ "ttlSeconds": 0 }""")).ShouldBe(60);
+        sut.ResolveTtlSeconds(FunctionCacheFromJson("""{ "ttlSeconds": -5 }""")).ShouldBe(60);
+        sut.ResolveTtlSeconds(null).ShouldBe(60);
+    }
+
+    [Fact]
+    public void Workflow_JsonBinding_ReadsFunctionCacheDefinition()
+    {
+        var json = """
+                   {
+                       "type": "F",
+                       "functionCache": { "ttlSeconds": 120 },
+                       "labels": [], "functions": [], "features": [], "states": [],
+                       "sharedTransitions": [], "extensions": [],
+                       "startTransition": {"key": "start", "from": null, "target": "review", "triggerType": "Manual", "versionStrategy": "Patch", "labels": [], "onExecutionTasks": [], "view": null}
+                   }
+                   """;
+        var options = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+        };
+
+        var workflow = JsonSerializer.Deserialize<Definitions.Workflow>(json, options);
+
+        workflow.ShouldNotBeNull();
+        workflow!.FunctionCache.ShouldNotBeNull();
+        workflow.FunctionCache!.TtlSeconds.ShouldBe(120);
+    }
+
+    [Fact]
+    public async Task GetAsync_WhenCacheThrows_ReturnsNull()
+    {
+        _distributedCache
+            .GetAsync<DataFunctionCacheEntry>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("redis down"));
+
+        var entry = await CreateSut().GetAsync("some-key", CancellationToken.None);
+
+        entry.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task SetAsync_WhenCacheThrows_DoesNotThrow()
+    {
+        _distributedCache
+            .SetAsync(Arg.Any<string>(), Arg.Any<DataFunctionCacheEntry>(),
+                Arg.Any<DistributedCacheEntryOptions>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("redis down"));
+
+        await Should.NotThrowAsync(() =>
+            CreateSut().SetAsync("some-key", new DataFunctionCacheEntry(), 60, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task SetAsync_UsesGivenTtl()
+    {
+        DistributedCacheEntryOptions? captured = null;
+        _distributedCache
+            .SetAsync(Arg.Any<string>(), Arg.Any<DataFunctionCacheEntry>(),
+                Arg.Do<DistributedCacheEntryOptions>(o => captured = o), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        var before = DateTimeOffset.UtcNow;
+        await CreateSut().SetAsync("some-key", new DataFunctionCacheEntry(), 120, CancellationToken.None);
+        var after = DateTimeOffset.UtcNow;
+
+        captured.ShouldNotBeNull();
+        captured!.AbsoluteExpiration.ShouldNotBeNull();
+        captured.AbsoluteExpiration!.Value.ShouldBeGreaterThanOrEqualTo(before.AddSeconds(119));
+        captured.AbsoluteExpiration!.Value.ShouldBeLessThanOrEqualTo(after.AddSeconds(121));
+    }
+
+    [Fact]
+    public void CacheEntry_JsonRoundTrip_PreservesData()
+    {
+        using var doc = JsonDocument.Parse("""{ "name": "Ada", "age": 36 }""");
+        var entry = new DataFunctionCacheEntry
+        {
+            Etag = "etag-1",
+            EntityEtag = "entity-1",
+            Data = doc.RootElement.Clone()
+        };
+
+        var json = JsonSerializer.Serialize(entry);
+        var roundTripped = JsonSerializer.Deserialize<DataFunctionCacheEntry>(json);
+
+        roundTripped.ShouldNotBeNull();
+        roundTripped!.Etag.ShouldBe("etag-1");
+        roundTripped.EntityEtag.ShouldBe("entity-1");
+        roundTripped.Data.ShouldNotBeNull();
+        roundTripped.Data!.Value.GetProperty("name").GetString().ShouldBe("Ada");
+    }
+
+    private static Definitions.FunctionCacheDefinition FunctionCacheFromJson(string json) =>
+        JsonSerializer.Deserialize<Definitions.FunctionCacheDefinition>(json, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        })!;
+}

--- a/test/BBT.Workflow.Application.Tests/Instances/Caching/InstanceSchemaFunctionCacheTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/Caching/InstanceSchemaFunctionCacheTests.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.DistributedCache;
+using BBT.Aether.Users;
+using BBT.Workflow.Instances.DTOs;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Instances.Caching;
+
+/// <summary>
+/// Unit tests for <see cref="InstanceSchemaFunctionCache"/>: master/schema key and ETag
+/// composition (state sensitivity only on schema, transition-key scoping, caller scoping
+/// without extensions), TTL resolution, failure-degrades-to-miss, and entry round-trip.
+/// </summary>
+public class InstanceSchemaFunctionCacheTests
+{
+    private const string TestDomain = "test-domain";
+    private const string TestWorkflow = "test-flow";
+    private const string TestInstance = "instance-1";
+
+    private readonly IDistributedCacheService _distributedCache = Substitute.For<IDistributedCacheService>();
+    private readonly ICurrentUser _currentUser = Substitute.For<ICurrentUser>();
+
+    private InstanceSchemaFunctionCache CreateSut(InstanceFunctionCacheOptions? options = null) =>
+        new(_distributedCache,
+            _currentUser,
+            Options.Create(options ?? new InstanceFunctionCacheOptions()),
+            Substitute.For<ILogger<InstanceSchemaFunctionCache>>());
+
+    private static GetMasterInput CreateMasterInput(
+        IReadOnlyList<string>? roles = null,
+        string? version = null,
+        Dictionary<string, string?>? headers = null) => new()
+    {
+        Domain = TestDomain,
+        Workflow = TestWorkflow,
+        Instance = TestInstance,
+        Roles = roles,
+        Version = version,
+        Headers = headers ?? new Dictionary<string, string?>()
+    };
+
+    private static GetSchemaInput CreateSchemaInput(
+        IReadOnlyList<string>? roles = null,
+        string? version = null,
+        Dictionary<string, string?>? headers = null) => new()
+    {
+        Domain = TestDomain,
+        Workflow = TestWorkflow,
+        Instance = TestInstance,
+        Roles = roles,
+        Version = version,
+        Headers = headers ?? new Dictionary<string, string?>()
+    };
+
+    private static InstanceDataFingerprint CreateFingerprint() =>
+        new(Guid.Parse("33333333-3333-3333-3333-333333333333"), "test-key",
+            "01JD2G4YV0EXAMPLEULID0000A", "1.0.0", "review", HasActiveSubFlow: false);
+
+    [Fact]
+    public void BuildKey_UsesDistinctPrefixesForMasterAndSchema()
+    {
+        var sut = CreateSut();
+
+        sut.BuildKey(CreateMasterInput())
+            .ShouldStartWith($"master-fn:{TestDomain}:{TestWorkflow}:{TestInstance}:");
+        sut.BuildKey(CreateSchemaInput(), "approve")
+            .ShouldStartWith($"schema-fn:{TestDomain}:{TestWorkflow}:{TestInstance}:");
+        sut.BuildKey(CreateSchemaInput(), "approve").ShouldEndWith(":approve");
+    }
+
+    [Fact]
+    public void SchemaBuildKey_DiffersByTransitionKey()
+    {
+        var sut = CreateSut();
+
+        sut.BuildKey(CreateSchemaInput(), "approve")
+            .ShouldNotBe(sut.BuildKey(CreateSchemaInput(), "reject"));
+    }
+
+    [Fact]
+    public void MasterEtag_IgnoresEffectiveState_SchemaEtagDoesNot()
+    {
+        var sut = CreateSut();
+        var fingerprint = CreateFingerprint();
+        var moved = fingerprint with { EffectiveState = "approved" };
+
+        sut.ComputeEtag(CreateMasterInput(), fingerprint)
+            .ShouldBe(sut.ComputeEtag(CreateMasterInput(), moved));
+        sut.ComputeEtag(CreateSchemaInput(), fingerprint, "approve")
+            .ShouldNotBe(sut.ComputeEtag(CreateSchemaInput(), moved, "approve"));
+    }
+
+    [Fact]
+    public void BothEtags_ChangeWithDataEtagAndFlowVersion()
+    {
+        var sut = CreateSut();
+        var fingerprint = CreateFingerprint();
+
+        var masterBaseline = sut.ComputeEtag(CreateMasterInput(), fingerprint);
+        sut.ComputeEtag(CreateMasterInput(), fingerprint with { LatestDataEtag = "01JD2G4YV0OTHERULID000000" })
+            .ShouldNotBe(masterBaseline);
+        sut.ComputeEtag(CreateMasterInput(), fingerprint with { FlowVersion = "2.0.0" })
+            .ShouldNotBe(masterBaseline);
+
+        var schemaBaseline = sut.ComputeEtag(CreateSchemaInput(), fingerprint, "approve");
+        sut.ComputeEtag(CreateSchemaInput(), fingerprint with { LatestDataEtag = "01JD2G4YV0OTHERULID000000" }, "approve")
+            .ShouldNotBe(schemaBaseline);
+        sut.ComputeEtag(CreateSchemaInput(), fingerprint with { FlowVersion = "2.0.0" }, "approve")
+            .ShouldNotBe(schemaBaseline);
+        sut.ComputeEtag(CreateSchemaInput(), fingerprint, "reject")
+            .ShouldNotBe(schemaBaseline);
+    }
+
+    [Fact]
+    public void Etags_ChangeWithCallerScope()
+    {
+        var sut = CreateSut();
+        var fingerprint = CreateFingerprint();
+
+        _currentUser.ActorUserName.Returns("alice");
+        var alice = sut.ComputeEtag(CreateMasterInput(), fingerprint);
+
+        _currentUser.ActorUserName.Returns("bob");
+        var bob = sut.ComputeEtag(CreateMasterInput(), fingerprint);
+        alice.ShouldNotBe(bob);
+
+        sut.ComputeEtag(CreateMasterInput(roles: ["admin"]), fingerprint).ShouldNotBe(bob);
+        sut.ComputeEtag(CreateMasterInput(version: "2.0.0"), fingerprint).ShouldNotBe(bob);
+        sut.ComputeEtag(CreateMasterInput(headers: new Dictionary<string, string?>
+        {
+            ["Accept-Language"] = "tr-TR"
+        }), fingerprint).ShouldNotBe(bob);
+    }
+
+    [Fact]
+    public void ResolveTtlSeconds_PrefersWorkflowAuthorValue()
+    {
+        var sut = CreateSut(new InstanceFunctionCacheOptions { DefaultTtlSeconds = 60 });
+
+        sut.ResolveTtlSeconds(FunctionCacheFromJson("""{ "ttlSeconds": 120 }""")).ShouldBe(120);
+        sut.ResolveTtlSeconds(FunctionCacheFromJson("""{ "ttlSeconds": 0 }""")).ShouldBe(60);
+        sut.ResolveTtlSeconds(null).ShouldBe(60);
+    }
+
+    [Fact]
+    public async Task GetAsync_WhenCacheThrows_ReturnsNull()
+    {
+        _distributedCache
+            .GetAsync<SchemaFunctionCacheEntry>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("redis down"));
+
+        (await CreateSut().GetAsync("master-fn:some-key", CancellationToken.None)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task SetAsync_WhenCacheThrows_DoesNotThrow()
+    {
+        _distributedCache
+            .SetAsync(Arg.Any<string>(), Arg.Any<SchemaFunctionCacheEntry>(),
+                Arg.Any<DistributedCacheEntryOptions>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("redis down"));
+
+        await Should.NotThrowAsync(() =>
+            CreateSut().SetAsync("schema-fn:some-key", new SchemaFunctionCacheEntry(), 60, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task SetAsync_UsesGivenTtl()
+    {
+        DistributedCacheEntryOptions? captured = null;
+        _distributedCache
+            .SetAsync(Arg.Any<string>(), Arg.Any<SchemaFunctionCacheEntry>(),
+                Arg.Do<DistributedCacheEntryOptions>(o => captured = o), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        var before = DateTimeOffset.UtcNow;
+        await CreateSut().SetAsync("master-fn:some-key", new SchemaFunctionCacheEntry(), 120, CancellationToken.None);
+        var after = DateTimeOffset.UtcNow;
+
+        captured.ShouldNotBeNull();
+        captured!.AbsoluteExpiration!.Value.ShouldBeGreaterThanOrEqualTo(before.AddSeconds(119));
+        captured.AbsoluteExpiration!.Value.ShouldBeLessThanOrEqualTo(after.AddSeconds(121));
+    }
+
+    [Fact]
+    public void CacheEntry_JsonRoundTrip_PreservesSchemaDocument()
+    {
+        using var doc = JsonDocument.Parse("""{ "type": "object", "properties": { "name": {} } }""");
+        var entry = new SchemaFunctionCacheEntry
+        {
+            Etag = "etag-1",
+            Output = new GetSchemaOutput
+            {
+                Key = "master-schema",
+                Type = "Json",
+                Schema = doc.RootElement.Clone()
+            }
+        };
+
+        var json = JsonSerializer.Serialize(entry);
+        var roundTripped = JsonSerializer.Deserialize<SchemaFunctionCacheEntry>(json);
+
+        roundTripped.ShouldNotBeNull();
+        roundTripped!.Etag.ShouldBe("etag-1");
+        roundTripped.Output.Key.ShouldBe("master-schema");
+        roundTripped.Output.Schema.GetProperty("type").GetString().ShouldBe("object");
+    }
+
+    private static Definitions.FunctionCacheDefinition FunctionCacheFromJson(string json) =>
+        JsonSerializer.Deserialize<Definitions.FunctionCacheDefinition>(json, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        })!;
+}

--- a/test/BBT.Workflow.Application.Tests/Instances/Caching/StateFunctionCacheTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/Caching/StateFunctionCacheTests.cs
@@ -1,0 +1,278 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.DistributedCache;
+using BBT.Aether.Users;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Instances.Caching;
+
+/// <summary>
+/// Unit tests for <see cref="StateFunctionCache"/>: cache-key composition (caller scoping),
+/// TTL propagation, failure-degrades-to-miss behavior, and envelope JSON round-trip.
+/// </summary>
+public class StateFunctionCacheTests
+{
+    private const string TestDomain = "test-domain";
+    private const string TestWorkflow = "test-flow";
+    private const string TestInstance = "instance-1";
+
+    private readonly IDistributedCacheService _distributedCache = Substitute.For<IDistributedCacheService>();
+    private readonly ICurrentUser _currentUser = Substitute.For<ICurrentUser>();
+
+    private StateFunctionCache CreateSut(StateFunctionCacheOptions? options = null) =>
+        new(_distributedCache,
+            _currentUser,
+            Options.Create(options ?? new StateFunctionCacheOptions()),
+            Substitute.For<ILogger<StateFunctionCache>>());
+
+    private static GetInstanceStateInput CreateInput(
+        string? role = null,
+        IReadOnlyList<string>? roles = null,
+        string[]? extensions = null,
+        string? version = null,
+        Dictionary<string, string?>? headers = null) => new()
+    {
+        Domain = TestDomain,
+        Workflow = TestWorkflow,
+        Instance = TestInstance,
+        Role = role,
+        Roles = roles,
+        Extensions = extensions,
+        Version = version,
+        Headers = headers ?? new Dictionary<string, string?>(),
+        QueryParams = new Dictionary<string, string?>()
+    };
+
+    [Fact]
+    public void Options_Defaults_AreEnabledWith60SecondTtl()
+    {
+        var options = new StateFunctionCacheOptions();
+
+        options.Enabled.ShouldBeTrue();
+        options.TtlSeconds.ShouldBe(60);
+    }
+
+    [Fact]
+    public void BuildKey_ContainsDomainWorkflowAndInstance()
+    {
+        var key = CreateSut().BuildKey(CreateInput());
+
+        key.ShouldStartWith($"state-fn:{TestDomain}:{TestWorkflow}:{TestInstance}:");
+    }
+
+    [Fact]
+    public void BuildKey_IsRolesOrderInsensitive()
+    {
+        var sut = CreateSut();
+
+        var key1 = sut.BuildKey(CreateInput(roles: ["backoffice", "admin"]));
+        var key2 = sut.BuildKey(CreateInput(roles: ["admin", "backoffice"]));
+
+        key1.ShouldBe(key2);
+    }
+
+    [Fact]
+    public void BuildKey_DiffersByRoles()
+    {
+        var sut = CreateSut();
+
+        var key1 = sut.BuildKey(CreateInput(roles: ["admin"]));
+        var key2 = sut.BuildKey(CreateInput(roles: ["backoffice"]));
+
+        key1.ShouldNotBe(key2);
+    }
+
+    [Fact]
+    public void BuildKey_DiffersByActorIdentity()
+    {
+        var sut = CreateSut();
+
+        _currentUser.ActorUserName.Returns("alice");
+        var key1 = sut.BuildKey(CreateInput());
+
+        _currentUser.ActorUserName.Returns("bob");
+        var key2 = sut.BuildKey(CreateInput());
+
+        key1.ShouldNotBe(key2);
+    }
+
+    [Fact]
+    public void BuildKey_DiffersByCulture()
+    {
+        var sut = CreateSut();
+
+        var key1 = sut.BuildKey(CreateInput(headers: new Dictionary<string, string?>
+        {
+            ["Accept-Language"] = "tr-TR"
+        }));
+        var key2 = sut.BuildKey(CreateInput(headers: new Dictionary<string, string?>
+        {
+            ["Accept-Language"] = "en-US"
+        }));
+
+        key1.ShouldNotBe(key2);
+    }
+
+    [Fact]
+    public void BuildKey_DiffersByExtensionsAndVersion()
+    {
+        var sut = CreateSut();
+
+        var baseline = sut.BuildKey(CreateInput());
+        var withExtensions = sut.BuildKey(CreateInput(extensions: ["ext-a"]));
+        var withVersion = sut.BuildKey(CreateInput(version: "2.0.0"));
+
+        withExtensions.ShouldNotBe(baseline);
+        withVersion.ShouldNotBe(baseline);
+    }
+
+    [Fact]
+    public async Task GetAsync_WhenCacheThrows_ReturnsNull()
+    {
+        _distributedCache
+            .GetAsync<StateFunctionCacheEntry>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("redis down"));
+
+        var entry = await CreateSut().GetAsync("some-key", CancellationToken.None);
+
+        entry.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task SetAsync_WhenCacheThrows_DoesNotThrow()
+    {
+        _distributedCache
+            .SetAsync(Arg.Any<string>(), Arg.Any<StateFunctionCacheEntry>(),
+                Arg.Any<DistributedCacheEntryOptions>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("redis down"));
+
+        await Should.NotThrowAsync(() =>
+            CreateSut().SetAsync("some-key", new StateFunctionCacheEntry(), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task SetAsync_UsesConfiguredTtl()
+    {
+        DistributedCacheEntryOptions? captured = null;
+        _distributedCache
+            .SetAsync(Arg.Any<string>(), Arg.Any<StateFunctionCacheEntry>(),
+                Arg.Do<DistributedCacheEntryOptions>(o => captured = o), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        var sut = CreateSut(new StateFunctionCacheOptions { TtlSeconds = 120 });
+        var before = DateTimeOffset.UtcNow;
+        await sut.SetAsync("some-key", new StateFunctionCacheEntry(), CancellationToken.None);
+        var after = DateTimeOffset.UtcNow;
+
+        captured.ShouldNotBeNull();
+        captured!.AbsoluteExpiration.ShouldNotBeNull();
+        captured.AbsoluteExpiration!.Value.ShouldBeGreaterThanOrEqualTo(before.AddSeconds(119));
+        captured.AbsoluteExpiration!.Value.ShouldBeLessThanOrEqualTo(after.AddSeconds(121));
+    }
+
+    [Fact]
+    public void CacheEntry_JsonRoundTrip_PreservesEtagsAndOutput()
+    {
+        var entry = new StateFunctionCacheEntry
+        {
+            Etag = "etag-1",
+            EntityEtag = "entity-1",
+            Output = new GetInstanceStateOutput
+            {
+                State = "review",
+                StateType = "intermediate",
+                Status = InstanceStatus.Active,
+                Transitions = [],
+                ActiveCorrelations = []
+            }
+        };
+
+        var json = JsonSerializer.Serialize(entry);
+        var roundTripped = JsonSerializer.Deserialize<StateFunctionCacheEntry>(json);
+
+        roundTripped.ShouldNotBeNull();
+        roundTripped!.Etag.ShouldBe("etag-1");
+        roundTripped.EntityEtag.ShouldBe("entity-1");
+        roundTripped.Output.State.ShouldBe("review");
+        roundTripped.Output.Status.ShouldBe(InstanceStatus.Active);
+    }
+
+    [Fact]
+    public void ComputeEtag_IsDeterministic()
+    {
+        var sut = CreateSut();
+        var fingerprint = CreateFingerprint();
+
+        var etag1 = sut.ComputeEtag(CreateInput(roles: ["b", "a"]), fingerprint);
+        var etag2 = sut.ComputeEtag(CreateInput(roles: ["a", "b"]), fingerprint);
+
+        etag1.ShouldBe(etag2);
+        etag1.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void ComputeEtag_ChangesWithEveryFingerprintComponent()
+    {
+        var sut = CreateSut();
+        var input = CreateInput();
+        var fingerprint = CreateFingerprint();
+        var baseline = sut.ComputeEtag(input, fingerprint);
+
+        sut.ComputeEtag(input, fingerprint with { Id = Guid.NewGuid() }).ShouldNotBe(baseline);
+        sut.ComputeEtag(input, fingerprint with { EffectiveState = "approved" }).ShouldNotBe(baseline);
+        sut.ComputeEtag(input, fingerprint with { Status = InstanceStatus.Busy }).ShouldNotBe(baseline);
+        sut.ComputeEtag(input, fingerprint with { FlowVersion = "2.0.0" }).ShouldNotBe(baseline);
+    }
+
+    [Fact]
+    public void ComputeEtag_ChangesWithCallerScope()
+    {
+        var sut = CreateSut();
+        var fingerprint = CreateFingerprint();
+
+        _currentUser.ActorUserName.Returns("alice");
+        var aliceEtag = sut.ComputeEtag(CreateInput(), fingerprint);
+
+        _currentUser.ActorUserName.Returns("bob");
+        var bobEtag = sut.ComputeEtag(CreateInput(), fingerprint);
+
+        aliceEtag.ShouldNotBe(bobEtag);
+    }
+
+    [Fact]
+    public void ComputeEtag_SubFlowOverload_FoldsDisplayedStateAndStatusIntoHash()
+    {
+        var sut = CreateSut();
+        var input = CreateInput();
+        var fingerprint = CreateFingerprint();
+        var plain = sut.ComputeEtag(input, fingerprint);
+
+        var subFlowActive = sut.ComputeEtag(input, fingerprint, new GetInstanceStateOutput
+        {
+            State = "sub-review",
+            Status = InstanceStatus.Active
+        });
+        var subFlowBusy = sut.ComputeEtag(input, fingerprint, new GetInstanceStateOutput
+        {
+            State = "sub-review",
+            Status = InstanceStatus.Busy
+        });
+
+        // Subflow Busy/Active flips within the same subflow state must produce distinct ETags,
+        // and the subflow variant must never collide with the plain fingerprint ETag.
+        subFlowActive.ShouldNotBe(plain);
+        subFlowBusy.ShouldNotBe(subFlowActive);
+    }
+
+    private static InstanceStateFingerprint CreateFingerprint() =>
+        new(Guid.Parse("11111111-1111-1111-1111-111111111111"), "test-key", "review",
+            InstanceStatus.Active, "1.0.0", HasActiveSubFlow: false);
+}

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceDataCacheTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceDataCacheTests.cs
@@ -128,6 +128,7 @@ public class InstanceQueryAppServiceDataCacheTests : IDisposable
             instanceFilteringOptions: Options.Create(new InstanceFilteringOptions()),
             stateFunctionCache: Substitute.For<Caching.IStateFunctionCache>(),
             dataFunctionCache: _dataFunctionCache,
+            instanceSchemaFunctionCache: Substitute.For<Caching.IInstanceSchemaFunctionCache>(),
             logger: Substitute.For<ILogger<InstanceQueryAppService>>());
     }
 
@@ -399,7 +400,7 @@ public class InstanceQueryAppServiceDataCacheTests : IDisposable
     private void SetupFingerprint(Guid instanceId, string? latestDataEtag = "01JD2G4YV0EXAMPLEULID0000A") =>
         _instanceRepository
             .GetDataFingerprintAsync(instanceId.ToString(), Arg.Any<CancellationToken>())
-            .Returns(new InstanceDataFingerprint(instanceId, "test-key", latestDataEtag, TestVersion));
+            .Returns(new InstanceDataFingerprint(instanceId, "test-key", latestDataEtag, TestVersion, "review", HasActiveSubFlow: false));
 
     private void SetupCachedEntry(out Caching.DataFunctionCacheEntry entry, string etag = "etag-current")
     {

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceDataCacheTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceDataCacheTests.cs
@@ -1,0 +1,474 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.DependencyInjection;
+using BBT.Aether.Results;
+using BBT.Aether.MultiSchema;
+using BBT.Aether.Users;
+using BBT.Aether.Uow;
+using BBT.Workflow.Authorization;
+using BBT.Workflow.Caching;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Gateway;
+using BBT.Workflow.RepresentationEtag;
+using BBT.Workflow.Runtime;
+using BBT.Workflow.Scripting;
+using BBT.Workflow.Tasks.Coordinator;
+using BBT.Workflow.Extentions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Instances;
+
+/// <summary>
+/// Unit tests for the data-function fingerprint-ETag fast path and cache flow in
+/// <see cref="InstanceQueryAppService.GetInstanceDataAsync"/>: 304 from the projection alone,
+/// cached 200 without aggregate load, latest-only restriction (pinned versions bypass),
+/// warm-on-build with workflow-author TTL, and stale-entry invalidation.
+/// </summary>
+public class InstanceQueryAppServiceDataCacheTests : IDisposable
+{
+    private readonly IRuntimeInfoProvider _runtimeInfoProvider;
+    private readonly IComponentCacheStore _componentCacheStore;
+    private readonly IInstanceRepository _instanceRepository;
+    private readonly IInstanceExtensionService _instanceExtensionService;
+    private readonly IScriptContextFactory _scriptContextFactory;
+    private readonly ITransitionAuthorizationManager _transitionAuthorizationManager;
+    private readonly ISchemaFieldFilterService _schemaFieldFilterService;
+    private readonly Caching.IDataFunctionCache _dataFunctionCache;
+    private readonly InstanceQueryAppService _service;
+    private readonly IServiceProvider _ambientServiceProvider;
+    private readonly IServiceProvider? _previousAmbientServiceProvider;
+
+    private const string TestDomain = "test-domain";
+    private const string TestWorkflow = "test-flow";
+    private const string TestVersion = "1.0.0";
+    private const string TestCacheKey = "data-fn:test-domain:test-flow:key-under-test";
+
+    public InstanceQueryAppServiceDataCacheTests()
+    {
+        _runtimeInfoProvider = Substitute.For<IRuntimeInfoProvider>();
+        _componentCacheStore = Substitute.For<IComponentCacheStore>();
+        _instanceRepository = Substitute.For<IInstanceRepository>();
+        _instanceExtensionService = Substitute.For<IInstanceExtensionService>();
+        _scriptContextFactory = Substitute.For<IScriptContextFactory>();
+        _transitionAuthorizationManager = Substitute.For<ITransitionAuthorizationManager>();
+        _schemaFieldFilterService = Substitute.For<ISchemaFieldFilterService>();
+        _dataFunctionCache = Substitute.For<Caching.IDataFunctionCache>();
+
+        var mockUoW = Substitute.For<IUnitOfWork>();
+        var mockUoWManager = Substitute.For<IUnitOfWorkManager>();
+        mockUoWManager
+            .BeginAsync(Arg.Any<UnitOfWorkOptions>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(mockUoW));
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(mockUoWManager);
+        services.AddSingleton(Substitute.For<IComponentCacheStore>());
+        services.AddSingleton(Substitute.For<BBT.Workflow.DefinitionContext.IWorkflowContext>());
+        _ambientServiceProvider = services.BuildServiceProvider();
+
+        _previousAmbientServiceProvider = AmbientServiceProvider.Current;
+        AmbientServiceProvider.Current = _ambientServiceProvider;
+
+        var scriptContextBuilder = Substitute.For<IScriptContextBuilder>();
+        scriptContextBuilder.WithWorkflow(Arg.Any<Definitions.Workflow?>()).Returns(scriptContextBuilder);
+        scriptContextBuilder.WithInstance(Arg.Any<Instance>()).Returns(scriptContextBuilder);
+        scriptContextBuilder.WithRuntime(Arg.Any<IRuntimeInfoProvider>()).Returns(scriptContextBuilder);
+        scriptContextBuilder.WithTransition(Arg.Any<string>()).Returns(scriptContextBuilder);
+        scriptContextBuilder.WithBody(Arg.Any<JsonData>()).Returns(scriptContextBuilder);
+        scriptContextBuilder.WithHeaders(Arg.Any<Dictionary<string, string?>?>()).Returns(scriptContextBuilder);
+        scriptContextBuilder.WithQueryParameters(Arg.Any<Dictionary<string, string?>?>()).Returns(scriptContextBuilder);
+        scriptContextBuilder.BuildAsync(Arg.Any<CancellationToken>())
+            .Returns(new ScriptContext(Substitute.For<ILogger<ScriptContext>>()));
+        _scriptContextFactory.NewBuilder(Arg.Any<IInstanceRepository>()).Returns(scriptContextBuilder);
+
+        _instanceExtensionService.ProcessExtensionsAsync(
+                Arg.Any<string[]?>(),
+                Arg.Any<ScriptContext>(),
+                Arg.Any<Definitions.Workflow>(),
+                Arg.Any<ExtensionScope>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Result<Dictionary<string, object>>.Ok(new Dictionary<string, object>()));
+
+        _transitionAuthorizationManager
+            .IsQueryAllowedAsync(
+                Arg.Any<Definitions.Workflow>(),
+                Arg.Any<Instance>(),
+                Arg.Any<IReadOnlyCollection<string>?>(),
+                Arg.Any<AuthorizationRequestContext?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        _service = new InstanceQueryAppService(
+            serviceProvider: _ambientServiceProvider,
+            runtimeInfoProvider: _runtimeInfoProvider,
+            componentCacheStore: _componentCacheStore,
+            instanceRepository: _instanceRepository,
+            instanceTransitionRepository: Substitute.For<IInstanceTransitionRepository>(),
+            instanceCorrelationRepository: Substitute.For<IInstanceCorrelationRepository>(),
+            instanceExtensionService: _instanceExtensionService,
+            scriptContextFactory: _scriptContextFactory,
+            instanceQueryGateway: Substitute.For<IInstanceQueryGateway>(),
+            viewContentResolutionService: Substitute.For<IViewContentResolutionService>(),
+            taskConditionService: Substitute.For<ITaskConditionService>(),
+            urlTemplateBuilder: Substitute.For<IUrlTemplateBuilder>(),
+            currentSchema: Substitute.For<ICurrentSchema>(),
+            transitionAuthorizationManager: _transitionAuthorizationManager,
+            representationEtagService: Substitute.For<IRepresentationEtagService>(),
+            schemaFieldFilterService: _schemaFieldFilterService,
+            currentUser: Substitute.For<ICurrentUser>(),
+            paginationLinkGenerator: Substitute.For<BBT.Aether.Application.Pagination.IPaginationLinkGenerator>(),
+            instanceFilteringOptions: Options.Create(new InstanceFilteringOptions()),
+            stateFunctionCache: Substitute.For<Caching.IStateFunctionCache>(),
+            dataFunctionCache: _dataFunctionCache,
+            logger: Substitute.For<ILogger<InstanceQueryAppService>>());
+    }
+
+    public void Dispose()
+    {
+        AmbientServiceProvider.Current = _previousAmbientServiceProvider;
+        (_ambientServiceProvider as IDisposable)?.Dispose();
+    }
+
+    [Fact]
+    public async Task GetInstanceDataAsync_WhenCacheDisabled_DoesNotTouchCacheOrFingerprint()
+    {
+        var instance = CreateInstanceWithData(out _);
+        SetupFullPathMocks(instance);
+
+        var result = await _service.GetInstanceDataAsync(CreateInput(instance.Id.ToString()), CancellationToken.None);
+
+        result.Result.IsSuccess.ShouldBeTrue();
+        _dataFunctionCache.DidNotReceive().BuildKey(Arg.Any<GetInstanceDataInput>());
+        await _dataFunctionCache.DidNotReceive().GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _dataFunctionCache.DidNotReceive()
+            .SetAsync(Arg.Any<string>(), Arg.Any<Caching.DataFunctionCacheEntry>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+        await _instanceRepository.DidNotReceive()
+            .GetDataFingerprintAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetInstanceDataAsync_WhenIfNoneMatchMatchesFingerprintEtag_Returns304WithoutCacheOrBuild()
+    {
+        var instanceId = Guid.NewGuid();
+        EnableCache();
+        SetupFingerprint(instanceId);
+
+        var input = CreateInput(instanceId.ToString());
+        input.IfNoneMatch = "\"etag-current\"";
+
+        var result = await _service.GetInstanceDataAsync(input, CancellationToken.None);
+
+        result.IsNotModified.ShouldBeTrue();
+        await _dataFunctionCache.DidNotReceive().GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _instanceRepository.DidNotReceive()
+            .FindByIdentifierAsReadOnlyAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _instanceExtensionService.DidNotReceive().ProcessExtensionsAsync(
+            Arg.Any<string[]?>(), Arg.Any<ScriptContext>(), Arg.Any<Definitions.Workflow>(),
+            Arg.Any<ExtensionScope>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// A validated cache entry supplies the DATA portion of the response — field filtering is
+    /// skipped — while the extension pipeline still runs fresh on the loaded aggregate.
+    /// </summary>
+    [Fact]
+    public async Task GetInstanceDataAsync_WhenCachedEtagMatchesCurrent_UsesCachedDataAndBuildsExtensionsFresh()
+    {
+        var instance = CreateInstanceWithData(out _);
+        SetupFullPathMocks(instance);
+        EnableCache();
+        SetupFingerprint(instance.Id);
+        SetupCachedEntry(out _);
+        _instanceExtensionService.ProcessExtensionsAsync(
+                Arg.Any<string[]?>(), Arg.Any<ScriptContext>(), Arg.Any<Definitions.Workflow>(),
+                Arg.Any<ExtensionScope>(), Arg.Any<CancellationToken>())
+            .Returns(Result<Dictionary<string, object>>.Ok(new Dictionary<string, object> { ["state"] = "fresh" }));
+
+        var result = await _service.GetInstanceDataAsync(CreateInput(instance.Id.ToString()), CancellationToken.None);
+
+        result.IsNotModified.ShouldBeFalse();
+        result.Result.IsSuccess.ShouldBeTrue();
+        // Data from the cache entry, extensions freshly computed.
+        result.Result.Value!.Data!.Value.GetProperty("key").GetString().ShouldBe("cached-value");
+        result.Result.Value!.Extensions!["state"].ShouldBe("fresh");
+        result.Result.Value!.ETag.ShouldBe("\"etag-current\"");
+        // Field filtering skipped; entry not re-written.
+        await _schemaFieldFilterService.DidNotReceive()
+            .ApplyAsync(Arg.Any<Definitions.Workflow>(), Arg.Any<System.Text.Json.JsonElement?>(),
+                Arg.Any<Instance>(), Arg.Any<CancellationToken>());
+        await _dataFunctionCache.DidNotReceive()
+            .SetAsync(Arg.Any<string>(), Arg.Any<Caching.DataFunctionCacheEntry>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Extension demand does not bypass the data cache: the cached DATA portion is reused for
+    /// extension-carrying requests too, and the requested extensions are computed fresh.
+    /// </summary>
+    [Fact]
+    public async Task GetInstanceDataAsync_WhenExtensionsRequested_StillUsesCachedDataWithFreshExtensions()
+    {
+        var instance = CreateInstanceWithData(out _);
+        SetupFullPathMocks(instance);
+        EnableCache();
+        SetupFingerprint(instance.Id);
+        SetupCachedEntry(out _);
+        _instanceExtensionService.ProcessExtensionsAsync(
+                Arg.Any<string[]?>(), Arg.Any<ScriptContext>(), Arg.Any<Definitions.Workflow>(),
+                Arg.Any<ExtensionScope>(), Arg.Any<CancellationToken>())
+            .Returns(Result<Dictionary<string, object>>.Ok(new Dictionary<string, object> { ["ext-a"] = "fresh" }));
+
+        var input = CreateInput(instance.Id.ToString());
+        input.Extensions = ["ext-a"];
+
+        var result = await _service.GetInstanceDataAsync(input, CancellationToken.None);
+
+        result.Result.IsSuccess.ShouldBeTrue();
+        result.Result.Value!.Data!.Value.GetProperty("key").GetString().ShouldBe("cached-value");
+        result.Result.Value!.Extensions!["ext-a"].ShouldBe("fresh");
+        await _dataFunctionCache.Received(1).GetAsync(TestCacheKey, Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// A matching If-None-Match answers 304 even for extension-demanding requests — the ETag
+    /// tracks the data change point, extension flux never moves it.
+    /// </summary>
+    [Fact]
+    public async Task GetInstanceDataAsync_WhenExtensionsRequestedWithMatchingEtag_Returns304()
+    {
+        var instanceId = Guid.NewGuid();
+        EnableCache();
+        SetupFingerprint(instanceId);
+
+        var input = CreateInput(instanceId.ToString());
+        input.Extensions = ["ext-a"];
+        input.IfNoneMatch = "\"etag-current\"";
+
+        var result = await _service.GetInstanceDataAsync(input, CancellationToken.None);
+
+        result.IsNotModified.ShouldBeTrue();
+        await _instanceRepository.DidNotReceive()
+            .FindByIdentifierAsReadOnlyAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// The entry stores only the field-filtered data — extension output (e.g. always-on Global
+    /// extensions) is never written to the cache.
+    /// </summary>
+    [Fact]
+    public async Task GetInstanceDataAsync_WhenBuildProducesExtensionOutput_WarmsCacheWithDataOnly()
+    {
+        var instance = CreateInstanceWithData(out _);
+        SetupFullPathMocks(instance);
+        EnableCache();
+        SetupFingerprint(instance.Id);
+        _instanceExtensionService.ProcessExtensionsAsync(
+                Arg.Any<string[]?>(), Arg.Any<ScriptContext>(), Arg.Any<Definitions.Workflow>(),
+                Arg.Any<ExtensionScope>(), Arg.Any<CancellationToken>())
+            .Returns(Result<Dictionary<string, object>>.Ok(new Dictionary<string, object> { ["state"] = "review" }));
+
+        var result = await _service.GetInstanceDataAsync(CreateInput(instance.Id.ToString()), CancellationToken.None);
+
+        result.Result.IsSuccess.ShouldBeTrue();
+        result.Result.Value!.Extensions!["state"].ShouldBe("review");
+        await _dataFunctionCache.Received(1).SetAsync(
+            TestCacheKey,
+            Arg.Is<Caching.DataFunctionCacheEntry>(e => e.Etag == "etag-current" && e.Data != null),
+            Arg.Any<int>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetInstanceDataAsync_WhenCacheMiss_BuildsAndWarmsCacheWithResolvedTtl()
+    {
+        var instance = CreateInstanceWithData(out _);
+        SetupFullPathMocks(instance, workflowTtlSeconds: 120);
+        EnableCache();
+        SetupFingerprint(instance.Id);
+        _dataFunctionCache
+            .ResolveTtlSeconds(Arg.Is<FunctionCacheDefinition?>(f => f != null && f.TtlSeconds == 120))
+            .Returns(120);
+
+        var result = await _service.GetInstanceDataAsync(CreateInput(instance.Id.ToString()), CancellationToken.None);
+
+        result.Result.IsSuccess.ShouldBeTrue();
+        result.Result.Value!.ETag.ShouldBe("\"etag-current\"");
+        await _dataFunctionCache.Received(1).SetAsync(
+            TestCacheKey,
+            Arg.Is<Caching.DataFunctionCacheEntry>(e => e.Etag == "etag-current"),
+            120,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetInstanceDataAsync_WhenCachedEtagIsStale_RebuildsAndRefreshesCache()
+    {
+        var instance = CreateInstanceWithData(out _);
+        SetupFullPathMocks(instance);
+        EnableCache();
+        SetupFingerprint(instance.Id);
+        SetupCachedEntry(out _, etag: "etag-old");
+
+        var result = await _service.GetInstanceDataAsync(CreateInput(instance.Id.ToString()), CancellationToken.None);
+
+        result.Result.IsSuccess.ShouldBeTrue();
+        await _instanceRepository.Received(1)
+            .FindByIdentifierAsReadOnlyAsync(instance.Id.ToString(), Arg.Any<CancellationToken>());
+        await _dataFunctionCache.Received(1).SetAsync(
+            TestCacheKey,
+            Arg.Is<Caching.DataFunctionCacheEntry>(e => e.Etag == "etag-current"),
+            Arg.Any<int>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetInstanceDataAsync_WhenPinnedVersionRequested_BypassesFastPathAndCache()
+    {
+        var instance = CreateInstanceWithData(out _);
+        SetupFullPathMocks(instance);
+        _instanceRepository
+            .FindByIdentifierWithFullHistoryAsync(instance.Id.ToString(), Arg.Any<CancellationToken>())
+            .Returns(instance);
+        EnableCache();
+
+        var input = CreateInput(instance.Id.ToString());
+        input.Version = TestVersion;
+
+        var result = await _service.GetInstanceDataAsync(input, CancellationToken.None);
+
+        result.Result.IsSuccess.ShouldBeTrue();
+        await _instanceRepository.DidNotReceive()
+            .GetDataFingerprintAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _dataFunctionCache.DidNotReceive().GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _dataFunctionCache.DidNotReceive()
+            .SetAsync(Arg.Any<string>(), Arg.Any<Caching.DataFunctionCacheEntry>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+        // ETag is still computed uniformly (from the resolved row) even off the fast path.
+        result.Result.Value!.ETag.ShouldBe("\"etag-current\"");
+    }
+
+    [Fact]
+    public async Task GetInstanceDataAsync_WhenInstanceHasNoDataRow_DoesNotWarmCache()
+    {
+        var instance = CreateInstanceWithoutData();
+        SetupFullPathMocks(instance);
+        EnableCache();
+        SetupFingerprint(instance.Id, latestDataEtag: null);
+
+        var result = await _service.GetInstanceDataAsync(CreateInput(instance.Id.ToString()), CancellationToken.None);
+
+        result.Result.IsSuccess.ShouldBeTrue();
+        await _dataFunctionCache.DidNotReceive()
+            .SetAsync(Arg.Any<string>(), Arg.Any<Caching.DataFunctionCacheEntry>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetInstanceDataAsync_WhenFingerprintNotFound_FallsThroughToFullPath()
+    {
+        var instance = CreateInstanceWithData(out _);
+        SetupFullPathMocks(instance);
+        EnableCache();
+        _instanceRepository
+            .GetDataFingerprintAsync(instance.Id.ToString(), Arg.Any<CancellationToken>())
+            .Returns((InstanceDataFingerprint?)null);
+
+        var result = await _service.GetInstanceDataAsync(CreateInput(instance.Id.ToString()), CancellationToken.None);
+
+        result.Result.IsSuccess.ShouldBeTrue();
+        await _instanceRepository.Received(1)
+            .FindByIdentifierAsReadOnlyAsync(instance.Id.ToString(), Arg.Any<CancellationToken>());
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private void EnableCache()
+    {
+        _dataFunctionCache.Enabled.Returns(true);
+        _dataFunctionCache.BuildKey(Arg.Any<GetInstanceDataInput>()).Returns(TestCacheKey);
+        _dataFunctionCache
+            .ComputeEtag(Arg.Any<GetInstanceDataInput>(), Arg.Any<InstanceDataFingerprint>())
+            .Returns("etag-current");
+    }
+
+    private void SetupFingerprint(Guid instanceId, string? latestDataEtag = "01JD2G4YV0EXAMPLEULID0000A") =>
+        _instanceRepository
+            .GetDataFingerprintAsync(instanceId.ToString(), Arg.Any<CancellationToken>())
+            .Returns(new InstanceDataFingerprint(instanceId, "test-key", latestDataEtag, TestVersion));
+
+    private void SetupCachedEntry(out Caching.DataFunctionCacheEntry entry, string etag = "etag-current")
+    {
+        using var doc = System.Text.Json.JsonDocument.Parse("""{ "key": "cached-value" }""");
+        entry = new Caching.DataFunctionCacheEntry
+        {
+            Etag = etag,
+            EntityEtag = "entity-1",
+            Data = doc.RootElement.Clone()
+        };
+        _dataFunctionCache.GetAsync(TestCacheKey, Arg.Any<CancellationToken>()).Returns(entry);
+    }
+
+    private static Instance CreateInstanceWithData(out Guid dataId)
+    {
+        var instance = Instance.Create(Guid.NewGuid(), TestWorkflow, TestVersion, "test-key");
+        var state = State.Create("review", StateType.Intermediate, StateSubType.None,
+            VersionStrategy.IncreaseMinor.Code);
+        instance.ChangeState(state);
+        dataId = Guid.NewGuid();
+        instance.AddDataWithVersion(dataId, new JsonData("{\"key\":\"value\"}"), TestVersion);
+        return instance;
+    }
+
+    private static Instance CreateInstanceWithoutData()
+    {
+        var instance = Instance.Create(Guid.NewGuid(), TestWorkflow, TestVersion, "test-key");
+        var state = State.Create("review", StateType.Intermediate, StateSubType.None,
+            VersionStrategy.IncreaseMinor.Code);
+        instance.ChangeState(state);
+        return instance;
+    }
+
+    private void SetupFullPathMocks(Instance instance, int? workflowTtlSeconds = null)
+    {
+        _instanceRepository
+            .FindByIdentifierAsReadOnlyAsync(instance.Id.ToString(), Arg.Any<CancellationToken>())
+            .Returns(instance);
+
+        var functionCacheJson = workflowTtlSeconds is not null
+            ? $$""", "functionCache": { "ttlSeconds": {{workflowTtlSeconds}} }"""
+            : string.Empty;
+        var json = $$"""
+                   {
+                       "type": "F"{{functionCacheJson}},
+                       "labels": [], "functions": [], "features": [], "states": [],
+                       "sharedTransitions": [], "extensions": [],
+                       "startTransition": {"key": "start", "from": null, "target": "review", "triggerType": "Manual", "versionStrategy": "Patch", "labels": [], "onExecutionTasks": [], "view": null}
+                   }
+                   """;
+        var options = new System.Text.Json.JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+        };
+        var workflow = System.Text.Json.JsonSerializer.Deserialize<Definitions.Workflow>(json, options)!;
+        workflow.SetReference(new Reference(TestWorkflow, TestDomain, "sys-flows", TestVersion));
+
+        _componentCacheStore
+            .GetFlowAsync(TestDomain, TestWorkflow, Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(Result<Definitions.Workflow>.Ok(workflow));
+    }
+
+    private static GetInstanceDataInput CreateInput(string instanceId) => new()
+    {
+        Domain = TestDomain,
+        Workflow = TestWorkflow,
+        Instance = instanceId,
+        Headers = new Dictionary<string, string?>(),
+        QueryParameters = new Dictionary<string, string?>()
+    };
+}

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceHistoryTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceHistoryTests.cs
@@ -82,6 +82,7 @@ public class InstanceQueryAppServiceHistoryTests : IDisposable
             paginationLinkGenerator: Substitute.For<BBT.Aether.Application.Pagination.IPaginationLinkGenerator>(),
             instanceFilteringOptions: Options.Create(new InstanceFilteringOptions()),
             stateFunctionCache: Substitute.For<Caching.IStateFunctionCache>(),
+            dataFunctionCache: Substitute.For<Caching.IDataFunctionCache>(),
             logger: Substitute.For<ILogger<InstanceQueryAppService>>());
     }
 

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceHistoryTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceHistoryTests.cs
@@ -81,6 +81,7 @@ public class InstanceQueryAppServiceHistoryTests : IDisposable
             currentUser: Substitute.For<ICurrentUser>(),
             paginationLinkGenerator: Substitute.For<BBT.Aether.Application.Pagination.IPaginationLinkGenerator>(),
             instanceFilteringOptions: Options.Create(new InstanceFilteringOptions()),
+            stateFunctionCache: Substitute.For<Caching.IStateFunctionCache>(),
             logger: Substitute.For<ILogger<InstanceQueryAppService>>());
     }
 

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceHistoryTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceHistoryTests.cs
@@ -83,6 +83,7 @@ public class InstanceQueryAppServiceHistoryTests : IDisposable
             instanceFilteringOptions: Options.Create(new InstanceFilteringOptions()),
             stateFunctionCache: Substitute.For<Caching.IStateFunctionCache>(),
             dataFunctionCache: Substitute.For<Caching.IDataFunctionCache>(),
+            instanceSchemaFunctionCache: Substitute.For<Caching.IInstanceSchemaFunctionCache>(),
             logger: Substitute.For<ILogger<InstanceQueryAppService>>());
     }
 

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceInstanceFilteringTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceInstanceFilteringTests.cs
@@ -275,6 +275,7 @@ public sealed class InstanceQueryAppServiceInstanceFilteringTests : IDisposable
             currentUser: Substitute.For<ICurrentUser>(),
             paginationLinkGenerator: _paginationLinkGenerator,
             instanceFilteringOptions: instanceFilteringOptions,
+            stateFunctionCache: Substitute.For<Caching.IStateFunctionCache>(),
             logger: Substitute.For<ILogger<InstanceQueryAppService>>());
     }
 

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceInstanceFilteringTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceInstanceFilteringTests.cs
@@ -276,6 +276,7 @@ public sealed class InstanceQueryAppServiceInstanceFilteringTests : IDisposable
             paginationLinkGenerator: _paginationLinkGenerator,
             instanceFilteringOptions: instanceFilteringOptions,
             stateFunctionCache: Substitute.For<Caching.IStateFunctionCache>(),
+            dataFunctionCache: Substitute.For<Caching.IDataFunctionCache>(),
             logger: Substitute.For<ILogger<InstanceQueryAppService>>());
     }
 

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceInstanceFilteringTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceInstanceFilteringTests.cs
@@ -277,6 +277,7 @@ public sealed class InstanceQueryAppServiceInstanceFilteringTests : IDisposable
             instanceFilteringOptions: instanceFilteringOptions,
             stateFunctionCache: Substitute.For<Caching.IStateFunctionCache>(),
             dataFunctionCache: Substitute.For<Caching.IDataFunctionCache>(),
+            instanceSchemaFunctionCache: Substitute.For<Caching.IInstanceSchemaFunctionCache>(),
             logger: Substitute.For<ILogger<InstanceQueryAppService>>());
     }
 

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceMasterTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceMasterTests.cs
@@ -89,6 +89,7 @@ public class InstanceQueryAppServiceMasterTests : IDisposable
             currentUser: Substitute.For<ICurrentUser>(),
             paginationLinkGenerator: Substitute.For<BBT.Aether.Application.Pagination.IPaginationLinkGenerator>(),
             instanceFilteringOptions: Options.Create(new InstanceFilteringOptions()),
+            stateFunctionCache: Substitute.For<Caching.IStateFunctionCache>(),
             logger: Substitute.For<ILogger<InstanceQueryAppService>>());
     }
 

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceMasterTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceMasterTests.cs
@@ -37,6 +37,7 @@ public class InstanceQueryAppServiceMasterTests : IDisposable
     private readonly IComponentCacheStore _componentCacheStore;
     private readonly IInstanceRepository _instanceRepository;
     private readonly IInstanceQueryGateway _instanceQueryGateway;
+    private readonly Caching.IInstanceSchemaFunctionCache _instanceSchemaFunctionCache;
     private readonly ITransitionAuthorizationManager _transitionAuthorizationManager;
     private readonly InstanceQueryAppService _service;
     private readonly IServiceProvider _ambientServiceProvider;
@@ -54,6 +55,8 @@ public class InstanceQueryAppServiceMasterTests : IDisposable
         _componentCacheStore = Substitute.For<IComponentCacheStore>();
         _instanceRepository = Substitute.For<IInstanceRepository>();
         _instanceQueryGateway = Substitute.For<IInstanceQueryGateway>();
+        // Enabled defaults to false so existing tests exercise the full build path.
+        _instanceSchemaFunctionCache = Substitute.For<Caching.IInstanceSchemaFunctionCache>();
         _transitionAuthorizationManager = Substitute.For<ITransitionAuthorizationManager>();
 
         var mockUoW = Substitute.For<IUnitOfWork>();
@@ -91,6 +94,7 @@ public class InstanceQueryAppServiceMasterTests : IDisposable
             instanceFilteringOptions: Options.Create(new InstanceFilteringOptions()),
             stateFunctionCache: Substitute.For<Caching.IStateFunctionCache>(),
             dataFunctionCache: Substitute.For<Caching.IDataFunctionCache>(),
+            instanceSchemaFunctionCache: _instanceSchemaFunctionCache,
             logger: Substitute.For<ILogger<InstanceQueryAppService>>());
     }
 
@@ -113,9 +117,9 @@ public class InstanceQueryAppServiceMasterTests : IDisposable
         var result = await _service.GetMasterAsync(CreateInput(instance.Id.ToString()), CancellationToken.None);
 
         // Assert
-        result.IsSuccess.ShouldBeTrue();
-        result.Value!.Key.ShouldBe(MasterSchemaKey);
-        result.Value.Type.ShouldBe("JSON");
+        result.Result.IsSuccess.ShouldBeTrue();
+        result.Result.Value!.Key.ShouldBe(MasterSchemaKey);
+        result.Result.Value.Type.ShouldBe("JSON");
 
         // No forwarding when there is no active subflow.
         await _instanceQueryGateway.DidNotReceive()
@@ -142,8 +146,8 @@ public class InstanceQueryAppServiceMasterTests : IDisposable
         var result = await _service.GetMasterAsync(CreateInput(instance.Id.ToString()), CancellationToken.None);
 
         // Assert — subflow's master schema is returned, parent's own schema is NOT resolved
-        result.IsSuccess.ShouldBeTrue();
-        result.Value!.Key.ShouldBe("subflow-master");
+        result.Result.IsSuccess.ShouldBeTrue();
+        result.Result.Value!.Key.ShouldBe("subflow-master");
         await _componentCacheStore.DidNotReceive()
             .GetSchemaAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
@@ -166,8 +170,8 @@ public class InstanceQueryAppServiceMasterTests : IDisposable
         var result = await _service.GetMasterAsync(CreateInput(instance.Id.ToString()), CancellationToken.None);
 
         // Assert
-        result.IsSuccess.ShouldBeFalse();
-        result.Error.Code.ShouldBe(WorkflowErrorCodes.AuthorizationRoleDenied);
+        result.Result.IsSuccess.ShouldBeFalse();
+        result.Result.Error.Code.ShouldBe(WorkflowErrorCodes.AuthorizationRoleDenied);
     }
 
     [Fact]
@@ -182,11 +186,134 @@ public class InstanceQueryAppServiceMasterTests : IDisposable
         var result = await _service.GetMasterAsync(CreateInput(instance.Id.ToString()), CancellationToken.None);
 
         // Assert
-        result.IsSuccess.ShouldBeFalse();
-        result.Error.Code.ShouldBe("notfound");
+        result.Result.IsSuccess.ShouldBeFalse();
+        result.Result.Error.Code.ShouldBe("notfound");
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────
+
+    // ── Master function cache ────────────────────────────────────────────────
+
+    private const string TestCacheKey = "master-fn:test-domain:test-flow:key-under-test";
+
+    private void EnableCache()
+    {
+        _instanceSchemaFunctionCache.Enabled.Returns(true);
+        _instanceSchemaFunctionCache.BuildKey(Arg.Any<GetMasterInput>()).Returns(TestCacheKey);
+        _instanceSchemaFunctionCache
+            .ComputeEtag(Arg.Any<GetMasterInput>(), Arg.Any<InstanceDataFingerprint>())
+            .Returns("etag-current");
+    }
+
+    private void SetupFingerprint(Guid instanceId, bool hasActiveSubFlow = false) =>
+        _instanceRepository
+            .GetDataFingerprintAsync(instanceId.ToString(), Arg.Any<CancellationToken>())
+            .Returns(new InstanceDataFingerprint(instanceId, "test-key",
+                "01JD2G4YV0EXAMPLEULID0000A", "1.0.0", "review", hasActiveSubFlow));
+
+    [Fact]
+    public async Task GetMasterAsync_WhenIfNoneMatchMatchesFingerprintEtag_Returns304WithoutBuild()
+    {
+        var instanceId = Guid.NewGuid();
+        EnableCache();
+        SetupFingerprint(instanceId);
+
+        var input = CreateInput(instanceId.ToString());
+        input.IfNoneMatch = "\"etag-current\"";
+
+        var result = await _service.GetMasterAsync(input, CancellationToken.None);
+
+        result.IsNotModified.ShouldBeTrue();
+        await _instanceSchemaFunctionCache.DidNotReceive().GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _instanceRepository.DidNotReceive()
+            .FindByIdentifierAsReadOnlyAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetMasterAsync_WhenCachedEtagMatchesCurrent_ServesFromCacheWithoutAggregateLoad()
+    {
+        var instanceId = Guid.NewGuid();
+        EnableCache();
+        SetupFingerprint(instanceId);
+        _instanceSchemaFunctionCache.GetAsync(TestCacheKey, Arg.Any<CancellationToken>())
+            .Returns(new Caching.SchemaFunctionCacheEntry
+            {
+                Etag = "etag-current",
+                Output = new GetSchemaOutput { Key = MasterSchemaKey, Type = "JSON" }
+            });
+
+        var result = await _service.GetMasterAsync(CreateInput(instanceId.ToString()), CancellationToken.None);
+
+        result.Result.IsSuccess.ShouldBeTrue();
+        result.Result.Value!.Key.ShouldBe(MasterSchemaKey);
+        result.Result.Value!.ETag.ShouldBe("\"etag-current\"");
+        await _instanceRepository.DidNotReceive()
+            .FindByIdentifierAsReadOnlyAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetMasterAsync_WhenCacheMiss_BuildsAndWarmsCache()
+    {
+        var instance = CreateInstance();
+        var workflow = BuildWorkflow(withMasterSchema: true);
+        SetupCommonMocks(instance, workflow);
+        SetupMasterSchema();
+        EnableCache();
+        SetupFingerprint(instance.Id);
+
+        var result = await _service.GetMasterAsync(CreateInput(instance.Id.ToString()), CancellationToken.None);
+
+        result.Result.IsSuccess.ShouldBeTrue();
+        result.Result.Value!.ETag.ShouldBe("\"etag-current\"");
+        await _instanceSchemaFunctionCache.Received(1).SetAsync(
+            TestCacheKey,
+            Arg.Is<Caching.SchemaFunctionCacheEntry>(e => e.Etag == "etag-current"),
+            Arg.Any<int>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetMasterAsync_WhenActiveSubFlow_BypassesCacheAndClearsForwardedEtag()
+    {
+        var instance = CreateInstanceWithActiveSubFlow();
+        var workflow = BuildWorkflow(withMasterSchema: true);
+        SetupCommonMocks(instance, workflow);
+        EnableCache();
+        SetupFingerprint(instance.Id, hasActiveSubFlow: true);
+        _instanceQueryGateway
+            .GetFunctionWithMasterAsync(Arg.Any<GetFunctionWithInstanceInput>(), Arg.Any<CancellationToken>())
+            .Returns(Result<GetSchemaOutput>.Ok(new GetSchemaOutput
+            {
+                Key = "sub-master",
+                Type = "JSON",
+                ETag = "sub-etag-should-not-leak"
+            }));
+
+        var result = await _service.GetMasterAsync(CreateInput(instance.Id.ToString()), CancellationToken.None);
+
+        result.Result.IsSuccess.ShouldBeTrue();
+        result.Result.Value!.Key.ShouldBe("sub-master");
+        result.Result.Value!.ETag.ShouldBeNull();
+        await _instanceSchemaFunctionCache.DidNotReceive().GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _instanceSchemaFunctionCache.DidNotReceive()
+            .SetAsync(Arg.Any<string>(), Arg.Any<Caching.SchemaFunctionCacheEntry>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetMasterAsync_WhenNoMasterSchema_DoesNotCacheFailure()
+    {
+        var instance = CreateInstance();
+        var workflow = BuildWorkflow(withMasterSchema: false);
+        SetupCommonMocks(instance, workflow);
+        EnableCache();
+        SetupFingerprint(instance.Id);
+
+        var result = await _service.GetMasterAsync(CreateInput(instance.Id.ToString()), CancellationToken.None);
+
+        result.Result.IsSuccess.ShouldBeFalse();
+        await _instanceSchemaFunctionCache.DidNotReceive()
+            .SetAsync(Arg.Any<string>(), Arg.Any<Caching.SchemaFunctionCacheEntry>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
 
     private static Instance CreateInstance()
     {

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceMasterTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceMasterTests.cs
@@ -90,6 +90,7 @@ public class InstanceQueryAppServiceMasterTests : IDisposable
             paginationLinkGenerator: Substitute.For<BBT.Aether.Application.Pagination.IPaginationLinkGenerator>(),
             instanceFilteringOptions: Options.Create(new InstanceFilteringOptions()),
             stateFunctionCache: Substitute.For<Caching.IStateFunctionCache>(),
+            dataFunctionCache: Substitute.For<Caching.IDataFunctionCache>(),
             logger: Substitute.For<ILogger<InstanceQueryAppService>>());
     }
 

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceSchemaCacheTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceSchemaCacheTests.cs
@@ -1,0 +1,304 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.DependencyInjection;
+using BBT.Aether.Results;
+using BBT.Aether.MultiSchema;
+using BBT.Aether.Users;
+using BBT.Aether.Uow;
+using BBT.Workflow.Authorization;
+using BBT.Workflow.Caching;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Definitions.Schemas;
+using BBT.Workflow.Gateway;
+using BBT.Workflow.Instances.DTOs;
+using BBT.Workflow.RepresentationEtag;
+using BBT.Workflow.Runtime;
+using BBT.Workflow.Scripting;
+using BBT.Workflow.Tasks.Coordinator;
+using BBT.Workflow.Extentions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Instances;
+
+/// <summary>
+/// Unit tests for the schema-function fingerprint-ETag fast path and cache flow in
+/// <see cref="InstanceQueryAppService.GetSchemaAsync"/>: 304 from the projection alone,
+/// cached 200 without aggregate load, transition-key scoping, subflow bypass, and
+/// no caching of failure outcomes.
+/// </summary>
+public class InstanceQueryAppServiceSchemaCacheTests : IDisposable
+{
+    private readonly IRuntimeInfoProvider _runtimeInfoProvider;
+    private readonly IComponentCacheStore _componentCacheStore;
+    private readonly IInstanceRepository _instanceRepository;
+    private readonly ITransitionAuthorizationManager _transitionAuthorizationManager;
+    private readonly Caching.IInstanceSchemaFunctionCache _instanceSchemaFunctionCache;
+    private readonly InstanceQueryAppService _service;
+    private readonly IServiceProvider _ambientServiceProvider;
+    private readonly IServiceProvider? _previousAmbientServiceProvider;
+
+    private const string TestDomain = "test-domain";
+    private const string TestWorkflow = "test-flow";
+    private const string TestVersion = "1.0.0";
+    private const string TestState = "review";
+    private const string TestTransition = "approve";
+    private const string TestCacheKey = "schema-fn:test-domain:test-flow:key-under-test:approve";
+
+    public InstanceQueryAppServiceSchemaCacheTests()
+    {
+        _runtimeInfoProvider = Substitute.For<IRuntimeInfoProvider>();
+        _componentCacheStore = Substitute.For<IComponentCacheStore>();
+        _instanceRepository = Substitute.For<IInstanceRepository>();
+        _transitionAuthorizationManager = Substitute.For<ITransitionAuthorizationManager>();
+        _instanceSchemaFunctionCache = Substitute.For<Caching.IInstanceSchemaFunctionCache>();
+
+        var mockUoW = Substitute.For<IUnitOfWork>();
+        var mockUoWManager = Substitute.For<IUnitOfWorkManager>();
+        mockUoWManager
+            .BeginAsync(Arg.Any<UnitOfWorkOptions>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(mockUoW));
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(mockUoWManager);
+        _ambientServiceProvider = services.BuildServiceProvider();
+
+        _previousAmbientServiceProvider = AmbientServiceProvider.Current;
+        AmbientServiceProvider.Current = _ambientServiceProvider;
+
+        _transitionAuthorizationManager
+            .IsQueryAllowedAsync(
+                Arg.Any<Definitions.Workflow>(),
+                Arg.Any<Instance>(),
+                Arg.Any<IReadOnlyCollection<string>?>(),
+                Arg.Any<AuthorizationRequestContext?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        _service = new InstanceQueryAppService(
+            serviceProvider: _ambientServiceProvider,
+            runtimeInfoProvider: _runtimeInfoProvider,
+            componentCacheStore: _componentCacheStore,
+            instanceRepository: _instanceRepository,
+            instanceTransitionRepository: Substitute.For<IInstanceTransitionRepository>(),
+            instanceCorrelationRepository: Substitute.For<IInstanceCorrelationRepository>(),
+            instanceExtensionService: Substitute.For<IInstanceExtensionService>(),
+            scriptContextFactory: Substitute.For<IScriptContextFactory>(),
+            instanceQueryGateway: Substitute.For<IInstanceQueryGateway>(),
+            viewContentResolutionService: Substitute.For<IViewContentResolutionService>(),
+            taskConditionService: Substitute.For<ITaskConditionService>(),
+            urlTemplateBuilder: Substitute.For<IUrlTemplateBuilder>(),
+            currentSchema: Substitute.For<ICurrentSchema>(),
+            transitionAuthorizationManager: _transitionAuthorizationManager,
+            representationEtagService: Substitute.For<IRepresentationEtagService>(),
+            schemaFieldFilterService: Substitute.For<ISchemaFieldFilterService>(),
+            currentUser: Substitute.For<ICurrentUser>(),
+            paginationLinkGenerator: Substitute.For<BBT.Aether.Application.Pagination.IPaginationLinkGenerator>(),
+            instanceFilteringOptions: Options.Create(new InstanceFilteringOptions()),
+            stateFunctionCache: Substitute.For<Caching.IStateFunctionCache>(),
+            dataFunctionCache: Substitute.For<Caching.IDataFunctionCache>(),
+            instanceSchemaFunctionCache: _instanceSchemaFunctionCache,
+            logger: Substitute.For<ILogger<InstanceQueryAppService>>());
+    }
+
+    public void Dispose()
+    {
+        AmbientServiceProvider.Current = _previousAmbientServiceProvider;
+        (_ambientServiceProvider as IDisposable)?.Dispose();
+    }
+
+    [Fact]
+    public async Task GetSchemaAsync_WhenCacheDisabled_DoesNotTouchCacheOrFingerprint()
+    {
+        var (instance, workflow) = CreateInstanceWithTransitionSchema();
+        SetupFullPathMocks(instance, workflow);
+
+        var result = await _service.GetSchemaAsync(CreateInput(instance.Id.ToString()), TestTransition, CancellationToken.None);
+
+        result.Result.IsSuccess.ShouldBeTrue();
+        _instanceSchemaFunctionCache.DidNotReceive().BuildKey(Arg.Any<GetSchemaInput>(), Arg.Any<string>());
+        await _instanceRepository.DidNotReceive()
+            .GetDataFingerprintAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetSchemaAsync_WhenIfNoneMatchMatchesFingerprintEtag_Returns304WithoutBuild()
+    {
+        var instanceId = Guid.NewGuid();
+        EnableCache();
+        SetupFingerprint(instanceId);
+
+        var input = CreateInput(instanceId.ToString());
+        input.IfNoneMatch = "\"etag-current\"";
+
+        var result = await _service.GetSchemaAsync(input, TestTransition, CancellationToken.None);
+
+        result.IsNotModified.ShouldBeTrue();
+        await _instanceSchemaFunctionCache.DidNotReceive().GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _instanceRepository.DidNotReceive()
+            .FindByIdentifierAsReadOnlyAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetSchemaAsync_WhenCachedEtagMatchesCurrent_ServesFromCacheWithoutAggregateLoad()
+    {
+        var instanceId = Guid.NewGuid();
+        EnableCache();
+        SetupFingerprint(instanceId);
+        _instanceSchemaFunctionCache.GetAsync(TestCacheKey, Arg.Any<CancellationToken>())
+            .Returns(new Caching.SchemaFunctionCacheEntry
+            {
+                Etag = "etag-current",
+                Output = new GetSchemaOutput { Key = "approve-schema", Type = "JSON" }
+            });
+
+        var result = await _service.GetSchemaAsync(CreateInput(instanceId.ToString()), TestTransition, CancellationToken.None);
+
+        result.Result.IsSuccess.ShouldBeTrue();
+        result.Result.Value!.Key.ShouldBe("approve-schema");
+        result.Result.Value!.ETag.ShouldBe("\"etag-current\"");
+        await _instanceRepository.DidNotReceive()
+            .FindByIdentifierAsReadOnlyAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetSchemaAsync_WhenCacheMiss_BuildsAndWarmsCache()
+    {
+        var (instance, workflow) = CreateInstanceWithTransitionSchema();
+        SetupFullPathMocks(instance, workflow);
+        EnableCache();
+        SetupFingerprint(instance.Id);
+
+        var result = await _service.GetSchemaAsync(CreateInput(instance.Id.ToString()), TestTransition, CancellationToken.None);
+
+        result.Result.IsSuccess.ShouldBeTrue();
+        result.Result.Value!.ETag.ShouldBe("\"etag-current\"");
+        await _instanceSchemaFunctionCache.Received(1).SetAsync(
+            TestCacheKey,
+            Arg.Is<Caching.SchemaFunctionCacheEntry>(e => e.Etag == "etag-current"),
+            Arg.Any<int>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetSchemaAsync_WhenFingerprintHasActiveSubFlow_BypassesFastPath()
+    {
+        var (instance, workflow) = CreateInstanceWithTransitionSchema();
+        SetupFullPathMocks(instance, workflow);
+        EnableCache();
+        SetupFingerprint(instance.Id, hasActiveSubFlow: true);
+
+        var result = await _service.GetSchemaAsync(CreateInput(instance.Id.ToString()), TestTransition, CancellationToken.None);
+
+        // Instance itself has no active subflow in this arrangement, so the full path resolves
+        // locally — the point is the fast path never consulted the cache.
+        result.Result.IsSuccess.ShouldBeTrue();
+        await _instanceSchemaFunctionCache.DidNotReceive().GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetSchemaAsync_WhenTransitionKeyMissing_FailsWithoutCaching()
+    {
+        var (instance, workflow) = CreateInstanceWithTransitionSchema();
+        SetupFullPathMocks(instance, workflow);
+        EnableCache();
+        SetupFingerprint(instance.Id);
+
+        var result = await _service.GetSchemaAsync(CreateInput(instance.Id.ToString()), transitionKey: null, CancellationToken.None);
+
+        result.Result.IsSuccess.ShouldBeFalse();
+        _instanceSchemaFunctionCache.DidNotReceive().BuildKey(Arg.Any<GetSchemaInput>(), Arg.Any<string>());
+        await _instanceSchemaFunctionCache.DidNotReceive()
+            .SetAsync(Arg.Any<string>(), Arg.Any<Caching.SchemaFunctionCacheEntry>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetSchemaAsync_WhenTransitionHasNoSchema_DoesNotCacheFailure()
+    {
+        var (instance, workflow) = CreateInstanceWithTransitionSchema(withSchemaRef: false);
+        SetupFullPathMocks(instance, workflow);
+        EnableCache();
+        SetupFingerprint(instance.Id);
+
+        var result = await _service.GetSchemaAsync(CreateInput(instance.Id.ToString()), TestTransition, CancellationToken.None);
+
+        result.Result.IsSuccess.ShouldBeFalse();
+        await _instanceSchemaFunctionCache.DidNotReceive()
+            .SetAsync(Arg.Any<string>(), Arg.Any<Caching.SchemaFunctionCacheEntry>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private void EnableCache()
+    {
+        _instanceSchemaFunctionCache.Enabled.Returns(true);
+        _instanceSchemaFunctionCache.BuildKey(Arg.Any<GetSchemaInput>(), Arg.Any<string>()).Returns(TestCacheKey);
+        _instanceSchemaFunctionCache
+            .ComputeEtag(Arg.Any<GetSchemaInput>(), Arg.Any<InstanceDataFingerprint>(), Arg.Any<string>())
+            .Returns("etag-current");
+    }
+
+    private void SetupFingerprint(Guid instanceId, bool hasActiveSubFlow = false) =>
+        _instanceRepository
+            .GetDataFingerprintAsync(instanceId.ToString(), Arg.Any<CancellationToken>())
+            .Returns(new InstanceDataFingerprint(instanceId, "test-key",
+                "01JD2G4YV0EXAMPLEULID0000A", TestVersion, TestState, hasActiveSubFlow));
+
+    private static (Instance instance, Definitions.Workflow workflow) CreateInstanceWithTransitionSchema(
+        bool withSchemaRef = true)
+    {
+        var instance = Instance.Create(Guid.NewGuid(), TestWorkflow, TestVersion, "test-key");
+        var state = State.Create(TestState, StateType.Intermediate, StateSubType.None,
+            VersionStrategy.IncreaseMinor.Code);
+        var transition = Transition.Create(TestTransition, TestState, "approved", TriggerType.Manual,
+            VersionStrategy.IncreasePatch.Code);
+        if (withSchemaRef)
+            transition.SetSchema(new Reference("approve-schema", TestDomain, "sys-schemas", TestVersion));
+        state.AddTransition(transition);
+        instance.ChangeState(state);
+
+        var workflow = Definitions.Workflow.Create();
+        workflow.SetReference(new Reference(TestWorkflow, TestDomain, "sys-flows", TestVersion));
+        workflow.SetType("F");
+        workflow.SetStartTransition(Transition.Create("start", null, TestState, TriggerType.Manual,
+            VersionStrategy.IncreasePatch.Code));
+        workflow.AddState(state);
+        return (instance, workflow);
+    }
+
+    private void SetupFullPathMocks(Instance instance, Definitions.Workflow workflow)
+    {
+        _instanceRepository
+            .FindByIdentifierAsReadOnlyAsync(instance.Id.ToString(), Arg.Any<CancellationToken>())
+            .Returns(instance);
+
+        _componentCacheStore
+            .GetFlowAsync(TestDomain, TestWorkflow, Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(Result<Definitions.Workflow>.Ok(workflow));
+
+        _componentCacheStore
+            .GetSchemaAsync(TestDomain, "approve-schema", Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(Result<SchemaDefinition>.Ok(SchemaFromJson()));
+    }
+
+    private static SchemaDefinition SchemaFromJson() =>
+        System.Text.Json.JsonSerializer.Deserialize<SchemaDefinition>("""
+            { "key": "approve-schema", "type": "JSON", "schema": { "type": "object" } }
+            """, new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
+
+    private static GetSchemaInput CreateInput(string instanceId) => new()
+    {
+        Domain = TestDomain,
+        Workflow = TestWorkflow,
+        Instance = instanceId,
+        Headers = new Dictionary<string, string?>(),
+        QueryParameters = new Dictionary<string, string?>()
+    };
+}

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceStateTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceStateTests.cs
@@ -44,6 +44,7 @@ public class InstanceQueryAppServiceStateTests : IDisposable
     private readonly IUrlTemplateBuilder _urlTemplateBuilder;
     private readonly IViewContentResolutionService _viewContentResolutionService;
     private readonly ITransitionAuthorizationManager _transitionAuthorizationManager;
+    private readonly Caching.IStateFunctionCache _stateFunctionCache;
     private readonly InstanceQueryAppService _service;
     private readonly IServiceProvider _ambientServiceProvider;
     private readonly IServiceProvider? _previousAmbientServiceProvider;
@@ -63,6 +64,9 @@ public class InstanceQueryAppServiceStateTests : IDisposable
         _urlTemplateBuilder = Substitute.For<IUrlTemplateBuilder>();
         _viewContentResolutionService = Substitute.For<IViewContentResolutionService>();
         _transitionAuthorizationManager = Substitute.For<ITransitionAuthorizationManager>();
+        // Enabled defaults to false so existing tests exercise the full build path;
+        // cache-specific tests opt in explicitly.
+        _stateFunctionCache = Substitute.For<Caching.IStateFunctionCache>();
 
         // Set up AmbientServiceProvider.Current needed by PostSharp UnitOfWorkAttribute
         var mockUoW = Substitute.For<IUnitOfWork>();
@@ -98,6 +102,7 @@ public class InstanceQueryAppServiceStateTests : IDisposable
             currentUser: Substitute.For<ICurrentUser>(),
             paginationLinkGenerator: Substitute.For<BBT.Aether.Application.Pagination.IPaginationLinkGenerator>(),
             instanceFilteringOptions: Options.Create(new InstanceFilteringOptions()),
+            stateFunctionCache: _stateFunctionCache,
             logger: Substitute.For<ILogger<InstanceQueryAppService>>());
     }
 
@@ -905,7 +910,236 @@ public class InstanceQueryAppServiceStateTests : IDisposable
         result.Result.Value!.Master.Href.ShouldBe("https://master-url");
     }
 
-    // ── Helpers ──────────────────────────────────────────────────────────────
+    // ── State Function Cache ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// When the cache is disabled (default), neither the fingerprint query nor the cache runs;
+    /// the full build path answers.
+    /// </summary>
+    [Fact]
+    public async Task GetInstanceStateAsync_WhenCacheDisabled_DoesNotTouchCacheOrFingerprint()
+    {
+        // Arrange — _stateFunctionCache.Enabled defaults to false
+        var (instance, workflow) = CreateSimpleActiveInstance();
+        SetupCommonMocks(instance, workflow);
+
+        // Act
+        var result = await _service.GetInstanceStateAsync(CreateInput(instance.Id.ToString()), CancellationToken.None);
+
+        // Assert
+        result.Result.IsSuccess.ShouldBeTrue();
+        _stateFunctionCache.DidNotReceive().BuildKey(Arg.Any<GetInstanceStateInput>());
+        await _stateFunctionCache.DidNotReceive().GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _stateFunctionCache.DidNotReceive()
+            .SetAsync(Arg.Any<string>(), Arg.Any<Caching.StateFunctionCacheEntry>(), Arg.Any<CancellationToken>());
+        await _instanceRepository.DidNotReceive()
+            .GetStateFingerprintAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// A matching If-None-Match is answered with 304 straight from the fingerprint projection:
+    /// no cache access, no aggregate load, no response build — even with an empty cache.
+    /// </summary>
+    [Fact]
+    public async Task GetInstanceStateAsync_WhenIfNoneMatchMatchesFingerprintEtag_Returns304WithoutCacheOrBuild()
+    {
+        // Arrange
+        var instanceId = Guid.NewGuid();
+        EnableCache();
+        SetupFingerprint(instanceId);
+
+        var input = CreateInput(instanceId.ToString());
+        input.IfNoneMatch = "\"etag-current\"";
+
+        // Act
+        var result = await _service.GetInstanceStateAsync(input, CancellationToken.None);
+
+        // Assert
+        result.IsNotModified.ShouldBeTrue();
+        await _stateFunctionCache.DidNotReceive().GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _instanceRepository.DidNotReceive()
+            .FindByIdentifierAsReadOnlyAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Without a current If-None-Match, a cache entry carrying the current fingerprint ETag
+    /// serves the cached response without loading the aggregate.
+    /// </summary>
+    [Fact]
+    public async Task GetInstanceStateAsync_WhenCachedEtagMatchesCurrent_ServesFromCacheWithoutAggregateLoad()
+    {
+        // Arrange
+        var instanceId = Guid.NewGuid();
+        EnableCache();
+        SetupFingerprint(instanceId);
+        SetupCachedEntry(out var entry);
+
+        // Act
+        var result = await _service.GetInstanceStateAsync(CreateInput(instanceId.ToString()), CancellationToken.None);
+
+        // Assert — cached output served, aggregate never loaded
+        result.IsNotModified.ShouldBeFalse();
+        result.Result.IsSuccess.ShouldBeTrue();
+        result.Result.Value!.State.ShouldBe(entry.Output.State);
+        result.Result.Value!.ETag.ShouldBe("\"etag-current\"");
+        result.Result.Value!.EntityEtag.ShouldBe("\"entity-1\"");
+        await _instanceRepository.DidNotReceive()
+            .FindByIdentifierAsReadOnlyAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// A cache miss runs the full build path and warms the cache under the same fingerprint ETag
+    /// the fast path computes.
+    /// </summary>
+    [Fact]
+    public async Task GetInstanceStateAsync_WhenCacheMiss_BuildsAndWarmsCacheWithFingerprintEtag()
+    {
+        // Arrange
+        var (instance, workflow) = CreateSimpleActiveInstance();
+        SetupCommonMocks(instance, workflow);
+        EnableCache();
+        SetupFingerprint(instance.Id);
+
+        // Act
+        var result = await _service.GetInstanceStateAsync(CreateInput(instance.Id.ToString()), CancellationToken.None);
+
+        // Assert — response built normally and stored under the deterministic ETag
+        result.Result.IsSuccess.ShouldBeTrue();
+        result.Result.Value!.ETag.ShouldBe("\"etag-current\"");
+        await _stateFunctionCache.Received(1).SetAsync(
+            TestCacheKey,
+            Arg.Is<Caching.StateFunctionCacheEntry>(e => e.Etag == "etag-current"),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// A stale cache entry (its ETag no longer matches the fingerprint ETag — state, status,
+    /// version, or resolved row changed) forces a rebuild and refreshes the cache.
+    /// </summary>
+    [Fact]
+    public async Task GetInstanceStateAsync_WhenCachedEtagIsStale_RebuildsAndRefreshesCache()
+    {
+        // Arrange — entry was built under an older fingerprint
+        var (instance, workflow) = CreateSimpleActiveInstance();
+        SetupCommonMocks(instance, workflow);
+        EnableCache();
+        SetupFingerprint(instance.Id);
+        SetupCachedEntry(out _, etag: "etag-old");
+
+        // Act
+        var result = await _service.GetInstanceStateAsync(CreateInput(instance.Id.ToString()), CancellationToken.None);
+
+        // Assert — full rebuild + cache refresh under the current ETag
+        result.Result.IsSuccess.ShouldBeTrue();
+        await _instanceRepository.Received(1)
+            .FindByIdentifierAsReadOnlyAsync(instance.Id.ToString(), Arg.Any<CancellationToken>());
+        await _stateFunctionCache.Received(1).SetAsync(
+            TestCacheKey,
+            Arg.Is<Caching.StateFunctionCacheEntry>(e => e.Etag == "etag-current"),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// When the fingerprint reports an active SubFlow, both the 304 fast path and the cache are
+    /// bypassed (live evaluation required) and nothing is written back.
+    /// </summary>
+    [Fact]
+    public async Task GetInstanceStateAsync_WhenFingerprintHasActiveSubFlow_BypassesCache()
+    {
+        // Arrange
+        var (instance, workflow) = CreateParentWithActiveSubFlow();
+        SetupCommonMocks(instance, workflow);
+        SetupSubFlowGateway(InstanceStatus.Active, "sub-review");
+        EnableCache();
+        _instanceRepository
+            .GetStateFingerprintAsync(instance.Id.ToString(), Arg.Any<CancellationToken>())
+            .Returns(new InstanceStateFingerprint(instance.Id, "test-key", TestState, InstanceStatus.Busy,
+                TestVersion, HasActiveSubFlow: true));
+
+        // Act
+        var result = await _service.GetInstanceStateAsync(CreateInput(instance.Id.ToString()), CancellationToken.None);
+
+        // Assert — served live from the subflow gateway with the subflow ETag variant, never cached
+        result.Result.IsSuccess.ShouldBeTrue();
+        result.Result.Value!.State.ShouldBe("sub-review");
+        result.Result.Value!.ETag.ShouldBe("\"etag-subflow\"");
+        await _stateFunctionCache.DidNotReceive().GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _stateFunctionCache.DidNotReceive()
+            .SetAsync(Arg.Any<string>(), Arg.Any<Caching.StateFunctionCacheEntry>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// When the fingerprint query finds no instance, the full path runs and produces its own outcome.
+    /// </summary>
+    [Fact]
+    public async Task GetInstanceStateAsync_WhenFingerprintNotFound_FallsThroughToFullPath()
+    {
+        // Arrange
+        var (instance, workflow) = CreateSimpleActiveInstance();
+        SetupCommonMocks(instance, workflow);
+        EnableCache();
+        _instanceRepository
+            .GetStateFingerprintAsync(instance.Id.ToString(), Arg.Any<CancellationToken>())
+            .Returns((InstanceStateFingerprint?)null);
+
+        // Act
+        var result = await _service.GetInstanceStateAsync(CreateInput(instance.Id.ToString()), CancellationToken.None);
+
+        // Assert — the full path answered (here: success, since the aggregate is mocked)
+        result.Result.IsSuccess.ShouldBeTrue();
+        await _instanceRepository.Received(1)
+            .FindByIdentifierAsReadOnlyAsync(instance.Id.ToString(), Arg.Any<CancellationToken>());
+    }
+
+    // ── Cache helpers ────────────────────────────────────────────────────────
+
+    private const string TestCacheKey = "state-fn:test-domain:test-flow:key-under-test";
+
+    private void EnableCache()
+    {
+        _stateFunctionCache.Enabled.Returns(true);
+        _stateFunctionCache.BuildKey(Arg.Any<GetInstanceStateInput>()).Returns(TestCacheKey);
+        _stateFunctionCache
+            .ComputeEtag(Arg.Any<GetInstanceStateInput>(), Arg.Any<InstanceStateFingerprint>())
+            .Returns("etag-current");
+        _stateFunctionCache
+            .ComputeEtag(Arg.Any<GetInstanceStateInput>(), Arg.Any<InstanceStateFingerprint>(),
+                Arg.Any<GetInstanceStateOutput>())
+            .Returns("etag-subflow");
+    }
+
+    private void SetupFingerprint(Guid instanceId) =>
+        _instanceRepository
+            .GetStateFingerprintAsync(instanceId.ToString(), Arg.Any<CancellationToken>())
+            .Returns(new InstanceStateFingerprint(instanceId, "test-key", TestState, InstanceStatus.Active,
+                TestVersion, HasActiveSubFlow: false));
+
+    private void SetupCachedEntry(out Caching.StateFunctionCacheEntry entry, string etag = "etag-current")
+    {
+        entry = new Caching.StateFunctionCacheEntry
+        {
+            Etag = etag,
+            EntityEtag = "entity-1",
+            Output = new GetInstanceStateOutput
+            {
+                State = TestState,
+                Status = InstanceStatus.Active,
+                Transitions = [],
+                ActiveCorrelations = []
+            }
+        };
+        _stateFunctionCache.GetAsync(TestCacheKey, Arg.Any<CancellationToken>()).Returns(entry);
+    }
+
+    private (Instance instance, Definitions.Workflow workflow) CreateSimpleActiveInstance()
+    {
+        var instance = Instance.Create(Guid.NewGuid(), TestWorkflow, TestVersion, "test-key");
+        var state = State.Create(TestState, StateType.Intermediate, StateSubType.None,
+            VersionStrategy.IncreaseMinor.Code);
+        instance.ChangeState(state);
+        var workflow = BuildWorkflow(state);
+        return (instance, workflow);
+    }
 
     private void DenyQueryRoles() =>
         _transitionAuthorizationManager

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceStateTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceStateTests.cs
@@ -104,6 +104,7 @@ public class InstanceQueryAppServiceStateTests : IDisposable
             instanceFilteringOptions: Options.Create(new InstanceFilteringOptions()),
             stateFunctionCache: _stateFunctionCache,
             dataFunctionCache: Substitute.For<Caching.IDataFunctionCache>(),
+            instanceSchemaFunctionCache: Substitute.For<Caching.IInstanceSchemaFunctionCache>(),
             logger: Substitute.For<ILogger<InstanceQueryAppService>>());
     }
 
@@ -884,8 +885,8 @@ public class InstanceQueryAppServiceStateTests : IDisposable
         }, transitionKey: "approve", CancellationToken.None);
 
         // Assert
-        result.IsSuccess.ShouldBeFalse();
-        result.Error.Code.ShouldBe(WorkflowErrorCodes.AuthorizationRoleDenied);
+        result.Result.IsSuccess.ShouldBeFalse();
+        result.Result.Error.Code.ShouldBe(WorkflowErrorCodes.AuthorizationRoleDenied);
     }
 
     [Fact]

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceStateTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceStateTests.cs
@@ -103,6 +103,7 @@ public class InstanceQueryAppServiceStateTests : IDisposable
             paginationLinkGenerator: Substitute.For<BBT.Aether.Application.Pagination.IPaginationLinkGenerator>(),
             instanceFilteringOptions: Options.Create(new InstanceFilteringOptions()),
             stateFunctionCache: _stateFunctionCache,
+            dataFunctionCache: Substitute.For<Caching.IDataFunctionCache>(),
             logger: Substitute.For<ILogger<InstanceQueryAppService>>());
     }
 

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceVersionTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceVersionTests.cs
@@ -118,6 +118,7 @@ public class InstanceQueryAppServiceVersionTests : IDisposable
             paginationLinkGenerator: Substitute.For<BBT.Aether.Application.Pagination.IPaginationLinkGenerator>(),
             instanceFilteringOptions: Options.Create(new InstanceFilteringOptions()),
             stateFunctionCache: Substitute.For<Caching.IStateFunctionCache>(),
+            dataFunctionCache: Substitute.For<Caching.IDataFunctionCache>(),
             logger: Substitute.For<ILogger<InstanceQueryAppService>>());
     }
 

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceVersionTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceVersionTests.cs
@@ -119,6 +119,7 @@ public class InstanceQueryAppServiceVersionTests : IDisposable
             instanceFilteringOptions: Options.Create(new InstanceFilteringOptions()),
             stateFunctionCache: Substitute.For<Caching.IStateFunctionCache>(),
             dataFunctionCache: Substitute.For<Caching.IDataFunctionCache>(),
+            instanceSchemaFunctionCache: Substitute.For<Caching.IInstanceSchemaFunctionCache>(),
             logger: Substitute.For<ILogger<InstanceQueryAppService>>());
     }
 

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceVersionTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceVersionTests.cs
@@ -117,6 +117,7 @@ public class InstanceQueryAppServiceVersionTests : IDisposable
             currentUser: Substitute.For<ICurrentUser>(),
             paginationLinkGenerator: Substitute.For<BBT.Aether.Application.Pagination.IPaginationLinkGenerator>(),
             instanceFilteringOptions: Options.Create(new InstanceFilteringOptions()),
+            stateFunctionCache: Substitute.For<Caching.IStateFunctionCache>(),
             logger: Substitute.For<ILogger<InstanceQueryAppService>>());
     }
 

--- a/test/BBT.Workflow.Infrastructure.Tests/Domains/Instances/InstanceDataFingerprintQueryTests.cs
+++ b/test/BBT.Workflow.Infrastructure.Tests/Domains/Instances/InstanceDataFingerprintQueryTests.cs
@@ -45,9 +45,10 @@ public sealed class InstanceDataFingerprintQueryTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task ById_ProjectsLatestDataEtagAndFlowVersion()
+    public async Task ById_ProjectsLatestDataEtagFlowVersionAndEffectiveState()
     {
         var instance = Instance.Create(Guid.NewGuid(), Flow, FlowVersion, "dfp-by-id");
+        instance.SetEffectiveState("review");
         await SeedAsync(instance);
         var latestEtag = await SeedDataRowAsync(instance.Id, version: "1.0.1", isLatest: true);
         await SeedDataRowAsync(instance.Id, version: "1.0.0", isLatest: false);
@@ -60,6 +61,30 @@ public sealed class InstanceDataFingerprintQueryTests : IAsyncLifetime
         fingerprint.Key.ShouldBe("dfp-by-id");
         fingerprint.LatestDataEtag.ShouldBe(latestEtag);
         fingerprint.FlowVersion.ShouldBe(FlowVersion);
+        fingerprint.EffectiveState.ShouldBe("review");
+        fingerprint.HasActiveSubFlow.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task WithActiveSubFlowCorrelation_SetsHasActiveSubFlow()
+    {
+        var instance = Instance.Create(Guid.NewGuid(), Flow, FlowVersion, "dfp-subflow");
+        instance.AddCorrelation(InstanceCorrelation.Create(
+            id: Guid.NewGuid(),
+            instanceId: instance.Id,
+            parentState: "review",
+            subFlowInstanceId: Guid.NewGuid(),
+            subFlowType: "S",
+            subFlowDomain: "sub-domain",
+            subFlowName: "sub-flow",
+            subFlowVersion: "1.0.0"));
+        await SeedAsync(instance);
+
+        await using var ctx = CreateContext();
+        var fingerprint = await QueryAsync(ctx, instance.Id.ToString());
+
+        fingerprint.ShouldNotBeNull();
+        fingerprint!.HasActiveSubFlow.ShouldBeTrue();
     }
 
     [Fact]

--- a/test/BBT.Workflow.Infrastructure.Tests/Domains/Instances/InstanceDataFingerprintQueryTests.cs
+++ b/test/BBT.Workflow.Infrastructure.Tests/Domains/Instances/InstanceDataFingerprintQueryTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.MultiSchema;
+using BBT.Workflow.Data;
+using BBT.Workflow.Instances;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Testcontainers.PostgreSql;
+using Xunit;
+
+namespace BBT.Workflow.Domains.Instances;
+
+/// <summary>
+/// Integration tests for the data-function fingerprint projection
+/// (<see cref="EfCoreInstanceRepository.QueryDataFingerprintAsync"/>) against a real PostgreSQL:
+/// verifies the latest-data ETag subquery (IsLatest row only, index-backed), id-then-key
+/// identifier resolution, and null semantics for data-less instances.
+/// </summary>
+public sealed class InstanceDataFingerprintQueryTests : IAsyncLifetime
+{
+    private const string Flow = "data-fingerprint-test-flow";
+    private const string FlowVersion = "2.0.0";
+
+    private PostgreSqlContainer _postgres = null!;
+    private string _connectionString = null!;
+
+    async Task IAsyncLifetime.InitializeAsync()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:16-alpine")
+            .WithDatabase("testdb").WithUsername("test").WithPassword("test")
+            .Build();
+        await _postgres.StartAsync();
+        _connectionString = _postgres.GetConnectionString();
+
+        await using var ctx = CreateContext();
+        await ctx.Database.EnsureCreatedAsync();
+    }
+
+    async Task IAsyncLifetime.DisposeAsync()
+    {
+        await _postgres.StopAsync();
+        await _postgres.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task ById_ProjectsLatestDataEtagAndFlowVersion()
+    {
+        var instance = Instance.Create(Guid.NewGuid(), Flow, FlowVersion, "dfp-by-id");
+        await SeedAsync(instance);
+        var latestEtag = await SeedDataRowAsync(instance.Id, version: "1.0.1", isLatest: true);
+        await SeedDataRowAsync(instance.Id, version: "1.0.0", isLatest: false);
+
+        await using var ctx = CreateContext();
+        var fingerprint = await QueryAsync(ctx, instance.Id.ToString());
+
+        fingerprint.ShouldNotBeNull();
+        fingerprint!.Id.ShouldBe(instance.Id);
+        fingerprint.Key.ShouldBe("dfp-by-id");
+        fingerprint.LatestDataEtag.ShouldBe(latestEtag);
+        fingerprint.FlowVersion.ShouldBe(FlowVersion);
+    }
+
+    [Fact]
+    public async Task ByKey_ReturnsMostRecentRow()
+    {
+        var older = Instance.Create(Guid.NewGuid(), Flow, FlowVersion, "dfp-dup-key");
+        await SeedAsync(older, createdAt: new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        await SeedDataRowAsync(older.Id, version: "1.0.0", isLatest: true);
+
+        var newer = Instance.Create(Guid.NewGuid(), Flow, FlowVersion, "dfp-dup-key");
+        await SeedAsync(newer, createdAt: new DateTime(2026, 1, 2, 0, 0, 0, DateTimeKind.Utc));
+        var newerEtag = await SeedDataRowAsync(newer.Id, version: "1.0.0", isLatest: true);
+
+        await using var ctx = CreateContext();
+        var fingerprint = await QueryAsync(ctx, "dfp-dup-key");
+
+        fingerprint.ShouldNotBeNull();
+        fingerprint!.Id.ShouldBe(newer.Id);
+        fingerprint.LatestDataEtag.ShouldBe(newerEtag);
+    }
+
+    [Fact]
+    public async Task WithoutDataRows_LatestDataEtagIsNull()
+    {
+        var instance = Instance.Create(Guid.NewGuid(), Flow, FlowVersion, "dfp-no-data");
+        await SeedAsync(instance);
+
+        await using var ctx = CreateContext();
+        var fingerprint = await QueryAsync(ctx, instance.Id.ToString());
+
+        fingerprint.ShouldNotBeNull();
+        fingerprint!.LatestDataEtag.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task UnknownIdentifier_ReturnsNull()
+    {
+        await using var ctx = CreateContext();
+
+        (await QueryAsync(ctx, Guid.NewGuid().ToString())).ShouldBeNull();
+        (await QueryAsync(ctx, "dfp-no-such-key")).ShouldBeNull();
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static Task<InstanceDataFingerprint?> QueryAsync(WorkflowDbContext ctx, string identifier) =>
+        EfCoreInstanceRepository.QueryDataFingerprintAsync(
+            ctx.Instances.AsNoTracking(), identifier, CancellationToken.None);
+
+    private async Task SeedAsync(Instance instance, DateTime? createdAt = null)
+    {
+        await using var ctx = CreateContext();
+        ctx.Instances.Add(instance);
+        await ctx.SaveChangesAsync();
+
+        if (createdAt is not null)
+        {
+            // CreatedAt is audit-stamped on save; pin it afterwards so duplicate-key
+            // ordering assertions are deterministic.
+            await ctx.Database.ExecuteSqlRawAsync(
+                "UPDATE \"public\".\"Instances\" SET \"CreatedAt\" = {0} WHERE \"Id\" = {1}",
+                createdAt.Value, instance.Id);
+        }
+    }
+
+    /// <summary>
+    /// Inserts an InstancesData row via raw SQL (bypasses the domain aggregate and the
+    /// production versioning trigger, which EnsureCreated does not install) so IsLatest can
+    /// be controlled explicitly per row. Returns the row's ETag.
+    /// </summary>
+    private async Task<string> SeedDataRowAsync(Guid instanceId, string version, bool isLatest)
+    {
+        var etag = Ulid.NewUlid().ToString();
+        await using var ctx = CreateContext();
+        // Data passed as a parameter — a literal '{}' would be misread as a {n} placeholder
+        // by the raw-SQL builder (see InstanceFilterQueryTests.SeedAsync).
+        await ctx.Database.ExecuteSqlRawAsync(
+            "INSERT INTO \"public\".\"InstancesData\" " +
+            "(\"Id\",\"InstanceId\",\"Version\",\"HistorySequence\",\"ETag\",\"DataHash\",\"Data\",\"EnteredAt\",\"VersionNo\",\"IsLatest\") " +
+            "VALUES ({0},{1},{2},0,{3},'hash',{4}::jsonb,{5},{6},{7})",
+            Guid.NewGuid(), instanceId, version, etag, "{}", DateTime.UtcNow, isLatest ? 2 : 1, isLatest);
+        return etag;
+    }
+
+    private WorkflowDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<WorkflowDbContext>()
+            .UseNpgsql(_connectionString)
+            .Options;
+        return new WorkflowDbContext(options, new StaticCurrentSchema("public"));
+    }
+}

--- a/test/BBT.Workflow.Infrastructure.Tests/Domains/Instances/InstanceStateFingerprintQueryTests.cs
+++ b/test/BBT.Workflow.Infrastructure.Tests/Domains/Instances/InstanceStateFingerprintQueryTests.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.MultiSchema;
+using BBT.Workflow.Data;
+using BBT.Workflow.Instances;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Testcontainers.PostgreSql;
+using Xunit;
+
+namespace BBT.Workflow.Domains.Instances;
+
+/// <summary>
+/// Integration tests for the state-function fingerprint projection
+/// (<see cref="EfCoreInstanceRepository.QueryStateFingerprintAsync"/>) against a real PostgreSQL:
+/// verifies EF translatability of the single-row projection (including the correlated
+/// <c>ChildCorrelations.Any</c> subquery over the SubFlowType value-converted column),
+/// id-then-key identifier resolution, and most-recent-row ordering for duplicate keys.
+/// </summary>
+public sealed class InstanceStateFingerprintQueryTests : IAsyncLifetime
+{
+    private const string Flow = "fingerprint-test-flow";
+    private const string FlowVersion = "1.0.0";
+
+    private PostgreSqlContainer _postgres = null!;
+    private string _connectionString = null!;
+
+    async Task IAsyncLifetime.InitializeAsync()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:16-alpine")
+            .WithDatabase("testdb").WithUsername("test").WithPassword("test")
+            .Build();
+        await _postgres.StartAsync();
+        _connectionString = _postgres.GetConnectionString();
+
+        await using var ctx = CreateContext();
+        await ctx.Database.EnsureCreatedAsync();
+    }
+
+    async Task IAsyncLifetime.DisposeAsync()
+    {
+        await _postgres.StopAsync();
+        await _postgres.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task ById_ProjectsFingerprintColumns()
+    {
+        var instance = Instance.Create(Guid.NewGuid(), Flow, FlowVersion, "fp-by-id");
+        instance.SetEffectiveState("review");
+        await SeedAsync(instance);
+
+        await using var ctx = CreateContext();
+        var fingerprint = await QueryAsync(ctx, instance.Id.ToString());
+
+        fingerprint.ShouldNotBeNull();
+        fingerprint!.Id.ShouldBe(instance.Id);
+        fingerprint.Key.ShouldBe("fp-by-id");
+        fingerprint.EffectiveState.ShouldBe("review");
+        fingerprint.Status.ShouldBe(InstanceStatus.Active);
+        fingerprint.FlowVersion.ShouldBe(FlowVersion);
+        fingerprint.HasActiveSubFlow.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ByKey_ReturnsMostRecentRow()
+    {
+        var older = Instance.Create(Guid.NewGuid(), Flow, FlowVersion, "fp-dup-key");
+        older.SetEffectiveState("review");
+        await SeedAsync(older, createdAt: new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        var newer = Instance.Create(Guid.NewGuid(), Flow, FlowVersion, "fp-dup-key");
+        newer.SetEffectiveState("approved");
+        await SeedAsync(newer, createdAt: new DateTime(2026, 1, 2, 0, 0, 0, DateTimeKind.Utc));
+
+        await using var ctx = CreateContext();
+        var fingerprint = await QueryAsync(ctx, "fp-dup-key");
+
+        fingerprint.ShouldNotBeNull();
+        fingerprint!.Id.ShouldBe(newer.Id);
+        fingerprint.EffectiveState.ShouldBe("approved");
+    }
+
+    [Fact]
+    public async Task WithActiveSubFlowCorrelation_SetsHasActiveSubFlow()
+    {
+        var instance = Instance.Create(Guid.NewGuid(), Flow, FlowVersion, "fp-subflow");
+        instance.SetEffectiveState("review");
+        instance.AddCorrelation(CreateCorrelation(instance.Id, subFlowType: "S"));
+        await SeedAsync(instance);
+
+        await using var ctx = CreateContext();
+        var fingerprint = await QueryAsync(ctx, instance.Id.ToString());
+
+        fingerprint.ShouldNotBeNull();
+        fingerprint!.HasActiveSubFlow.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task WithCompletedOrSubProcessCorrelations_DoesNotSetHasActiveSubFlow()
+    {
+        var instance = Instance.Create(Guid.NewGuid(), Flow, FlowVersion, "fp-no-active-subflow");
+        instance.SetEffectiveState("review");
+
+        var completedSubFlow = CreateCorrelation(instance.Id, subFlowType: "S");
+        completedSubFlow.Completed();
+        instance.AddCorrelation(completedSubFlow);
+        instance.AddCorrelation(CreateCorrelation(instance.Id, subFlowType: "P"));
+        await SeedAsync(instance);
+
+        await using var ctx = CreateContext();
+        var fingerprint = await QueryAsync(ctx, instance.Id.ToString());
+
+        fingerprint.ShouldNotBeNull();
+        fingerprint!.HasActiveSubFlow.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task UnknownIdentifier_ReturnsNull()
+    {
+        await using var ctx = CreateContext();
+
+        var byGuid = await QueryAsync(ctx, Guid.NewGuid().ToString());
+        var byKey = await QueryAsync(ctx, "fp-no-such-key");
+
+        byGuid.ShouldBeNull();
+        byKey.ShouldBeNull();
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static Task<InstanceStateFingerprint?> QueryAsync(WorkflowDbContext ctx, string identifier) =>
+        EfCoreInstanceRepository.QueryStateFingerprintAsync(
+            ctx.Instances.AsNoTracking(), identifier, CancellationToken.None);
+
+    private static InstanceCorrelation CreateCorrelation(Guid instanceId, string subFlowType) =>
+        InstanceCorrelation.Create(
+            id: Guid.NewGuid(),
+            instanceId: instanceId,
+            parentState: "review",
+            subFlowInstanceId: Guid.NewGuid(),
+            subFlowType: subFlowType,
+            subFlowDomain: "sub-domain",
+            subFlowName: "sub-flow",
+            subFlowVersion: "1.0.0");
+
+    private async Task SeedAsync(Instance instance, DateTime? createdAt = null)
+    {
+        await using var ctx = CreateContext();
+        ctx.Instances.Add(instance);
+        await ctx.SaveChangesAsync();
+
+        if (createdAt is not null)
+        {
+            // CreatedAt is audit-stamped on save; pin it afterwards so duplicate-key
+            // ordering assertions are deterministic.
+            await ctx.Database.ExecuteSqlRawAsync(
+                "UPDATE \"public\".\"Instances\" SET \"CreatedAt\" = {0} WHERE \"Id\" = {1}",
+                createdAt.Value, instance.Id);
+        }
+    }
+
+    private WorkflowDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<WorkflowDbContext>()
+            .UseNpgsql(_connectionString)
+            .Options;
+        return new WorkflowDbContext(options, new StaticCurrentSchema("public"));
+    }
+}

--- a/test/BBT.Workflow.Infrastructure.Tests/Domains/Instances/RemoteInstanceQueryStateCallHeaderTests.cs
+++ b/test/BBT.Workflow.Infrastructure.Tests/Domains/Instances/RemoteInstanceQueryStateCallHeaderTests.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.Results;
+using BBT.Aether.Users;
+using BBT.Workflow.Discovery;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Instances.Remote;
+using BBT.Workflow.Remote.Configuration;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Domains.Instances;
+
+/// <summary>
+/// Verifies the conditional-header contract of the remote state-function call
+/// (<see cref="RemoteInstanceQueryAppService.GetFunctionWithStateAsync"/>): the caller's own
+/// If-None-Match (an ETag for a different resource — e.g. the parent instance during the
+/// subflow window) must never be forwarded from the headers dictionary; only the typed
+/// <c>input.IfNoneMatch</c> may produce a conditional request.
+/// </summary>
+public sealed class RemoteInstanceQueryStateCallHeaderTests
+{
+    private HttpRequestMessage? _capturedRequest;
+
+    private RemoteInstanceQueryAppService CreateSut(HttpStatusCode responseStatus = HttpStatusCode.OK)
+    {
+        var handler = new CapturingHandler(request =>
+        {
+            _capturedRequest = request;
+            var response = new HttpResponseMessage(responseStatus);
+            if (responseStatus == HttpStatusCode.OK)
+                response.Content = new StringContent("""{ "state": "review" }""");
+            return response;
+        });
+
+        var endpointResolver = Substitute.For<IDomainDiscoveryResolver>();
+        endpointResolver
+            .GetEndpointAsync(Arg.Any<string>(), Arg.Any<EndpointKind>(), Arg.Any<CancellationToken>())
+            .Returns(Result<DiscoveryEndpoint>.Ok(
+                new DiscoveryEndpoint(EndpointKind.Url, new Uri("https://remote-domain.test/"))));
+
+        return new RemoteInstanceQueryAppService(
+            new HttpClient(handler),
+            Options.Create(new RemoteOptions()),
+            endpointResolver,
+            Substitute.For<ICurrentUser>());
+    }
+
+    private static GetFunctionWithInstanceInput CreateInput(
+        string? ifNoneMatch = null,
+        Dictionary<string, string?>? headers = null) => new()
+    {
+        Domain = "sub-domain",
+        Workflow = "sub-flow",
+        Instance = Guid.NewGuid().ToString(),
+        IfNoneMatch = ifNoneMatch,
+        Headers = headers ?? new Dictionary<string, string?>(),
+        QueryParams = new Dictionary<string, string?>()
+    };
+
+    [Fact]
+    public async Task GetFunctionWithStateAsync_DoesNotForwardCallersIfNoneMatchHeader()
+    {
+        var sut = CreateSut();
+        var input = CreateInput(headers: new Dictionary<string, string?>
+        {
+            ["if-none-match"] = "\"parent-etag\"",
+            ["accept-language"] = "tr-TR"
+        });
+
+        var result = await sut.GetFunctionWithStateAsync(input, CancellationToken.None);
+
+        result.Result.IsSuccess.ShouldBeTrue();
+        _capturedRequest.ShouldNotBeNull();
+        _capturedRequest!.Headers.Contains("If-None-Match").ShouldBeFalse();
+        _capturedRequest.Headers.GetValues("accept-language").Single().ShouldBe("tr-TR");
+    }
+
+    [Fact]
+    public async Task GetFunctionWithStateAsync_SendsTypedIfNoneMatchExactlyOnce()
+    {
+        var sut = CreateSut();
+        var input = CreateInput(
+            ifNoneMatch: "\"intended-etag\"",
+            headers: new Dictionary<string, string?> { ["if-none-match"] = "\"leaked-etag\"" });
+
+        await sut.GetFunctionWithStateAsync(input, CancellationToken.None);
+
+        _capturedRequest.ShouldNotBeNull();
+        _capturedRequest!.Headers.GetValues("If-None-Match").Single().ShouldBe("\"intended-etag\"");
+    }
+
+    [Fact]
+    public async Task GetFunctionWithStateAsync_MapsRemote304ToNotModified()
+    {
+        var sut = CreateSut(HttpStatusCode.NotModified);
+        var input = CreateInput(ifNoneMatch: "\"intended-etag\"");
+
+        var result = await sut.GetFunctionWithStateAsync(input, CancellationToken.None);
+
+        result.IsNotModified.ShouldBeTrue();
+    }
+
+    private sealed class CapturingHandler(Func<HttpRequestMessage, HttpResponseMessage> respond)
+        : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(respond(request));
+    }
+}


### PR DESCRIPTION
## Summary

Introduces a fingerprint-validated ETag + Redis response cache family for the built-in instance functions. Today every poll/read rebuilds the full response (aggregate load, authorization, role/field filtering, extension execution) and hashes the body to produce an ETag — so even a `304 Not Modified` costs a full build. This PR derives ETags from lightweight **fingerprint projections** instead, making `If-None-Match` answerable from a single index-backed row read, and backs the bodies with a distributed cache.

Delivered in three commits, one per function group:

| Commit | Function | ETag material |
|---|---|---|
| 0fdd4d5d | **state** (long-poll) | `h(id \| effectiveState \| status \| flowVersion \| callerScope)` |
| afdeab20 | **data** | `h(id \| latestDataEtag \| flowVersion \| callerScope)` |
| a29e08d1 | **master / schema** | data material (+ `effectiveState` + `transitionKey` for schema) |

## How it works

- **Light DB query**: a single-row projection (`GetStateFingerprintAsync` / `GetDataFingerprintAsync`) — no includes; the latest data ETag is index-only via `UX_InstancesData_Instance_IsLatest`, the active-subflow flag is an EXISTS probe on a partial index.
- **304 fast path**: the ETag is deterministic across pods, so an `If-None-Match` match returns 304 from the projection alone — no cache entry, no aggregate, no build, no extension run. Works even with an empty/flushed Redis.
- **Body cache**: serves callers without a current ETag. Validation on a hit is a single ETag equality check (state/status/data/version/caller scope are all inside the hash). Fail-open: any cache error degrades to a miss.
- **Caller scoping**: keys and ETags fold in a `callerScope` hash (roles, actor identity — `$InstanceStarter`/`$PreviousUser` are actor-dependent — culture, requested version) so no caller can receive another scope's response or a false 304.
- **Workflow-author TTL**: new flow-definition object `"functionCache": { "ttlSeconds": N }` overrides the host default (`InstanceFunctionCache:DefaultTtlSeconds`, one value for the data/master/schema family). The state function keeps its own `StateFunctionCache` section.

## Function-specific behavior

- **State**: subflow-active instances bypass entirely (the response comes from a live subflow call whose Busy/Active flips the parent row cannot see); the subflow ETag variant folds the displayed state/status into the hash.
- **Data**: the cache stores **only the field-filtered data payload** — extension output is never cached. A validated entry feeds the data portion of the build (skipping x-roles filtering and its dynamic-role scripts) while extensions always run fresh. Extensions are excluded from the key/ETag: the ETag tracks the data change point. Latest-data requests only — older-line version writes don't move the IsLatest ETag, so pinned-version requests stay on the full path and hash the resolved row's ETag.
- **Master / schema**: these functions previously had no conditional-read support at all (no ETag field, no If-None-Match, plain `Result` types) — this PR adds the full plumbing (`ConditionalResult`, handler 304 + ETag header). Only successful outcomes are cached; subflow-active bypasses and the forwarded subflow body's ETag is nulled. The master function's queryRoles gate — previously disabled by a commented-out block — is **re-enabled**, matching the schema function and turning the pre-existing red test `GetMasterAsync_WhenQueryRolesDeny_Returns403` green.

## Security hardening included

Subflow composition calls must always return a body: the remote state/master/schema calls now strip the caller's `If-None-Match` from forwarded headers (the caller's ETag belongs to a different resource; a false 304 downstream would leave the composer with no body). The equivalent leak in the remote **view/extensions** calls is a known follow-up for the upcoming view-function phase.

## Accepted staleness (by design, documented)

- State: `X-Entity-ETag` may lag data-only writes until the next state/status change.
- Data: extension flux never moves the ETag — clients needing fresh extension output call without `If-None-Match` and always get a fresh build.
- All: same-version component/flow republish does not move ETags (same exposure class as the component cache).

## Docs & observability

- New doc: `docs/runtime/state-function-cache-and-etag.md` (mermaid request-flow diagram, materials, bypass rules, config, staleness classes) — linked from the docs reading order.
- Structured logs: EventIds 20400-20405 (state), 20410-20414 (data), 20420-20425 (master/schema); OTel spans under `BBT.Workflow.Cache` with per-function component types.

## Testing

- ~75 new unit tests (ETag/key composition, TTL resolution, fail-open, cache-flow scenarios per function) plus Testcontainers integration tests running the exact production fingerprint projections against real PostgreSQL.
- Full-suite baselines vs master: Application 27 → **26** pre-existing failures (the master-gate test fix), Infrastructure 11 → 11 (+ new tests passing). No regressions.

## Follow-ups (out of scope)

- View function ETag/cache (rule-based selection needs an author-declared vary contract; plan drafted) + the remote view/extensions If-None-Match strip.
- `@burgan-tech/vnext-template` flow schema + `vnext-meta` features entries for `functionCache`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)