### PR TITLE
feat(tasks): add Dapr Conversation (AI/LLM) task type (#334)

### DIFF
--- a/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/TaskServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/TaskServiceCollectionExtensions.cs
@@ -99,6 +99,7 @@ public static class TaskServiceCollectionExtensions
         services.AddTaskExecutor<DaprBindingTaskExecutor>();
         services.AddTaskExecutor<DaprHttpEndpointTaskExecutor>();
         services.AddTaskExecutor<DaprPubSubTaskExecutor>();
+        services.AddTaskExecutor<DaprConversationTaskExecutor>();
         services.AddTaskExecutor<StateStoreTaskExecutor>();
 
         // Cache-Aside (read-through) executor: cache get/set is dispatched to the Execution service via

--- a/src/BBT.Workflow.Application/Tasks/Executors/Dapr/DaprConversationTaskExecutor.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Dapr/DaprConversationTaskExecutor.cs
@@ -1,0 +1,149 @@
+using BBT.Aether.Results;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Execution;
+using BBT.Workflow.Logging;
+using BBT.Workflow.Scripting;
+using BBT.Workflow.Tasks.Mapping;
+using Microsoft.Extensions.Logging;
+
+namespace BBT.Workflow.Tasks.Executors;
+
+/// <summary>
+/// Executor for Dapr Conversation (AI/LLM) tasks.
+/// Handles input mapping locally, then delegates to RemoteInvokerService for execution.
+/// </summary>
+public sealed class DaprConversationTaskExecutor : TaskExecutorBase<DaprConversationTask>
+{
+    private readonly IRemoteInvokerService _remoteInvoker;
+    private readonly IScriptEngine _scriptEngine;
+
+    /// <summary>
+    /// Initializes a new instance of DaprConversationTaskExecutor.
+    /// </summary>
+    public DaprConversationTaskExecutor(
+        IRemoteInvokerService remoteInvoker,
+        IScriptEngine scriptEngine,
+        ILogger<DaprConversationTaskExecutor> logger)
+        : base(logger)
+    {
+        _remoteInvoker = remoteInvoker;
+        _scriptEngine = scriptEngine;
+    }
+
+    /// <inheritdoc />
+    public override TaskType TaskType => TaskType.DaprConversation;
+
+    /// <inheritdoc />
+    protected override async Task<Result<ScriptResponse?>> PrepareInputAsync(
+        DaprConversationTask task,
+        TaskExecutorContext context,
+        CancellationToken cancellationToken)
+    {
+        var mapping = context.OnExecuteTask.Mapping;
+        if (mapping is null || !mapping.HasMappingCode)
+        {
+            return Result<ScriptResponse?>.Ok(null);
+        }
+
+        var result = await ResultExtensions.TryAsync<ScriptResponse?>(async ct =>
+        {
+            var scriptRunner = await _scriptEngine.CompileToInstanceAsync<IMapping>(
+                mapping,
+                flowScripts: context.ScriptContext.Workflow?.Scripts,
+                cancellationToken: ct);
+
+            return await scriptRunner.InputHandler(task, context.ScriptContext);
+        }, cancellationToken, ex => Error.Failure(
+            WorkflowErrorCodes.TaskExecution,
+            $"DaprConversation task input handler failed: {ScriptDiagnostics.Explain(ex)}"));
+
+        if (!result.IsSuccess)
+        {
+            Logger.TaskInputHandlerFailed(
+                task.Key,
+                TaskType.ToString(),
+                context.ScriptContext.Instance?.Id ?? Guid.Empty,
+                result.Error.Message ?? "Unknown error");
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    protected override async Task<Result<TaskInvocationResult>> InvokeAsync(
+        DaprConversationTask task,
+        TaskExecutorContext context,
+        CancellationToken cancellationToken)
+    {
+        var envelopeResult = TaskBindingMapper.CreateEnvelope(task);
+        if (!envelopeResult.IsSuccess)
+        {
+            Logger.TaskEnvelopeCreationFailed(
+                task.Key,
+                TaskType.ToString(),
+                context.ScriptContext.Instance?.Id ?? Guid.Empty,
+                envelopeResult.Error.Message ?? "Unknown error");
+            return Result<TaskInvocationResult>.Fail(envelopeResult.Error);
+        }
+
+        var traceContext = _remoteInvoker.CreateTraceContext(context.ScriptContext);
+
+        var result = await _remoteInvoker.InvokeAsync(
+            TaskTypes.DaprConversation,
+            task.Key,
+            envelopeResult.Value!,
+            traceContext,
+            cancellationToken);
+
+        if (!result.IsSuccess)
+        {
+            Logger.TaskInvocationFailed(
+                task.Key,
+                TaskType.ToString(),
+                context.ScriptContext.Instance?.Id ?? Guid.Empty,
+                result.Error.Message ?? "Unknown error");
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    protected override async Task<Result<object?>> ProcessOutputAsync(
+        DaprConversationTask task,
+        TaskInvocationResult invocationResult,
+        TaskExecutorContext context,
+        CancellationToken cancellationToken)
+    {
+        var mapping = context.OnExecuteTask.Mapping;
+        if (mapping is null || !mapping.HasMappingCode)
+        {
+            return Result<object?>.Ok(invocationResult.Data);
+        }
+
+        UpdateScriptContextWithResponse(task.Key, invocationResult, context.ScriptContext);
+
+        var result = await ResultExtensions.TryAsync<object?>(async ct =>
+        {
+            var scriptRunner = await _scriptEngine.CompileToInstanceAsync<IMapping>(
+                mapping,
+                flowScripts: context.ScriptContext.Workflow?.Scripts,
+                cancellationToken: ct);
+
+            var outputResponse = await scriptRunner.OutputHandler(context.ScriptContext);
+            return outputResponse.Data;
+        }, cancellationToken, ex => Error.Failure(
+            WorkflowErrorCodes.TaskExecution,
+            $"DaprConversation task output handler failed: {ScriptDiagnostics.Explain(ex)}"));
+
+        if (!result.IsSuccess)
+        {
+            Logger.TaskOutputHandlerFailed(
+                task.Key,
+                TaskType.ToString(),
+                context.ScriptContext.Instance?.Id ?? Guid.Empty,
+                result.Error.Message ?? "Unknown error");
+        }
+
+        return result;
+    }
+}

--- a/src/BBT.Workflow.Application/Tasks/Mapping/TaskBindingMapper.cs
+++ b/src/BBT.Workflow.Application/Tasks/Mapping/TaskBindingMapper.cs
@@ -45,6 +45,7 @@ public static class TaskBindingMapper
                 DaprBindingTask daprBinding => (TaskTypes.DaprBinding, MapDaprBindingTask(daprBinding)),
                 DaprHttpEndpointTask daprHttpEndpoint => (TaskTypes.DaprHttpEndpoint, MapDaprHttpEndpointTask(daprHttpEndpoint)),
                 DaprPubSubTask daprPubSub => (TaskTypes.DaprPubSub, MapDaprPubSubTask(daprPubSub)),
+                DaprConversationTask daprConversation => (TaskTypes.DaprConversation, (object)MapDaprConversationTask(daprConversation)),
                 StateStoreTask stateStore => (TaskTypes.StateStore, (object)MapStateStoreTask(stateStore)),
 
                 // Trigger tasks (basic mapping - runtime context handled by invokers)
@@ -327,6 +328,80 @@ public static class TaskBindingMapper
             ? task.Metadata.Deserialize<Dictionary<string, string>>()
             : null
     };
+
+    /// <summary>
+    /// Maps DaprConversationTask to DaprConversationBinding.
+    /// Parses the JSON <c>inputs</c> array into typed messages and normalizes
+    /// <c>parameters</c>/<c>metadata</c> objects into string dictionaries.
+    /// </summary>
+    private static DaprConversationBinding MapDaprConversationTask(DaprConversationTask task)
+    {
+        var inputs = new List<ConversationMessageBinding>();
+        if (task.Inputs.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var element in task.Inputs.EnumerateArray())
+            {
+                if (element.ValueKind != JsonValueKind.Object)
+                {
+                    continue;
+                }
+
+                var role = element.TryGetProperty("role", out var roleElement)
+                    ? roleElement.GetString()
+                    : null;
+                var content = element.TryGetProperty("content", out var contentElement)
+                    ? contentElement.GetString()
+                    : null;
+                var name = element.TryGetProperty("name", out var nameElement)
+                    ? nameElement.GetString()
+                    : null;
+                bool? scrubPii = element.TryGetProperty("scrubPII", out var scrubElement)
+                    && scrubElement.ValueKind is JsonValueKind.True or JsonValueKind.False
+                        ? scrubElement.GetBoolean()
+                        : null;
+
+                inputs.Add(new ConversationMessageBinding
+                {
+                    Role = string.IsNullOrWhiteSpace(role) ? "user" : role!,
+                    Content = content ?? string.Empty,
+                    Name = name,
+                    ScrubPII = scrubPii
+                });
+            }
+        }
+
+        return new DaprConversationBinding
+        {
+            ComponentName = task.ComponentName,
+            Inputs = inputs,
+            ContextId = string.IsNullOrWhiteSpace(task.ContextId) ? null : task.ContextId,
+            Temperature = task.Temperature,
+            ScrubPII = task.ScrubPII,
+            Metadata = ToStringDictionary(task.Metadata),
+            Parameters = ToStringDictionary(task.Parameters)
+        };
+    }
+
+    /// <summary>
+    /// Converts an optional JSON object into a string dictionary, coercing non-string values to their raw JSON text.
+    /// </summary>
+    private static IReadOnlyDictionary<string, string>? ToStringDictionary(JsonElement? source)
+    {
+        if (source is not { ValueKind: JsonValueKind.Object } element)
+        {
+            return null;
+        }
+
+        var result = new Dictionary<string, string>();
+        foreach (var property in element.EnumerateObject())
+        {
+            result[property.Name] = property.Value.ValueKind == JsonValueKind.String
+                ? property.Value.GetString() ?? string.Empty
+                : property.Value.GetRawText();
+        }
+
+        return result.Count > 0 ? result : null;
+    }
 
     /// <summary>
     /// Maps StateStoreTask to StateStoreBinding.

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/DaprConversationTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/DaprConversationTask.cs
@@ -1,0 +1,212 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace BBT.Workflow.Definitions;
+
+/// <summary>
+/// Dapr Conversation Task Definition.
+/// Invokes an LLM/AI provider through the Dapr Conversation building block, giving workflows a
+/// provider-agnostic way to run prompts (OpenAI, Anthropic, AWS Bedrock, etc.) over the same
+/// Dapr sidecar used by the other Dapr task types.
+/// </summary>
+public sealed class DaprConversationTask : WorkflowTask
+{
+    private DaprConversationTask()
+    {
+
+    }
+
+    [JsonConstructor]
+    private DaprConversationTask(
+        JsonElement config) : base(config)
+    {
+        Type = ((int)TaskType.DaprConversation).ToString();
+    }
+
+    /// <summary>
+    /// The Dapr conversation component name (the configured LLM provider), e.g. "openai".
+    /// </summary>
+    public string ComponentName { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Conversation inputs as a JSON array of messages, each shaped as
+    /// <c>{ "role": "user|system|assistant|developer|tool", "content": "...", "scrubPII": bool?, "name": "..." }</c>.
+    /// </summary>
+    public JsonElement Inputs { get; private set; }
+
+    /// <summary>
+    /// Provider-specific parameters (e.g. model, maxTokens) forwarded to the component as string values.
+    /// </summary>
+    public JsonElement? Parameters { get; private set; }
+
+    /// <summary>
+    /// Dapr component metadata forwarded with the request as string values.
+    /// </summary>
+    public JsonElement? Metadata { get; private set; }
+
+    /// <summary>
+    /// Optional context identifier used to continue a stateful conversation.
+    /// </summary>
+    public string? ContextId { get; private set; }
+
+    /// <summary>
+    /// Optional sampling temperature.
+    /// </summary>
+    public double? Temperature { get; private set; }
+
+    /// <summary>
+    /// When true, requests the provider scrub PII from prompts and responses.
+    /// </summary>
+    public bool? ScrubPII { get; private set; }
+
+    /// <summary>
+    /// Timeout seconds.
+    /// </summary>
+    public int TimeoutSeconds { get; private set; } = 30;
+
+    public void SetComponentName(string componentName) => ComponentName = componentName;
+    public void SetContextId(string? contextId) => ContextId = contextId;
+    public void SetTimeoutSeconds(int? timeoutSeconds) => TimeoutSeconds = timeoutSeconds ?? 30;
+    public void SetScrubPII(bool? scrubPII) => ScrubPII = scrubPII;
+    public void SetTemperature(double? temperature) => Temperature = temperature;
+
+    public void SetInputs(dynamic inputs)
+    {
+        Inputs = JsonSerializer.SerializeToElement(inputs);
+    }
+
+    public void SetParameters(Dictionary<string, string?> parameters)
+    {
+        Parameters = JsonSerializer.SerializeToElement(parameters);
+    }
+    
+    public void SetMetadata(dynamic metadata)
+    {
+        Metadata = JsonSerializer.SerializeToElement(metadata);
+    }
+    
+    public void SetMetadata(Dictionary<string, string?> metadata)
+    {
+        Metadata = JsonSerializer.SerializeToElement(metadata);
+    }
+
+    /// <summary>
+    /// Internal property setters for object pooling.
+    /// </summary>
+    internal void SetComponentNameInternal(string componentName) => ComponentName = componentName;
+    internal void SetInputsInternal(JsonElement inputs) => Inputs = inputs;
+    internal void SetParametersInternal(JsonElement? parameters) => Parameters = parameters;
+    internal void SetMetadataInternal(JsonElement? metadata) => Metadata = metadata;
+    internal void SetContextIdInternal(string? contextId) => ContextId = contextId;
+    internal void SetTemperatureInternal(double? temperature) => Temperature = temperature;
+    internal void SetScrubPiiInternal(bool? scrubPii) => ScrubPII = scrubPii;
+    internal void SetTimeoutSecondsInternal(int timeoutSeconds) => TimeoutSeconds = timeoutSeconds;
+
+    protected override void Configure(JsonElement config)
+    {
+        base.Configure(config);
+
+        if (config.TryGetProperty("componentName", out var componentName))
+            ComponentName = componentName.GetString() ?? throw new ArgumentNullException(nameof(componentName));
+
+        if (config.TryGetProperty("inputs", out var inputs))
+            Inputs = inputs.Clone();
+
+        if (config.TryGetProperty("parameters", out var parameters))
+            Parameters = parameters.Clone();
+
+        if (config.TryGetProperty("metadata", out var metadata))
+            Metadata = metadata.Clone();
+
+        if (config.TryGetProperty("contextId", out var contextId))
+            ContextId = contextId.GetString();
+
+        if (config.TryGetProperty("temperature", out var temperature) &&
+            temperature.ValueKind is JsonValueKind.Number)
+            Temperature = temperature.GetDouble();
+
+        if (config.TryGetProperty("scrubPII", out var scrubPii) &&
+            scrubPii.ValueKind is JsonValueKind.True or JsonValueKind.False)
+            ScrubPII = scrubPii.GetBoolean();
+
+        if (config.TryGetProperty("timeoutSeconds", out var timeout))
+            TimeoutSeconds = timeout.GetInt32();
+    }
+
+    public static DaprConversationTask Create(
+        JsonElement config)
+    {
+        return new DaprConversationTask(config);
+    }
+
+    /// <summary>
+    /// Creates a deep copy of the current DaprConversationTask instance.
+    /// </summary>
+    /// <returns>A new DaprConversationTask instance with identical configuration.</returns>
+    public override WorkflowTask Clone()
+    {
+        return CloneTyped();
+    }
+
+    /// <summary>
+    /// Creates a typed deep copy of the current DaprConversationTask instance.
+    /// </summary>
+    /// <returns>A new DaprConversationTask instance with identical configuration.</returns>
+    public DaprConversationTask CloneTyped()
+    {
+        var cloned = new DaprConversationTask();
+        CopyBaseTo(cloned);
+
+        cloned.ComponentName = ComponentName;
+        cloned.Inputs = Inputs; // JsonElement is a struct, so this is safe
+        cloned.Parameters = Parameters;
+        cloned.Metadata = Metadata;
+        cloned.ContextId = ContextId;
+        cloned.Temperature = Temperature;
+        cloned.ScrubPII = ScrubPII;
+        cloned.TimeoutSeconds = TimeoutSeconds;
+
+        return cloned;
+    }
+
+    /// <summary>
+    /// Internal method for object pooling - copies all properties efficiently.
+    /// </summary>
+    /// <param name="source">Source task to copy from.</param>
+    public void CopyFromInternal(DaprConversationTask source)
+    {
+        source.CopyBaseToInternal(this);
+        SetComponentNameInternal(source.ComponentName);
+        SetInputsInternal(source.Inputs);
+        SetParametersInternal(source.Parameters);
+        SetMetadataInternal(source.Metadata);
+        SetContextIdInternal(source.ContextId);
+        SetTemperatureInternal(source.Temperature);
+        SetScrubPiiInternal(source.ScrubPII);
+        SetTimeoutSecondsInternal(source.TimeoutSeconds);
+    }
+
+    /// <summary>
+    /// Resets the task instance to a clean state for object pooling.
+    /// </summary>
+    public override void Reset()
+    {
+        base.Reset();
+        ComponentName = string.Empty;
+        Inputs = default;
+        Parameters = null;
+        Metadata = null;
+        ContextId = null;
+        Temperature = null;
+        ScrubPII = null;
+        TimeoutSeconds = 30;
+    }
+
+    /// <summary>
+    /// Creates a new instance for object pooling - internal use only.
+    /// </summary>
+    public static DaprConversationTask CreateEmpty()
+    {
+        return new DaprConversationTask();
+    }
+}

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/TaskEnums.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/TaskEnums.cs
@@ -26,7 +26,8 @@ public enum TaskType
     Soap = 16,
     StateStore = 17,
     CacheAside = 18,
-    GetInstance = 19
+    GetInstance = 19,
+    DaprConversation = 20
 }
 
 /// <summary>

--- a/src/BBT.Workflow.Domain/Definitions/Tasks/WorkflowTask.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Tasks/WorkflowTask.cs
@@ -26,6 +26,7 @@ namespace BBT.Workflow.Definitions;
 [JsonDerivedType(typeof(StateStoreTask), typeDiscriminator: "17")]
 [JsonDerivedType(typeof(CacheAsideTask), typeDiscriminator: "18")]
 [JsonDerivedType(typeof(GetInstanceTask), typeDiscriminator: "19")]
+[JsonDerivedType(typeof(DaprConversationTask), typeDiscriminator: "20")]
 public abstract class WorkflowTask : IDomainEntity, ITaskReference, IReferenceSetter, ITaskClonable
 {
     protected WorkflowTask()

--- a/src/BBT.Workflow.Execution.Abstractions/Bindings/DaprConversationBinding.cs
+++ b/src/BBT.Workflow.Execution.Abstractions/Bindings/DaprConversationBinding.cs
@@ -1,0 +1,69 @@
+namespace BBT.Workflow.Execution.Bindings;
+
+/// <summary>
+/// Binding configuration for a Dapr Conversation (AI/LLM) task invocation.
+/// Holds plain, serializable data only; the invoker maps it onto the Dapr.AI conversation model.
+/// </summary>
+public sealed class DaprConversationBinding
+{
+    /// <summary>
+    /// The Dapr conversation component name (the configured LLM provider) to invoke.
+    /// </summary>
+    public required string ComponentName { get; init; }
+
+    /// <summary>
+    /// Ordered conversation messages to send to the provider.
+    /// </summary>
+    public required IReadOnlyList<ConversationMessageBinding> Inputs { get; init; }
+
+    /// <summary>
+    /// Optional context identifier used to continue a stateful conversation.
+    /// </summary>
+    public string? ContextId { get; init; }
+
+    /// <summary>
+    /// Optional sampling temperature.
+    /// </summary>
+    public double? Temperature { get; init; }
+
+    /// <summary>
+    /// When true, requests the provider scrub PII from prompts and responses.
+    /// </summary>
+    public bool? ScrubPII { get; init; }
+
+    /// <summary>
+    /// Dapr component metadata forwarded with the request.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? Metadata { get; init; }
+
+    /// <summary>
+    /// Provider-specific parameters (e.g. model, maxTokens) forwarded with the request.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? Parameters { get; init; }
+}
+
+/// <summary>
+/// A single conversation message within a <see cref="DaprConversationBinding"/>.
+/// </summary>
+public sealed record ConversationMessageBinding
+{
+    /// <summary>
+    /// The message role: user, system, assistant, developer or tool.
+    /// </summary>
+    public required string Role { get; init; }
+
+    /// <summary>
+    /// The textual content of the message.
+    /// </summary>
+    public required string Content { get; init; }
+
+    /// <summary>
+    /// Optional author name for the message.
+    /// </summary>
+    public string? Name { get; init; }
+
+    /// <summary>
+    /// When true, requests PII scrubbing for this message.
+    /// </summary>
+    public bool? ScrubPII { get; init; }
+}

--- a/src/BBT.Workflow.Execution.Abstractions/TaskTypes.cs
+++ b/src/BBT.Workflow.Execution.Abstractions/TaskTypes.cs
@@ -12,6 +12,7 @@ public static class TaskTypes
     public const string DaprBinding = "daprbinding";
     public const string DaprHttpEndpoint = "daprhttpendpoint";
     public const string DaprPubSub = "daprpubsub";
+    public const string DaprConversation = "daprconversation";
 
     public const string StateStore = "statestore";
 

--- a/src/BBT.Workflow.Execution/BBT.Workflow.Execution.csproj
+++ b/src/BBT.Workflow.Execution/BBT.Workflow.Execution.csproj
@@ -5,10 +5,14 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>BBT.Workflow.Execution</RootNamespace>
+    <!-- Dapr Conversation building block is Alpha; the Dapr.AI client is marked [Experimental].
+         Suppress the evaluation-only diagnostic so it can be consumed by the DaprConversation invoker. -->
+    <NoWarn>$(NoWarn);DAPR_CONVERSATION</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <!-- No Domain dependency! Execution is completely independent -->
     <PackageReference Include="Dapr.Client" Version="$(DaprPackageVersion)" />
+    <PackageReference Include="Dapr.AI" Version="$(DaprPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="$(MicrosoftPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="$(MicrosoftPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftPackageVersion)" />

--- a/src/BBT.Workflow.Execution/Invokers/DaprConversationTaskInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/DaprConversationTaskInvoker.cs
@@ -1,0 +1,233 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Text.Json;
+using BBT.Workflow.Execution.Bindings;
+using BBT.Workflow.Execution.Metrics;
+using Dapr.AI.Conversation;
+using Dapr.AI.Conversation.ConversationRoles;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.Logging;
+
+namespace BBT.Workflow.Execution.Invokers;
+
+/// <summary>
+/// Dapr Conversation (AI/LLM) task invoker - stateless execution with strongly-typed binding.
+/// Maps the prepared binding onto the Dapr.AI conversation model and calls the configured provider
+/// component through the Dapr sidecar via <see cref="DaprConversationClient"/>.
+/// </summary>
+public sealed class DaprConversationTaskInvoker(
+    DaprConversationClient conversationClient,
+    ILogger<DaprConversationTaskInvoker> logger,
+    ITaskMetrics? metrics = null)
+    : ITaskInvoker<DaprConversationBinding>
+{
+    private readonly ITaskMetrics _metrics = metrics ?? NullTaskMetrics.Instance;
+
+    /// <inheritdoc />
+    public string TaskType => TaskTypes.DaprConversation;
+
+    /// <inheritdoc />
+    public System.Type BindingType => typeof(DaprConversationBinding);
+
+    /// <inheritdoc />
+    public async Task<TaskInvocationResult> InvokeAsync(
+        TaskDescriptor<DaprConversationBinding> descriptor,
+        CancellationToken cancellationToken = default)
+    {
+        return await ExecuteAsync(descriptor.TaskKey, descriptor.Binding, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<TaskInvocationResult> InvokeAsync(
+        string? taskKey,
+        JsonElement binding,
+        CancellationToken cancellationToken = default)
+    {
+        var typedBinding = binding.Deserialize<DaprConversationBinding>()
+            ?? throw new InvalidOperationException("Failed to deserialize DaprConversationBinding");
+
+        return await ExecuteAsync(taskKey, typedBinding, cancellationToken);
+    }
+
+    private async Task<TaskInvocationResult> ExecuteAsync(
+        string? taskKey,
+        DaprConversationBinding binding,
+        CancellationToken cancellationToken)
+    {
+        var stopwatch = Stopwatch.StartNew();
+
+        if (string.IsNullOrWhiteSpace(binding.ComponentName))
+        {
+            return TaskInvocationResult.Failure(
+                error: "Dapr conversation task requires a 'componentName'",
+                executionDurationMs: stopwatch.ElapsedMilliseconds,
+                taskType: TaskType);
+        }
+
+        if (binding.Inputs is null || binding.Inputs.Count == 0)
+        {
+            return TaskInvocationResult.Failure(
+                error: "Dapr conversation task requires at least one input message",
+                executionDurationMs: stopwatch.ElapsedMilliseconds,
+                taskType: TaskType);
+        }
+
+        try
+        {
+            var inputs = binding.Inputs
+                .Select(message => new ConversationInput(
+                    [BuildMessage(message.Role, message.Content, message.Name)],
+                    message.ScrubPII))
+                .ToList();
+
+            var options = new ConversationOptions(binding.ComponentName)
+            {
+                ContextId = binding.ContextId,
+                Temperature = binding.Temperature,
+                ScrubPII = binding.ScrubPII,
+                Metadata = binding.Metadata ?? new Dictionary<string, string>(),
+                Parameters = ToAnyParameters(binding.Parameters)
+            };
+
+            var response = await conversationClient.ConverseAsync(inputs, options, cancellationToken);
+
+            stopwatch.Stop();
+
+            var payload = new
+            {
+                contextId = response.ConversationId,
+                text = response.Outputs?
+                    .FirstOrDefault()?.Choices?
+                    .FirstOrDefault()?.Message?.Content,
+                outputs = response.Outputs?.Select(output => new
+                {
+                    model = output.Model,
+                    usage = output.Usage is null
+                        ? null
+                        : new
+                        {
+                            promptTokens = output.Usage.PromptTokens,
+                            completionTokens = output.Usage.CompletionTokens,
+                            totalTokens = output.Usage.TotalTokens
+                        },
+                    choices = output.Choices?.Select(choice => new
+                    {
+                        index = choice.Index,
+                        finishReason = choice.FinishReason?.ToString(),
+                        content = choice.Message?.Content
+                    })
+                })
+            };
+
+            var body = JsonSerializer.Serialize(payload);
+            var responseData = InvokerHelpers.TryParseJson(body);
+
+            _metrics.RecordDaprConversationInvocation(binding.ComponentName, "success");
+
+            return TaskInvocationResult.Success(
+                data: responseData,
+                body: body,
+                executionDurationMs: stopwatch.ElapsedMilliseconds,
+                taskType: TaskType,
+                metadata: new Dictionary<string, object>
+                {
+                    ["ComponentName"] = binding.ComponentName,
+                    ["ContextId"] = response.ConversationId ?? string.Empty,
+                    ["OutputCount"] = response.Outputs?.Count ?? 0
+                });
+        }
+        catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested)
+        {
+            stopwatch.Stop();
+            _metrics.RecordDaprConversationInvocation(binding.ComponentName, "cancelled");
+            logger.LogWarning("Dapr conversation invocation was cancelled: {ComponentName}",
+                binding.ComponentName);
+
+            return TaskInvocationResult.Failure(
+                error: "Dapr conversation invocation was cancelled",
+                executionDurationMs: stopwatch.ElapsedMilliseconds,
+                taskType: TaskType,
+                metadata: new Dictionary<string, object>
+                {
+                    ["ComponentName"] = binding.ComponentName,
+                    ["Cancelled"] = true,
+                    ["ExceptionType"] = ex.GetType().Name
+                });
+        }
+        catch (Exception ex)
+        {
+            stopwatch.Stop();
+            _metrics.RecordDaprConversationInvocation(binding.ComponentName, "failure");
+            logger.LogError(ex, "Unexpected error during Dapr conversation invocation: {ComponentName}",
+                binding.ComponentName);
+
+            return TaskInvocationResult.Failure(
+                error: ex.Message,
+                executionDurationMs: stopwatch.ElapsedMilliseconds,
+                taskType: TaskType,
+                metadata: new Dictionary<string, object>
+                {
+                    ["ComponentName"] = binding.ComponentName,
+                    ["ExceptionType"] = ex.GetType().Name,
+                    ["StackTrace"] = ex.StackTrace ?? string.Empty
+                });
+        }
+    }
+
+    /// <summary>
+    /// Builds a role-typed conversation message from a plain role string and content.
+    /// Unknown roles default to a user message.
+    /// </summary>
+    private static IConversationMessage BuildMessage(string role, string content, string? name)
+    {
+        var messageContent = new List<MessageContent> { new(content) };
+
+        var author = name ?? string.Empty;
+
+        return role?.Trim().ToLowerInvariant() switch
+        {
+            "system" => new SystemMessage { Name = author, Content = messageContent },
+            "assistant" => new AssistantMessage { Name = author, Content = messageContent },
+            "developer" => new DeveloperMessage { Name = author, Content = messageContent },
+            "tool" => new ToolMessage { Name = author, Content = messageContent },
+            _ => new UserMessage { Name = author, Content = messageContent }
+        };
+    }
+
+    /// <summary>
+    /// Packs provider parameters into the protobuf <c>Any</c> map expected by the Conversation API,
+    /// wrapping each value as a <see cref="Value"/> (numbers and booleans are preserved; everything else
+    /// is sent as a string).
+    /// </summary>
+    private static IReadOnlyDictionary<string, Any>? ToAnyParameters(
+        IReadOnlyDictionary<string, string>? parameters)
+    {
+        if (parameters is null || parameters.Count == 0)
+        {
+            return null;
+        }
+
+        var result = new Dictionary<string, Any>(parameters.Count);
+        foreach (var parameter in parameters)
+        {
+            result[parameter.Key] = Any.Pack(ToProtoValue(parameter.Value));
+        }
+
+        return result;
+    }
+
+    private static Value ToProtoValue(string raw)
+    {
+        if (bool.TryParse(raw, out var boolean))
+        {
+            return Value.ForBool(boolean);
+        }
+
+        if (double.TryParse(raw, NumberStyles.Any, CultureInfo.InvariantCulture, out var number))
+        {
+            return Value.ForNumber(number);
+        }
+
+        return Value.ForString(raw);
+    }
+}

--- a/src/BBT.Workflow.Execution/Metrics/ITaskMetrics.cs
+++ b/src/BBT.Workflow.Execution/Metrics/ITaskMetrics.cs
@@ -40,6 +40,13 @@ public interface ITaskMetrics
     /// <param name="command">The command executed (get, set, delete).</param>
     /// <param name="status">The status of the operation (success, failure, cancelled).</param>
     void RecordStateStoreOperation(string storeName, string command, string status);
+
+    /// <summary>
+    /// Records a Dapr conversation (AI/LLM) invocation.
+    /// </summary>
+    /// <param name="componentName">The name of the conversation component (LLM provider).</param>
+    /// <param name="status">The status of the invocation (success, failure, cancelled).</param>
+    void RecordDaprConversationInvocation(string componentName, string status);
 }
 
 /// <summary>
@@ -56,5 +63,6 @@ public sealed class NullTaskMetrics : ITaskMetrics
     public void RecordDaprPubSubPublish(string pubSubName, string topic, string status) { }
     public void RecordNotificationInvocation(string bindingName, string bindingKind, string status) { }
     public void RecordStateStoreOperation(string storeName, string command, string status) { }
+    public void RecordDaprConversationInvocation(string componentName, string status) { }
 }
 

--- a/src/BBT.Workflow.Execution/Microsoft/Extensions/DependencyInjection/ExecutionServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Execution/Microsoft/Extensions/DependencyInjection/ExecutionServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using BBT.Workflow.Execution;
+using Dapr.AI.Conversation.Extensions;
 using BBT.Workflow.Execution.Configuration;
 using BBT.Workflow.Execution.Invokers;
 using BBT.Workflow.Execution.Metrics;
@@ -45,6 +46,9 @@ public static class ExecutionServiceCollectionExtensions
         // Register null metrics as default (can be overridden)
         services.TryAddSingleton<ITaskMetrics>(NullTaskMetrics.Instance);
 
+        // Dapr Conversation (AI/LLM) client used by the DaprConversation invoker.
+        services.AddDaprConversationClient();
+
         // Shared Dapr state-store gateway used by the StateStore and CacheAside invokers.
         services.TryAddSingleton<BBT.Workflow.Execution.StateStores.IStateStoreClient,
             BBT.Workflow.Execution.StateStores.DaprStateStoreClient>();
@@ -56,6 +60,7 @@ public static class ExecutionServiceCollectionExtensions
         services.AddSingleton<ITaskInvoker, DaprBindingTaskInvoker>();
         services.AddSingleton<ITaskInvoker, DaprHttpEndpointTaskInvoker>();
         services.AddSingleton<ITaskInvoker, DaprPubSubTaskInvoker>();
+        services.AddSingleton<ITaskInvoker, DaprConversationTaskInvoker>();
         services.AddSingleton<ITaskInvoker, StateStoreTaskInvoker>();
         services.AddSingleton<ITaskInvoker, CacheAsideTaskInvoker>();
         

--- a/test/BBT.Workflow.Application.Tests/BBT.Workflow.Application.Tests.csproj
+++ b/test/BBT.Workflow.Application.Tests/BBT.Workflow.Application.Tests.csproj
@@ -6,6 +6,9 @@
         <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <RootNamespace>BBT.Workflow</RootNamespace>
+        <!-- Dapr Conversation building block is Alpha; suppress the [Experimental] diagnostic
+             so the DaprConversation invoker tests can reference the Dapr.AI client. -->
+        <NoWarn>$(NoWarn);DAPR_CONVERSATION</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/BBT.Workflow.Application.Tests/Tasks/Invokers/DaprConversationTaskInvokerTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Tasks/Invokers/DaprConversationTaskInvokerTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Workflow.Execution;
+using BBT.Workflow.Execution.Bindings;
+using BBT.Workflow.Execution.Invokers;
+using Dapr.AI.Conversation;
+using Dapr.AI.Conversation.ConversationRoles;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Tasks.Invokers;
+
+public sealed class DaprConversationTaskInvokerTests
+{
+    [Fact]
+    public async Task InvokeAsync_Success_ReturnsResponseText()
+    {
+        IReadOnlyList<ConversationInput>? capturedInputs = null;
+        ConversationOptions? capturedOptions = null;
+
+        var invoker = CreateInvoker((inputs, options) =>
+        {
+            capturedInputs = inputs;
+            capturedOptions = options;
+            var choice = new ConversationResultChoice(null, 0, new ResultMessage("Hello from AI"));
+            var output = new ConversationResponseResult([choice]);
+            return Task.FromResult(new ConversationResponse([output], "ctx-1"));
+        });
+
+        var result = await invoker.InvokeAsync(Descriptor(new DaprConversationBinding
+        {
+            ComponentName = "openai",
+            Inputs =
+            [
+                new ConversationMessageBinding { Role = "system", Content = "You are helpful." },
+                new ConversationMessageBinding { Role = "user", Content = "Hi" }
+            ]
+        }));
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Body.ShouldContain("Hello from AI");
+        result.Metadata!["ComponentName"].ShouldBe("openai");
+        result.Metadata!["ContextId"].ShouldBe("ctx-1");
+
+        // Verify mapping onto the Dapr.AI model.
+        capturedOptions!.ConversationComponentId.ShouldBe("openai");
+        capturedInputs!.Count.ShouldBe(2);
+        capturedInputs[0].Messages[0].Role.ShouldBe(MessageRole.System);
+        capturedInputs[1].Messages[0].Role.ShouldBe(MessageRole.User);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_NoInputs_ReturnsFailure()
+    {
+        var invoker = CreateInvoker((_, _) =>
+            Task.FromResult(new ConversationResponse([], null!)));
+
+        var result = await invoker.InvokeAsync(Descriptor(new DaprConversationBinding
+        {
+            ComponentName = "openai",
+            Inputs = []
+        }));
+
+        result.IsSuccess.ShouldBeFalse();
+        result.ErrorMessage.ShouldContain("at least one input message");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ProviderThrows_ReturnsFailure()
+    {
+        var invoker = CreateInvoker((_, _) =>
+            throw new InvalidOperationException("provider unavailable"));
+
+        var result = await invoker.InvokeAsync(Descriptor(new DaprConversationBinding
+        {
+            ComponentName = "openai",
+            Inputs = [new ConversationMessageBinding { Role = "user", Content = "Hi" }]
+        }));
+
+        result.IsSuccess.ShouldBeFalse();
+        result.ErrorMessage.ShouldContain("provider unavailable");
+        result.Metadata!["ComponentName"].ShouldBe("openai");
+    }
+
+    private static DaprConversationTaskInvoker CreateInvoker(
+        Func<IReadOnlyList<ConversationInput>, ConversationOptions, Task<ConversationResponse>> handler)
+    {
+        return new DaprConversationTaskInvoker(
+            new StubConversationClient(handler),
+            NullLogger<DaprConversationTaskInvoker>.Instance);
+    }
+
+    private static TaskDescriptor<DaprConversationBinding> Descriptor(DaprConversationBinding binding) =>
+        new()
+        {
+            TaskType = TaskTypes.DaprConversation,
+            TaskKey = "conversation-task",
+            Binding = binding
+        };
+
+    private sealed class StubConversationClient : DaprConversationClient
+    {
+        private readonly Func<IReadOnlyList<ConversationInput>, ConversationOptions, Task<ConversationResponse>> _handler;
+
+        // The base fields (autogen gRPC client / HttpClient / token) are never used because
+        // ConverseAsync is fully overridden, so nulls are safe here.
+        public StubConversationClient(
+            Func<IReadOnlyList<ConversationInput>, ConversationOptions, Task<ConversationResponse>> handler)
+            : base(null!, null!, null!)
+        {
+            _handler = handler;
+        }
+
+        public override Task<ConversationResponse> ConverseAsync(
+            IReadOnlyList<ConversationInput> inputs,
+            ConversationOptions options,
+            CancellationToken cancellationToken = default)
+        {
+            return _handler(inputs, options);
+        }
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/Tasks/Mapping/TaskBindingMapperDaprConversationTaskTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Tasks/Mapping/TaskBindingMapperDaprConversationTaskTests.cs
@@ -1,0 +1,90 @@
+using System.Text.Json;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Execution;
+using BBT.Workflow.Execution.Bindings;
+using BBT.Workflow.Tasks.Mapping;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Tasks.Mapping;
+
+public sealed class TaskBindingMapperDaprConversationTaskTests
+{
+    [Fact]
+    public void CreateEnvelope_MapsConversationTask()
+    {
+        var config = """
+            {
+              "componentName": "openai",
+              "contextId": "ctx-1",
+              "temperature": 0.7,
+              "scrubPII": true,
+              "inputs": [
+                { "role": "system", "content": "You are helpful." },
+                { "role": "user", "content": "Hello", "name": "ada", "scrubPII": false }
+              ],
+              "parameters": { "model": "gpt-4o", "max_tokens": 256 },
+              "metadata": { "region": "eu" }
+            }
+            """;
+        var task = DaprConversationTask.Create(config.ToJsonElement());
+        task.SetReference(new Reference("ask-llm", "test-domain", "sys-tasks", "1.0.0"));
+
+        var result = TaskBindingMapper.CreateEnvelope(task);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.TaskType.ShouldBe(TaskTypes.DaprConversation);
+
+        var binding = result.Value!.Binding.Deserialize<DaprConversationBinding>();
+        binding.ShouldNotBeNull();
+        binding!.ComponentName.ShouldBe("openai");
+        binding.ContextId.ShouldBe("ctx-1");
+        binding.Temperature.ShouldBe(0.7);
+        binding.ScrubPII.ShouldBe(true);
+
+        binding.Inputs.Count.ShouldBe(2);
+        binding.Inputs[0].Role.ShouldBe("system");
+        binding.Inputs[0].Content.ShouldBe("You are helpful.");
+        binding.Inputs[1].Role.ShouldBe("user");
+        binding.Inputs[1].Content.ShouldBe("Hello");
+        binding.Inputs[1].Name.ShouldBe("ada");
+        binding.Inputs[1].ScrubPII.ShouldBe(false);
+
+        binding.Parameters.ShouldNotBeNull();
+        binding.Parameters!["model"].ShouldBe("gpt-4o");
+        binding.Parameters!["max_tokens"].ShouldBe("256");
+        binding.Metadata.ShouldNotBeNull();
+        binding.Metadata!["region"].ShouldBe("eu");
+    }
+
+    [Fact]
+    public void CreateEnvelope_DefaultsRoleToUser_WhenMissing()
+    {
+        var config = """
+            {
+              "componentName": "openai",
+              "inputs": [ { "content": "Hi there" } ]
+            }
+            """;
+        var task = DaprConversationTask.Create(config.ToJsonElement());
+        task.SetReference(new Reference("ask-llm", "test-domain", "sys-tasks", "1.0.0"));
+
+        var binding = MapToBinding(task);
+
+        binding.Inputs.Count.ShouldBe(1);
+        binding.Inputs[0].Role.ShouldBe("user");
+        binding.Inputs[0].Content.ShouldBe("Hi there");
+        binding.ContextId.ShouldBeNull();
+        binding.Parameters.ShouldBeNull();
+        binding.Metadata.ShouldBeNull();
+    }
+
+    private static DaprConversationBinding MapToBinding(DaprConversationTask task)
+    {
+        var result = TaskBindingMapper.CreateEnvelope(task);
+        result.IsSuccess.ShouldBeTrue();
+        var binding = result.Value!.Binding.Deserialize<DaprConversationBinding>();
+        binding.ShouldNotBeNull();
+        return binding!;
+    }
+}


### PR DESCRIPTION
## What & why

Closes #334. Adds a new **DaprConversation** workflow task (`TaskType` enum `20`, string `daprconversation`) that lets workflows call LLM/AI providers (OpenAI, Anthropic, AWS Bedrock, …) through Dapr's **Conversation building block** — provider-agnostic, over the same Dapr sidecar the other Dapr tasks already use.

The task follows the existing `DaprService` triplet pattern end-to-end:

- **`DaprConversationTask`** (Domain) — full config: `componentName`, multi-turn `inputs` (role/content/name/scrubPII), `parameters`, `metadata`, `contextId`, `temperature`, `scrubPII`, `timeoutSeconds`.
- **`DaprConversationBinding`** (Execution.Abstractions) — plain serializable DTO.
- **`MapDaprConversationTask`** (`TaskBindingMapper`) — domain → binding.
- **`DaprConversationTaskExecutor`** (Application) — input/output C# script mapping + dispatch via `IRemoteInvokerService`.
- **`DaprConversationTaskInvoker`** (Execution) — maps the binding onto the Dapr.AI model and calls `DaprConversationClient.ConverseAsync`.
- `RecordDaprConversationInvocation` metric on `ITaskMetrics`; DI wiring in both service-collection extensions (`AddDaprConversationClient()` + invoker/executor registration).

## Reviewer notes

- **New dependency:** the Conversation API is **not** on `Dapr.Client` in 1.17.9 — it ships in the separate **`Dapr.AI`** package (added at the shared `DaprPackageVersion` 1.17.9).
- The Dapr Conversation API is **`[Experimental]`**, emitting diagnostic id `DAPR_CONVERSATION` as an error; suppressed via `<NoWarn>` in `BBT.Workflow.Execution.csproj` and `BBT.Workflow.Application.Tests.csproj`.
- `ConversationOptions.Parameters` is a protobuf `Any` map (Go `structpb.Value` pattern), so provider parameters are packed via `Any.Pack(Value.ForString/ForNumber/ForBool)`. `Metadata` stays `string`→`string`.

## Tests

- New unit tests: `TaskBindingMapperDaprConversationTaskTests` + `DaprConversationTaskInvokerTests` — **5 passing**.
- Full solution builds green (0 errors).
- The wider `dotnet test` run shows ~191 **pre-existing** failures in this environment (`AmbientServiceProvider.Current not set`, PostSharp/Aether aspect runtime) — verified identical on a clean tree via `git stash`, i.e. unrelated to this change.

## Out of scope (follow-ups)

- `vnext-sys-flow/core/Schemas/task.json` — add `type` enum `"20"` + `oneOf` branch (required for Forge designer validation).
- `/docs` page under `docs/components/tasks/` and a sample Dapr conversation component YAML under `etc/docker`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a new DaprConversation task pipeline that lets workflows perform AI/LLM conversations via Dapr's Conversation building block, including domain model, binding, executor/invoker wiring, metrics, and tests.

New Features:
- Introduce a new DaprConversation workflow task type for invoking AI/LLM providers via Dapr's Conversation building block.
- Add a DaprConversation binding and task invoker to execute conversation requests through the Dapr.AI client.
- Provide a DaprConversation task executor that integrates with existing scripting-based input/output mapping.

Enhancements:
- Extend task type enums, workflow task polymorphic configuration, and task type strings to support the new DaprConversation task.
- Wire the DaprConversation client, executor, and invoker into the application and execution dependency injection pipelines.
- Add task metrics support for tracking Dapr conversation invocations.

Tests:
- Add unit tests for mapping DaprConversationTask domain objects into bindings via TaskBindingMapper.
- Add unit tests for the DaprConversationTaskInvoker to validate successful, error, and edge-case invocation behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Dapr conversation tasks, including configurable messages, context, temperature, PII handling, metadata, and provider parameters.
  * Added integration with Dapr AI conversation services and structured conversation responses.
  * Added input and output mapping for conversation workflows, including script-based transformations.

* **Bug Fixes**
  * Added validation and error handling for missing inputs, provider failures, cancellations, and mapping errors.

* **Tests**
  * Added coverage for successful conversations, validation failures, provider errors, and configuration mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->