### PR TITLE
refactor(instances): treat wizard states like normal states in State/View functions

### DIFF
--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -781,8 +781,7 @@ public sealed class InstanceQueryAppService(
     private static ViewDefinition? GetViewDefinition(
         Definitions.Workflow currentWorkflow,
         State currentState,
-        string? transitionKey,
-        IReadOnlyList<string>? authorizedAvailableTransitionKeys)
+        string? transitionKey)
     {
         if (!transitionKey.IsNullOrWhiteSpace())
         {
@@ -790,31 +789,7 @@ public sealed class InstanceQueryAppService(
             return transition?.View;
         }
 
-        return ResolveWizardViewSelection(currentState, authorizedAvailableTransitionKeys ?? [])
-            .ViewDefinition ?? currentState.View;
-    }
-
-    private static WizardViewSelection ResolveWizardViewSelection(
-        State currentState,
-        IReadOnlyList<string> authorizedAvailableTransitionKeys)
-    {
-        if (currentState.StateType != StateType.Wizard)
-            return new WizardViewSelection(null, null);
-
-        var stateTransitions = authorizedAvailableTransitionKeys
-            .Select(currentState.FindTransition)
-            .Where(transition => transition != null)
-            .Cast<Transition>()
-            .ToList();
-
-        if (stateTransitions.Count == 1)
-        {
-            var transition = stateTransitions[0];
-            if (transition.View is { Views.Count: > 0 })
-                return new WizardViewSelection(transition.View, transition.Key);
-        }
-
-        return new WizardViewSelection(currentState.View, null);
+        return currentState.View;
     }
 
     private static string ToCamelCaseName<TEnum>(TEnum value) where TEnum : struct, Enum
@@ -857,26 +832,6 @@ public sealed class InstanceQueryAppService(
 
     private static bool IsTransitionKey(Transition? transition, string transitionKey) =>
         transition?.Key.Equals(transitionKey, StringComparison.OrdinalIgnoreCase) == true;
-
-    private async Task<IReadOnlyList<string>> GetAuthorizedAvailableTransitionKeysAsync(
-        Instance instance,
-        Definitions.Workflow currentWorkflow,
-        State currentState,
-        string? role,
-        CancellationToken cancellationToken)
-    {
-        if (!instance.Status.Equals(InstanceStatus.Active))
-            return [];
-
-        var availableTransitionKeys = currentWorkflow.GetAvailableUserTransitionKeys(currentState);
-        return await transitionAuthorizationManager.FilterAuthorizedTransitionKeysAsync(
-            currentWorkflow,
-            currentState,
-            instance,
-            availableTransitionKeys,
-            role,
-            cancellationToken);
-    }
 
     public async Task<ConditionalResult<GetInstanceStateOutput>> GetInstanceStateAsync(
         GetInstanceStateInput input,
@@ -1119,8 +1074,6 @@ public sealed class InstanceQueryAppService(
             }
         }
 
-        var wizardViewSelection = ResolveWizardViewSelection(currentStateValue, keysForTransitions);
-
         List<TransitionItem> transitionItems;
         if (subFlowStateInfo.SubFlowTransitionItems != null)
         {
@@ -1147,8 +1100,6 @@ public sealed class InstanceQueryAppService(
                         hasSchema = transition?.Schema != null;
                         annotations = transition?.Annotations;
                     }
-                    if (key.Equals(wizardViewSelection.TransitionViewKey, StringComparison.Ordinal))
-                        hasView = false;
 
                     return new TransitionItem
                     {
@@ -1193,7 +1144,7 @@ public sealed class InstanceQueryAppService(
                     {
                         Href = urlTemplateBuilder.BuildViewUrl(input.Domain, input.Workflow, instance.Id.ToString(),
                             transitionKey),
-                        HasView = !transitionKey.Equals(wizardViewSelection.TransitionViewKey, StringComparison.Ordinal) && hasView
+                        HasView = hasView
                     },
                     Schema = new SchemaHref
                     {
@@ -1206,7 +1157,7 @@ public sealed class InstanceQueryAppService(
             }).ToList();
         }
 
-        var viewDefinition = wizardViewSelection.ViewDefinition ?? currentStateValue.View;
+        var viewDefinition = currentStateValue.View;
         var firstViewEntry = viewDefinition?.Views.FirstOrDefault();
         var viewExtensions = firstViewEntry?.Extensions ?? [];
         var viewLoadData = firstViewEntry?.LoadData ?? false;
@@ -1983,21 +1934,11 @@ public sealed class InstanceQueryAppService(
             }
         }
 
-        var authorizedAvailableTransitionKeys = transitionKey.IsNullOrWhiteSpace()
-            ? await GetAuthorizedAvailableTransitionKeysAsync(
-                instance,
-                currentWorkflow,
-                currentState,
-                input.Role,
-                cancellationToken)
-            : [];
-
         // Get view definition
         var viewDefinition = GetViewDefinition(
             currentWorkflow,
             currentState,
-            transitionKey,
-            authorizedAvailableTransitionKeys);
+            transitionKey);
 
         if (viewDefinition == null || viewDefinition.Views.Count == 0)
         {
@@ -2112,7 +2053,7 @@ public sealed class InstanceQueryAppService(
 
         // If current state has view overrides, resolve override view (local or remote) via service
         // EffectiveViewOverrides: overrides.views takes precedence over legacy viewOverrides
-        if (currentState.SubFlow!.HasViewOverrides)
+        if (currentState.SubFlow?.HasViewOverrides == true)
         {
             var overrideViewRef = currentState.SubFlow!.EffectiveViewOverrides!.GetOrDefault(subFlowViewResult.Value!.Key);
 
@@ -2510,10 +2451,6 @@ public sealed class InstanceQueryAppService(
         List<ActiveCorrelationHref>? SubFlowActiveCorrelations = null,
         List<TransitionItem>? SubFlowTransitionItems = null,
         InstanceInteractionOutput? Interaction = null);
-
-    private sealed record WizardViewSelection(
-        ViewDefinition? ViewDefinition,
-        string? TransitionViewKey);
 
     private static Dictionary<string, SubFlowTransitionOverride>? TryGetParentTransitionRoleOverrides(Instance instance)
     {

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceStateTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceStateTests.cs
@@ -423,7 +423,7 @@ public class InstanceQueryAppServiceStateTests : IDisposable
     }
 
     [Fact]
-    public async Task GetInstanceStateAsync_WhenWizardStateTransitionHasView_ReturnsStateHasViewAndHidesTransitionView()
+    public async Task GetInstanceStateAsync_WhenWizardStateTransitionHasView_ReturnsTransitionViewAndNoStateView()
     {
         // Arrange
         var instanceId = Guid.NewGuid();
@@ -446,16 +446,16 @@ public class InstanceQueryAppServiceStateTests : IDisposable
         // Act
         var result = await _service.GetInstanceStateAsync(input, CancellationToken.None);
 
-        // Assert
+        // Assert: a wizard state is treated like any other state. The state has no own view,
+        // and the transition exposes its own view. No wizard-specific view borrowing/hiding.
         result.Result.IsSuccess.ShouldBeTrue();
         var output = result.Result.Value!;
-        output.View.HasView.ShouldBeTrue();
-        output.View.LoadData.ShouldBeTrue();
-        output.Transitions.Single().View!.HasView.ShouldBeFalse();
+        output.View.HasView.ShouldBeFalse();
+        output.Transitions.Single().View!.HasView.ShouldBeTrue();
     }
 
     [Fact]
-    public async Task GetInstanceStateAsync_WhenWizardStateTransitionHasNoView_FallsBackToStateView()
+    public async Task GetInstanceStateAsync_WhenWizardStateHasOwnView_ReturnsStateView()
     {
         // Arrange
         var instanceId = Guid.NewGuid();
@@ -486,7 +486,7 @@ public class InstanceQueryAppServiceStateTests : IDisposable
     }
 
     [Fact]
-    public async Task GetViewAsync_WhenWizardStateTransitionHasView_ReturnsTransitionView()
+    public async Task GetViewAsync_WhenWizardStateWithTransitionKey_ReturnsTransitionView()
     {
         // Arrange
         var instanceId = Guid.NewGuid();
@@ -515,7 +515,7 @@ public class InstanceQueryAppServiceStateTests : IDisposable
                 Label = string.Empty
             }));
 
-        // Act
+        // Act: the transition's view is requested explicitly — a wizard state gets no special handling.
         var result = await _service.GetViewAsync(new GetViewInput
         {
             Domain = TestDomain,
@@ -523,7 +523,7 @@ public class InstanceQueryAppServiceStateTests : IDisposable
             Instance = instance.Id.ToString(),
             Headers = new Dictionary<string, string?>(),
             QueryParameters = new Dictionary<string, string?>()
-        }, transitionKey: null, CancellationToken.None);
+        }, transitionKey: "continue", CancellationToken.None);
 
         // Assert
         result.IsSuccess.ShouldBeTrue();
@@ -531,7 +531,7 @@ public class InstanceQueryAppServiceStateTests : IDisposable
     }
 
     [Fact]
-    public async Task GetViewAsync_WhenWizardStateTransitionHasNoView_ReturnsStateView()
+    public async Task GetViewAsync_WhenWizardStateWithoutTransitionKey_ReturnsStateView()
     {
         // Arrange
         var instanceId = Guid.NewGuid();


### PR DESCRIPTION
## What

Removes the wizard-specific view handling from the **State** and **View** functions in `InstanceQueryAppService`. A wizard state is now treated exactly like any other state; the client owns wizard-flow orchestration.

### Previous behavior
- **State function**: for a wizard state, the state-level `hasView` was derived from a single available transition's view, and that transition's own `hasView` was forced to `false`.
- **View function**: for a wizard state with no explicit `transitionKey`, the runtime returned a transition's view.

### New behavior
- **State function**: state-level `hasView` reflects **only the state's own view**; each transition's `hasView` reflects **only its own view**. No borrowing/hiding.
- **View function**: no `transitionKey` → returns the **state's** view; with a `transitionKey` → returns **that transition's** view. Single, uniform behavior.

## Why
Wizard-step navigation and which view to render is a client concern. Removing the special-case keeps the read functions deterministic and consistent across all state types.

## Changes
- `BuildInstanceStateOutputAsync`: dropped `ResolveWizardViewSelection`; `hasView` for state and transitions now comes from their own definitions.
- `GetViewDefinition` / `ResolveViewAsync`: removed the wizard view-selection branch and the now-unused authorized-transition-keys lookup.
- Removed dead code that only served the old path: `ResolveWizardViewSelection`, the `WizardViewSelection` record, and `GetAuthorizedAvailableTransitionKeysAsync`.

## Tests
Updated `InstanceQueryAppServiceStateTests` to assert the new contract (transition view now visible in wizard states; View function state-vs-transition selection driven by `transitionKey`).

- Build: Application project — **0 errors**
- `dotnet test` filtered to `InstanceQueryAppServiceStateTests` — **35 passed, 0 failed**

## Reviewer notes
- `StateType.Wizard` remains a valid domain enum value; this only changes the State/View read behavior — no pipeline or validation changes.
- Pre-existing LSP warnings (CS9107, CS1573 XML-doc mismatches, CS8019 unused `using` at line 4 of `InstanceQueryAppService.cs`) are unrelated and left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Treat wizard workflow states the same as normal states in instance State and View queries by removing wizard-specific view selection logic.

Enhancements:
- Simplified view resolution so state-level views and transition views are determined solely by their own definitions, without wizard-specific borrowing or hiding.
- Removed unused wizard view selection and authorization helper logic, including the WizardViewSelection record and associated transition-key filtering.
- Adjusted sub-flow view override handling to safely handle missing SubFlow configurations.

Tests:
- Updated InstanceQueryAppServiceStateTests to assert the new wizard behavior for State and View queries, including explicit transitionKey-based view selection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow view resolution for wizard states and transitions.
  * Transition views are now displayed when a transition is selected, while the state view is hidden when appropriate.
  * State views are correctly displayed when the wizard state provides its own view.
  * Improved handling of subflows without view overrides to prevent incorrect view resolution.

* **Tests**
  * Updated coverage for wizard state and transition view scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->