### PR TITLE
fix(events): accept content-type-less and octet-stream event bodies

### DIFF
--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
@@ -493,11 +493,16 @@ public sealed class InstanceController(
     /// <param name="workflow">Target workflow key.</param>
     /// <param name="action">Either <c>start</c> (create a new instance) or <c>transition</c> (advance an existing one).</param>
     /// <param name="transitionKey">Transition to execute. Required when <paramref name="action"/> is <c>transition</c>.</param>
-    /// <param name="payload">Raw event payload, mapped by the workflow's/transition's event mapping.</param>
     /// <param name="sync">When true, blocks until the pipeline completes; otherwise accepted and run asynchronously.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
+    /// <remarks>
+    /// The raw event payload is read directly from the request body and parsed as JSON, independent of the
+    /// request <c>Content-Type</c>. Kafka / pub-sub sources routed through Dapr routinely deliver bodies with
+    /// no content type or <c>application/octet-stream</c>; binding via <c>[FromBody]</c> would reject those with
+    /// <c>415 Unsupported Media Type</c>, so the body is bound manually here instead.
+    /// </remarks>
     /// <response code="200">Event processed (or intentionally ignored when no active instance matches).</response>
-    /// <response code="400">Invalid action, or transitionKey missing for action=transition.</response>
+    /// <response code="400">Invalid action, transitionKey missing for action=transition, or malformed JSON body.</response>
     /// <response code="404">Workflow or event definition not found.</response>
     [ApiExplorerSettings(IgnoreApi = true)]
     [HttpPost("{domain}/workflows/{workflow}/instances/events")]
@@ -509,7 +514,6 @@ public sealed class InstanceController(
         [FromRoute] string workflow,
         [FromQuery] string action,
         [FromQuery] string? transitionKey = null,
-        [FromBody] JsonElement payload = default,
         [FromQuery] bool sync = false,
         CancellationToken cancellationToken = default)
     {
@@ -520,6 +524,21 @@ public sealed class InstanceController(
                 Detail = $"action must be 'start' or 'transition'. Received: '{action}'.",
                 Status = StatusCodes.Status400BadRequest
             });
+
+        JsonElement payload;
+        try
+        {
+            payload = await ReadEventPayloadAsync(HttpContext.Request, cancellationToken);
+        }
+        catch (JsonException exception)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Invalid payload",
+                Detail = $"The request body could not be parsed as JSON: {exception.Message}",
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
 
         var input = new EventInput
         {
@@ -535,6 +554,27 @@ public sealed class InstanceController(
 
         var result = await eventAppService.HandleAsync(input, cancellationToken);
         return WorkflowResultActionResultMapper.ToActionResult(result, HttpContext);
+    }
+
+    /// <summary>
+    /// Reads the event request body as raw bytes and parses it into a <see cref="JsonElement"/>, ignoring the
+    /// request <c>Content-Type</c>. An empty body yields a default (<see cref="JsonValueKind.Undefined"/>) element,
+    /// preserving the previous <c>[FromBody]</c> optional-body behaviour. Malformed JSON surfaces as
+    /// <see cref="JsonException"/> for the caller to translate into a 400 response.
+    /// </summary>
+    internal static async Task<JsonElement> ReadEventPayloadAsync(
+        HttpRequest request,
+        CancellationToken cancellationToken)
+    {
+        using var buffer = new MemoryStream();
+        await request.Body.CopyToAsync(buffer, cancellationToken);
+
+        if (buffer.Length == 0)
+            return default;
+
+        buffer.Position = 0;
+        using var document = await JsonDocument.ParseAsync(buffer, cancellationToken: cancellationToken);
+        return document.RootElement.Clone();
     }
 
     /// <summary>

--- a/test/BBT.Workflow.Application.Tests/HttpApi/EventPayloadBindingTests.cs
+++ b/test/BBT.Workflow.Application.Tests/HttpApi/EventPayloadBindingTests.cs
@@ -1,0 +1,69 @@
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Workflow.Orchestration.Controllers.Instances;
+using Microsoft.AspNetCore.Http;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Application.Tests.HttpApi;
+
+/// <summary>
+/// Guards the content-type-independent body binding of the <c>/instances/events</c> endpoint.
+/// Kafka / pub-sub sources routed through Dapr deliver event bodies with no content type or
+/// <c>application/octet-stream</c>; the endpoint reads the raw body manually so those are accepted
+/// instead of being rejected with 415 by <c>[FromBody]</c> JSON model binding.
+/// </summary>
+public sealed class EventPayloadBindingTests
+{
+    private const string PayloadJson = """{"accountNo":"9530","balance":52294471}""";
+
+    [Theory]
+    [InlineData("application/octet-stream")]
+    [InlineData("application/json")]
+    [InlineData("text/plain")]
+    [InlineData(null)]
+    public async Task ReadEventPayload_ParsesJson_RegardlessOfContentType(string? contentType)
+    {
+        var request = BuildRequest(PayloadJson, contentType);
+
+        var payload = await InstanceController.ReadEventPayloadAsync(request, CancellationToken.None);
+
+        payload.ValueKind.ShouldBe(JsonValueKind.Object);
+        payload.GetProperty("accountNo").GetString().ShouldBe("9530");
+        payload.GetProperty("balance").GetInt64().ShouldBe(52294471);
+    }
+
+    [Fact]
+    public async Task ReadEventPayload_EmptyBody_ReturnsUndefined()
+    {
+        var request = BuildRequest(string.Empty, "application/octet-stream");
+
+        var payload = await InstanceController.ReadEventPayloadAsync(request, CancellationToken.None);
+
+        payload.ValueKind.ShouldBe(JsonValueKind.Undefined);
+    }
+
+    [Fact]
+    public async Task ReadEventPayload_MalformedJson_ThrowsJsonException()
+    {
+        var request = BuildRequest("{ not-json", "application/octet-stream");
+
+        await Should.ThrowAsync<JsonException>(() =>
+            InstanceController.ReadEventPayloadAsync(request, CancellationToken.None));
+    }
+
+    private static HttpRequest BuildRequest(string body, string? contentType)
+    {
+        var bytes = Encoding.UTF8.GetBytes(body);
+        var context = new DefaultHttpContext();
+        context.Request.Body = new MemoryStream(bytes);
+        context.Request.ContentLength = bytes.Length;
+        if (contentType is not null)
+            context.Request.ContentType = contentType;
+
+        return context.Request;
+    }
+}


### PR DESCRIPTION
## What

The `/instances/events` endpoint bound its request body via `[FromBody] JsonElement`, which relies on the `SystemTextJsonInputFormatter` and only accepts the `application/json` media type. Kafka / pub-sub sources routed through Dapr routinely deliver event bodies with **no `Content-Type`** or **`application/octet-stream`**, so every such delivery was rejected with **415 Unsupported Media Type** before the action ran — no events were processed.

This PR reads the raw request body directly in `HandleEventAsync` and parses it as JSON **regardless of `Content-Type`**.

## Why

- The Kafka source (bank core) publishes raw JSON with no JSON content type.
- Both Dapr subscription modes failed: no `rawPayload` → request has no content type → 415; `rawPayload: "true"` → Dapr sends `application/octet-stream` → 415.
- No Dapr setting can convert the source into `application/json`, so the fix must live in the HTTP binding layer.

## Changes

- `InstanceController.HandleEventAsync` — removed `[FromBody] JsonElement payload`; body is now read via a new `ReadEventPayloadAsync` helper straight from `Request.Body` and parsed with `JsonDocument`, ignoring `Content-Type`.
  - Empty body → default (`Undefined`) element — preserves the previous `[FromBody]` optional-body behaviour.
  - Malformed JSON → `400 Bad Request` (`ProblemDetails`) — same status the old binding produced.
- `EventPayloadBindingTests` — 6 unit tests covering `octet-stream` / `application/json` / `text/plain` / no-content-type bodies, empty body, and malformed JSON.

## Scope / reviewer notes

- **Endpoint-scoped fix.** No global MVC input-formatter change; other endpoints and the Execution host are unaffected. (This mirrors the existing `FormUrlEncodedJsonElementInputFormatter` precedent, but deliberately stays local to avoid opening content-type-less binding on every `[FromBody] JsonElement` endpoint.)
- `RawRequestBodyBufferingMiddleware` resets `Request.Body` to position 0, so reading it in the action is safe and does not interfere with the JWS/mTLS signature-verification flow.
- After this fix, Dapr subscriptions no longer need `rawPayload`; it works either way.

## Testing

- `dotnet test --filter EventPayloadBindingTests` → **6/6 passed**.
- Orchestration host project builds clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle workflow instance event payloads by reading and parsing the raw request body as JSON regardless of Content-Type, ensuring Kafka/Dapr-delivered events are accepted and malformed JSON yields a 400 response.

Bug Fixes:
- Allow /instances/events endpoint to accept event bodies without Content-Type or with application/octet-stream instead of returning 415 Unsupported Media Type.

Enhancements:
- Add controller-level helper to read and parse event payloads from the raw HTTP request body while preserving previous optional-body semantics.
- Update API documentation for the /instances/events endpoint to describe JSON parsing behaviour and error responses for invalid payloads.

Tests:
- Add unit tests covering content-type-independent JSON payload parsing, empty bodies, and malformed JSON handling for the /instances/events endpoint.