### PR TITLE
fix(resource-lock): idempotent release, automatic terminal cleanup, a…

### DIFF
--- a/.claude/rules/vnext-workflow-developer.md
+++ b/.claude/rules/vnext-workflow-developer.md
@@ -41,7 +41,7 @@ Flow: apply `MutateDirectives` → Stop → break; SkipTo → replan; else conti
 | Profile | Trigger | Key Exclusions |
 |---------|---------|----------------|
 | Manual | Manual (0) | None |
-| AutoChain | Automatic (1) | Preflight, SetBusy, CreateTransition, ResourceLock, ResolveAvailable |
+| AutoChain | Automatic (1) | Preflight, CheckParentUpdateData, ForwardSubflow, SetBusy, ApplyTimeoutState (ResourceLock runs — auto-chained transitions can acquire locks) |
 | Scheduled | Scheduled (2) | Preflight, ForwardSubflow, SetBusy, ResourceLock |
 | Event | Event (3) | Preflight, ForwardSubflow, SetBusy, ResourceLock |
 | ErrorBoundary | Error boundary | Preflight, UpdateDataCheck, ForwardSubflow, ResourceLock, Auto, Schedule; `AllowAutoChain=false`, `AllowSubFlow=false` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,7 @@ Transitions execute through a deterministic pipeline of ordered steps. Each step
 
 **StepOutcome**: `Continue()` (next step), `Stop()` (break loop), `SkipTo(order)` (jump + replan), `SkipToFinalize()` (shorthand), `With(Action<PipelineDirectives>)` (mutate directives).
 
-**PipelineExecutionProfile**: Each trigger type resolves to a profile (`IPipelineProfileResolver`) that excludes irrelevant steps. Profiles: Manual (no exclusions), AutoChain (skip Preflight/SetBusy/CreateTransition/ResourceLock/ResolveAvailable), Scheduled, Event, ErrorBoundary (`AllowAutoChain=false`, `AllowSubFlow=false`).
+**PipelineExecutionProfile**: Each trigger type resolves to a profile (`IPipelineProfileResolver`) that excludes irrelevant steps. Profiles: Manual (no exclusions), AutoChain (skip Preflight/CheckParentUpdateData/ForwardSubflow/SetBusy/ApplyTimeoutState — ResourceLock runs so auto-chained transitions can lock), Scheduled, Event, ErrorBoundary (`AllowAutoChain=false`, `AllowSubFlow=false`).
 
 **TransitionExecutionContext**: Built by `TransitionContextFactory` (workflow from `IComponentCacheStore`, instance from `instanceRepository.GetActiveAsync`). Same context reference flows through all steps. `Cache` dict cleared at Finalize. `Directives` accumulate mutations (next transition, post-commit jobs, epilogue skip).
 

--- a/src/BBT.Workflow.Application/Execution/ExecutionErrors.cs
+++ b/src/BBT.Workflow.Application/Execution/ExecutionErrors.cs
@@ -136,15 +136,9 @@ public static class ExecutionErrors
             WorkflowErrorCodes.ResourceLockInvalidAction,
             $"Unknown resource lock action: {action}");
 
-    /// <summary>
-    /// Creates an error when a resource lock release fails because the lock is not held by this owner.
-    /// </summary>
-    /// <param name="resourceKey">The lock key that could not be released.</param>
-    public static Error ResourceLockReleaseFailed(string resourceKey)
-        => Error.Failure(
-            WorkflowErrorCodes.ResourceLockReleaseFailed,
-            $"Failed to release resource lock for key '{resourceKey}'. Lock not held by this owner.",
-            detail: resourceKey);
+    // Note: Release is idempotent, best-effort cleanup and never faults the transition
+    // (see ResourceLockStep.ReleaseAsync / DaprResourceLockService.ReleaseAsync), so there is
+    // deliberately no release-failure Error here — anomalies are logged, not surfaced as failures.
 
     #endregion
 

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ResourceLockStep.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/Steps/ResourceLockStep.cs
@@ -46,7 +46,7 @@ public sealed class ResourceLockStep(
 
         return lockDef.Action switch
         {
-            ResourceLockAction.Acquire => await AcquireAsync(resourceKey, owner, lockDef, cancellationToken),
+            ResourceLockAction.Acquire => await AcquireAsync(context, resourceKey, owner, lockDef, cancellationToken),
             ResourceLockAction.Release => await ReleaseAsync(resourceKey, owner, cancellationToken),
             ResourceLockAction.Extend  => await ExtendAsync(resourceKey, owner, lockDef, cancellationToken),
             _ => Result<StepOutcome>.Fail(
@@ -85,11 +85,19 @@ public sealed class ResourceLockStep(
     }
 
     private async Task<Result<StepOutcome>> AcquireAsync(
+        TransitionExecutionContext context,
         string resourceKey, string owner, ResourceLockDefinition lockDef, CancellationToken ct)
     {
         var acquired = await resourceLockService.AcquireAsync(resourceKey, owner, lockDef.TtlSeconds, ct);
         if (!acquired)
             return Result<StepOutcome>.Fail(ExecutionErrors.ResourceLockConflict(resourceKey));
+
+        // Record the key on the instance so its terminal cleanup releases the lock automatically,
+        // independent of which transition path completes/faults the instance. The pipeline's normal
+        // persistence flushes this ExtraProperties change; if the transition rolls back before commit
+        // (or the instance snapshot is absent), the lock's TTL remains the safety net — the same
+        // fallback as an un-run explicit Release.
+        context.Instance?.TrackResourceLock(resourceKey);
 
         return Result<StepOutcome>.Ok(StepOutcome.Continue());
     }
@@ -97,10 +105,11 @@ public sealed class ResourceLockStep(
     private async Task<Result<StepOutcome>> ReleaseAsync(
         string resourceKey, string owner, CancellationToken ct)
     {
-        var released = await resourceLockService.ReleaseAsync(resourceKey, owner, ct);
-        if (!released)
-            return Result<StepOutcome>.Fail(ExecutionErrors.ResourceLockReleaseFailed(resourceKey));
-
+        // Release is best-effort cleanup and must NEVER fault an otherwise-successful transition:
+        // an idempotent no-op (TTL expired / already released) is a success, and a genuine anomaly
+        // (lock held by another owner, infra error) is logged/metered by the service but must not
+        // roll back the business outcome. The lock's TTL is the ultimate safety net.
+        await resourceLockService.ReleaseAsync(resourceKey, owner, ct);
         return Result<StepOutcome>.Ok(StepOutcome.Continue());
     }
 

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/TransitionPipeline.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/TransitionPipeline.cs
@@ -40,6 +40,21 @@ public class TransitionPipeline
     private const int MaxChainDepth = 50;
 
     /// <summary>
+    /// Pipeline error codes that represent a caller-actionable condition rather than an internal
+    /// fault. When a step fails with one of these, the instance is still faulted but the failure is
+    /// propagated to the caller so it maps to the intended HTTP status (e.g. 409) instead of being
+    /// swallowed into the default "200 + Status=F" outcome. Extend deliberately — each entry must
+    /// have a matching non-500 mapping in <c>AddExceptionHandling</c>.
+    /// </summary>
+    private static readonly HashSet<string> ClientFacingErrorCodes = new(StringComparer.Ordinal)
+    {
+        WorkflowErrorCodes.ResourceLockConflict,
+    };
+
+    private static bool IsClientFacingError(Error error)
+        => error.Code is not null && ClientFacingErrorCodes.Contains(error.Code);
+
+    /// <summary>
     /// Initializes a new instance of the TransitionPipeline.
     /// </summary>
     public TransitionPipeline(
@@ -179,6 +194,14 @@ public class TransitionPipeline
             if (!pipelineResult.IsSuccess)
             {
                 await MarkInstanceFaultedAsync(context, pipelineResult.Error, cancellationToken);
+
+                // The instance is now faulted (F) regardless. For caller-actionable errors
+                // (e.g. ResourceLockConflict) propagate the failure so the HTTP layer returns the
+                // mapped status (409) instead of swallowing it into "200 + Status=F". All other
+                // pipeline faults keep the existing 200 + Status=F behavior.
+                if (IsClientFacingError(pipelineResult.Error))
+                    return Result<TransitionExecutionContext>.Fail(pipelineResult.Error);
+
                 return Result<TransitionExecutionContext>.Ok(context);
             }
 

--- a/src/BBT.Workflow.Application/Instances/Managers/InstanceCancellationService.cs
+++ b/src/BBT.Workflow.Application/Instances/Managers/InstanceCancellationService.cs
@@ -1,6 +1,7 @@
 using BBT.Aether.BackgroundJob;
 using BBT.Aether.Results;
 using BBT.Aether.Uow;
+using BBT.Workflow.Execution;
 using BBT.Workflow.Logging;
 using Microsoft.Extensions.Logging;
 
@@ -18,6 +19,7 @@ public sealed class InstanceCancellationService(
     IInstanceRepository instanceRepository,
     IInstanceJobRepository instanceJobRepository,
     IBackgroundJobService backgroundJobService,
+    IResourceLockService resourceLockService,
     IUnitOfWorkManager uowManager,
     ILogger<InstanceCancellationService> logger)
     :  IInstanceCancellationService
@@ -40,6 +42,12 @@ public sealed class InstanceCancellationService(
                 logger.InstanceNotFound(instanceId, string.Empty);
                 return Result.Fail(WorkflowErrors.InstanceNotFound(instanceId.ToString()));
             }
+
+            // Release any distributed resource locks this instance holds. Runs on every terminal
+            // path (completed / faulted / canceled) and before the job-cleanup early return, so a
+            // lock is freed the moment the instance reaches a terminal state — no per-transition
+            // Release wiring, and no leak until TTL on unexpected faults. Best-effort and idempotent.
+            await ReleaseTrackedResourceLocksAsync(instance, cancellationToken);
 
             var jobs = await instanceJobRepository.GetListActiveAsync(instance.Id, cancellationToken);
 
@@ -151,6 +159,35 @@ public sealed class InstanceCancellationService(
         {
             logger.InstanceCanceledProcessingFailed(ex, instanceId);
             return Result.Fail(WorkflowErrors.InstanceCancellationFailed(instanceId, ex.Message));
+        }
+    }
+
+    /// <summary>
+    /// Releases every distributed resource lock recorded on the instance (owner = instance ID).
+    /// Best-effort: release is idempotent (an already-expired/released lock is a no-op) and a failure
+    /// to release one key must never abort terminal cleanup — the lock's TTL is the ultimate safety net.
+    /// The tracked key set is intentionally left in metadata (re-release is harmless) to avoid an
+    /// extra persistence write on the cleanup path.
+    /// </summary>
+    private async Task ReleaseTrackedResourceLocksAsync(Instance instance, CancellationToken cancellationToken)
+    {
+        var lockKeys = instance.GetTrackedResourceLocks();
+        if (lockKeys.Count == 0)
+        {
+            return;
+        }
+
+        var owner = instance.Id.ToString();
+        foreach (var lockKey in lockKeys)
+        {
+            try
+            {
+                await resourceLockService.ReleaseAsync(lockKey, owner, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                logger.ResourceLockAutoReleaseError(ex, lockKey, instance.Id);
+            }
         }
     }
 

--- a/src/BBT.Workflow.Domain/DomainConsts.cs
+++ b/src/BBT.Workflow.Domain/DomainConsts.cs
@@ -21,5 +21,11 @@ public class DomainConsts
         public const string StateRoleOverrides = "subflow.state_role_overrides";
         /// <summary>Root (ancestor) flow instance ID — always carries the original A-flow ID down the entire chain.</summary>
         public const string RootInstanceId = "root.instance.id";
+        /// <summary>
+        /// JSON array of distributed resource-lock keys acquired by this instance (owner = instance ID).
+        /// Recorded on Acquire so the instance's terminal cleanup can release them automatically,
+        /// independent of which transition path completes the instance.
+        /// </summary>
+        public const string ResourceLocks = "resource.locks";
     }
 }

--- a/src/BBT.Workflow.Domain/Execution/Transitions/Pipeline/PipelineExecutionProfile.cs
+++ b/src/BBT.Workflow.Domain/Execution/Transitions/Pipeline/PipelineExecutionProfile.cs
@@ -28,12 +28,16 @@ public sealed class PipelineExecutionProfile
     /// </summary>
     public required bool AllowSubFlow { get; init; }
 
+    // NOTE: ResourceLock is intentionally NOT excluded here. It is per-transition business logic
+    // (acquire/release a shared-resource lock keyed by the transition's script), not chain-head
+    // request setup like SetBusy. Excluding it made a schema-valid `resourceLock` on an auto-chained
+    // transition silently no-op — and it is inconsistent with the Scheduled/Event profiles, which
+    // already run it. Only the genuine per-request/subflow-prelude steps stay excluded.
     private static readonly ImmutableHashSet<int> AutoChainExcluded = ImmutableHashSet.Create(
         LifecycleOrder.Preflight,
         LifecycleOrder.CheckParentUpdateDataTransition,
         LifecycleOrder.ForwardToActiveSubflow,
         LifecycleOrder.SetBusy,
-        LifecycleOrder.ResourceLock,
         LifecycleOrder.ApplyTimeoutState);
 
     private static readonly ImmutableHashSet<int> ScheduledExcluded = ImmutableHashSet.Create(
@@ -98,7 +102,8 @@ public sealed class PipelineExecutionProfile
 
     /// <summary>
     /// Creates the profile optimized for automatic (auto-chain) transitions:
-    /// excludes preflight, parent/subflow forwarding, resource lock, and timeout application; subflow disabled.
+    /// excludes preflight, parent/subflow forwarding, busy marking, and timeout application; subflow disabled.
+    /// Resource lock steps still run so a <c>resourceLock</c> defined on an auto-chained transition is honored.
     /// </summary>
     public static PipelineExecutionProfile ForAutoChain() => AutoChainInstance;
 

--- a/src/BBT.Workflow.Domain/Instances/InstanceMetadataExtensions.cs
+++ b/src/BBT.Workflow.Domain/Instances/InstanceMetadataExtensions.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Text.Json;
 using BBT.Aether;
 using BBT.Workflow.Definitions;
 
@@ -6,6 +7,55 @@ namespace BBT.Workflow.Instances;
 
 public static class InstanceMetadataExtensions
 {
+    /// <summary>
+    /// Records a distributed resource-lock key acquired by this instance so that the instance's
+    /// terminal cleanup can release it automatically (owner = instance ID), regardless of which
+    /// transition path completes/faults the instance. Idempotent: a key already tracked is ignored.
+    /// The key set is stored as a JSON array string under <see cref="DomainConsts.MetaDataKeys.ResourceLocks"/>.
+    /// </summary>
+    public static void TrackResourceLock(this Instance instance, string resourceKey)
+    {
+        if (instance is null)
+            throw new ArgumentNullException(nameof(instance));
+        if (string.IsNullOrWhiteSpace(resourceKey))
+            return;
+
+        var keys = instance.GetTrackedResourceLocks().ToList();
+        if (keys.Contains(resourceKey))
+            return;
+
+        keys.Add(resourceKey);
+
+        var metadata = new ExtraPropertyDictionary(instance.ExtraProperties ?? new ExtraPropertyDictionary())
+        {
+            [DomainConsts.MetaDataKeys.ResourceLocks] = JsonSerializer.Serialize(keys)
+        };
+        instance.SetMetaData(metadata);
+    }
+
+    /// <summary>
+    /// Returns the distributed resource-lock keys currently tracked for this instance
+    /// (see <see cref="TrackResourceLock"/>). Never returns null; tolerates missing or malformed metadata.
+    /// </summary>
+    public static IReadOnlyList<string> GetTrackedResourceLocks(this Instance instance)
+    {
+        if (instance is null)
+            throw new ArgumentNullException(nameof(instance));
+
+        var raw = GetString(instance.ExtraProperties, DomainConsts.MetaDataKeys.ResourceLocks);
+        if (string.IsNullOrWhiteSpace(raw))
+            return Array.Empty<string>();
+
+        try
+        {
+            return JsonSerializer.Deserialize<List<string>>(raw) ?? (IReadOnlyList<string>)Array.Empty<string>();
+        }
+        catch (JsonException)
+        {
+            return Array.Empty<string>();
+        }
+    }
+
     public static SubFlowContractInfo ToSubFlowContractInfo(this Instance instance)
     {
         if (instance is null)

--- a/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
@@ -1987,7 +1987,21 @@ public static partial class WorkflowLogs
         string owner);
 
     /// <summary>
-    /// Logs when a resource lock release fails (lock not held by this owner).
+    /// Logs when a resource lock release is a no-op because the lock no longer exists
+    /// (TTL already expired or it was never acquired). Treated as an idempotent success.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 10102,
+        Level = LogLevel.Debug,
+        Message = "Resource lock release no-op (lock does not exist): Key={ResourceKey}, Owner={Owner}")]
+    public static partial void ResourceLockReleaseNoop(
+        this ILogger logger,
+        string resourceKey,
+        string owner);
+
+    /// <summary>
+    /// Logs when a resource lock release hits a genuine anomaly (lock held by another owner
+    /// or an infrastructure error). Best-effort cleanup: surfaced for metrics, does not fault the caller.
     /// </summary>
     [LoggerMessage(
         EventId = 10104,
@@ -1998,6 +2012,20 @@ public static partial class WorkflowLogs
         string resourceKey,
         string owner,
         string status);
+
+    /// <summary>
+    /// Logs when the automatic terminal-cleanup release of a tracked resource lock throws.
+    /// Best-effort: the failure is swallowed (TTL is the safety net) and only surfaced for metrics.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 10105,
+        Level = LogLevel.Warning,
+        Message = "Resource lock auto-release errored: Key={ResourceKey}, InstanceId={InstanceId}")]
+    public static partial void ResourceLockAutoReleaseError(
+        this ILogger logger,
+        Exception exception,
+        string resourceKey,
+        Guid instanceId);
 
     /// <summary>
     /// Logs when a distributed resource lock TTL is successfully extended.

--- a/src/BBT.Workflow.Domain/WorkflowErrorCodes.cs
+++ b/src/BBT.Workflow.Domain/WorkflowErrorCodes.cs
@@ -75,7 +75,6 @@ public static class WorkflowErrorCodes
     public const string ResourceLockKeyEmpty = "Execution:200011";
     public const string ResourceLockKeyResolutionFailed = "Execution:200012";
     public const string ResourceLockInvalidAction = "Execution:200013";
-    public const string ResourceLockReleaseFailed = "Execution:200014";
     
     #endregion
     

--- a/src/BBT.Workflow.HttpApi.Shared/Microsoft/Extensions/DependencyInjection/WorkflowApiBaseServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.HttpApi.Shared/Microsoft/Extensions/DependencyInjection/WorkflowApiBaseServiceCollectionExtensions.cs
@@ -313,7 +313,6 @@ public static class WorkflowApiBaseServiceCollectionExtensions
             // Execution errors
             opt.Map(WorkflowErrorCodes.ExecutionStepFailed, HttpStatusCode.BadRequest);
             opt.Map(WorkflowErrorCodes.ResourceLockConflict, HttpStatusCode.Conflict);
-            opt.Map(WorkflowErrorCodes.ResourceLockReleaseFailed, HttpStatusCode.InternalServerError);
 
             // Task errors
             opt.Map(WorkflowErrorCodes.TaskContextCreation, HttpStatusCode.InternalServerError);

--- a/src/BBT.Workflow.Infrastructure/Execution/ResourceLock/DaprResourceLockService.cs
+++ b/src/BBT.Workflow.Infrastructure/Execution/ResourceLock/DaprResourceLockService.cs
@@ -35,24 +35,37 @@ public sealed class DaprResourceLockService(
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Release is idempotent, like DELETE: the postcondition is "this owner no longer holds the lock".
+    /// <see cref="LockStatus.Success"/> and <see cref="LockStatus.LockDoesNotExist"/> both satisfy that
+    /// postcondition and return <c>true</c> — a lock whose TTL already expired (or was never held) is a
+    /// no-op, not a failure. Only a genuine anomaly (<see cref="LockStatus.LockBelongsToOthers"/> or an
+    /// infrastructure error) returns <c>false</c>, and is logged as a warning so it can be metered
+    /// without faulting the caller's (already-successful) business transition.
+    /// </remarks>
     public async Task<bool> ReleaseAsync(
         string resourceKey, string owner, CancellationToken cancellationToken)
     {
         var response = await daprClient.Unlock(
             lockStoreName, resourceKey, owner, cancellationToken);
 
-        var success = response.status == LockStatus.Success;
-
-        if (success)
+        switch (response.status)
         {
-            logger.ResourceLockReleased(resourceKey, owner);
-        }
-        else
-        {
-            logger.ResourceLockReleaseFailed(resourceKey, owner, response.status.ToString());
-        }
+            case LockStatus.Success:
+                logger.ResourceLockReleased(resourceKey, owner);
+                return true;
 
-        return success;
+            case LockStatus.LockDoesNotExist:
+                // Idempotent: nothing to release (TTL expired or never acquired). Postcondition holds.
+                logger.ResourceLockReleaseNoop(resourceKey, owner);
+                return true;
+
+            default:
+                // LockBelongsToOthers / InternalError: a real anomaly, but releasing is best-effort
+                // cleanup — surface it via a warning/metric, never fault the business transition.
+                logger.ResourceLockReleaseFailed(resourceKey, owner, response.status.ToString());
+                return false;
+        }
     }
 
     /// <inheritdoc />

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/Steps/ResourceLockStepTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/Steps/ResourceLockStepTests.cs
@@ -82,10 +82,12 @@ public class ResourceLockStepTests
 
         result.IsSuccess.ShouldBeTrue();
         result.Value!.StopPipeline.ShouldBeFalse();
+        // A successful acquire records the key on the instance so terminal cleanup can auto-release it.
+        context.Instance.GetTrackedResourceLocks().ShouldContain(TestResourceKey);
     }
 
     [Fact]
-    public async Task ExecuteAsync_Acquire_WhenConflict_ShouldFail()
+    public async Task ExecuteAsync_Acquire_WhenConflict_ShouldNotTrackAndShouldFail()
     {
         var context = CreateContext(ResourceLockAction.Acquire);
         SetupScriptEngine(TestResourceKey);
@@ -97,6 +99,8 @@ public class ResourceLockStepTests
 
         result.IsSuccess.ShouldBeFalse();
         result.Error.Code.ShouldBe(WorkflowErrorCodes.ResourceLockConflict);
+        // A failed acquire must not record anything — nothing to release later.
+        context.Instance.GetTrackedResourceLocks().ShouldBeEmpty();
     }
 
     [Fact]
@@ -115,8 +119,10 @@ public class ResourceLockStepTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_Release_WhenFailed_ShouldFail()
+    public async Task ExecuteAsync_Release_WhenServiceReportsAnomaly_ShouldStillContinue()
     {
+        // Release is best-effort cleanup: even a false result (lock held by another owner /
+        // infra error) must NOT fault the transition — it only gets logged/metered by the service.
         var context = CreateContext(ResourceLockAction.Release);
         SetupScriptEngine(TestResourceKey);
         _resourceLockService
@@ -125,8 +131,8 @@ public class ResourceLockStepTests
 
         var result = await _step.ExecuteAsync(context, CancellationToken.None);
 
-        result.IsSuccess.ShouldBeFalse();
-        result.Error.Code.ShouldBe(WorkflowErrorCodes.ResourceLockReleaseFailed);
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.StopPipeline.ShouldBeFalse();
     }
 
     [Fact]

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/TransitionPipelineTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Pipeline/TransitionPipelineTests.cs
@@ -630,6 +630,39 @@ public class TransitionPipelineTests
     }
 
     [Fact]
+    public async Task RunAsync_WhenStepFailsWithClientFacingError_ShouldFaultInstanceAndReturnFailure()
+    {
+        // A caller-actionable failure (ResourceLockConflict) must fault the instance AND surface the
+        // failure so the HTTP layer returns the mapped status (409) instead of "200 + Status=F".
+        var context = CreateTransitionExecutionContext();
+        var workflowContext = CreateWorkflowExecutionContext(context);
+        var error = Error.Conflict(WorkflowErrorCodes.ResourceLockConflict, "Resource is already locked");
+
+        SetupContextFactory(context);
+
+        _mockSteps[0].ExecuteAsync(Arg.Any<TransitionExecutionContext>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Result<StepOutcome>.Fail(error)));
+        for (int i = 1; i < _mockSteps.Count; i++)
+        {
+            _mockSteps[i].ExecuteAsync(Arg.Any<TransitionExecutionContext>(), Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult(Result<StepOutcome>.Ok(StepOutcome.Continue())));
+        }
+
+        // Act
+        var result = await _pipeline.RunAsync(workflowContext, CancellationToken.None);
+
+        // Assert: instance still faulted...
+        await _mockInstanceRepository.Received(1)
+            .UpdateAsync(
+                Arg.Is<Instance>(x => x.Status.Equals(InstanceStatus.Faulted)),
+                true,
+                Arg.Any<CancellationToken>());
+        // ...but the failure is propagated to the caller (→ 409), not swallowed into a success.
+        result.IsSuccess.ShouldBeFalse();
+        result.Error.Code.ShouldBe(WorkflowErrorCodes.ResourceLockConflict);
+    }
+
+    [Fact]
     public async Task RunAsync_WhenStepReturnsStop_ShouldStopPipeline()
     {
         // Arrange

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceCancellationServiceTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceCancellationServiceTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using BBT.Aether.BackgroundJob;
 using BBT.Aether.Uow;
 using BBT.Workflow.Definitions;
+using BBT.Workflow.Execution;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Shouldly;
@@ -23,6 +24,7 @@ public sealed class InstanceCancellationServiceTests
     private readonly Mock<IInstanceRepository> _instanceRepository = new();
     private readonly Mock<IInstanceJobRepository> _instanceJobRepository = new();
     private readonly Mock<IBackgroundJobService> _backgroundJobService = new();
+    private readonly Mock<IResourceLockService> _resourceLockService = new();
     private readonly Mock<IUnitOfWorkManager> _uowManager = new();
     private readonly Mock<IUnitOfWork> _uow = new();
     private readonly CapturingLogger _logger = new();
@@ -215,6 +217,44 @@ public sealed class InstanceCancellationServiceTests
             $"Processed 1 scheduled jobs for instance {_instance.Id}, transitions: failed, waiting, running");
     }
 
+    [Fact]
+    public async Task ProcessCancellation_releases_all_tracked_resource_locks_even_without_jobs()
+    {
+        // Auto-release must run on the terminal path regardless of whether the instance has jobs.
+        _instance.TrackResourceLock("limit:scope:2026-07-24");
+        _instance.TrackResourceLock("seat:A1");
+        _instanceJobRepository
+            .Setup(r => r.GetListActiveAsync(_instance.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<InstanceJob>());
+
+        var result = await CreateService().ProcessCancellationAsync(_instance.Id);
+
+        result.IsSuccess.ShouldBeTrue();
+        _resourceLockService.Verify(
+            s => s.ReleaseAsync("limit:scope:2026-07-24", _instance.Id.ToString(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _resourceLockService.Verify(
+            s => s.ReleaseAsync("seat:A1", _instance.Id.ToString(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ProcessCancellation_lockReleaseThrows_stillCompletesCleanup()
+    {
+        // Releasing is best-effort: an exception from the lock store must not fail terminal cleanup.
+        _instance.TrackResourceLock("k1");
+        _resourceLockService
+            .Setup(s => s.ReleaseAsync("k1", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("lock store unavailable"));
+        _instanceJobRepository
+            .Setup(r => r.GetListActiveAsync(_instance.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<InstanceJob>());
+
+        var result = await CreateService().ProcessCancellationAsync(_instance.Id);
+
+        result.IsSuccess.ShouldBeTrue();
+    }
+
     private InstanceJob CreateInstanceJob(string transition = "check") =>
         InstanceJob.Create(
             Guid.NewGuid(),
@@ -229,6 +269,7 @@ public sealed class InstanceCancellationServiceTests
             _instanceRepository.Object,
             _instanceJobRepository.Object,
             _backgroundJobService.Object,
+            _resourceLockService.Object,
             _uowManager.Object,
             _logger);
 

--- a/test/BBT.Workflow.Domain.Tests/Execution/Transitions/Pipeline/PipelineExecutionProfileTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Execution/Transitions/Pipeline/PipelineExecutionProfileTests.cs
@@ -36,11 +36,13 @@ public class PipelineExecutionProfileTests : DomainTestBase<DomainEntryPoint>
             LifecycleOrder.Preflight,
             LifecycleOrder.CheckParentUpdateDataTransition,
             LifecycleOrder.ForwardToActiveSubflow,
-            LifecycleOrder.ResourceLock,
+            LifecycleOrder.SetBusy,
             LifecycleOrder.ApplyTimeoutState,
         };
         profile.ExcludedStepOrders.OrderBy(x => x).ToArray().ShouldBe(expected);
         profile.ExcludedStepOrders.Count.ShouldBe(5);
+        // ResourceLock must NOT be excluded: a `resourceLock` on an auto-chained transition must run.
+        profile.ExcludedStepOrders.ShouldNotContain(LifecycleOrder.ResourceLock);
     }
 
     [Fact]

--- a/test/BBT.Workflow.Domain.Tests/Instances/InstanceMetadataExtensionsTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Instances/InstanceMetadataExtensionsTests.cs
@@ -7,6 +7,58 @@ namespace BBT.Workflow.Instances;
 public class InstanceMetadataExtensionsTests : DomainTestBase<DomainEntryPoint>
 {
     [Fact]
+    public void TrackResourceLock_RecordsKey_AndGetReturnsIt()
+    {
+        var instance = Instance.Create(Guid.NewGuid(), "flow", "1.0.0", "key");
+
+        instance.TrackResourceLock("limit:scope:2026-07-24");
+
+        Assert.Equal(new[] { "limit:scope:2026-07-24" }, instance.GetTrackedResourceLocks());
+    }
+
+    [Fact]
+    public void TrackResourceLock_IsIdempotent_AndPreservesOrderForDistinctKeys()
+    {
+        var instance = Instance.Create(Guid.NewGuid(), "flow", "1.0.0", "key");
+
+        instance.TrackResourceLock("a");
+        instance.TrackResourceLock("b");
+        instance.TrackResourceLock("a"); // duplicate ignored
+
+        Assert.Equal(new[] { "a", "b" }, instance.GetTrackedResourceLocks());
+    }
+
+    [Fact]
+    public void TrackResourceLock_IgnoresNullOrWhitespaceKeys()
+    {
+        var instance = Instance.Create(Guid.NewGuid(), "flow", "1.0.0", "key");
+
+        instance.TrackResourceLock("   ");
+
+        Assert.Empty(instance.GetTrackedResourceLocks());
+    }
+
+    [Fact]
+    public void GetTrackedResourceLocks_WhenNothingTracked_ReturnsEmpty()
+    {
+        var instance = Instance.Create(Guid.NewGuid(), "flow", "1.0.0", "key");
+
+        Assert.Empty(instance.GetTrackedResourceLocks());
+    }
+
+    [Fact]
+    public void GetTrackedResourceLocks_WhenMetadataMalformed_ReturnsEmpty()
+    {
+        var instance = Instance.Create(Guid.NewGuid(), "flow", "1.0.0", "key");
+        instance.SetMetaData(new ExtraPropertyDictionary
+        {
+            [DomainConsts.MetaDataKeys.ResourceLocks] = "not-a-json-array"
+        });
+
+        Assert.Empty(instance.GetTrackedResourceLocks());
+    }
+
+    [Fact]
     public void GetRootInstanceId_WhenNoRootKeyInExtraProperties_ReturnsSelfId()
     {
         // Arrange — root instance (A): no parent, no root.instance.id

--- a/test/BBT.Workflow.Infrastructure.Tests/Execution/ResourceLock/DaprResourceLockServiceTests.cs
+++ b/test/BBT.Workflow.Infrastructure.Tests/Execution/ResourceLock/DaprResourceLockServiceTests.cs
@@ -90,11 +90,26 @@ public class DaprResourceLockServiceTests
     }
 
     [Fact]
-    public async Task ReleaseAsync_WhenUnlockFails_ShouldReturnFalse()
+    public async Task ReleaseAsync_WhenLockDoesNotExist_ShouldReturnTrueIdempotently()
     {
+        // TTL already expired or lock was never held: releasing is a no-op, not a failure.
         _mockDaprClient
             .Setup(c => c.Unlock(LockStoreName, ResourceKey, Owner, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new UnlockResponse(LockStatus.LockDoesNotExist));
+
+        var result = await _service.ReleaseAsync(ResourceKey, Owner, CancellationToken.None);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ReleaseAsync_WhenLockBelongsToOthers_ShouldReturnFalse()
+    {
+        // A genuine anomaly: the lock is held by a different owner. Reported as false (logged/metered),
+        // but the step layer still declines to fault the transition.
+        _mockDaprClient
+            .Setup(c => c.Unlock(LockStoreName, ResourceKey, Owner, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UnlockResponse(LockStatus.LockBelongsToOthers));
 
         var result = await _service.ReleaseAsync(ResourceKey, Owner, CancellationToken.None);
 


### PR DESCRIPTION
…nd 409 on conflict

Harden the transition-pipeline ResourceLock feature after first real testing on the morph-idm domain. Three related changes:

- Release is now idempotent and best-effort. DaprResourceLockService.ReleaseAsync treats LockDoesNotExist (TTL expired / never held) as success and only reports LockBelongsToOthers / infra errors as a warning; ResourceLockStep never faults the transition on release. Removes the now-dead ResourceLockReleaseFailed error/code/mapping.

- Automatic terminal release. A successful Acquire records the lock key on the instance (ExtraProperties, Instance.TrackResourceLock); InstanceCancellationService.ProcessCancellationAsync releases all tracked locks (owner = instanceId) on every terminal path (completed / faulted / cancelled), before the job-cleanup early return. Flows only need Acquire — no per-transition Release wiring, and no leak-until-TTL on unexpected faults.

- Conflict now surfaces as HTTP 409. TransitionPipeline.RunChainAsync still faults the instance on a pipeline-step failure but propagates caller-actionable errors (ResourceLockConflict) via Result.Fail so the existing 409 mapping applies, instead of swallowing them into 200 + Status=F. Selective allowlist keeps all other faults on the existing 200 + Status=F behavior.

Feature is opt-in per transition and domain-agnostic: instances that never acquire a lock are unaffected. All work stays within the Orchestration-side pipeline/cleanup layer.

Tests: Domain 9/9, Application 39/39, Infrastructure 10/10.

## Summary by Sourcery

Make resource lock handling idempotent, best-effort, and client-aware while adding automatic terminal cleanup of acquired locks.

New Features:
- Track acquired resource lock keys on instances so terminal cleanup can automatically release them across all completion paths.
- Surface resource lock conflicts to callers as pipeline failures that preserve faulted instance state and map to HTTP 409.

Bug Fixes:
- Ensure pipeline propagates caller-facing errors like resource lock conflicts instead of swallowing them into successful responses.
- Treat missing or malformed resource-lock metadata on instances as empty to avoid errors during cleanup.

Enhancements:
- Make resource lock release idempotent, treating non-existent locks as successful no-ops and logging anomalies without faulting transitions.
- Add automatic best-effort release of all tracked resource locks during instance cancellation/terminal cleanup, regardless of active jobs.
- Relax ResourceLockStep release semantics so release anomalies no longer fault otherwise successful transitions and remove the unused release-failed error code and mapping.
- Extend logging around resource lock release behavior, including distinct messages for no-op releases and auto-release failures.
- Introduce a client-facing error allowlist in the transition pipeline to distinguish actionable errors from internal faults.

Tests:
- Add unit tests for instance resource-lock tracking metadata behavior, including idempotency and malformed data handling.
- Add tests ensuring instance cancellation releases tracked resource locks and remains successful even when release operations fail.
- Add tests verifying DaprResourceLockService idempotent release semantics and anomaly handling.
- Update resource lock step and transition pipeline tests to cover auto-tracking on acquire, non-tracking on conflict, non-faulting release anomalies, and client-facing error propagation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resource locks are now automatically tracked and released when workflow instances complete or are cancelled.
  * Caller-facing transition conflicts are propagated to the caller while the instance is marked as faulted.

* **Bug Fixes**
  * Lock release is idempotent and best-effort; missing/expired locks and release anomalies no longer interrupt cleanup or cancellation.

* **Documentation**
  * Auto-chain pipeline execution now explicitly keeps the Resource Lock step enabled (and related pipeline profile docs were updated).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->