### PR TITLE
fix(transitions): normalize request headers case-insensitively

### DIFF
--- a/src/BBT.Workflow.Application/Execution/PostCommit/Handlers/ForwardToSubflowJobHandler.cs
+++ b/src/BBT.Workflow.Application/Execution/PostCommit/Handlers/ForwardToSubflowJobHandler.cs
@@ -108,10 +108,14 @@ public sealed class ForwardToSubflowJobHandler(
     /// </summary>
     private static TransitionInput CreateTransitionInput(ForwardToSubflowJob job, ExecMode mode)
     {
-        var headers = new Dictionary<string, string?>(job.Headers)
-        {
-            [TelemetryConstants.HeaderNames.ParentInstanceId] = job.ParentInstanceId.ToString()
-        };
+        // HTTP headers are case-insensitive. Build with OrdinalIgnoreCase and copy the forwarded
+        // headers with last-wins semantics so a parent-instance-id already present (possibly
+        // lower-cased by an upstream hop) collapses into a single entry. Stamping the current
+        // parent id then REPLACES it instead of producing a duplicate / "same key" collision.
+        var headers = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        foreach (var kv in job.Headers)
+            headers[kv.Key] = kv.Value;
+        headers[TelemetryConstants.HeaderNames.ParentInstanceId] = job.ParentInstanceId.ToString();
 
         return new TransitionInput(
             job.SubflowDomain,

--- a/src/BBT.Workflow.Application/Execution/Transitions/Factory/TransitionContextFactory.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Factory/TransitionContextFactory.cs
@@ -129,7 +129,7 @@ public sealed class TransitionContextFactory(
             // Telemetry
             TraceId = traceId,
             SpanId = spanId,
-            Headers = input.Headers
+            Headers = ToCaseInsensitiveHeaders(input.Headers)
         };
 
         // Configure pipeline directives
@@ -146,6 +146,26 @@ public sealed class TransitionContextFactory(
             executionContext.Directives.MarkAsTimeoutTransition();
 
         return executionContext;
+    }
+
+    /// <summary>
+    /// Builds a case-insensitive view of the request headers. HTTP headers are case-insensitive,
+    /// but upstream hops may lower-case keys (e.g. <c>x-parent-instance-id</c>) while the runtime
+    /// stamps the canonical form (<c>X-Parent-Instance-Id</c>). A case-insensitive dictionary makes
+    /// both lookups (e.g. <c>TryGetValue</c>) and writes (replace, not duplicate) behave correctly.
+    /// Copy uses last-wins so any case-variant duplicates collapse into a single entry.
+    /// </summary>
+    private static IReadOnlyDictionary<string, string?> ToCaseInsensitiveHeaders(
+        IReadOnlyDictionary<string, string?>? headers)
+    {
+        var result = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        if (headers is null)
+            return result;
+
+        foreach (var kv in headers)
+            result[kv.Key] = kv.Value;
+
+        return result;
     }
 
     /// <inheritdoc />

--- a/src/BBT.Workflow.Application/SubFlow/Services/SubflowStarter.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubflowStarter.cs
@@ -180,7 +180,10 @@ public sealed class SubflowStarter(
                 }
             }
 
-            var headers = new Dictionary<string, string?>();
+            // HTTP headers are case-insensitive. Use OrdinalIgnoreCase so a parent/root instance-id
+            // supplied by the input mapping (any casing) is REPLACED by the framework-stamped value
+            // below instead of producing a duplicate header entry.
+            var headers = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
             if (inputMappingResult?.Headers is IDictionary<string, string?> fromMapping)
             {
                 foreach (var kv in fromMapping)

--- a/test/BBT.Workflow.Application.Tests/Execution/Transitions/Factory/TransitionContextFactoryTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Transitions/Factory/TransitionContextFactoryTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using System.Text.Json;
 using System.Threading;
@@ -175,6 +176,49 @@ public class TransitionContextFactoryTests
 
         result.IsSuccess.ShouldBeTrue();
         result.Value!.Termination.ShouldBe(termination);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShouldNormalizeHeadersCaseInsensitively()
+    {
+        const string domain = "test-domain";
+        const string workflowKey = "test-workflow";
+        var workflow = CreateWorkflow(workflowKey, domain);
+        var instance = Instance.Create(Guid.NewGuid(), workflowKey, workflow.Version);
+        instance.ChangeState(workflow.GetState("state1").Value!);
+        var parentId = Guid.NewGuid().ToString();
+        var input = new WorkflowExecutionContext
+        {
+            Domain = domain,
+            InstanceId = instance.Id.ToString(),
+            WorkflowKey = workflowKey,
+            WorkflowVersion = workflow.Version,
+            TransitionKey = "resume",
+            TriggerType = TriggerType.Manual,
+            Mode = ExecMode.Resume,
+            // Upstream hop lower-cased the header key.
+            Headers = new Dictionary<string, string?> { ["x-parent-instance-id"] = parentId }
+        };
+
+        var instanceRepository = new Mock<IInstanceRepository>();
+        instanceRepository
+            .Setup(x => x.GetActiveAsync(input.InstanceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<Instance>.Ok(instance));
+        var componentCacheStore = new Mock<IComponentCacheStore>();
+        componentCacheStore
+            .Setup(x => x.GetFlowAsync(domain, workflowKey, workflow.Version, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<Definitions.Workflow>.Ok(workflow));
+        var sut = new TransitionContextFactory(
+            instanceRepository.Object,
+            componentCacheStore.Object,
+            Mock.Of<IRuntimeInfoProvider>());
+
+        var result = await sut.CreateAsync(input, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        // Canonical (mixed-case) lookup must resolve the lower-cased incoming header.
+        result.Value!.Headers.TryGetValue("X-Parent-Instance-Id", out var resolved).ShouldBeTrue();
+        resolved.ShouldBe(parentId);
     }
 
     private static Definitions.Workflow CreateWorkflow(string key, string domain)


### PR DESCRIPTION
## What

Normalize workflow request headers case-insensitively and make the parent/root instance-id header producers use replace (not add) semantics.

## Why

HTTP headers are case-insensitive, but the runtime built its header dictionaries with the default **ordinal** comparer. Across service hops:

1. The incoming controller lower-cases keys: `input.Headers = Request.Headers.ToDictionary(s => s.Key.ToLower(), ...)` → `x-parent-instance-id`.
2. The runtime later stamps the canonical mixed-case constant `X-Parent-Instance-Id`.

Under an ordinal comparer these are **two distinct keys for the same header**, which caused:

- Duplicate `X-Parent-Instance-Id` propagation on forwarded/sub-flow calls.
- `"An item with the same key has already been added"` collisions when the header is added on top of an existing one.
- Silently missed lookups — `context.Headers.TryGetValue("X-Parent-Instance-Id", ...)` in `TransitionExecutor` never matched a lower-cased incoming header, so parent-id log scope was dropped.

## Changes

- **`TransitionContextFactory`** — single chokepoint: request headers are wrapped in an `OrdinalIgnoreCase` dictionary via a `ToCaseInsensitiveHeaders` helper (last-wins copy). Every `context.Headers` read/write is now case-insensitive and case-variant duplicates collapse into one entry.
- **`ForwardToSubflowJobHandler`** — replaced the copy-constructor + indexer initializer (which could also throw on case-variant duplicates) with an `OrdinalIgnoreCase` dictionary + last-wins copy; the parent id is then stamped as a **replace**.
- **`SubflowStarter`** — outbound header dictionary now `OrdinalIgnoreCase`, so a parent/root id supplied by an input mapping (any casing) is replaced rather than duplicated.
- **Regression test** — `CreateAsync_ShouldNormalizeHeadersCaseInsensitively` asserts a lower-cased incoming `x-parent-instance-id` resolves via the canonical `X-Parent-Instance-Id` key.

## Reviewer notes

- `RemoteInstanceCommandAppService` was already safe — `CurrentUserForwardHeadersHelper.MergeIntoRequest` uses `Remove` + `TryAddWithoutValidation` per key. No change needed there.
- `OrdinalIgnoreCase` is strictly more correct for HTTP headers; last-wins copy avoids the copy-constructor throwing on any pre-existing case-variant duplicates.

## Verification

- `dotnet build` (Application) — **0 errors**.
- Affected tests (`TransitionContextFactory`, `ForwardToSubflowJobHandler`, `SubflowStarter`) — **all passing**, including the new regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Normalize workflow request headers handling to be case-insensitive and ensure parent/root instance-id headers are replaced rather than duplicated across transitions and subflows.

New Features:
- Add a regression test ensuring transition header resolution works case-insensitively for parent instance-id.

Bug Fixes:
- Prevent duplicate or conflicting parent instance-id headers caused by case-sensitive dictionaries in transition and subflow execution paths.
- Ensure parent instance-id lookup in transition execution contexts succeeds regardless of header key casing.

Enhancements:
- Wrap workflow request headers in a case-insensitive dictionary within TransitionContextFactory so reads and writes treat HTTP headers correctly.
- Update ForwardToSubflowJobHandler to build transition headers with a case-insensitive dictionary and last-wins copy semantics.
- Update SubflowStarter to use a case-insensitive header dictionary so framework-stamped parent/root ids replace any existing variants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Header handling is now case-insensitive across workflow transitions and subflows.
  * Duplicate headers with different capitalization are resolved consistently, with the latest value taking precedence.
  * Parent instance identifiers are correctly replaced and exposed regardless of header casing.

* **Tests**
  * Added coverage verifying case-insensitive header normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->