### PR TITLE
fix(scripting): stop caching failed helper-set builds

### DIFF
--- a/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Helpers/IScriptHelperRegistry.cs
+++ b/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Helpers/IScriptHelperRegistry.cs
@@ -44,7 +44,9 @@ public interface IScriptHelperRegistry
     /// <param name="allowedAssemblies">Per-mapping sandbox grant merged on top of the baseline.</param>
     /// <param name="contractReferences">Runtime-owned contract references (e.g. ScriptBase) to include.</param>
     /// <param name="baseUsings">Using directives prepended to every helper source.</param>
-    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    /// <param name="cancellationToken">Checked before the build starts so an abandoned caller does not
+    /// kick off an expensive shared compile. It does NOT cancel a build in progress: the helper set is a
+    /// process-wide artifact, so one caller going away must not fail the build other callers await.</param>
     HelperSet GetOrBuildHelpers(
         IReadOnlyList<HelperSource> helpers,
         IReadOnlyList<string>? allowedAssemblies,

--- a/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Helpers/ScriptHelperRegistry.cs
+++ b/modules/BBT.Workflow.Modules.Scripting/BBT/Workflow/Scripting/Helpers/ScriptHelperRegistry.cs
@@ -19,6 +19,10 @@ namespace BBT.Workflow.Scripting.Helpers;
 /// consuming mapping — are loaded, so a superseded set can be unloaded independently. Operator-mounted
 /// plugin DLLs are preloaded into each set's context so helper code can resolve them at runtime even
 /// though the host does not reference them.
+///
+/// A failed build is never cached: <see cref="Lazy{T}"/> retains the factory's exception, and since this
+/// registry is a singleton a cached fault would be replayed for the whole process lifetime, so faulted
+/// entries are evicted and their load context unloaded.
 /// </summary>
 public sealed class ScriptHelperRegistry(IEvaluator evaluator, ScriptSandboxOptions? sandboxOptions = null)
     : IScriptHelperRegistry, IDisposable
@@ -37,12 +41,62 @@ public sealed class ScriptHelperRegistry(IEvaluator evaluator, ScriptSandboxOpti
         if (helpers is null || helpers.Count == 0)
             throw new ArgumentException("At least one helper is required.", nameof(helpers));
 
-        var key = HashOf(helpers, allowedAssemblies);
-        var fromCache = _cache.ContainsKey(key);
+        // The caller's token only gates entry: an already-abandoned request must not start an expensive
+        // shared compile. Once the build starts it is deliberately detached from the request — see
+        // BuildHelperSet.
+        cancellationToken.ThrowIfCancellationRequested();
 
-        var lazy = _cache.GetOrAdd(key, _ => new Lazy<HelperSet>(() =>
+        var key = HashOf(helpers, allowedAssemblies);
+
+        // Fast path: an already-materialised set is a cache hit no matter which caller produced it.
+        if (_cache.TryGetValue(key, out var existing) && existing.IsValueCreated)
+            return existing.Value with { FromCache = true };
+
+        // Set from inside the factory so a call that triggered a real compile reports FromCache: false,
+        // while calls served by an already-published set report a hit.
+        var built = false;
+
+        var lazy = _cache.GetOrAdd(key, _ => new Lazy<HelperSet>(
+            () =>
+            {
+                built = true;
+                return BuildHelperSet(key, helpers, allowedAssemblies, contractReferences, baseUsings);
+            },
+            LazyThreadSafetyMode.ExecutionAndPublication));
+
+        try
         {
-            var alc = new ScriptAssemblyLoadContext($"Helpers_{key[..8]}");
+            var set = lazy.Value;
+            return built ? set : set with { FromCache = true };
+        }
+        catch
+        {
+            // Lazy<T> caches the *exception* as well as the value, so without eviction a single
+            // transient failure would be replayed from cache for the rest of the process lifetime
+            // (this registry is a singleton). Drop the poisoned entry so the next caller recompiles.
+            Evict(key, lazy);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Compiles a helper set into its own collectible context. Compilation runs with
+    /// <see cref="CancellationToken.None"/> on purpose: the result is a process-wide artifact shared by
+    /// every request, so a single client disconnect (or a request timeout) must not be able to abort —
+    /// and thereby fail — a build that all other callers are waiting on. On failure the context is
+    /// unloaded so a failed build leaves nothing behind.
+    /// </summary>
+    private HelperSet BuildHelperSet(
+        string key,
+        IReadOnlyList<HelperSource> helpers,
+        IReadOnlyList<string>? allowedAssemblies,
+        IEnumerable<MetadataReference> contractReferences,
+        IEnumerable<string> baseUsings)
+    {
+        var alc = new ScriptAssemblyLoadContext($"Helpers_{key[..8]}");
+
+        try
+        {
             PreloadPlugins(alc);
 
             var compiled = evaluator.CompileHelpers(
@@ -51,13 +105,25 @@ public sealed class ScriptHelperRegistry(IEvaluator evaluator, ScriptSandboxOpti
                 extraReferences: contractReferences,
                 usingDirectives: baseUsings,
                 sandboxGrant: allowedAssemblies,
-                cancellationToken: cancellationToken);
+                cancellationToken: CancellationToken.None);
 
             return new HelperSet(compiled.Reference, compiled.Namespaces, alc, FromCache: false);
-        }));
+        }
+        catch
+        {
+            // A failed build must not leak its collectible context and preloaded plugin assemblies.
+            TryUnload(alc);
+            throw;
+        }
+    }
 
-        var set = lazy.Value;
-        return fromCache ? set with { FromCache = true } : set;
+    /// <summary>
+    /// Removes a faulted cache entry, but only when it is still the entry we observed — never clobbers a
+    /// healthy set that another caller has already published under the same key.
+    /// </summary>
+    private void Evict(string key, Lazy<HelperSet> lazy)
+    {
+        _cache.TryRemove(new KeyValuePair<string, Lazy<HelperSet>>(key, lazy));
     }
 
     /// <summary>
@@ -96,24 +162,33 @@ public sealed class ScriptHelperRegistry(IEvaluator evaluator, ScriptSandboxOpti
         return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(sb.ToString())));
     }
 
+    /// <summary>
+    /// Unloads a collectible context, tolerating unload failures (nothing actionable remains at that point).
+    /// </summary>
+    private static void TryUnload(AssemblyLoadContext context)
+    {
+        if (context is not ScriptAssemblyLoadContext owned)
+            return;
+
+        try
+        {
+            owned.Unload();
+        }
+        catch
+        {
+            // Ignore unload failures.
+        }
+    }
+
     public void Dispose()
     {
         foreach (var entry in _cache.Values.ToList())
         {
+            // A faulted Lazy still reports IsValueCreated == false; reading .Value would rethrow.
             if (!entry.IsValueCreated)
                 continue;
 
-            if (entry.Value.LoadContext is ScriptAssemblyLoadContext owned)
-            {
-                try
-                {
-                    owned.Unload();
-                }
-                catch
-                {
-                    // Ignore unload failures.
-                }
-            }
+            TryUnload(entry.Value.LoadContext);
         }
 
         _cache.Clear();

--- a/src/BBT.Workflow.Application/Instances/WorkflowOutputMappingService.cs
+++ b/src/BBT.Workflow.Application/Instances/WorkflowOutputMappingService.cs
@@ -38,6 +38,12 @@ public sealed class WorkflowOutputMappingService(
                 response.StatusCode,
                 NormalizeHeaders((object?)response.Headers)));
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // The caller itself went away — propagate rather than reporting a script failure and
+            // silently degrading to the standard envelope.
+            throw;
+        }
         catch (Exception ex)
         {
             logger.WorkflowOutputScriptFailed(workflow.Key, ex);

--- a/test/BBT.Workflow.Application.Tests/Scripting/SandboxedScriptingTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Scripting/SandboxedScriptingTests.cs
@@ -1,6 +1,11 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Loader;
+using System.Threading;
 using System.Threading.Tasks;
 using BBT.Workflow.Scripting.Evaluators;
+using BBT.Workflow.Scripting.Functions;
 using BBT.Workflow.Scripting.Helpers;
 using BBT.Workflow.Scripting.Sandbox;
 using Microsoft.CodeAnalysis;
@@ -314,5 +319,149 @@ public class SandboxedScriptingTests
             loadContext: set.LoadContext);
 
         instance.Calc().ShouldBe(10);
+    }
+
+    [Fact]
+    public void HelperRegistry_Does_Not_Cache_A_Failed_Build()
+    {
+        // Regression: the registry stored the build in a Lazy<T>, which caches the factory's exception.
+        // Because the registry is a singleton, one transient failure (e.g. an OperationCanceledException
+        // from a torn-down request) was replayed for the whole process lifetime and the helper set could
+        // never be compiled again. The faulted entry must be evicted instead.
+        var sandbox = EnabledSandbox();
+        var evaluator = new FailOnceEvaluator(new CSharpEvaluator(sandbox));
+        var registry = new ScriptHelperRegistry(evaluator, sandbox);
+
+        Should.Throw<OperationCanceledException>(() =>
+        {
+            registry.GetOrBuildHelpers([TaxHelper], null, [], ["System"]);
+        });
+
+        // Second attempt must reach the evaluator again rather than replaying the cached exception.
+        var set = registry.GetOrBuildHelpers([TaxHelper], null, [], ["System"]);
+
+        set.Namespaces.ShouldContain("MyHelpers");
+        set.FromCache.ShouldBeFalse();
+        evaluator.Attempts.ShouldBe(2);
+    }
+
+    [Fact]
+    public void HelperRegistry_Does_Not_Pass_Caller_Token_To_The_Compiler()
+    {
+        // The helper set is a process-wide artifact, so a build in progress must not be cancellable by
+        // the request that happened to trigger it: the compile runs with CancellationToken.None.
+        var sandbox = EnabledSandbox();
+        var evaluator = new TokenCapturingEvaluator(new CSharpEvaluator(sandbox));
+        var registry = new ScriptHelperRegistry(evaluator, sandbox);
+
+        using var cts = new CancellationTokenSource();
+
+        var set = registry.GetOrBuildHelpers([TaxHelper], null, [], ["System"], cts.Token);
+
+        set.Namespaces.ShouldContain("MyHelpers");
+        evaluator.ObservedToken.CanBeCanceled.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void HelperRegistry_Rejects_An_Already_Cancelled_Caller_Before_Compiling()
+    {
+        // An abandoned caller should not kick off an expensive shared compile at all.
+        var sandbox = EnabledSandbox();
+        var evaluator = new TokenCapturingEvaluator(new CSharpEvaluator(sandbox));
+        var registry = new ScriptHelperRegistry(evaluator, sandbox);
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Should.Throw<OperationCanceledException>(() =>
+        {
+            registry.GetOrBuildHelpers([TaxHelper], null, [], ["System"], cts.Token);
+        });
+
+        evaluator.Attempts.ShouldBe(0);
+    }
+
+    private static HelperSource TaxHelper => new(
+        "tax-calculator", "1.0.0",
+        "namespace MyHelpers { public static class TaxCalc { public static int Tax(int x) => x / 10; } }",
+        "tax-calculator.csx");
+
+    /// <summary>
+    /// Delegating evaluator that simulates a cancelled first helper compilation and then succeeds,
+    /// so the registry's poisoned-entry eviction can be observed.
+    /// </summary>
+    private sealed class FailOnceEvaluator(IEvaluator inner) : DelegatingEvaluator(inner)
+    {
+        public override CompiledHelpers CompileHelpers(
+            IReadOnlyList<(string Path, string Code)> sources,
+            AssemblyLoadContext loadContext,
+            IEnumerable<MetadataReference>? extraReferences,
+            IEnumerable<string>? usingDirectives,
+            IReadOnlyList<string>? sandboxGrant,
+            CancellationToken cancellationToken)
+        {
+            Attempts++;
+
+            if (Attempts == 1)
+                throw new OperationCanceledException("The operation was canceled.");
+
+            return Inner.CompileHelpers(
+                sources, loadContext, extraReferences, usingDirectives, sandboxGrant, cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Delegating evaluator that records the token the registry hands to the compiler.
+    /// </summary>
+    private sealed class TokenCapturingEvaluator(IEvaluator inner) : DelegatingEvaluator(inner)
+    {
+        public CancellationToken ObservedToken { get; private set; }
+
+        public override CompiledHelpers CompileHelpers(
+            IReadOnlyList<(string Path, string Code)> sources,
+            AssemblyLoadContext loadContext,
+            IEnumerable<MetadataReference>? extraReferences,
+            IEnumerable<string>? usingDirectives,
+            IReadOnlyList<string>? sandboxGrant,
+            CancellationToken cancellationToken)
+        {
+            Attempts++;
+            ObservedToken = cancellationToken;
+
+            return Inner.CompileHelpers(
+                sources, loadContext, extraReferences, usingDirectives, sandboxGrant, cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Test-only <see cref="IEvaluator"/> base that forwards to a real evaluator, letting each test
+    /// override only the helper-compilation behaviour it cares about.
+    /// </summary>
+    private abstract class DelegatingEvaluator(IEvaluator inner) : IEvaluator
+    {
+        protected IEvaluator Inner { get; } = inner;
+
+        public int Attempts { get; protected set; }
+
+        public Task<T> CompileToInstanceAsync<T>(
+            string code,
+            IScriptServices? services = null,
+            IEnumerable<MetadataReference>? extraReferences = null,
+            IEnumerable<string>? usingDirectives = null,
+            CancellationToken cancellationToken = default,
+            AssemblyLoadContext? loadContext = null,
+            IReadOnlyList<string>? sandboxGrant = null)
+            => Inner.CompileToInstanceAsync<T>(
+                code, services, extraReferences, usingDirectives, cancellationToken, loadContext, sandboxGrant);
+
+        // Declared without default values: defaults are not part of the signature, so this still
+        // implements IEvaluator.CompileHelpers, and every call site here passes all arguments.
+        public abstract CompiledHelpers CompileHelpers(
+            IReadOnlyList<(string Path, string Code)> sources,
+            AssemblyLoadContext loadContext,
+            IEnumerable<MetadataReference>? extraReferences,
+            IEnumerable<string>? usingDirectives,
+            IReadOnlyList<string>? sandboxGrant,
+            CancellationToken cancellationToken);
     }
 }


### PR DESCRIPTION
## What

Fixes a recurring `OperationCanceledException` out of Roslyn's `Emit` in `ScriptHelperRegistry`: once a helper-set compilation failed or was cancelled, the failure was replayed from cache for the rest of the process lifetime — even for requests whose own cancellation token was still live.

## Why

Two independent causes, both in `ScriptHelperRegistry`:

1. **`Lazy<T>` caches exceptions, not just values.** The build ran inside a `Lazy<HelperSet>`, and the registry is a singleton — so a single transient failure poisoned that helper-set hash until the process restarted.

2. **The compile used the caller's request-scoped `CancellationToken`.** A client disconnect or request timeout aborted a *process-wide* artifact that other callers were concurrently waiting on.

## Changes

- **Faulted entries are evicted** via compare-and-remove, so a healthy set published concurrently is never clobbered; the next caller recompiles.
- **Token now only gates entry.** An already-cancelled caller does not start an expensive shared compile, but the build itself runs with `CancellationToken.None` so it cannot be torn down by one caller's lifetime.
- **No more leak on failure**: a failed build disposes its collectible `AssemblyLoadContext` and preloaded plugin assemblies.
- **`FromCache` is derived from the build itself** instead of a racy pre-`GetOrAdd` `ContainsKey` probe.
- **`WorkflowOutputMappingService`** propagates a genuine caller cancellation instead of logging it as a script failure and silently degrading to the standard envelope.

## Reviewer notes

- The registry is a singleton and the helper set is shared across requests — the key design point is that *shared* artifact lifetime is deliberately decoupled from *per-request* cancellation. Entry is still gated so a dead caller never pays for a compile.
- Eviction is compare-and-remove rather than a plain `TryRemove` specifically to avoid dropping a good entry published by a concurrent builder.
- `SandboxedScriptingTests` adds coverage for the poisoned-cache and cancellation-propagation paths (+149 lines).

## Files

- `modules/BBT.Workflow.Modules.Scripting/Scripting/Helpers/ScriptHelperRegistry.cs`
- `modules/BBT.Workflow.Modules.Scripting/Scripting/Helpers/IScriptHelperRegistry.cs`
- `src/BBT.Workflow.Application/Instances/WorkflowOutputMappingService.cs`
- `test/.../Scripting/SandboxedScriptingTests.cs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent script helper registry from caching failed helper-set builds and ensure helper compilation is decoupled from per-request cancellation while cleaning up failed contexts and improving cancellation propagation.

Bug Fixes:
- Evict failed helper-set build entries from the script helper registry so transient compilation errors or cancellations are not cached for the process lifetime.
- Run helper compilation with an uncancellable token while still rejecting already-cancelled callers to prevent a single request from aborting shared helper builds.
- Ensure collectible assembly load contexts from failed helper-set builds are unloaded to avoid leaking plugin assemblies and load contexts.
- Propagate genuine caller cancellations in WorkflowOutputMappingService instead of treating them as script failures and falling back to the default envelope.

Tests:
- Add SandboxedScriptingTests coverage to verify failed helper builds are not cached, per-request cancellation does not cancel shared compilation, and abandoned callers do not trigger compilation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failed script helper builds can now be retried instead of permanently reusing the failure.
  * Improved cleanup after unsuccessful script compilation.
  * Caller cancellation is honored before compilation begins without interrupting shared builds.
  * Output mapping now correctly propagates caller-requested cancellation while preserving fallback behavior for other errors.

* **Tests**
  * Added regression coverage for failed builds, cancellation, and shared compilation behavior.

* **Documentation**
  * Clarified cancellation behavior for script helper compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->