### PR TITLE
fix(events): return a Dapr-compatible response from /instances/events

### DIFF
--- a/.claude/rules/vnext-workflow-developer.md
+++ b/.claude/rules/vnext-workflow-developer.md
@@ -125,8 +125,13 @@ If subflow is in terminal status (`Completed`/`Faulted`/`Passive`) while parent 
 - **Events**: `event.mapping` on the workflow (`action=start`) or on a `triggerType: 3` transition
   (`action=transition`). Mapping implements `IEventMapping` → `EventMappingResult { InstanceKey, Body, Selector }`.
   Delivery is domain-owned Dapr Subscription YAMLs routing topics to
-  `POST /api/v1/{domain}/workflows/{workflow}/instances/events?action=...`. No active match ⇒ 200 + ignore
-  (no redelivery). Full guide: `docs/domain/event-driven-workflows.md`.
+  `POST /api/v1/{domain}/workflows/{workflow}/instances/events?action=...`.
+  **Response is a Dapr pub/sub protocol body** (`EventDeliveryResponse`), never an instance DTO — Dapr
+  reads the top-level `status` field as its signal, so an `InstanceStatus` code there (`"B"`) causes
+  endless redelivery. Processed or no-active-match ⇒ `200 {"status":"SUCCESS"}`; permanently
+  unprocessable (bad `transitionKey`/action/domain, non-JSON body, missing event definition) ⇒
+  `200 {"status":"DROP","reason":…}` + `EventDeliveryDropped` warning; transient failures keep non-2xx
+  so the broker retries. Full guide: `docs/domain/event-driven-workflows.md`.
 - **Filtering**: author instance queries with fluent `InstanceQuery` (default script import), never
   hand-concatenated GraphQL JSON. Terminals: `.First()/.Last()` → event `Selector` (single-resolve);
   `.Build()` → `InstanceQuerySpec` for `GetInstancesTask.SetFilterSpec(...)` (preferred; in-process when

--- a/docs/domain/event-driven-workflows.md
+++ b/docs/domain/event-driven-workflows.md
@@ -124,6 +124,27 @@ POST /api/v1/{domain}/workflows/{workflow}/instances/events
 
 Body: the raw event payload (CloudEvent envelopes are unwrapped automatically).
 
+### The response is a Dapr protocol body, not an instance envelope
+
+Dapr reads the **top-level `status` field of the subscriber's JSON response** as its delivery signal
+— `SUCCESS`, `RETRY` or `DROP`; any other value is an error and the message is redelivered
+([Dapr pub/sub API](https://docs.dapr.io/reference/api/pubsub_api/#expected-http-response)). That
+field name collides with the instance DTOs the rest of `InstanceController` returns, whose `status`
+is an `InstanceStatus` code (`"A"`, `"B"`, `"C"`, `"F"`, `"P"`). So this endpoint returns its own
+`EventDeliveryResponse` instead:
+
+```jsonc
+{ "status": "SUCCESS" }                       // processed, or intentionally ignored
+{ "status": "DROP", "reason": "TransitionNotFound: …" }   // unprocessable, discarded
+{ "status": "SUCCESS", "instance": { "id": "…", "key": "…", "status": "C" } }  // sync=true only
+```
+
+The instance snapshot is nested (`instance`) and emitted only for `sync=true` — Dapr inspects the
+top level only, so an instance status code is safe there. **Never return `StartInstanceOutput` /
+`TransitionOutput` from this endpoint**: a body like `{"id":"…","status":"B"}` makes Dapr treat every
+delivery as failed, and it will redeliver the same message forever without ever advancing the
+partition offset.
+
 ## Delivery infrastructure (owned by the domain)
 
 The runtime never subscribes. You route broker messages to the endpoint with **declarative Dapr
@@ -164,6 +185,20 @@ Rules of thumb:
 - Locally the YAMLs live in the folder mounted into the orchestration sidecar; in Kubernetes they
   are `Subscription` custom resources in your namespace scoped to the orchestration app-id.
 - Shipping a new event = one more YAML. No runtime change, no redeploy of vNext.
+- **Add a dead-letter topic.** The runtime drops permanently-unprocessable messages itself, but a
+  transient-looking failure that never clears (a mapping script throwing on every attempt) is
+  retried per your resiliency policy. Without a bound, that blocks the partition:
+
+  ```yaml
+  spec:
+    topic: morph-touch.event-driven-workflow
+    route: /api/v1/morph-touch/workflows/event-driven-workflow/instances/events?action=start
+    pubsubname: vnext-pubsub
+    deadLetterTopic: morph-touch.event-driven-workflow.dlq
+  ```
+
+  Pair it with a `maxRetries` resiliency policy on the pub/sub component, and subscribe something to
+  the DLQ — even just an alert.
 
 ## Producers
 
@@ -179,19 +214,37 @@ Anything that can publish to the topic is a valid producer — it needs zero kno
 Delivery order: endpoint → resolve workflow from the component cache → pick the event definition
 (workflow-level for start, transition-level for transition) → compile + run the mapping → act.
 
+Failures are split by intent. A message that can **never** succeed no matter how often it is
+redelivered (a `transitionKey` typo, a missing event definition, a body that is not JSON, a
+subscription pointed at the wrong domain) is answered `200 DROP`: retrying it would block the
+partition behind a message that will never be accepted. Only genuinely transient failures keep a
+non-2xx response, which is already Dapr's redelivery signal.
+
 | Situation | Response | Broker behavior |
 | --- | --- | --- |
-| Processed (start or transition executed) | 200 | done |
-| No active instance matches the key/selector | **200, logged, intentionally ignored** | no redelivery |
+| Processed (start or transition executed) | `200 SUCCESS` | offset advances |
+| No active instance matches the key/selector | **`200 SUCCESS`, logged, intentionally ignored** | no redelivery |
+| `action` is neither `start` nor `transition` | `200 DROP` `InvalidEventAction` | discarded, logged |
+| Body is not parseable JSON | `200 DROP` `InvalidEventPayload` | discarded, logged |
+| Route domain is not this runtime's domain | `200 DROP` `EventDomainMismatch` | discarded, logged |
+| `transitionKey` unknown in the workflow | `200 DROP` `TransitionNotFound` | discarded, logged |
+| `transitionKey` missing for `action=transition` | `200 DROP` `EventTransitionKeyRequired` | discarded, logged |
+| Transition exists but `triggerType != 3` | `200 DROP` `NotAnEventTransition` | discarded, logged |
+| Workflow/transition has no `event` definition | `200 DROP` `EventDefinitionMissing` | discarded, logged |
 | Mapping script throws / returns null | 500 `EventMappingFailed` / `EventMappingNullResult` | retried per resiliency policy |
-| `transitionKey` unknown in the workflow | 404 `TransitionNotFound` | retried per resiliency policy |
-| Transition exists but `triggerType != 3` | 400 `NotAnEventTransition` | retried per resiliency policy |
-| Workflow/transition has no `event` definition | 404 `EventDefinitionMissing` | retried per resiliency policy |
+| Pipeline / infrastructure failure | 500 (or 409 on concurrency conflict) | retried per resiliency policy |
 
 Notes:
 
 - The 200-on-no-match rule is deliberate: an abort event for an already-completed instance must
   evaporate, not redeliver forever.
+- Every `DROP` is logged as a **Warning** (`EventDeliveryDropped`, EventId 40994) with the error code
+  and reason, and the reason is echoed in the response body — a discarded message is still
+  diagnosable. Alert on that log; a silently dropped event is worse than a noisy one.
+- A mapping script that throws deterministically is in the *retry* class, so it will be redelivered
+  until the resiliency policy gives up. Bound it: give the subscription a `maxRetries` policy and a
+  `deadLetterTopic` so the poison message ends up somewhere inspectable instead of consuming the
+  consumer indefinitely.
 - `sync=true` blocks the delivery until the transition pipeline completes; without it the event is
   accepted and processed asynchronously.
 - Event transitions run with the **Event pipeline profile** (skips Preflight, ForwardSubflow,
@@ -219,6 +272,11 @@ curl -X POST "http://localhost:4201/api/v1/morph-touch/workflows/event-driven-wo
   -d '{"orderId":"ord-1","amount":250}'
 ```
 
+Expect `200 {"status":"SUCCESS"}`. Add `&sync=true` to also get the `instance` snapshot back. Because
+unprocessable messages answer `200 DROP` rather than 4xx, read the `status` field — not just the
+status code — when testing by hand: a `DROP` means the delivery was discarded, and the `reason` says
+why.
+
 Then validate the YAML routing with the real path:
 
 ```bash
@@ -232,6 +290,8 @@ startup — restart the Dapr sidecar after adding or changing a YAML.
 ## References
 
 - Endpoint: `orchestration/.../Controllers/Instances/InstanceController.cs` (`HandleEventAsync`)
+- Response contract: `src/BBT.Workflow.Application/Events/EventDeliveryResponse.cs`,
+  `orchestration/.../Controllers/Instances/EventDeliveryResultMapper.cs`
 - Application service: `src/BBT.Workflow.Application/Events/EventAppService.cs`
 - Mapping contract: `src/BBT.Workflow.Domain/Scripting/Contracts/IEventMapping.cs`
 - Event definition: `src/BBT.Workflow.Domain/Definitions/Events/Event.cs`

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/EventDeliveryResultMapper.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/EventDeliveryResultMapper.cs
@@ -1,0 +1,102 @@
+using BBT.Aether.Results;
+using BBT.Workflow.Events;
+using BBT.Workflow.HttpApi.Results;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Logging;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BBT.Workflow.Orchestration.Controllers.Instances;
+
+/// <summary>
+/// Maps event-delivery results to Dapr pub/sub protocol responses for
+/// <c>POST /{domain}/workflows/{workflow}/instances/events</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Dapr reads the top-level <c>status</c> field of the response body as a protocol signal
+/// (<c>SUCCESS</c> / <c>RETRY</c> / <c>DROP</c>), so this endpoint cannot return the instance DTOs
+/// the rest of <c>InstanceController</c> returns — their <c>status</c> property carries an
+/// <see cref="InstanceStatus"/> code, which Dapr rejects and then redelivers forever.
+/// Everything here therefore goes out as an <see cref="EventDeliveryResponse"/>.
+/// </para>
+/// <para>
+/// Failures are split by intent rather than mapped uniformly:
+/// permanently unprocessable messages (bad <c>transitionKey</c>, missing event definition, wrong
+/// domain, malformed body) are <c>DROP</c>ped with <c>200</c> so a single poison message cannot wedge
+/// a partition, while transient failures keep their non-2xx <c>ProblemDetails</c> response — Dapr
+/// already redelivers on non-2xx, and the error stays visible to metrics, traces and alerts.
+/// Bounding those retries is the subscription's job (<c>maxRetries</c> resiliency policy plus a
+/// <c>deadLetterTopic</c>).
+/// </para>
+/// </remarks>
+internal static class EventDeliveryResultMapper
+{
+    /// <summary>
+    /// Error prefixes whose failures can never be resolved by redelivering the same message —
+    /// configuration or payload defects rather than infrastructure hiccups.
+    /// </summary>
+    private static readonly HashSet<string> PermanentErrorPrefixes =
+    [
+        ErrorCodes.Prefixes.Validation,
+        ErrorCodes.Prefixes.NotFound,
+        ErrorCodes.Prefixes.NotSupported,
+        ErrorCodes.Prefixes.Unauthorized,
+        ErrorCodes.Prefixes.Forbidden
+    ];
+
+    /// <summary>
+    /// Translates the event service result into a Dapr-compatible response.
+    /// </summary>
+    /// <param name="result">Outcome of <c>IEventAppService.HandleAsync</c>.</param>
+    /// <param name="input">The event request, used for log context.</param>
+    /// <param name="httpContext">Current request context (used for the failure passthrough).</param>
+    /// <param name="logger">Logger for the drop warning.</param>
+    internal static IActionResult ToActionResult(
+        Result<object?> result,
+        EventInput input,
+        HttpContext httpContext,
+        ILogger logger)
+    {
+        if (result.IsSuccess)
+        {
+            // A null value is the deliberate "no active instance matched" acknowledgement: the event
+            // evaporates instead of being redelivered.
+            var instance = input.Sync ? ToInstance(result.Value) : null;
+            return new OkObjectResult(EventDeliveryResponse.Succeeded(instance));
+        }
+
+        if (PermanentErrorPrefixes.Contains(result.Error.Prefix))
+            return Drop(
+                $"{result.Error.Code}: {result.Error.Message}",
+                input.Domain,
+                input.Workflow,
+                input.TransitionKey,
+                result.Error.Code,
+                logger);
+
+        // Transient / infrastructure failure: keep the ProblemDetails response. Non-2xx already means
+        // "retry" to Dapr, so no body-level RETRY signal is needed.
+        return WorkflowResultActionResultMapper.ToActionResult(result, httpContext);
+    }
+
+    /// <summary>
+    /// Builds a <c>200 DROP</c> response for a delivery that can never succeed, logging why so the
+    /// discarded message remains diagnosable even though the status code is a success.
+    /// </summary>
+    internal static IActionResult Drop(
+        string reason,
+        string? domain,
+        string? workflow,
+        string? transitionKey,
+        string? errorCode,
+        ILogger logger)
+    {
+        logger.EventDeliveryDropped(domain, workflow, transitionKey, errorCode, reason);
+        return new OkObjectResult(EventDeliveryResponse.Dropped(reason));
+    }
+
+    private static EventDeliveryInstance? ToInstance(object? value)
+        => value is InstanceOutputBase output
+            ? new EventDeliveryInstance(output.Id, output.Key, output.Status?.Code)
+            : null;
+}

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs
@@ -496,19 +496,27 @@ public sealed class InstanceController(
     /// <param name="sync">When true, blocks until the pipeline completes; otherwise accepted and run asynchronously.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <remarks>
+    /// <para>
     /// The raw event payload is read directly from the request body and parsed as JSON, independent of the
     /// request <c>Content-Type</c>. Kafka / pub-sub sources routed through Dapr routinely deliver bodies with
     /// no content type or <c>application/octet-stream</c>; binding via <c>[FromBody]</c> would reject those with
     /// <c>415 Unsupported Media Type</c>, so the body is bound manually here instead.
+    /// </para>
+    /// <para>
+    /// The response is an <see cref="EventDeliveryResponse"/> — a Dapr pub/sub protocol body, not an
+    /// instance envelope. Dapr reads the top-level <c>status</c> field as its delivery signal, so
+    /// returning an instance DTO here (whose <c>status</c> is an <see cref="InstanceStatus"/> code such
+    /// as <c>"B"</c>) makes Dapr treat every delivery as failed and redeliver the same message forever,
+    /// blocking the partition. Unprocessable messages are answered with <c>200 DROP</c> for the same
+    /// reason; only transient failures return non-2xx so the broker retries them.
+    /// </para>
     /// </remarks>
-    /// <response code="200">Event processed (or intentionally ignored when no active instance matches).</response>
-    /// <response code="400">Invalid action, transitionKey missing for action=transition, or malformed JSON body.</response>
-    /// <response code="404">Workflow or event definition not found.</response>
+    /// <response code="200">Dapr signal: <c>SUCCESS</c> when processed (or intentionally ignored because no active instance matches), <c>DROP</c> when the message can never be processed.</response>
+    /// <response code="500">Transient failure — the broker should redeliver.</response>
     [ApiExplorerSettings(IgnoreApi = true)]
     [HttpPost("{domain}/workflows/{workflow}/instances/events")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(EventDeliveryResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> HandleEventAsync(
         [FromRoute] string domain,
         [FromRoute] string workflow,
@@ -517,13 +525,12 @@ public sealed class InstanceController(
         [FromQuery] bool sync = false,
         CancellationToken cancellationToken = default)
     {
+        // A subscription routed at the wrong action, or a producer publishing a body that is not JSON,
+        // is a permanent defect: retrying it can never succeed, so drop instead of wedging the topic.
         if (!Enum.TryParse<EventAction>(action, ignoreCase: true, out var eventAction))
-            return BadRequest(new ProblemDetails
-            {
-                Title = "Invalid action",
-                Detail = $"action must be 'start' or 'transition'. Received: '{action}'.",
-                Status = StatusCodes.Status400BadRequest
-            });
+            return EventDeliveryResultMapper.Drop(
+                $"InvalidEventAction: action must be 'start' or 'transition'. Received: '{action}'.",
+                domain, workflow, transitionKey, "InvalidEventAction", Logger);
 
         JsonElement payload;
         try
@@ -532,12 +539,9 @@ public sealed class InstanceController(
         }
         catch (JsonException exception)
         {
-            return BadRequest(new ProblemDetails
-            {
-                Title = "Invalid payload",
-                Detail = $"The request body could not be parsed as JSON: {exception.Message}",
-                Status = StatusCodes.Status400BadRequest
-            });
+            return EventDeliveryResultMapper.Drop(
+                $"InvalidEventPayload: the request body could not be parsed as JSON: {exception.Message}",
+                domain, workflow, transitionKey, "InvalidEventPayload", Logger);
         }
 
         var input = new EventInput
@@ -553,7 +557,7 @@ public sealed class InstanceController(
         };
 
         var result = await eventAppService.HandleAsync(input, cancellationToken);
-        return WorkflowResultActionResultMapper.ToActionResult(result, HttpContext);
+        return EventDeliveryResultMapper.ToActionResult(result, input, HttpContext, Logger);
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Application/Events/EventAppService.cs
+++ b/src/BBT.Workflow.Application/Events/EventAppService.cs
@@ -3,6 +3,7 @@ using BBT.Aether.Results;
 using BBT.Workflow.Caching;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Definitions.Events;
+using BBT.Workflow.ExceptionHandling;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Logging;
 using BBT.Workflow.Runtime;
@@ -32,7 +33,18 @@ public sealed class EventAppService(
     /// <inheritdoc />
     public async Task<Result<object?>> HandleAsync(EventInput input, CancellationToken cancellationToken = default)
     {
-        runtimeInfoProvider.Check(input.Domain);
+        // A misrouted subscription is a permanent defect, so surface it as a Result the delivery mapper
+        // can turn into a Dapr DROP. Letting NotFoundDomainException escape would produce a 500 that the
+        // broker retries forever on a message this runtime can never accept.
+        try
+        {
+            runtimeInfoProvider.Check(input.Domain);
+        }
+        catch (NotFoundDomainException exception)
+        {
+            return Result<object?>.Fail(Error.NotFound("EventDomainMismatch", exception.Message));
+        }
+
         logger.EventReceived(input.Domain, input.Workflow, input.Action.ToString(), input.TransitionKey);
 
         // Resolve the flow definition from the component cache (sys-flows).

--- a/src/BBT.Workflow.Application/Events/EventDeliveryResponse.cs
+++ b/src/BBT.Workflow.Application/Events/EventDeliveryResponse.cs
@@ -1,0 +1,79 @@
+using System.Text.Json.Serialization;
+
+namespace BBT.Workflow.Events;
+
+/// <summary>
+/// Dapr pub/sub protocol signal values. Dapr reads the top-level <c>status</c> field of the
+/// subscriber's JSON response body: <c>SUCCESS</c> acknowledges the message, <c>RETRY</c> asks for
+/// redelivery, <c>DROP</c> logs a warning and discards it. Any other value is treated as an error
+/// and the message is redelivered indefinitely.
+/// See https://docs.dapr.io/reference/api/pubsub_api/#expected-http-response.
+/// </summary>
+public static class DaprPubSubStatus
+{
+    /// <summary>Message processed; the broker may advance its offset.</summary>
+    public const string Success = "SUCCESS";
+
+    /// <summary>Message can never be processed; discard it instead of blocking the partition.</summary>
+    public const string Drop = "DROP";
+
+    /// <summary>Message failed transiently; ask the broker to redeliver.</summary>
+    public const string Retry = "RETRY";
+}
+
+/// <summary>
+/// Response body of the pub/sub event delivery endpoint
+/// (<c>POST /{domain}/workflows/{workflow}/instances/events</c>).
+/// </summary>
+/// <remarks>
+/// This endpoint is driven by Dapr pub/sub subscriptions, so its body is a protocol contract before
+/// it is a payload: the top-level <c>status</c> field is consumed by Dapr itself. Instance DTOs
+/// (<c>StartInstanceOutput</c> / <c>TransitionOutput</c>) must never be returned here — their
+/// <c>status</c> property serializes to an <c>InstanceStatus</c> code (<c>"A"</c>, <c>"B"</c>, …),
+/// which Dapr does not recognize, causing endless redelivery of the same message.
+/// </remarks>
+public sealed record EventDeliveryResponse
+{
+    /// <summary>
+    /// Dapr protocol signal. Always one of the <see cref="DaprPubSubStatus"/> constants — never an
+    /// <c>InstanceStatus</c> code.
+    /// </summary>
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    /// <summary>
+    /// Why the message was dropped. Diagnostic only — Dapr ignores it; present so a message
+    /// discarded as unprocessable is still explainable from the response alone.
+    /// </summary>
+    [JsonPropertyName("reason")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Reason { get; init; }
+
+    /// <summary>
+    /// Instance snapshot, emitted only for <c>sync=true</c> callers (manual testing and integration
+    /// tests). Nested on purpose: Dapr only inspects the top-level <c>status</c>, so the instance's
+    /// own status code is safe here.
+    /// </summary>
+    [JsonPropertyName("instance")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public EventDeliveryInstance? Instance { get; init; }
+
+    /// <summary>Acknowledges a processed (or intentionally ignored) delivery.</summary>
+    public static EventDeliveryResponse Succeeded(EventDeliveryInstance? instance = null)
+        => new() { Status = DaprPubSubStatus.Success, Instance = instance };
+
+    /// <summary>Discards a delivery that can never succeed, recording why.</summary>
+    public static EventDeliveryResponse Dropped(string reason)
+        => new() { Status = DaprPubSubStatus.Drop, Reason = reason };
+}
+
+/// <summary>
+/// Minimal instance projection returned alongside a successful synchronous event delivery.
+/// </summary>
+/// <param name="Id">Instance identifier.</param>
+/// <param name="Key">Business key the event correlated to.</param>
+/// <param name="Status">Instance status code (<c>A</c>, <c>B</c>, <c>C</c>, <c>F</c>, <c>P</c>).</param>
+public sealed record EventDeliveryInstance(
+    [property: JsonPropertyName("id")] Guid Id,
+    [property: JsonPropertyName("key")] string? Key,
+    [property: JsonPropertyName("status")] string? Status);

--- a/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
@@ -2324,6 +2324,22 @@ public static partial class WorkflowLogs
         string? transitionKey,
         string error);
 
+    /// <summary>
+    /// Logs when an event delivery is discarded because it can never be processed, so the response
+    /// signals Dapr to DROP the message rather than block the partition with endless redelivery.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 40994,
+        Level = LogLevel.Warning,
+        Message = "Event delivery dropped (Dapr DROP). Domain: {Domain}, Workflow: {Workflow}, TransitionKey: {TransitionKey}, Code: {ErrorCode}, Reason: {Reason}")]
+    public static partial void EventDeliveryDropped(
+        this ILogger logger,
+        string? domain,
+        string? workflow,
+        string? transitionKey,
+        string? errorCode,
+        string? reason);
+
     #endregion
 
     #region Authorization (authorize / permissions)

--- a/test/BBT.Workflow.Application.Tests/HttpApi/EventPayloadBindingTests.cs
+++ b/test/BBT.Workflow.Application.Tests/HttpApi/EventPayloadBindingTests.cs
@@ -3,8 +3,19 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using BBT.Aether.DependencyInjection;
+using BBT.Workflow.BackgroundJobs;
+using BBT.Workflow.Events;
+using BBT.Workflow.Gateway;
+using BBT.Workflow.Instances;
 using BBT.Workflow.Orchestration.Controllers.Instances;
+using BBT.Workflow.SubFlow;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 using Shouldly;
 using Xunit;
 
@@ -53,6 +64,67 @@ public sealed class EventPayloadBindingTests
 
         await Should.ThrowAsync<JsonException>(() =>
             InstanceController.ReadEventPayloadAsync(request, CancellationToken.None));
+    }
+
+    /// <summary>
+    /// A body that is not JSON, or a subscription routed at an action the endpoint does not know, can
+    /// never be processed. Both must be answered with Dapr's <c>DROP</c> signal rather than a 4xx —
+    /// Dapr redelivers non-2xx responses, so a single such message would block the topic partition.
+    /// </summary>
+    [Theory]
+    [InlineData("{ not-json", "start", "InvalidEventPayload")]
+    [InlineData(PayloadJson, "strat", "InvalidEventAction")]
+    public async Task HandleEvent_PermanentlyUnprocessableDelivery_ReturnsDropSignal(
+        string body, string action, string expectedCode)
+    {
+        var controller = BuildController(body);
+
+        var actionResult = await controller.HandleEventAsync(
+            domain: "orders",
+            workflow: "order-flow",
+            action: action,
+            cancellationToken: CancellationToken.None);
+
+        var objectResult = actionResult.ShouldBeAssignableTo<ObjectResult>()!;
+        objectResult.StatusCode.ShouldBe(StatusCodes.Status200OK);
+
+        var response = objectResult.Value.ShouldBeOfType<EventDeliveryResponse>();
+        response.Status.ShouldBe(DaprPubSubStatus.Drop);
+        response.Reason!.ShouldContain(expectedCode);
+    }
+
+    /// <summary>
+    /// Builds a controller wired only far enough to reach the two pre-service guards; the event app
+    /// service is never invoked on those paths.
+    /// </summary>
+    private static InstanceController BuildController(string body)
+    {
+        var controller = new InstanceController(
+            commandAppService: Substitute.For<IInstanceCommandAppService>(),
+            queryAppService: Substitute.For<IInstanceQueryAppService>(),
+            retryAppService: Substitute.For<IInstanceRetryAppService>(),
+            httpContextAccessor: Substitute.For<IHttpContextAccessor>(),
+            subflowCompletionService: Substitute.For<ISubflowCompletionService>(),
+            subflowStateService: Substitute.For<ISubflowStateService>(),
+            subflowFaultService: Substitute.For<ISubflowFaultService>(),
+            subflowCancellationService: Substitute.For<ISubflowCancellationService>(),
+            cancellationService: Substitute.For<IInstanceCancellationService>(),
+            childSubflowCancellationService: Substitute.For<IChildSubflowCancellationService>(),
+            childSubflowFaultService: Substitute.For<IChildSubflowFaultService>(),
+            transitionJobEnqueuer: Substitute.For<ITransitionJobEnqueuer>(),
+            instanceCommandGateway: Substitute.For<IInstanceCommandGateway>(),
+            eventAppService: Substitute.For<IEventAppService>());
+
+        // AetherControllerBase resolves its Logger through the request services.
+        var services = new ServiceCollection();
+        services.AddSingleton<ILazyServiceProvider, LazyServiceProvider>();
+        services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+
+        var context = BuildRequest(body, "application/octet-stream").HttpContext;
+        context.RequestServices = services.BuildServiceProvider();
+        controller.ControllerContext = new ControllerContext { HttpContext = context };
+
+        return controller;
     }
 
     private static HttpRequest BuildRequest(string body, string? contentType)

--- a/test/BBT.Workflow.Application.Tests/HttpApi/Results/EventDeliveryResultMapperTests.cs
+++ b/test/BBT.Workflow.Application.Tests/HttpApi/Results/EventDeliveryResultMapperTests.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Text.Json;
+using BBT.Aether.AspNetCore.ExceptionHandling;
+using BBT.Aether.Results;
+using BBT.Workflow.Definitions.Events;
+using BBT.Workflow.Events;
+using BBT.Workflow.Instances;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Orchestration.Controllers.Instances;
+
+/// <summary>
+/// Guards the Dapr pub/sub response contract of the <c>/instances/events</c> endpoint.
+/// Dapr reads the top-level <c>status</c> field of the response body as its delivery signal, so a body
+/// carrying an <c>InstanceStatus</c> code there (<c>"B"</c>, <c>"A"</c>, …) makes Dapr treat every
+/// delivery as failed and redeliver the same message forever, blocking the topic partition.
+/// </summary>
+public sealed class EventDeliveryResultMapperTests
+{
+    [Fact]
+    public void ToActionResult_Success_ReturnsDaprSuccessSignal()
+    {
+        var actionResult = Map(SuccessResult(), Input(sync: false));
+
+        var body = ShouldBeOkWith(actionResult);
+        body.Status.ShouldBe(DaprPubSubStatus.Success);
+    }
+
+    [Fact]
+    public void ToActionResult_SuccessWithoutSync_OmitsInstanceSnapshot()
+    {
+        var actionResult = Map(SuccessResult(), Input(sync: false));
+
+        ShouldBeOkWith(actionResult).Instance.ShouldBeNull();
+        Serialize(actionResult).TryGetProperty("instance", out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ToActionResult_SuccessWithSync_NestsInstanceSnapshot()
+    {
+        var actionResult = Map(SuccessResult(key: "instance-1"), Input(sync: true));
+
+        var body = ShouldBeOkWith(actionResult);
+        body.Instance.ShouldNotBeNull();
+        body.Instance!.Key.ShouldBe("instance-1");
+        // The instance status code is safe here because Dapr only reads the top-level status.
+        body.Instance.Status.ShouldBe(InstanceStatus.Busy.Code);
+    }
+
+    [Fact]
+    public void ToActionResult_SuccessWithNullValue_ReturnsOkSuccessNotNoContent()
+    {
+        // "No active instance matched" is a deliberate acknowledgement — the event must evaporate,
+        // not be redelivered. Previously this mapped to 204 via Aether's null-value convention.
+        var actionResult = Map(Result<object?>.Ok(null), Input(sync: false));
+
+        var objectResult = actionResult.ShouldBeAssignableTo<ObjectResult>()!;
+        objectResult.StatusCode.ShouldBe(StatusCodes.Status200OK);
+        ShouldBeOkWith(actionResult).Status.ShouldBe(DaprPubSubStatus.Success);
+    }
+
+    /// <summary>
+    /// Serialized guard for the original defect: the body Dapr parses must carry a protocol signal,
+    /// never an instance status code.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ToActionResult_Success_SerializedStatusIsProtocolSignal(bool sync)
+    {
+        var json = Serialize(Map(SuccessResult(), Input(sync)));
+
+        json.GetProperty("status").GetString().ShouldBe("SUCCESS");
+        json.GetProperty("status").GetString().ShouldNotBe(InstanceStatus.Busy.Code);
+    }
+
+    [Fact]
+    public void ToActionResult_ValidationError_DropsInsteadOfRetrying()
+    {
+        var result = Result<object?>.Fail(Error.Validation(
+            "NotAnEventTransition", "Transition 'abort' is not an event transition."));
+
+        var body = ShouldBeOkWith(Map(result, Input(sync: false)));
+
+        body.Status.ShouldBe(DaprPubSubStatus.Drop);
+        body.Reason!.ShouldContain("NotAnEventTransition");
+        body.Reason!.ShouldContain("is not an event transition");
+    }
+
+    [Fact]
+    public void ToActionResult_NotFoundError_DropsInsteadOfRetrying()
+    {
+        var result = Result<object?>.Fail(Error.NotFound(
+            "TransitionNotFound", "Transition 'typo' not found in workflow 'orders'."));
+
+        var body = ShouldBeOkWith(Map(result, Input(sync: false)));
+
+        body.Status.ShouldBe(DaprPubSubStatus.Drop);
+        body.Reason!.ShouldContain("TransitionNotFound");
+    }
+
+    [Fact]
+    public void Drop_ReturnsOkDropSignalWithReason()
+    {
+        var actionResult = EventDeliveryResultMapper.Drop(
+            "InvalidEventAction: action must be 'start' or 'transition'. Received: 'strat'.",
+            "orders", "order-flow", null, "InvalidEventAction", NullLogger.Instance);
+
+        var objectResult = actionResult.ShouldBeAssignableTo<ObjectResult>()!;
+        objectResult.StatusCode.ShouldBe(StatusCodes.Status200OK);
+
+        var body = objectResult.Value.ShouldBeOfType<EventDeliveryResponse>();
+        body.Status.ShouldBe(DaprPubSubStatus.Drop);
+        body.Reason!.ShouldContain("InvalidEventAction");
+    }
+
+    [Fact]
+    public void ToActionResult_TransientFailure_KeepsNonSuccessStatusForRedelivery()
+    {
+        // Infrastructure failures should still be retried by the broker, so they keep the
+        // ProblemDetails response rather than being acknowledged with a 200 signal.
+        var result = Result<object?>.Fail(Error.Failure("EventMappingFailed", "Redis timeout."));
+
+        var actionResult = Map(result, Input(sync: false));
+
+        var objectResult = actionResult.ShouldBeAssignableTo<ObjectResult>()!;
+        objectResult.StatusCode.ShouldBe(StatusCodes.Status500InternalServerError);
+        objectResult.Value.ShouldNotBeOfType<EventDeliveryResponse>();
+    }
+
+    private static IActionResult Map(Result<object?> result, EventInput input)
+        => EventDeliveryResultMapper.ToActionResult(result, input, BuildHttpContext(), NullLogger.Instance);
+
+    private static Result<object?> SuccessResult(string? key = null)
+        => Result<object?>.Ok(new StartInstanceOutput
+        {
+            Id = Guid.NewGuid(),
+            Key = key,
+            Status = InstanceStatus.Busy
+        });
+
+    private static EventInput Input(bool sync) => new()
+    {
+        Domain = "orders",
+        Workflow = "order-flow",
+        Action = EventAction.Start,
+        Sync = sync
+    };
+
+    private static EventDeliveryResponse ShouldBeOkWith(IActionResult actionResult)
+    {
+        var objectResult = actionResult.ShouldBeAssignableTo<ObjectResult>()!;
+        objectResult.StatusCode.ShouldBe(StatusCodes.Status200OK);
+        return objectResult.Value.ShouldBeOfType<EventDeliveryResponse>();
+    }
+
+    private static JsonElement Serialize(IActionResult actionResult)
+    {
+        var value = actionResult.ShouldBeAssignableTo<ObjectResult>()!.Value;
+        return JsonSerializer.SerializeToElement(value, JsonSerializerOptions.Web);
+    }
+
+    /// <summary>
+    /// Aether's failure path resolves <see cref="IProblemDetailsFactory"/> from request services, so
+    /// the transient-failure passthrough needs a container.
+    /// </summary>
+    private static HttpContext BuildHttpContext()
+    {
+        var factory = Substitute.For<IProblemDetailsFactory>();
+        factory.CreateProblemDetails(Arg.Any<Error>(), Arg.Any<HttpContext>())
+            .Returns(callInfo => new ProblemDetails
+            {
+                Title = callInfo.Arg<Error>().Code,
+                Status = StatusCodes.Status500InternalServerError
+            });
+
+        var services = new ServiceCollection();
+        services.AddSingleton(factory);
+
+        return new DefaultHttpContext { RequestServices = services.BuildServiceProvider() };
+    }
+}


### PR DESCRIPTION
## Problem

`POST /{domain}/workflows/{workflow}/instances/events` is the pub/sub delivery endpoint — Dapr Subscription YAMLs route broker topics straight at it. Dapr reads the **top-level `status` field of the JSON response body** as its delivery signal (`SUCCESS` / `RETRY` / `DROP`; [anything else is an error and the message is redelivered](https://docs.dapr.io/reference/api/pubsub_api/#expected-http-response)).

The endpoint returned `StartInstanceOutput` / `TransitionOutput`, whose `InstanceStatus` serializes to a bare code via `IEquatableJsonConverter` — landing in exactly that field:

```
HTTP 200 {"id":"d3f7e197-…","key":"bal-evt-…","status":"B"}
```

Dapr doesn't recognize `"B"`, marks the delivery failed, and redelivers forever. Reported symptom: 21 deliveries of the same Kafka offset (`__offset=53722`) in 110s, all HTTP 200, all the same instance key, while 113 later messages on the topic went unread for 30+ minutes. Consumer-group lag read 0 because offsets were being committed — the block was in the processing loop. Any status code (`A`/`B`/`C`/`F`) triggers it, which is why offset resets didn't help.

## Fix

The endpoint now returns its own `EventDeliveryResponse` instead of an instance DTO:

```jsonc
{ "status": "SUCCESS" }                                    // processed, or intentionally ignored
{ "status": "DROP", "reason": "TransitionNotFound: …" }     // unprocessable, discarded
{ "status": "SUCCESS", "instance": { "id": "…", "key": "…", "status": "C" } }  // sync=true only
```

`Status` is a plain `string` constant, so no converter can rewrite it. The instance snapshot is nested under `instance` and emitted only for `sync=true`, where Dapr does not look — manual tests and integration tests keep the instance id.

### Two adjacent defects with the same failure mode

Both could wedge a partition exactly like the reported bug, so they're fixed here:

1. **Permanently unprocessable messages returned non-2xx, which Dapr also retries forever.** No retry of a `transitionKey` typo, an unknown `action`, a non-JSON body, a missing event definition, or a misrouted domain will ever succeed. These now answer `200 DROP` with a `EventDeliveryDropped` warning log (EventId 40994) and the reason echoed in the body, so a discarded message stays diagnosable. Transient failures (`Failure`/`Dependency`/`Transient`/`Conflict`) keep their non-2xx `ProblemDetails`.
2. **`NotFoundDomainException` from a misrouted subscription escaped as an unhandled 500** and was retried indefinitely. Now an `EventDomainMismatch` result in the DROP class.

Also corrected: the no-match path returned **204**, not the 200 the docs claimed, because Aether maps null result values to `NoContentResult`.

## Response contract

| Situation | Response | Broker behavior |
| --- | --- | --- |
| Processed (start or transition executed) | `200 SUCCESS` | offset advances |
| No active instance matches the key/selector | `200 SUCCESS`, logged, intentionally ignored | no redelivery |
| Unknown `action`, non-JSON body, wrong domain | `200 DROP` | discarded, logged |
| `TransitionNotFound` / `NotAnEventTransition` / `EventDefinitionMissing` / `EventTransitionKeyRequired` | `200 DROP` | discarded, logged |
| Mapping script throws / returns null | 500 | retried per resiliency policy |
| Pipeline / infrastructure failure | 500 (409 on concurrency conflict) | retried per resiliency policy |

## Notes for reviewers

Two deliberate judgment calls worth a look:

- **`Conflict` stays in the retry class.** An instance-busy or optimistic-concurrency conflict *does* clear on redelivery, so retrying is correct. A duplicate-key conflict on start would be retried too — that's the DLQ's job, not this mapper's.
- **Transient failures keep non-2xx rather than a body-level `RETRY`.** Dapr already redelivers on any non-2xx, so the body signal adds nothing, while the 500 keeps the error visible to metrics, traces and alerts. Bounding those retries stays the subscription's responsibility, so the docs now recommend `deadLetterTopic` + a `maxRetries` resiliency policy.

Swallowing 4xx into `200 DROP` does mean a `curl` tester no longer sees a 4xx for a config error. Mitigated by the Warning log with the full reason plus the `reason` field in the body; the testing section of the docs now says to read the `status` field, not just the status code.

## Changes

| File | What |
| --- | --- |
| `src/BBT.Workflow.Application/Events/EventDeliveryResponse.cs` (new) | Dapr protocol body + `DaprPubSubStatus` constants |
| `orchestration/.../Controllers/Instances/EventDeliveryResultMapper.cs` (new) | Splits failures into DROP vs retry classes |
| `orchestration/.../Controllers/Instances/InstanceController.cs` | Uses the new mapper; invalid `action` and malformed JSON DROP; response types + XML docs |
| `src/BBT.Workflow.Application/Events/EventAppService.cs` | Domain-mismatch guard |
| `src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs` | `EventDeliveryDropped` (40994, Warning) |
| `docs/domain/event-driven-workflows.md` | Response contract, why it can't be an instance DTO, dead-letter guidance |
| `.claude/rules/vnext-workflow-developer.md` | Updated one-line summary |

## Verification

- Solution builds clean; no new warnings in the touched files.
- **12 new tests**, all passing — including a serialized guard asserting the top-level `status` is `SUCCESS` and never an `InstanceStatus` code (the test that would have caught the original bug), and a regression guard for the old 204.
- Failure counts identical to a stashed baseline on `master`: Application.Tests 26 pre-existing failures in both runs (885 → 897 passed, +12 new), Domain.Tests 153 in both.

```bash
dotnet test test/BBT.Workflow.Application.Tests --filter "FullyQualifiedName~EventDeliveryResultMapperTests|FullyQualifiedName~EventPayloadBindingTests"
```

Not yet run: broker-level confirmation that a single publish advances the consumer offset by exactly one. That needs local infra up, and is the check worth doing before release.

## Open item

The issue reports engine **0.0.76**, but `common.props` on `master` is `<Version>0.0.26</Version>`. I held off on a `vnext-meta/known-issues.json` entry since it needs an accurate `affectedVersions` / `fixedIn` range — worth confirming which numbering the report refers to and adding the entry as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Return a Dapr-compatible pub/sub response from the workflow instance events endpoint and ensure permanently unprocessable messages are dropped instead of endlessly retried.

Bug Fixes:
- Prevent /instances/events from returning instance DTOs whose status codes cause Dapr to endlessly redeliver messages.
- Treat invalid actions, malformed JSON bodies, and misrouted domains as permanently unprocessable deliveries that return a 200 DROP signal instead of a retriable error.

Enhancements:
- Introduce an EventDeliveryResponse contract and mapper to shape Dapr pub/sub responses and separate permanent from transient failures.
- Add structured warning logging when event deliveries are dropped so discarded messages remain diagnosable.

Documentation:
- Document the Dapr pub/sub response contract for the events endpoint, including DROP vs SUCCESS semantics, dead-letter topic guidance, and testing expectations.

Tests:
- Add unit tests covering the Dapr response contract, DROP handling for invalid payloads/actions, and regression guards so instance status codes never appear as the top-level response status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved event delivery handling with Dapr-compatible `SUCCESS`, `DROP`, and retry outcomes.
  - Permanently invalid or unsupported events are acknowledged and discarded with diagnostic reasons.
  - Successfully processed events can include instance details when requested.

- **Bug Fixes**
  - Prevented malformed, misrouted, or unsupported events from causing endless redelivery.
  - Preserved retry behavior for temporary and infrastructure failures.

- **Documentation**
  - Added guidance on delivery responses, poison events, dead-letter topics, retries, and validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->