### PR TITLE
feat(functions): varyKey cache-key helper + config-driven vary-by

### DIFF
--- a/src/BBT.Workflow.Application/Functions/FunctionAppService.cs
+++ b/src/BBT.Workflow.Application/Functions/FunctionAppService.cs
@@ -171,6 +171,15 @@ public sealed class FunctionAppService(
             ? (object)body.Value
             : new JsonData("{}");
 
+        // Carry the domain-supplied cache vary-by config into the script context so the generic
+        // varyKey() key-expression helper can read it (the runtime imposes no header convention itself).
+        var metadata = new Dictionary<string, object>();
+        if (function.Cache is { } cacheConfig)
+        {
+            metadata[DynamicExpressoValueEvaluator.VaryByHeadersMetadataKey] = cacheConfig.VaryByHeaders;
+            metadata[DynamicExpressoValueEvaluator.VaryByPrefixesMetadataKey] = cacheConfig.VaryByHeaderPrefixes;
+        }
+
         var scriptContext = await scriptContextFactory.NewBuilder(instanceRepository)
             .WithWorkflow(workflow)
             .WithInstance(instance)
@@ -178,17 +187,32 @@ public sealed class FunctionAppService(
             .WithBody(scriptBody)
             .WithHeaders(headers)
             .WithQueryParameters(queryParameters)
+            .WithMetadata(metadata)
             .BuildAsync(cancellationToken);
 
         // Read-through cache: when the function opts in, serve the cached response on a hit (tasks skipped).
         string? cacheKey = null;
         if (function.Cache is { } cache && cache.HasKeySource)
         {
+            if (cache.KeyExpression is not null &&
+                cache.VaryByHeaders.Count == 0 && cache.VaryByHeaderPrefixes.Count == 0)
+                Logger.LogWarning(
+                    "Function {FunctionKey}: cache enabled without varyByHeaders/varyByHeaderPrefixes; a keyExpression using varyKey() falls back to ALL request headers (poor hit rate).",
+                    function.Key);
+
             var keyResult = ResolveCacheKey(cache, scriptContext);
             if (!keyResult.IsSuccess)
-                return Result<FunctionResponseOutput>.Fail(keyResult.Error);
+            {
+                // A key that cannot be computed cannot be cached — never fail the endpoint over it; run uncached.
+                Logger.LogWarning(
+                    "Function {FunctionKey}: cache key expression failed ({Error}); executing without caching.",
+                    function.Key, keyResult.Error.Message ?? "unknown");
+            }
+            else
+            {
+                cacheKey = keyResult.Value;
+            }
 
-            cacheKey = keyResult.Value;
             if (!string.IsNullOrWhiteSpace(cacheKey))
             {
                 var traceContext = remoteInvoker.CreateTraceContext(scriptContext);

--- a/src/BBT.Workflow.Application/Tasks/Evaluators/DynamicExpressoValueEvaluator.cs
+++ b/src/BBT.Workflow.Application/Tasks/Evaluators/DynamicExpressoValueEvaluator.cs
@@ -1,6 +1,8 @@
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json;
 using BBT.Aether.Results;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Scripting;
@@ -87,9 +89,12 @@ public sealed class DynamicExpressoValueEvaluator(ILogger<DynamicExpressoValueEv
     private static Func<ExpressoRuleContext, string> CompileExpression(string expression)
     {
         var interpreter = new Interpreter(InterpreterOptions.Default);
-        // Deterministic hash helper for building bounded, vary-by-correct cache keys from many/large
-        // header sets, e.g. "dcs:" + context.Headers.configKey + ":" + sha256(context.Headers.varyBy).
+        // Deterministic hash helper for building bounded, vary-by-correct cache keys, e.g.
+        // "cfg:" + context.Instance.Key + ":" + sha256(varyKey(context)).
         interpreter.SetFunction("sha256", (Func<string?, string>)Sha256Hex);
+        // Canonical vary-by string builder (see VaryKey). Because DynamicExpresso cannot express list
+        // operations (no LINQ / array literals), the header-name set is assembled in C# here.
+        interpreter.SetFunction("varyKey", (Func<ExpressoRuleContext, string>)VaryKey);
         var lambda = interpreter.Parse(expression, typeof(string), new Parameter("context", typeof(ExpressoRuleContext)));
         return lambda.Compile<Func<ExpressoRuleContext, string>>();
     }
@@ -101,5 +106,138 @@ public sealed class DynamicExpressoValueEvaluator(ILogger<DynamicExpressoValueEv
     {
         var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(input ?? string.Empty));
         return Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+
+    /// <summary>MetaData key carrying the exact vary-by header names (domain-supplied cache config).</summary>
+    public const string VaryByHeadersMetadataKey = "__cacheVaryByHeaders";
+
+    /// <summary>MetaData key carrying the vary-by header-name prefixes (domain-supplied cache config).</summary>
+    public const string VaryByPrefixesMetadataKey = "__cacheVaryByHeaderPrefixes";
+
+    private const string VaryByInstanceDataKey = "varyBy";
+    private const string VersionQueryParam = "version";
+    private const string DefaultVersion = "latest";
+
+    /// <summary>
+    /// Builds a canonical, UNhashed vary-by string from exactly the request inputs that can change the
+    /// result. Header-name set resolution (most-specific first):
+    /// <list type="number">
+    ///   <item><c>context.Instance.Data["varyBy"]</c> when it is a non-empty string array (per-request,
+    ///   most precise; the domain populates it with the headers the linked feature-flag actually reads);</item>
+    ///   <item>otherwise the domain-supplied cache config — exact <c>VaryByHeaders</c> unioned with all
+    ///   request headers matching <c>VaryByHeaderPrefixes</c> (carried in MetaData);</item>
+    ///   <item>otherwise the last-resort superset: every request header (never under-keys).</item>
+    /// </list>
+    /// Then canonicalizes: names lowercased/trimmed, de-duplicated, ordinal-sorted; each value read
+    /// case-insensitively (missing → empty); joined as <c>name=value</c> with <c>|</c>; the version
+    /// selector (query param <c>version</c>, default <c>latest</c>) is prepended as <c>v=&lt;version&gt;|…</c>.
+    /// The result is intended to be hashed by the caller via <c>sha256(...)</c>. Generic and reusable.
+    /// </summary>
+    private static string VaryKey(ExpressoRuleContext context)
+    {
+        var headers = AsElement(context.Headers);
+
+        var names = ResolveVaryByNames(context, headers)
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            .Select(n => n.Trim().ToLowerInvariant())
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToList();
+
+        var pairs = string.Join("|", names.Select(n => $"{n}={GetStringValue(headers, n)}"));
+        var version = GetStringValue(AsElement(context.QueryParameters), VersionQueryParam);
+        if (string.IsNullOrEmpty(version))
+            version = DefaultVersion;
+
+        return $"v={version}|{pairs}";
+    }
+
+    private static IEnumerable<string> ResolveVaryByNames(ExpressoRuleContext context, JsonElement headers)
+    {
+        // 1) Per-request varyBy from instance data.
+        var instanceElement = context.Instance is { } instance ? AsElement(instance.Data) : default;
+        var instanceVaryBy = ReadStringArray(instanceElement, VaryByInstanceDataKey);
+        if (instanceVaryBy.Count > 0)
+            return instanceVaryBy;
+
+        // 2) Domain-supplied config (via MetaData): exact names ∪ prefix matches.
+        var meta = AsElement(context.MetaData);
+        var configNames = ReadStringArray(meta, VaryByHeadersMetadataKey);
+        var configPrefixes = ReadStringArray(meta, VaryByPrefixesMetadataKey);
+        if (configNames.Count > 0 || configPrefixes.Count > 0)
+        {
+            var set = new List<string>(configNames);
+            if (configPrefixes.Count > 0 && headers.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var header in headers.EnumerateObject())
+                {
+                    if (configPrefixes.Any(p => header.Name.StartsWith(p, StringComparison.OrdinalIgnoreCase)))
+                        set.Add(header.Name);
+                }
+            }
+
+            return set;
+        }
+
+        // 3) Last resort: every header (safe superset; low hit rate — caller should warn).
+        return headers.ValueKind == JsonValueKind.Object
+            ? headers.EnumerateObject().Select(p => p.Name)
+            : Enumerable.Empty<string>();
+    }
+
+    private static JsonElement AsElement(RuleJsonDynamic? value) => value?.AsJsonElement() ?? default;
+
+    private static List<string> ReadStringArray(JsonElement obj, string key)
+    {
+        var result = new List<string>();
+        if (obj.ValueKind == JsonValueKind.Object &&
+            TryGetPropertyIgnoreCase(obj, key, out var array) &&
+            array.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in array.EnumerateArray())
+            {
+                if (item.ValueKind == JsonValueKind.String)
+                {
+                    var s = item.GetString();
+                    if (!string.IsNullOrWhiteSpace(s))
+                        result.Add(s!);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static string GetStringValue(JsonElement obj, string name)
+    {
+        if (obj.ValueKind == JsonValueKind.Object && TryGetPropertyIgnoreCase(obj, name, out var value))
+        {
+            return value.ValueKind switch
+            {
+                JsonValueKind.String => value.GetString() ?? string.Empty,
+                JsonValueKind.Null or JsonValueKind.Undefined => string.Empty,
+                _ => value.GetRawText()
+            };
+        }
+
+        return string.Empty;
+    }
+
+    private static bool TryGetPropertyIgnoreCase(JsonElement obj, string name, out JsonElement value)
+    {
+        if (obj.TryGetProperty(name, out value))
+            return true;
+
+        foreach (var property in obj.EnumerateObject())
+        {
+            if (string.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase))
+            {
+                value = property.Value;
+                return true;
+            }
+        }
+
+        value = default;
+        return false;
     }
 }

--- a/src/BBT.Workflow.Domain/Definitions/Functions/FunctionCache.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Functions/FunctionCache.cs
@@ -19,7 +19,9 @@ public sealed class FunctionCache
         string? consistency = null,
         bool bypassOnCacheError = true,
         ScriptCode? generationKeyExpression = null,
-        string? generationKey = null)
+        string? generationKey = null,
+        IReadOnlyList<string>? varyByHeaders = null,
+        IReadOnlyList<string>? varyByHeaderPrefixes = null)
     {
         KeyExpression = keyExpression;
         Key = key;
@@ -29,6 +31,8 @@ public sealed class FunctionCache
         BypassOnCacheError = bypassOnCacheError;
         GenerationKeyExpression = generationKeyExpression;
         GenerationKey = generationKey;
+        VaryByHeaders = varyByHeaders ?? [];
+        VaryByHeaderPrefixes = varyByHeaderPrefixes ?? [];
     }
 
     /// <summary>
@@ -81,6 +85,20 @@ public sealed class FunctionCache
     /// <see cref="GenerationKeyExpression"/> is absent).
     /// </summary>
     public string? GenerationKey { get; }
+
+    /// <summary>
+    /// Optional exact request-header names that vary the result. Used by the <c>varyKey(context)</c>
+    /// key-expression helper as the header-name set (unioned with <see cref="VaryByHeaderPrefixes"/>)
+    /// when the instance does not supply <c>Instance.Data["varyBy"]</c>. Domain-supplied so the runtime
+    /// stays free of any specific header convention.
+    /// </summary>
+    public IReadOnlyList<string> VaryByHeaders { get; }
+
+    /// <summary>
+    /// Optional request-header name prefixes that vary the result (e.g. all headers starting with a
+    /// given prefix). See <see cref="VaryByHeaders"/>.
+    /// </summary>
+    public IReadOnlyList<string> VaryByHeaderPrefixes { get; }
 
     /// <summary>
     /// True when a key source (expression or static key) is configured.

--- a/src/BBT.Workflow.Domain/Scripting/Rules/RuleJsonDynamic.cs
+++ b/src/BBT.Workflow.Domain/Scripting/Rules/RuleJsonDynamic.cs
@@ -34,6 +34,12 @@ public sealed class RuleJsonDynamic : DynamicObject
     public static RuleJsonDynamic FromJsonElement(JsonElement element) => new(element);
 
     /// <summary>
+    /// Returns the underlying (cloned, read-only) <see cref="JsonElement"/> for callers that need to
+    /// enumerate object properties or array items — operations the dynamic surface does not expose.
+    /// </summary>
+    public JsonElement AsJsonElement() => _element;
+
+    /// <summary>
     /// Numeric JSON value as <see cref="double"/> for use in expressions (e.g. comparisons).
     /// </summary>
     public double AsDouble() =>

--- a/test/BBT.Workflow.Application.Tests/Functions/FunctionAppServiceScopeTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Functions/FunctionAppServiceScopeTests.cs
@@ -46,6 +46,7 @@ public sealed class FunctionAppServiceScopeTests : IDisposable
     private readonly IComponentCacheStore _componentCacheStore;
     private readonly ITaskCoordinator _taskCoordinator;
     private readonly IStateStoreCacheGateway _cacheGateway;
+    private readonly IDynamicExpressoValueEvaluator _keyEvaluator;
     private readonly FunctionAppService _service;
 
     private readonly IServiceProvider _ambientServiceProvider;
@@ -57,6 +58,7 @@ public sealed class FunctionAppServiceScopeTests : IDisposable
         _componentCacheStore = Substitute.For<IComponentCacheStore>();
         _taskCoordinator = Substitute.For<ITaskCoordinator>();
         _cacheGateway = Substitute.For<IStateStoreCacheGateway>();
+        _keyEvaluator = Substitute.For<IDynamicExpressoValueEvaluator>();
 
         // Ambient provider needed by PostSharp UnitOfWork interception.
         var mockUoW = Substitute.For<IUnitOfWork>();
@@ -66,6 +68,9 @@ public sealed class FunctionAppServiceScopeTests : IDisposable
             .Returns(Task.FromResult(mockUoW));
         var services = new ServiceCollection();
         services.AddSingleton(mockUoWManager);
+        services.AddLogging();
+        // ApplicationService.Logger resolves through ILazyServiceProvider.
+        services.AddTransient<ILazyServiceProvider, LazyServiceProvider>();
         _ambientServiceProvider = services.BuildServiceProvider();
         _previousAmbientServiceProvider = AmbientServiceProvider.Current;
         AmbientServiceProvider.Current = _ambientServiceProvider;
@@ -79,6 +84,7 @@ public sealed class FunctionAppServiceScopeTests : IDisposable
         builder.WithBody(Arg.Any<object?>()).Returns(builder);
         builder.WithHeaders(Arg.Any<Dictionary<string, string?>?>()).Returns(builder);
         builder.WithQueryParameters(Arg.Any<Dictionary<string, string?>?>()).Returns(builder);
+        builder.WithMetadata(Arg.Any<Dictionary<string, object>?>()).Returns(builder);
         builder.BuildAsync(Arg.Any<CancellationToken>()).Returns(scriptContext);
 
         var scriptContextFactory = Substitute.For<IScriptContextFactory>();
@@ -105,7 +111,7 @@ public sealed class FunctionAppServiceScopeTests : IDisposable
             scriptEngine: Substitute.For<IScriptEngine>(),
             currentUser: Substitute.For<ICurrentUser>(),
             transitionAuthorizationManager: Substitute.For<ITransitionAuthorizationManager>(),
-            keyEvaluator: Substitute.For<IDynamicExpressoValueEvaluator>(),
+            keyEvaluator: _keyEvaluator,
             cacheGateway: _cacheGateway,
             remoteInvoker: Substitute.For<IRemoteInvokerService>());
     }
@@ -238,7 +244,7 @@ public sealed class FunctionAppServiceScopeTests : IDisposable
         result.Value!.StatusCode.ShouldBe(200);
         // On a hit the tasks are not executed and nothing is written back.
         await _taskCoordinator.DidNotReceive().ExecuteAsync(
-            Arg.Any<IEnumerable<OnExecuteTask>>(), Arg.Any<Guid?>(), Arg.Any<TaskTrigger>(),
+            Arg.Any<IEnumerable<OnExecuteTask>>(), Arg.Any<Guid?>(), Arg.Any<TaskTrigger>(), Arg.Any<TaskExecutionOrigin>(),
             Arg.Any<ScriptContext>(), Arg.Any<CancellationToken>());
         await _cacheGateway.DidNotReceive().SetAsync(
             Arg.Any<string>(), Arg.Any<object?>(), Arg.Any<int?>(), Arg.Any<string?>(),
@@ -261,7 +267,7 @@ public sealed class FunctionAppServiceScopeTests : IDisposable
 
         result.IsSuccess.ShouldBeTrue();
         await _taskCoordinator.Received(1).ExecuteAsync(
-            Arg.Any<IEnumerable<OnExecuteTask>>(), Arg.Any<Guid?>(), Arg.Any<TaskTrigger>(),
+            Arg.Any<IEnumerable<OnExecuteTask>>(), Arg.Any<Guid?>(), Arg.Any<TaskTrigger>(), Arg.Any<TaskExecutionOrigin>(),
             Arg.Any<ScriptContext>(), Arg.Any<CancellationToken>());
         await _cacheGateway.Received(1).SetAsync(
             "fn:test", Arg.Any<object?>(), Arg.Any<int?>(), Arg.Any<string?>(),
@@ -293,17 +299,41 @@ public sealed class FunctionAppServiceScopeTests : IDisposable
             Arg.Any<string?>(), Arg.Any<TaskTraceContext>(), Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task GetFunctionByKeyAsync_KeyExpressionFails_BypassesCache_AndRunsFunction()
+    {
+        SetupCachedFunction(keyExpressionCode: "varyKey(context)");
+        // A failing key expression must NOT 500 the endpoint — it bypasses the cache and runs the function.
+        _keyEvaluator
+            .Evaluate(Arg.Any<ScriptCode>(), Arg.Any<ScriptContext>())
+            .Returns(Result<string>.Fail(Error.Failure("expr.fail", "boom")));
+
+        var result = await _service.GetFunctionByKeyAsync(FunctionKey, TestDomain);
+
+        result.IsSuccess.ShouldBeTrue();
+        // Function executed; cache never touched.
+        await _taskCoordinator.Received(1).ExecuteAsync(
+            Arg.Any<IEnumerable<OnExecuteTask>>(), Arg.Any<Guid?>(), Arg.Any<TaskTrigger>(), Arg.Any<TaskExecutionOrigin>(),
+            Arg.Any<ScriptContext>(), Arg.Any<CancellationToken>());
+        await _cacheGateway.DidNotReceive().GetAsync(
+            Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<TaskTraceContext>(), Arg.Any<CancellationToken>());
+    }
+
     // ─── Helpers ────────────────────────────────────────────────────────────────
 
-    private void SetupCachedFunction(string? generationKey = null)
+    private void SetupCachedFunction(string? generationKey = null, string? keyExpressionCode = null)
     {
         var task = OnExecuteTask.Create(
             1,
             new Reference("my-task", TestDomain, "sys-tasks", TestVersion),
             ScriptCode.FromNative(string.Empty));
+        var keyExpression = keyExpressionCode is null
+            ? null
+            : ScriptCode.FromNative(keyExpressionCode, "dynamicExpresso");
         var function = new Function(
             TaskScope.Domain, task,
-            cache: new FunctionCache(key: "fn:test", ttlInSeconds: 300, generationKey: generationKey));
+            cache: new FunctionCache(
+                key: "fn:test", ttlInSeconds: 300, generationKey: generationKey, keyExpression: keyExpression));
         function.SetReference(new Reference(FunctionKey, TestDomain, "sys-functions", TestVersion));
 
         _componentCacheStore

--- a/test/BBT.Workflow.Application.Tests/Tasks/Evaluators/DynamicExpressoValueEvaluatorTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Tasks/Evaluators/DynamicExpressoValueEvaluatorTests.cs
@@ -1,18 +1,47 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.DependencyInjection;
+using BBT.Aether.Uow;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Scripting;
 using BBT.Workflow.Scripting.Rules;
 using BBT.Workflow.Tasks.Evaluators;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 using Shouldly;
 using Xunit;
 
 namespace BBT.Workflow.Application.Tests.Tasks.Evaluators;
 
-public sealed class DynamicExpressoValueEvaluatorTests
+public sealed class DynamicExpressoValueEvaluatorTests : IDisposable
 {
+    private readonly IServiceProvider? _previousAmbientServiceProvider;
+
+    public DynamicExpressoValueEvaluatorTests()
+    {
+        // Required for the PostSharp SchemaValidation aspect used by Instance.AddData.
+        var mockUoW = Substitute.For<IUnitOfWork>();
+        var mockUoWManager = Substitute.For<IUnitOfWorkManager>();
+        mockUoWManager.BeginAsync(Arg.Any<UnitOfWorkOptions>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(mockUoW));
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(mockUoWManager);
+        services.AddSingleton(Substitute.For<BBT.Workflow.Caching.IComponentCacheStore>());
+        services.AddSingleton(Substitute.For<BBT.Workflow.DefinitionContext.IWorkflowContext>());
+        _previousAmbientServiceProvider = AmbientServiceProvider.Current;
+        AmbientServiceProvider.Current = services.BuildServiceProvider();
+    }
+
+    public void Dispose()
+    {
+        AmbientServiceProvider.Current = _previousAmbientServiceProvider;
+    }
+
     private static DynamicExpressoValueEvaluator CreateEvaluator() =>
         new(NullLogger<DynamicExpressoValueEvaluator>.Instance);
 
@@ -70,6 +99,64 @@ public sealed class DynamicExpressoValueEvaluatorTests
 
         result.IsSuccess.ShouldBeTrue();
         result.Value.ShouldBe("v:2.0.0");
+    }
+
+    [Fact]
+    public void VaryKey_UsesConfigHeadersAndPrefixes_Canonicalized_WithVersion()
+    {
+        var script = ScriptCode.FromNative("varyKey(context)", ConditionScriptLocations.DynamicExpresso);
+        var context = new ScriptContext.Builder(NullLogger<ScriptContext>.Instance)
+            .SetHeaders(new Dictionary<string, string> { ["x-param-b"] = "2", ["x-param-a"] = "1", ["x-other"] = "z", ["x-tenant"] = "acme" })
+            .SetQueryParameters(new Dictionary<string, string> { ["version"] = "3" })
+            .SetMetadata(new Dictionary<string, object>
+            {
+                [DynamicExpressoValueEvaluator.VaryByHeadersMetadataKey] = new[] { "x-tenant" },
+                [DynamicExpressoValueEvaluator.VaryByPrefixesMetadataKey] = new[] { "x-param-" }
+            })
+            .Build();
+
+        var result = CreateEvaluator().Evaluate(script, context);
+
+        result.IsSuccess.ShouldBeTrue();
+        // sorted names, x-other excluded, version prepended.
+        result.Value.ShouldBe("v=3|x-param-a=1|x-param-b=2|x-tenant=acme");
+    }
+
+    [Fact]
+    public void VaryKey_InstanceVaryBy_OverridesConfig_AndIgnoresOtherHeaders()
+    {
+        var instance = Instance.Create(Guid.NewGuid(), "flow", "1.0", "k");
+        instance.AddData(Guid.NewGuid(), new JsonData("""{ "varyBy": ["x-param-userroles"] }"""));
+
+        var script = ScriptCode.FromNative("varyKey(context)", ConditionScriptLocations.DynamicExpresso);
+        var context = new ScriptContext.Builder(NullLogger<ScriptContext>.Instance)
+            .SetInstance(instance)
+            .SetHeaders(new Dictionary<string, string> { ["x-param-userroles"] = "admin", ["x-param-customertype"] = "gold" })
+            .SetMetadata(new Dictionary<string, object>
+            {
+                [DynamicExpressoValueEvaluator.VaryByPrefixesMetadataKey] = new[] { "x-param-" }
+            })
+            .Build();
+
+        var result = CreateEvaluator().Evaluate(script, context);
+
+        result.IsSuccess.ShouldBeTrue();
+        // instance varyBy wins over config prefixes → only userroles; customertype excluded; default version.
+        result.Value.ShouldBe("v=latest|x-param-userroles=admin");
+    }
+
+    [Fact]
+    public void VaryKey_NoVaryByOrConfig_FallsBackToAllHeaders()
+    {
+        var script = ScriptCode.FromNative("varyKey(context)", ConditionScriptLocations.DynamicExpresso);
+        var context = new ScriptContext.Builder(NullLogger<ScriptContext>.Instance)
+            .SetHeaders(new Dictionary<string, string> { ["b"] = "2", ["a"] = "1" })
+            .Build();
+
+        var result = CreateEvaluator().Evaluate(script, context);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.ShouldBe("v=latest|a=1|b=2");
     }
 
     [Fact]

--- a/test/BBT.Workflow.Domain.Tests/Definitions/Functions/FunctionCacheTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Definitions/Functions/FunctionCacheTests.cs
@@ -65,6 +65,35 @@ public sealed class FunctionCacheTests
     }
 
     [Fact]
+    public void Deserialize_ParsesVaryByHeadersAndPrefixes()
+    {
+        var json = """
+        {
+          "key": "dcs:configA",
+          "varyByHeaders": ["x-tenant", "x-channel"],
+          "varyByHeaderPrefixes": ["x-param-"]
+        }
+        """;
+
+        var cache = JsonSerializer.Deserialize<FunctionCache>(json, JsonSerializerConstants.JsonOptions);
+
+        cache.ShouldNotBeNull();
+        cache!.VaryByHeaders.ShouldBe(new[] { "x-tenant", "x-channel" });
+        cache.VaryByHeaderPrefixes.ShouldBe(new[] { "x-param-" });
+    }
+
+    [Fact]
+    public void VaryByCollections_DefaultToEmpty_WhenAbsent()
+    {
+        var cache = JsonSerializer.Deserialize<FunctionCache>(
+            """{ "key": "dcs:configA" }""", JsonSerializerConstants.JsonOptions);
+
+        cache.ShouldNotBeNull();
+        cache!.VaryByHeaders.ShouldBeEmpty();
+        cache.VaryByHeaderPrefixes.ShouldBeEmpty();
+    }
+
+    [Fact]
     public void HasGenerationSource_False_WhenNoGenerationKey()
     {
         var cache = JsonSerializer.Deserialize<FunctionCache>(


### PR DESCRIPTION
Add a generic varyKey(context) helper to the FunctionCache keyExpression (Dynamic Expresso) evaluator so a function's cache key can be built from exactly the request inputs that change the result. Header-name resolution is most-specific-first: Instance.Data["varyBy"] -> FunctionCache varyByHeaders u varyByHeaderPrefixes (carried via ScriptContext.MetaData) -> last-resort all-headers. The runtime imposes no header convention; the domain supplies the vary-by config.

- RuleJsonDynamic.AsJsonElement(): read-only accessor for the underlying element (headers/instance-data/metadata inspection in varyKey).
- FunctionCache: optional VaryByHeaders / VaryByHeaderPrefixes fields.
- DynamicExpressoValueEvaluator: varyKey() with canonicalization (lowercase/trim/dedupe/ordinal-sort, name=value join, v={version} prefix).
- FunctionAppService: inject vary-by config into MetaData; a failing key expression bypasses the cache and runs the function (never 500s); warn when a keyExpression is configured without any vary-by config.

Tests: 6 new (3 varyKey, 1 key-eval bypass, 2 FunctionCache parse); full baseline-vs-changes regression shows zero new failures across Domain, Application, Infrastructure.

## Summary by Sourcery

Introduce configuration-driven cache key variation support for functions and improve cache key evaluation robustness.

New Features:
- Add a generic varyKey(context) helper for Dynamic Expresso key expressions to build canonical vary-by strings from request inputs and version query parameters.
- Allow FunctionCache to specify vary-by headers and header-name prefixes that drive cache key composition without imposing a runtime header convention.

Enhancements:
- Expose RuleJsonDynamic.AsJsonElement() to support low-level JSON inspection needed by cache key building utilities.
- Propagate FunctionCache vary-by configuration into ScriptContext metadata so key expressions can consume it, and log when cache is enabled without vary-by configuration.
- Change FunctionAppService to bypass caching and execute functions when cache key expressions fail, avoiding endpoint failures and adding diagnostic logging.
- Extend tests for DynamicExpressoValueEvaluator, FunctionAppService, and FunctionCache to cover varyKey behavior, cache-key evaluation bypass, and vary-by configuration parsing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added header-based cache variation using configurable headers and header prefixes.
  * Added the `varyKey()` helper for generating consistent cache keys, including version support.
  * Added support for inspecting JSON values when building cache variation keys.

* **Bug Fixes**
  * Cache key evaluation failures now bypass caching and continue executing the function successfully.
  * Added warnings for incomplete cache variation configuration and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->