### PR TITLE
fix(functions): preserve author Content-Type without charset suffix

### DIFF
--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionResponseActionResultMapper.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionResponseActionResultMapper.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using BBT.Aether.AspNetCore.Results;
 using BBT.Aether.Results;
 using BBT.Workflow.Functions;
@@ -18,12 +19,28 @@ internal static class FunctionResponseActionResultMapper
         var output = result.Value!;
         ResponseOutputWriter.ApplyHeaders(output.Headers, httpContext);
 
-        var objectResult = new ObjectResult(output.Data)
+        // Use ContentResult (not ObjectResult) so the author-supplied media type is written
+        // verbatim. ObjectResult runs content negotiation and the SystemTextJson output formatter
+        // appends "; charset=utf-8" to the resolved media type; ContentResult preserves the exact
+        // content-type string when it carries no charset of its own.
+        return new ContentResult
         {
-            StatusCode = output.StatusCode ?? StatusCodes.Status200OK
+            StatusCode = output.StatusCode ?? StatusCodes.Status200OK,
+            ContentType = ResponseOutputWriter.ResolveContentType(output.Headers),
+            Content = SerializeContent(output.Data)
         };
-        objectResult.ContentTypes.Add(ResponseOutputWriter.ResolveContentType(output.Headers));
-
-        return objectResult;
     }
+
+    /// <summary>
+    /// Serializes the response payload. String payloads are written verbatim (the author has
+    /// already produced the wire representation, e.g. XML for a custom Content-Type); any other
+    /// object is serialized with the centralized JSON options for parity with the previous
+    /// ObjectResult behavior.
+    /// </summary>
+    private static string? SerializeContent(object? data) => data switch
+    {
+        null => null,
+        string s => s,
+        _ => JsonSerializer.Serialize(data, JsonSerializerConstants.JsonOptions)
+    };
 }

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/ResponseOutputWriter.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/ResponseOutputWriter.cs
@@ -8,10 +8,10 @@ namespace BBT.Workflow.Orchestration.Controllers;
 /// server-owned headers, and resolves the response Content-Type.
 /// </summary>
 /// <remarks>
-/// <c>content-type</c> is intentionally not written as a raw header — it is applied through
-/// <see cref="ObjectResult.ContentTypes"/> so the exact media-type string is preserved (no
-/// implicit <c>charset</c> suffix). When the author does not supply one, it defaults to
-/// <c>application/json</c>. Functions act as a BFF layer, so authors may set a custom
+/// <c>content-type</c> is intentionally not written as a raw header — the resolved media type is
+/// applied through <see cref="ContentResult.ContentType"/> so the exact media-type string is
+/// preserved (no implicit <c>charset</c> suffix). When the author does not supply one, it defaults
+/// to <c>application/json</c>. Functions act as a BFF layer, so authors may set a custom
 /// Content-Type for integration scenarios.
 /// </remarks>
 internal static class ResponseOutputWriter
@@ -25,7 +25,7 @@ internal static class ResponseOutputWriter
     {
         "connection",
         "content-length",
-        ContentTypeHeader, // applied via ObjectResult.ContentTypes, never as a raw header
+        ContentTypeHeader, // applied via ContentResult.ContentType, never as a raw header
         "date", // server writes its own
         "host", // upstream internal hostname must not leak
         "keep-alive",

--- a/test/BBT.Workflow.Application.Tests/Functions/FunctionResponseActionResultMapperTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Functions/FunctionResponseActionResultMapperTests.cs
@@ -20,9 +20,9 @@ public sealed class FunctionResponseActionResultMapperTests
 
         var actionResult = FunctionResponseActionResultMapper.ToActionResult(result, new DefaultHttpContext());
 
-        var objectResult = actionResult.ShouldBeOfType<ObjectResult>();
-        objectResult.ContentTypes.ShouldContain("application/json");
-        objectResult.ContentTypes.ShouldNotContain("application/json; charset=utf-8");
+        var contentResult = actionResult.ShouldBeOfType<ContentResult>();
+        // ContentResult preserves the media type verbatim — no "; charset=utf-8" suffix.
+        contentResult.ContentType.ShouldBe("application/json");
     }
 
     [Fact]
@@ -40,8 +40,10 @@ public sealed class FunctionResponseActionResultMapperTests
         var httpContext = new DefaultHttpContext();
         var actionResult = FunctionResponseActionResultMapper.ToActionResult(result, httpContext);
 
-        var objectResult = actionResult.ShouldBeOfType<ObjectResult>();
-        objectResult.ContentTypes.ShouldContain("application/xml");
+        var contentResult = actionResult.ShouldBeOfType<ContentResult>();
+        contentResult.ContentType.ShouldBe("application/xml");
+        // string payloads are written verbatim (no JSON quoting) for custom content types.
+        contentResult.Content.ShouldBe("<root/>");
         // content-type must not be duplicated as a raw response header.
         httpContext.Response.Headers.ContainsKey("Content-Type").ShouldBeFalse();
     }
@@ -75,6 +77,22 @@ public sealed class FunctionResponseActionResultMapperTests
 
         var actionResult = FunctionResponseActionResultMapper.ToActionResult(result, new DefaultHttpContext());
 
-        actionResult.ShouldBeOfType<ObjectResult>().StatusCode.ShouldBe(StatusCodes.Status201Created);
+        actionResult.ShouldBeOfType<ContentResult>().StatusCode.ShouldBe(StatusCodes.Status201Created);
+    }
+
+    [Fact]
+    public void ToActionResult_WithObjectData_SerializesBodyAsJson()
+    {
+        var result = Result<FunctionResponseOutput>.Ok(new FunctionResponseOutput
+        {
+            Data = new { a = 1 }
+        });
+
+        var actionResult = FunctionResponseActionResultMapper.ToActionResult(result, new DefaultHttpContext());
+
+        var contentResult = actionResult.ShouldBeOfType<ContentResult>();
+        contentResult.Content.ShouldNotBeNull();
+        contentResult.Content!.ShouldContain("\"a\"");
+        contentResult.Content!.ShouldContain("1");
     }
 }


### PR DESCRIPTION
## What

Function endpoint responses no longer have `; charset=utf-8` appended to the author-supplied `Content-Type`. A function that sets `Content-Type: application/json` now returns exactly `application/json` on the wire.

## Why

`FunctionResponseActionResultMapper` returned the payload via `ObjectResult`. `ObjectResult` runs content negotiation, and the default `SystemTextJsonOutputFormatter` (via `TextOutputFormatter.WriteResponseHeaders` → `SelectCharacterEncoding`) appends `; charset=<encoding>` to the resolved media type. So even though vNext resolved the content-type as a bare string, the wire header became `application/json; charset=utf-8`, overriding the intended value.

This is ASP.NET Core default formatter behavior — not Aether or vNext middleware. The prior doc comment on `ResponseOutputWriter` claiming `ObjectResult.ContentTypes` preserves the exact media type was incorrect.

## How

- **`FunctionResponseActionResultMapper`**: return `ContentResult` instead of `ObjectResult`. `ContentResult` writes the content-type string verbatim when it carries no charset of its own, bypassing the formatter's charset append. The body is serialized with the centralized `JsonSerializerConstants.JsonOptions` (parity with the previous JSON output). String payloads (e.g. XML for a custom Content-Type, the BFF use case) are now written verbatim instead of being JSON-quoted.
- **`ResponseOutputWriter`**: refresh the now-inaccurate `ObjectResult.ContentTypes` references in the doc comment and restricted-header comment.

## Tests

`FunctionResponseActionResultMapperTests` updated to assert `ContentResult` and the exact media type (no charset suffix), plus new cases covering string-payload passthrough and object JSON serialization. All 5 tests pass.

Note: these are in-memory assertions on `ContentResult.ContentType`. If desired I can add a `WebApplicationFactory` integration test to assert the actual wire header end-to-end.

## Reviewer notes

- Behavior change worth flagging: a **string** `Data` under a custom Content-Type is now emitted raw rather than JSON-quoted. This was arguably always broken (JSON-quoting an XML string under `application/xml`), and aligns with the BFF intent documented on `ResponseOutputWriter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Preserve author-supplied Content-Type headers for function responses by switching to ContentResult-based responses and updating serialization behavior and documentation accordingly.

Bug Fixes:
- Prevent ASP.NET Core from appending an automatic charset suffix to function response Content-Type headers, ensuring the exact author-specified media type is returned.

Enhancements:
- Emit string response payloads verbatim for custom Content-Types while JSON-serializing non-string payloads with shared options for parity with previous behavior.
- Update ResponseOutputWriter documentation comments to reflect the use of ContentResult and accurate Content-Type handling semantics.

Tests:
- Extend FunctionResponseActionResultMapperTests to assert ContentResult usage, exact Content-Type values, raw string passthrough, JSON serialization of object payloads, and status code propagation.