### PR TITLE
refactor(workflow): consolidate flow-level functionCache under a config object

### DIFF
--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -717,7 +717,7 @@ public sealed class InstanceQueryAppService(
                             Etag = etag,
                             EntityEtag = entityEtag,
                             Data = result.Data
-                        }, dataFunctionCache.ResolveTtlSeconds(flow.FunctionCache), cancellationToken);
+                        }, dataFunctionCache.ResolveTtlSeconds(flow.Config?.FunctionCache), cancellationToken);
                     }
 
                     if (!string.IsNullOrEmpty(input.IfNoneMatch) && etag.MatchesIfNoneMatch(input.IfNoneMatch))
@@ -1487,7 +1487,7 @@ public sealed class InstanceQueryAppService(
             {
                 Etag = etag,
                 Output = output
-            }, instanceSchemaFunctionCache.ResolveTtlSeconds(flow.FunctionCache), cancellationToken);
+            }, instanceSchemaFunctionCache.ResolveTtlSeconds(flow.Config?.FunctionCache), cancellationToken);
         }
 
         if (!string.IsNullOrEmpty(ifNoneMatch) && etag.MatchesIfNoneMatch(ifNoneMatch))

--- a/src/BBT.Workflow.Domain/Definitions/FunctionCacheDefinition.cs
+++ b/src/BBT.Workflow.Domain/Definitions/FunctionCacheDefinition.cs
@@ -6,7 +6,7 @@ namespace BBT.Workflow.Definitions;
 /// Workflow-author-controlled cache tuning for the built-in instance functions
 /// (data, view, schema, ...). A single TTL covers all of them. The state function is
 /// configured host-side (<c>StateFunctionCache</c> options) and is NOT covered by this object.
-/// JSON shape on the flow definition: <c>"functionCache": { "ttlSeconds": 120 }</c>.
+/// JSON shape on the flow definition: <c>"config": { "functionCache": { "ttlSeconds": 120 } }</c>.
 /// </summary>
 public sealed class FunctionCacheDefinition
 {

--- a/src/BBT.Workflow.Domain/Definitions/Workflow.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Workflow.cs
@@ -107,11 +107,12 @@ public sealed class Workflow : IDomainEntity, IReference, IReferenceSetter, IHas
     public WorkflowTimeout? Timeout { get; private set; }
 
     /// <summary>
-    /// Optional author-controlled cache tuning for the built-in instance functions
-    /// (data, view, schema, ...). Null means host defaults apply.
+    /// Optional flow-level configuration container. Consolidates author-controlled,
+    /// workflow-scoped settings (currently function cache tuning) under a single
+    /// <c>config</c> object. Null means host defaults apply.
     /// </summary>
-    [JsonInclude] [JsonPropertyName("functionCache")]
-    public FunctionCacheDefinition? FunctionCache { get; private set; }
+    [JsonInclude] [JsonPropertyName("config")]
+    public WorkflowConfig? Config { get; private set; }
 
     /// <summary>
     /// Defines the cancellation configuration for this workflow.

--- a/src/BBT.Workflow.Domain/Definitions/WorkflowConfig.cs
+++ b/src/BBT.Workflow.Domain/Definitions/WorkflowConfig.cs
@@ -1,0 +1,29 @@
+using System.Text.Json.Serialization;
+
+namespace BBT.Workflow.Definitions;
+
+/// <summary>
+/// Flow-level configuration container. Consolidates author-controlled, workflow-scoped
+/// settings under a single <c>config</c> object on the flow definition, so future
+/// flow-level options can be added without widening the root shape.
+/// JSON shape: <c>"config": { "functionCache": { "ttlSeconds": 120 } }</c>.
+/// </summary>
+public sealed class WorkflowConfig
+{
+    private WorkflowConfig()
+    {
+    }
+
+    [JsonConstructor]
+    private WorkflowConfig(FunctionCacheDefinition? functionCache)
+    {
+        FunctionCache = functionCache;
+    }
+
+    /// <summary>
+    /// Optional author-controlled cache tuning for the built-in instance functions
+    /// (data, view, schema, ...). Null means host defaults apply.
+    /// </summary>
+    [JsonInclude] [JsonPropertyName("functionCache")]
+    public FunctionCacheDefinition? FunctionCache { get; private set; }
+}

--- a/test/BBT.Workflow.Application.Tests/Instances/Caching/DataFunctionCacheTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/Caching/DataFunctionCacheTests.cs
@@ -156,7 +156,7 @@ public class DataFunctionCacheTests
         var json = """
                    {
                        "type": "F",
-                       "functionCache": { "ttlSeconds": 120 },
+                       "config": { "functionCache": { "ttlSeconds": 120 } },
                        "labels": [], "functions": [], "features": [], "states": [],
                        "sharedTransitions": [], "extensions": [],
                        "startTransition": {"key": "start", "from": null, "target": "review", "triggerType": "Manual", "versionStrategy": "Patch", "labels": [], "onExecutionTasks": [], "view": null}
@@ -171,8 +171,9 @@ public class DataFunctionCacheTests
         var workflow = JsonSerializer.Deserialize<Definitions.Workflow>(json, options);
 
         workflow.ShouldNotBeNull();
-        workflow!.FunctionCache.ShouldNotBeNull();
-        workflow.FunctionCache!.TtlSeconds.ShouldBe(120);
+        workflow!.Config.ShouldNotBeNull();
+        workflow.Config!.FunctionCache.ShouldNotBeNull();
+        workflow.Config.FunctionCache!.TtlSeconds.ShouldBe(120);
     }
 
     [Fact]

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceDataCacheTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceDataCacheTests.cs
@@ -441,7 +441,7 @@ public class InstanceQueryAppServiceDataCacheTests : IDisposable
             .Returns(instance);
 
         var functionCacheJson = workflowTtlSeconds is not null
-            ? $$""", "functionCache": { "ttlSeconds": {{workflowTtlSeconds}} }"""
+            ? $$""", "config": { "functionCache": { "ttlSeconds": {{workflowTtlSeconds}} } }"""
             : string.Empty;
         var json = $$"""
                    {


### PR DESCRIPTION
## What

Introduces a flow-level `config` container on the workflow definition and moves the existing author-controlled `functionCache` setting into it.

**JSON contract change:**

```jsonc
// before
{ "functionCache": { "ttlSeconds": 60 } }

// after
{ "config": { "functionCache": { "ttlSeconds": 60 } } }
```

## Why

`functionCache` was sitting at the flow-definition root. It's really a piece of workflow *config*, and more flow-level settings are expected. Consolidating them under a single `config` object keeps the root shape stable — future settings become a one-property addition to `WorkflowConfig` instead of another top-level key.

## Changes

- **New** `WorkflowConfig` (`Definitions/WorkflowConfig.cs`) — immutable flow-level config container, follows the same `[JsonConstructor]` / private-setter pattern as neighbouring definitions. Currently holds `FunctionCache`.
- `Workflow.FunctionCache` (`"functionCache"`) → `Workflow.Config` (`"config"`).
- The two consumers in `InstanceQueryAppService` now read `flow.Config?.FunctionCache` (null-safe; `ResolveTtlSeconds` already maps null → host default).
- `FunctionCacheDefinition` (the inner type) is **unchanged** and reused as-is — only its container moved. Its doc comment now reflects the nested shape.
- Updated the affected cache tests to the nested JSON.

## Reviewer notes

- **Breaking JSON change, no root-level fallback** (deliberate). `functionCache` is a 5-day-old feature (added 2026-07-22) with no committed sample/domain JSON — only test strings. Any flow already persisted with root-level `functionCache` will silently fall back to the host-default TTL until re-published under `config`. Re-publish preprod flows if applicable.
- Not to be confused with the unrelated per-*Function-component* `FunctionCache` type (`Definitions/Functions/FunctionCache.cs`) — untouched.

## Testing

- `dotnet build` (Domain + Application): 0 errors.
- Cache test suite: **69 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Consolidate workflow-level settings under a new config container and update function cache usage to read from it.

Enhancements:
- Introduce a WorkflowConfig container to hold flow-level configuration such as function cache settings.
- Update workflow definition, documentation comments, and cache consumers to use the nested config.functionCache structure instead of the root-level functionCache property.

Tests:
- Adjust workflow JSON binding and instance cache tests to the new config-based function cache JSON shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added workflow-level configuration support for function-cache settings.
  - Function-cache options are now provided under the workflow’s `config` section.

- **Bug Fixes**
  - Updated cache expiration handling to consistently use workflow configuration settings.

- **Documentation**
  - Updated configuration examples to reflect the new structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->