### PR TITLE
fix(subflow): make terminal delivery dedup cheap and settlement-aware

### DIFF
--- a/etc/monitoring/dapr/components/config.yaml
+++ b/etc/monitoring/dapr/components/config.yaml
@@ -1,7 +1,7 @@
 apiVersion: dapr.io/v1alpha1
 kind: Component
 metadata:
-  name: vnext-execution-config
+  name: vnext-config
 spec:
   type: configuration.redis
   metadata:

--- a/etc/monitoring/dapr/components/lock.yaml
+++ b/etc/monitoring/dapr/components/lock.yaml
@@ -1,7 +1,7 @@
 apiVersion: dapr.io/v1alpha1
 kind: Component
 metadata:
-  name: vnext-execution-lock
+  name: vnext-lock
 spec:
   type: lock.redis
   version: v1

--- a/etc/monitoring/dapr/components/pubsub.yaml
+++ b/etc/monitoring/dapr/components/pubsub.yaml
@@ -1,7 +1,7 @@
 apiVersion: dapr.io/v1alpha1
 kind: Component
 metadata:
-  name: vnext-execution-pubsub
+  name: vnext-pubsub
 spec:
   type: pubsub.redis
   metadata:

--- a/etc/monitoring/dapr/components/secretstore.yaml
+++ b/etc/monitoring/dapr/components/secretstore.yaml
@@ -1,7 +1,7 @@
 apiVersion: dapr.io/v1alpha1
 kind: Component
 metadata:
-  name: vnext-execution-secret
+  name: vnext-secret
 spec:
   type: secretstores.hashicorp.vault
   version: v1

--- a/etc/monitoring/dapr/components/state.yaml
+++ b/etc/monitoring/dapr/components/state.yaml
@@ -1,7 +1,7 @@
 apiVersion: dapr.io/v1alpha1
 kind: Component
 metadata:
-  name: vnext-execution-state
+  name: vnext-state
 spec:
   type: state.redis
   version: v1

--- a/monitoring/BBT.Workflow.Monitor.HttpApi.Host/Properties/launchSettings.json
+++ b/monitoring/BBT.Workflow.Monitor.HttpApi.Host/Properties/launchSettings.json
@@ -22,7 +22,9 @@
         "OTEL_LOGS_EXPORTER": "otlp",
         "DAPR_SECRET_STORE_NAME": "vnext-secret",
         "DAPR_STATE_STORE_NAME": "vnext-state",
-        "DAPR_LOCK_STORE_NAME": "vnext-lock"
+        "DAPR_LOCK_STORE_NAME": "vnext-lock",
+        "DAPR_PUBSUB_STORE_NAME": "vnext-pubsub",
+        "DAPR_PUBSUB_BROADCAST_STORE_NAME": "vnext-pubsub-broadcast"
       }
     },
     "https": {
@@ -45,7 +47,9 @@
         "OTEL_LOGS_EXPORTER": "otlp",
         "DAPR_SECRET_STORE_NAME": "vnext-secret",
         "DAPR_STATE_STORE_NAME": "vnext-state",
-        "DAPR_LOCK_STORE_NAME": "vnext-lock"
+        "DAPR_LOCK_STORE_NAME": "vnext-lock",
+        "DAPR_PUBSUB_STORE_NAME": "vnext-pubsub",
+        "DAPR_PUBSUB_BROADCAST_STORE_NAME": "vnext-pubsub-broadcast"
       }
     }
   }

--- a/monitoring/BBT.Workflow.Monitor.HttpApi.Host/appsettings.json
+++ b/monitoring/BBT.Workflow.Monitor.HttpApi.Host/appsettings.json
@@ -48,11 +48,11 @@
     },
     "Telemetry": {
         "ServiceName": "vnext-monitor",
-        "ServiceNamespace": "BBT.Workflow.Monitor",
+        "ServiceNamespace": "core",
         "ServiceVersion": "1.0.0",
-        "TracingEnabled": false,
-        "MetricsEnabled": false,
-        "LoggingEnabled": false,
+        "TracingEnabled": true,
+        "MetricsEnabled": true,
+        "LoggingEnabled": true,
         "Otlp": {
             "Endpoint": "http://localhost:4318",
             "Protocol": "http/protobuf"

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/appsettings.json
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/appsettings.json
@@ -70,7 +70,7 @@
   },
   "Telemetry": {
     "ServiceName": "vnext-app",
-    "ServiceNamespace": "BBT.Workflow.Orchestration",
+    "ServiceNamespace": "core",
     "ServiceVersion": "1.0.0",
     "TracingEnabled": true,
     "MetricsEnabled": true,

--- a/src/BBT.Workflow.Application/BackgroundJobs/Options/WorkflowExecutionOptions.cs
+++ b/src/BBT.Workflow.Application/BackgroundJobs/Options/WorkflowExecutionOptions.cs
@@ -1,3 +1,5 @@
+using BBT.Workflow.Execution.Pipeline;
+
 namespace BBT.Workflow.BackgroundJobs.Options;
 
 public sealed class WorkflowExecutionOptions
@@ -132,6 +134,22 @@ public sealed class WorkflowExecutionOptions
     /// a short bounded retry absorbs that instead of losing the transition.
     /// </summary>
     public LockConflictRetryOptions LockConflictRetry { get; set; } = new();
+
+    /// <summary>
+    /// Bounded wait applied when acquiring the per-subInstance terminal lock in the SubFlow
+    /// completion / fault / cancellation services.
+    /// <para>
+    /// Terminal sub-item signals are delivered at least twice by design (DurablePostCommit hook
+    /// plus the Inbox worker). A duplicate that arrives while the original is still inside its
+    /// transaction cannot see the pending write, so it must wait the short critical section out
+    /// rather than fail fast into a full broker re-delivery cycle.
+    /// </para>
+    /// </summary>
+    public LockConflictRetryOptions SubItemTerminalLockRetry { get; set; } = new()
+    {
+        MaxAttempts = 4,
+        BaseDelayMilliseconds = 120
+    };
 }
 
 public sealed class TransitionJobFailurePolicyOptions
@@ -141,9 +159,13 @@ public sealed class TransitionJobFailurePolicyOptions
 }
 
 /// <summary>
-/// Bounded exponential-backoff retry settings for instance-lock conflicts in
-/// <c>TransitionJobHandler</c>. Worst case total delay with defaults:
-/// 100 + 200 + 400 + 800 = 1.5s across 5 attempts.
+/// Bounded retry settings for lock contention.
+/// <para>
+/// Used by <c>TransitionJobHandler</c> for instance-lock conflicts (exponential backoff; worst
+/// case with its defaults: 100 + 200 + 400 + 800 = 1.5s across 5 attempts), and by the SubFlow
+/// terminal services for the per-subInstance lock (linear backoff plus jitter; worst case with
+/// its defaults: roughly 120 + 240 + 360 ms plus jitter across 4 attempts).
+/// </para>
 /// </summary>
 public sealed class LockConflictRetryOptions
 {
@@ -152,4 +174,19 @@ public sealed class LockConflictRetryOptions
 
     /// <summary>Base delay before the first retry; doubles per attempt. Default: 100ms.</summary>
     public int BaseDelayMilliseconds { get; set; } = 100;
+}
+
+/// <summary>
+/// Conversions from configured retry settings to the lock-acquisition contract.
+/// </summary>
+public static class LockConflictRetryOptionsExtensions
+{
+    /// <summary>
+    /// Projects the configured retry settings onto a <see cref="LockAcquireWait"/>, clamping
+    /// misconfigured values so a bad setting can never produce a negative delay or zero attempts.
+    /// </summary>
+    public static LockAcquireWait ToLockAcquireWait(this LockConflictRetryOptions options)
+        => new(
+            Math.Max(1, options.MaxAttempts),
+            TimeSpan.FromMilliseconds(Math.Max(0, options.BaseDelayMilliseconds)));
 }

--- a/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
@@ -92,6 +92,7 @@ public static class WorkflowApplicationModuleServiceCollectionExtensions
         services.AddScoped<IInstanceExtensionService, InstanceExtensionService>();
         services.AddScoped<IWorkflowOutputMappingService, WorkflowOutputMappingService>();
         services.AddScoped<ISubflowOutputMappingService, SubflowOutputMappingService>();
+        services.AddScoped<ISubItemTerminalGuard, SubItemTerminalGuard>();
         services.AddScoped<ISubflowCompletionService, SubflowCompletionService>();
         services.AddScoped<ISubflowCancellationService, SubflowCancellationService>();
         services.AddScoped<ISubflowFaultService, SubflowFaultService>();

--- a/src/BBT.Workflow.Application/SubFlow/Services/SubItemTerminalGuard.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubItemTerminalGuard.cs
@@ -1,0 +1,77 @@
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Logging;
+using Microsoft.Extensions.Logging;
+
+namespace BBT.Workflow.SubFlow;
+
+/// <inheritdoc cref="ISubItemTerminalGuard" />
+public sealed class SubItemTerminalGuard(
+    IInstanceCorrelationRepository correlationRepository,
+    ILogger<SubItemTerminalGuard> logger) : ISubItemTerminalGuard
+{
+    /// <inheritdoc />
+    public async Task<SubItemTerminalProbe> ProbeAsync(
+        Guid parentInstanceId,
+        Guid subInstanceId,
+        SubItemTerminalOutcome incomingOutcome,
+        CancellationToken cancellationToken = default)
+    {
+        InstanceCorrelation? correlation;
+
+        try
+        {
+            correlation = await correlationRepository.FindBySubInstanceIdAsReadOnlyAsync(
+                subInstanceId,
+                cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            // The probe is a pure fast-path optimisation. If the snapshot read fails for any
+            // reason, fall through to the authoritative locked path rather than failing the
+            // delivery — correctness never depends on this read succeeding.
+            logger.SubItemTerminalProbeFailed(ex, parentInstanceId, subInstanceId);
+            return SubItemTerminalProbe.Proceed;
+        }
+
+        // Unknown or still-open correlation: the locked path owns the decision. A correlation that
+        // is not yet visible here (writer's transaction still open) MUST reach the lock, otherwise
+        // a delivery that genuinely still has work to do would be dropped.
+        if (correlation is null || !correlation.IsCompleted)
+        {
+            return SubItemTerminalProbe.Proceed;
+        }
+
+        // A persisted terminal outcome only proves settlement for a non-blocking SubProcess, which
+        // commits its correlation and returns. A blocking SubFlow releases the lock and resumes the
+        // parent in a second phase, reverting the correlation if that resume fails — acknowledging
+        // from the flag alone would consume a durable delivery whose work is about to roll back.
+        if (!correlation.SubFlowType.Equals(SubFlowType.SubProcess))
+        {
+            logger.SubItemTerminalSettlementNotProvable(
+                correlation.SubFlowType.Code,
+                parentInstanceId,
+                subInstanceId);
+
+            return SubItemTerminalProbe.Proceed;
+        }
+
+        if (correlation.TerminalOutcome == incomingOutcome)
+        {
+            logger.SubItemTerminalDuplicateSkippedPreLock(
+                incomingOutcome.ToString(),
+                parentInstanceId,
+                subInstanceId);
+
+            return SubItemTerminalProbe.AlreadySettled;
+        }
+
+        logger.SubItemTerminalConflict(
+            parentInstanceId,
+            subInstanceId,
+            correlation.TerminalOutcome?.ToString() ?? "legacy",
+            incomingOutcome.ToString());
+
+        return SubItemTerminalProbe.Conflict;
+    }
+}

--- a/src/BBT.Workflow.Application/SubFlow/Services/SubflowCancellationService.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubflowCancellationService.cs
@@ -1,4 +1,5 @@
 using BBT.Aether.Uow;
+using BBT.Workflow.BackgroundJobs.Options;
 using BBT.Workflow.Caching;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.ExceptionHandling;
@@ -9,6 +10,7 @@ using BBT.Workflow.Instances;
 using BBT.Workflow.Logging;
 using BBT.Workflow.Shared;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace BBT.Workflow.SubFlow;
 
@@ -19,9 +21,13 @@ public sealed class SubflowCancellationService(
     IInstanceRepository instanceRepository,
     IWorkflowExecutionService workflowExecutionService,
     ITransitionLockScopeFactory transitionLockScopeFactory,
+    ISubItemTerminalGuard terminalGuard,
+    IOptions<WorkflowExecutionOptions> executionOptions,
     ILogger<SubflowCancellationService> logger)
     : ISubflowCancellationService
 {
+    private LockAcquireWait TerminalLockWait => executionOptions.Value.SubItemTerminalLockRetry.ToLockAcquireWait();
+
     /// <inheritdoc />
     public async Task CancellationAsync(
         SubItemCanceledInput input,
@@ -67,7 +73,28 @@ public sealed class SubflowCancellationService(
         // Sync/async safe: distinct from the parent's held key (no self-deadlock); nested
         // same-key reentry is still handled by ChainLockRegistry.
         var lockKey = $"vnext:{input.Domain}:{input.Flow}:{input.InstanceId}:sub:{input.SubInstanceId:N}";
-        await using (var lockScope = await transitionLockScopeFactory.AcquireAsync(lockKey, cancellationToken))
+
+        // Lock-free duplicate short-circuit — see SubflowCompletionService for the rationale.
+        var probe = await terminalGuard.ProbeAsync(
+            input.InstanceId,
+            input.SubInstanceId,
+            SubItemTerminalOutcome.Canceled,
+            cancellationToken);
+
+        if (probe != SubItemTerminalProbe.Proceed)
+        {
+            activity?.SetTag("vnext.subflow.result",
+                probe == SubItemTerminalProbe.AlreadySettled
+                    ? "correlation_already_settled_prelock"
+                    : "terminal_outcome_conflict_prelock");
+            SubFlowActivityHelper.SetSuccess(activity);
+            return;
+        }
+
+        // Bounded wait rather than fail-fast: absorbs duplicates that collide with the original
+        // while its transaction is still open.
+        await using (var lockScope = await transitionLockScopeFactory.AcquireAsync(
+                         lockKey, TerminalLockWait, cancellationToken))
         {
             if (!lockScope.IsAcquired)
             {

--- a/src/BBT.Workflow.Application/SubFlow/Services/SubflowCompletionService.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubflowCompletionService.cs
@@ -1,4 +1,5 @@
 using BBT.Aether.Uow;
+using BBT.Workflow.BackgroundJobs.Options;
 using BBT.Workflow.Caching;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.ExceptionHandling;
@@ -7,6 +8,7 @@ using BBT.Workflow.Instances;
 using BBT.Workflow.Logging;
 using BBT.Workflow.Runtime;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using BBT.Workflow.Execution.Pipeline;
 using BBT.Workflow.Execution.Services;
 using BBT.Workflow.Shared;
@@ -22,9 +24,13 @@ public sealed class SubflowCompletionService(
     IWorkflowExecutionService workflowExecutionService,
     ISubflowOutputMappingService outputMappingService,
     ITransitionLockScopeFactory transitionLockScopeFactory,
+    ISubItemTerminalGuard terminalGuard,
+    IOptions<WorkflowExecutionOptions> executionOptions,
     ILogger<SubflowCompletionService> logger)
     : ISubflowCompletionService
 {
+    private LockAcquireWait TerminalLockWait => executionOptions.Value.SubItemTerminalLockRetry.ToLockAcquireWait();
+
     /// <inheritdoc />
     public async Task CompletionAsync(
         FlowCompletedInput completedInput,
@@ -86,7 +92,34 @@ public sealed class SubflowCompletionService(
                 // Sync/async safe: distinct from the parent's held key (no self-deadlock); nested
                 // same-key reentry is still handled by ChainLockRegistry.
                 var lockKey = $"vnext:{completedInput.Domain}:{completedInput.Flow}:{completedInput.InstanceId}:sub:{completedInput.SubInstanceId:N}";
-                await using (var lockScope = await transitionLockScopeFactory.AcquireAsync(lockKey, cancellationToken))
+
+                // Lock-free duplicate short-circuit. This signal is delivered at least twice by
+                // design (DurablePostCommit hook + Inbox worker), so the common case is a duplicate
+                // whose work is already persisted. Answering it from a read-only snapshot keeps it
+                // off the distributed lock entirely; only genuinely-open deliveries contend.
+                var probe = await terminalGuard.ProbeAsync(
+                    completedInput.InstanceId,
+                    completedInput.SubInstanceId,
+                    SubItemTerminalOutcome.Completed,
+                    cancellationToken);
+
+                if (probe != SubItemTerminalProbe.Proceed)
+                {
+                    activity?.SetTag("vnext.subflow.result",
+                        probe == SubItemTerminalProbe.AlreadySettled
+                            ? "correlation_already_settled_prelock"
+                            : "terminal_outcome_conflict_prelock");
+                    SubFlowActivityHelper.SetSuccess(activity);
+                    return;
+                }
+
+                // Bounded wait rather than fail-fast: a duplicate that arrives while the original is
+                // still inside its transaction cannot see the pending write, so short-circuiting
+                // above is impossible and failing immediately would push it into a full broker
+                // re-delivery cycle. The critical section is one short transaction — waiting it out
+                // is far cheaper, and the re-read after acquisition settles the outcome correctly.
+                await using (var lockScope = await transitionLockScopeFactory.AcquireAsync(
+                                 lockKey, TerminalLockWait, cancellationToken))
                 {
                     if (!lockScope.IsAcquired)
                     {

--- a/src/BBT.Workflow.Application/SubFlow/Services/SubflowFaultService.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubflowFaultService.cs
@@ -1,4 +1,5 @@
 using BBT.Aether.Uow;
+using BBT.Workflow.BackgroundJobs.Options;
 using BBT.Workflow.Caching;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.ExceptionHandling;
@@ -10,6 +11,7 @@ using BBT.Workflow.Instances;
 using BBT.Workflow.Logging;
 using BBT.Workflow.Shared;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace BBT.Workflow.SubFlow;
 
@@ -23,9 +25,13 @@ public sealed class SubflowFaultService(
     IErrorBoundaryResolver errorBoundaryResolver,
     IErrorActionExecutor errorActionExecutor,
     ITransitionLockScopeFactory transitionLockScopeFactory,
+    ISubItemTerminalGuard terminalGuard,
+    IOptions<WorkflowExecutionOptions> executionOptions,
     ILogger<SubflowFaultService> logger)
     : ISubflowFaultService
 {
+    private LockAcquireWait TerminalLockWait => executionOptions.Value.SubItemTerminalLockRetry.ToLockAcquireWait();
+
     /// <inheritdoc />
     public async Task FaultAsync(
         SubFlowFaultedInput input,
@@ -77,7 +83,28 @@ public sealed class SubflowFaultService(
                 // Sync/async safe: distinct from the parent's held key (no self-deadlock); nested
                 // same-key reentry is still handled by ChainLockRegistry.
                 var lockKey = $"vnext:{input.Domain}:{input.Flow}:{input.InstanceId}:sub:{input.SubInstanceId:N}";
-                await using (var lockScope = await transitionLockScopeFactory.AcquireAsync(lockKey, cancellationToken))
+
+                // Lock-free duplicate short-circuit — see SubflowCompletionService for the rationale.
+                var probe = await terminalGuard.ProbeAsync(
+                    input.InstanceId,
+                    input.SubInstanceId,
+                    SubItemTerminalOutcome.Faulted,
+                    cancellationToken);
+
+                if (probe != SubItemTerminalProbe.Proceed)
+                {
+                    activity?.SetTag("vnext.subflow.result",
+                        probe == SubItemTerminalProbe.AlreadySettled
+                            ? "correlation_already_settled_prelock"
+                            : "terminal_outcome_conflict_prelock");
+                    SubFlowActivityHelper.SetSuccess(activity);
+                    return;
+                }
+
+                // Bounded wait rather than fail-fast: absorbs duplicates that collide with the
+                // original while its transaction is still open.
+                await using (var lockScope = await transitionLockScopeFactory.AcquireAsync(
+                                 lockKey, TerminalLockWait, cancellationToken))
                 {
                     if (!lockScope.IsAcquired)
                     {

--- a/src/BBT.Workflow.Application/SubFlow/Services/SubflowStateService.cs
+++ b/src/BBT.Workflow.Application/SubFlow/Services/SubflowStateService.cs
@@ -66,15 +66,6 @@ public sealed class SubflowStateService(
                     return;
                 }
 
-                if (correlation.IsCompleted)
-                {
-                    logger.LogDebug(
-                        "Correlation for SubInstance {SubInstanceId} is already completed, skipping state update",
-                        input.SubInstanceId);
-                    activity?.SetTag("vnext.subflow.result", "already_completed");
-                    return;
-                }
-
                 // Out-of-order event detection using timestamp:
                 // If correlation already has a state update with a later timestamp,
                 // this event is out-of-order/stale - reject it to prevent downgrade.

--- a/src/BBT.Workflow.Domain/Execution/Transitions/Pipeline/ITransitionLockScope.cs
+++ b/src/BBT.Workflow.Domain/Execution/Transitions/Pipeline/ITransitionLockScope.cs
@@ -27,16 +27,52 @@ public interface ITransitionLockScope : IAsyncDisposable
 }
 
 /// <summary>
+/// Controls how long <see cref="ITransitionLockScopeFactory.AcquireAsync(string, LockAcquireWait, CancellationToken)"/>
+/// keeps retrying before reporting the lock as not acquired.
+/// <para>
+/// The default (<see cref="None"/>) is a single attempt — the historical fail-fast behaviour the
+/// transition pipeline relies on to surface a busy instance immediately.
+/// </para>
+/// </summary>
+/// <param name="MaxAttempts">Total acquisition attempts, including the first. Must be at least 1.</param>
+/// <param name="Delay">Base delay between attempts. Jitter is applied by the implementation.</param>
+public readonly record struct LockAcquireWait(int MaxAttempts, TimeSpan Delay)
+{
+    /// <summary>
+    /// Single attempt, no waiting. Preserves the original fail-fast semantics.
+    /// </summary>
+    public static LockAcquireWait None => new(1, TimeSpan.Zero);
+}
+
+/// <summary>
 /// Factory for acquiring request-scoped transition lock scopes.
 /// </summary>
 public interface ITransitionLockScopeFactory
 {
     /// <summary>
-    /// Acquires a lock scope for the given lock key.
+    /// Acquires a lock scope for the given lock key using a single attempt (fail-fast).
     /// The returned scope should be disposed when the entire transition chain completes.
     /// </summary>
     /// <param name="lockKey">Instance-level lock key (e.g. <c>vnext:{domain}:{flow}:{instanceId}</c>).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A lock scope. Check <see cref="ITransitionLockScope.IsAcquired"/> before proceeding.</returns>
     Task<ITransitionLockScope> AcquireAsync(string lockKey, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Acquires a lock scope for the given lock key, retrying according to <paramref name="wait"/>.
+    /// <para>
+    /// The default implementation ignores <paramref name="wait"/> and delegates to the fail-fast
+    /// overload, so implementations written before this member existed keep compiling and keep
+    /// their original behaviour. Implementations that can honour a retry budget should override it.
+    /// </para>
+    /// </summary>
+    /// <param name="lockKey">Instance-level lock key (e.g. <c>vnext:{domain}:{flow}:{instanceId}</c>).</param>
+    /// <param name="wait">Retry policy. Use <see cref="LockAcquireWait.None"/> for fail-fast.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A lock scope. Check <see cref="ITransitionLockScope.IsAcquired"/> before proceeding.</returns>
+    Task<ITransitionLockScope> AcquireAsync(
+        string lockKey,
+        LockAcquireWait wait,
+        CancellationToken cancellationToken = default)
+        => AcquireAsync(lockKey, cancellationToken);
 }

--- a/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
@@ -896,6 +896,62 @@ public static partial class WorkflowLogs
         string outcome);
 
     /// <summary>
+    /// Logs when a duplicate terminal delivery is short-circuited before the distributed lock is
+    /// taken, because the identical outcome is already persisted on the correlation.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 40056,
+        Level = LogLevel.Debug,
+        Message = "Duplicate {Outcome} SubItem terminal delivery skipped pre-lock for parent {ParentInstanceId}, child {SubInstanceId}")]
+    public static partial void SubItemTerminalDuplicateSkippedPreLock(
+        this ILogger logger,
+        string outcome,
+        Guid parentInstanceId,
+        Guid subInstanceId);
+
+    /// <summary>
+    /// Logs when the pre-lock fast path is declined because settlement cannot be proven from the
+    /// snapshot — a blocking SubFlow settles only after its second-phase parent resume succeeds.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 40059,
+        Level = LogLevel.Debug,
+        Message = "SubItem terminal settlement not provable for {SubItemType} (parent {ParentInstanceId}, child {SubInstanceId}); using locked path")]
+    public static partial void SubItemTerminalSettlementNotProvable(
+        this ILogger logger,
+        string subItemType,
+        Guid parentInstanceId,
+        Guid subInstanceId);
+
+    /// <summary>
+    /// Logs when the lock-free terminal probe could not read the correlation snapshot. The caller
+    /// falls back to the authoritative locked path, so this is not a failure of the delivery.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 40057,
+        Level = LogLevel.Debug,
+        Message = "SubItem terminal pre-lock probe failed for parent {ParentInstanceId}, child {SubInstanceId}; falling back to locked path")]
+    public static partial void SubItemTerminalProbeFailed(
+        this ILogger logger,
+        Exception exception,
+        Guid parentInstanceId,
+        Guid subInstanceId);
+
+    /// <summary>
+    /// Logs when a contended transition lock acquisition is retried after a jittered backoff.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 40058,
+        Level = LogLevel.Debug,
+        Message = "Transition lock {LockKey} busy (attempt {Attempt}/{MaxAttempts}); retrying in {DelayMs}ms")]
+    public static partial void TransitionLockRetryScheduled(
+        this ILogger logger,
+        string lockKey,
+        int attempt,
+        int maxAttempts,
+        int delayMs);
+
+    /// <summary>
     /// Logs when a correlation is marked as completed.
     /// </summary>
     [LoggerMessage(

--- a/src/BBT.Workflow.Domain/SubFlow/ISubItemTerminalGuard.cs
+++ b/src/BBT.Workflow.Domain/SubFlow/ISubItemTerminalGuard.cs
@@ -1,0 +1,76 @@
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Instances;
+
+namespace BBT.Workflow.SubFlow;
+
+/// <summary>
+/// Outcome of the pre-lock terminal settlement probe.
+/// </summary>
+public enum SubItemTerminalProbe
+{
+    /// <summary>
+    /// Settlement could not be proven from the read-only snapshot — the terminal outcome is not
+    /// persisted yet, the correlation is not visible, or the sub-item type does not allow a
+    /// lock-free decision. The caller must acquire the lock and re-evaluate authoritatively.
+    /// </summary>
+    Proceed = 0,
+
+    /// <summary>
+    /// The same terminal outcome is already persisted <em>and</em> fully settled — this delivery is
+    /// a duplicate and the caller can return successfully without touching the distributed lock.
+    /// </summary>
+    AlreadySettled = 1,
+
+    /// <summary>
+    /// A <em>different</em> terminal outcome already settled the correlation. It is closed, so the
+    /// caller must not reopen it; the incoming outcome is dropped.
+    /// </summary>
+    Conflict = 2
+}
+
+/// <summary>
+/// Lock-free pre-check for sub-item terminal deliveries (Completed / Faulted / Canceled).
+/// <para>
+/// Terminal sub-item events are published with <c>EventHookMode.DurablePostCommit</c>, so every
+/// signal is delivered twice by design: once inline by the local publish hook and once through the
+/// Inbox worker. On top of that the broker guarantees only at-least-once delivery. Without this
+/// probe, each duplicate has to win the per-subInstance distributed lock purely to discover that
+/// the work is already done — and a duplicate that loses the race is reported as a transient
+/// failure, forcing a full broker re-delivery cycle.
+/// </para>
+/// <para>
+/// <b>Why this only answers for <see cref="SubFlowType.SubProcess"/>:</b> a persisted terminal
+/// outcome is not by itself proof that the delivery has been fully discharged. A blocking
+/// <see cref="SubFlowType.SubFlow"/> completes its correlation, <em>releases the lock</em>, and
+/// only then resumes the parent in a second phase; if that resume fails the correlation is
+/// reverted so the delivery can be retried. Acknowledging such a delivery from the persisted flag
+/// alone would consume a durable message whose work is about to be rolled back. A SubProcess has
+/// no second phase — it commits the correlation and returns — so there the flag really is final.
+/// Widening this fast path to SubFlow requires a durable settlement marker first.
+/// </para>
+/// <para>
+/// This guard is an optimisation only: whenever the answer is not conclusive it returns
+/// <see cref="SubItemTerminalProbe.Proceed"/> and the authoritative locked path decides.
+/// </para>
+/// </summary>
+public interface ISubItemTerminalGuard
+{
+    /// <summary>
+    /// Probes whether the given terminal outcome has already been applied <em>and settled</em>.
+    /// </summary>
+    /// <param name="parentInstanceId">Parent instance owning the correlation.</param>
+    /// <param name="subInstanceId">Sub-flow / sub-process instance that reached a terminal state.</param>
+    /// <param name="incomingOutcome">The terminal outcome carried by this delivery.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// <see cref="SubItemTerminalProbe.AlreadySettled"/> when this is a duplicate of an identical
+    /// outcome that is provably settled, <see cref="SubItemTerminalProbe.Conflict"/> when a
+    /// different settled outcome already closed the correlation, otherwise
+    /// <see cref="SubItemTerminalProbe.Proceed"/>.
+    /// </returns>
+    Task<SubItemTerminalProbe> ProbeAsync(
+        Guid parentInstanceId,
+        Guid subInstanceId,
+        SubItemTerminalOutcome incomingOutcome,
+        CancellationToken cancellationToken = default);
+}

--- a/src/BBT.Workflow.Infrastructure/Execution/Locks/TransitionLockScopeFactory.cs
+++ b/src/BBT.Workflow.Infrastructure/Execution/Locks/TransitionLockScopeFactory.cs
@@ -28,8 +28,15 @@ public sealed class TransitionLockScopeFactory(
     private readonly int _leaseSeconds = executionOptions.Value.GetEffectiveLockLeaseSeconds();
 
     /// <inheritdoc />
+    public Task<ITransitionLockScope> AcquireAsync(
+        string lockKey,
+        CancellationToken cancellationToken = default)
+        => AcquireAsync(lockKey, LockAcquireWait.None, cancellationToken);
+
+    /// <inheritdoc />
     public async Task<ITransitionLockScope> AcquireAsync(
         string lockKey,
+        LockAcquireWait wait,
         CancellationToken cancellationToken = default)
     {
         // Chain-reentrant acquisition: when this exact key is already held higher up in the
@@ -42,21 +49,41 @@ public sealed class TransitionLockScopeFactory(
             return TransitionLockScope.Reentrant(lockKey);
         }
 
-        var handle = await distributedLockService.TryAcquireLockAsync(
-            lockKey,
-            _leaseSeconds,
-            cancellationToken);
+        var attempts = Math.Max(1, wait.MaxAttempts);
 
-        if (handle is null)
+        for (var attempt = 1; attempt <= attempts; attempt++)
         {
-            logger.InstanceLockFailed(lockKey);
-            return TransitionLockScope.NotAcquired(lockKey);
+            var handle = await distributedLockService.TryAcquireLockAsync(
+                lockKey,
+                _leaseSeconds,
+                cancellationToken);
+
+            if (handle is not null)
+            {
+                logger.LogDebug("Transition lock acquired for {LockKey} (lease={LeaseSeconds}s, attempt={Attempt})",
+                    lockKey, _leaseSeconds, attempt);
+
+                return new TransitionLockScope(lockKey, handle, _leaseSeconds, logger);
+            }
+
+            if (attempt == attempts)
+            {
+                break;
+            }
+
+            // Jittered backoff: concurrent duplicate deliveries of the same key must not retry in
+            // lockstep, or they would keep colliding on every attempt.
+            var baseDelay = wait.Delay.TotalMilliseconds * attempt;
+            var jitter = Random.Shared.NextDouble() * wait.Delay.TotalMilliseconds;
+            var delay = TimeSpan.FromMilliseconds(baseDelay + jitter);
+
+            logger.TransitionLockRetryScheduled(lockKey, attempt, attempts, (int)delay.TotalMilliseconds);
+
+            await Task.Delay(delay, cancellationToken);
         }
 
-        logger.LogDebug("Transition lock acquired for {LockKey} (lease={LeaseSeconds}s)",
-            lockKey, _leaseSeconds);
-
-        return new TransitionLockScope(lockKey, handle, _leaseSeconds, logger);
+        logger.InstanceLockFailed(lockKey);
+        return TransitionLockScope.NotAcquired(lockKey);
     }
 }
 

--- a/test/BBT.Workflow.Application.Tests/Execution/Services/TransitionRunnerPostCommitTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Execution/Services/TransitionRunnerPostCommitTests.cs
@@ -481,6 +481,12 @@ public sealed class TransitionRunnerPostCommitTests
                 Interlocked.Increment(ref owner._activeTransitionLocks);
                 return Task.FromResult<ITransitionLockScope>(new RecordingTransitionLockScope(owner, lockKey));
             }
+
+            public Task<ITransitionLockScope> AcquireAsync(
+                string lockKey,
+                LockAcquireWait wait,
+                CancellationToken cancellationToken = default)
+                => AcquireAsync(lockKey, cancellationToken);
         }
 
         private sealed class RecordingTransitionLockScope(RunnerHarness owner, string lockKey)

--- a/test/BBT.Workflow.Application.Tests/SubFlow/SubItemTerminalGuardTests.cs
+++ b/test/BBT.Workflow.Application.Tests/SubFlow/SubItemTerminalGuardTests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Instances;
+using BBT.Workflow.SubFlow;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Application.Tests.SubFlow;
+
+/// <summary>
+/// Covers the lock-free pre-check that keeps duplicate at-least-once terminal deliveries off the
+/// per-subInstance distributed lock — and, critically, the settlement rule that stops it from
+/// acknowledging a blocking SubFlow whose parent resume may still roll back.
+/// </summary>
+public sealed class SubItemTerminalGuardTests
+{
+    private readonly Mock<IInstanceCorrelationRepository> _correlationRepository = new();
+    private readonly Mock<ILogger<SubItemTerminalGuard>> _logger = new();
+
+    private readonly Guid _parentId = Guid.NewGuid();
+    private readonly Guid _subId = Guid.NewGuid();
+
+    public SubItemTerminalGuardTests()
+        => _logger.Setup(x => x.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
+
+    private SubItemTerminalGuard CreateGuard()
+        => new(_correlationRepository.Object, _logger.Object);
+
+    private void SetupSnapshot(InstanceCorrelation? correlation)
+        => _correlationRepository
+            .Setup(x => x.FindBySubInstanceIdAsReadOnlyAsync(_subId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(correlation);
+
+    private InstanceCorrelation CreateCorrelation(
+        SubItemTerminalOutcome? terminal,
+        SubFlowType? subFlowType = null)
+    {
+        var correlation = InstanceCorrelation.Create(
+            Guid.NewGuid(), _parentId, "waiting-state", _subId,
+            (subFlowType ?? SubFlowType.SubProcess).Code, "bank", "child-flow", "1.0.0");
+
+        if (terminal.HasValue)
+        {
+            correlation.ApplyTerminalOutcome(terminal.Value, DateTime.UtcNow);
+        }
+
+        return correlation;
+    }
+
+    [Fact]
+    public async Task ProbeAsync_SubProcess_WhenSameOutcomePersisted_ShouldReportAlreadySettled()
+    {
+        SetupSnapshot(CreateCorrelation(SubItemTerminalOutcome.Completed, SubFlowType.SubProcess));
+
+        var result = await CreateGuard()
+            .ProbeAsync(_parentId, _subId, SubItemTerminalOutcome.Completed);
+
+        // A SubProcess commits its correlation and returns — no second phase, so the flag is final.
+        result.ShouldBe(SubItemTerminalProbe.AlreadySettled);
+    }
+
+    [Fact]
+    public async Task ProbeAsync_SubProcess_WhenDifferentOutcomePersisted_ShouldReportConflict()
+    {
+        SetupSnapshot(CreateCorrelation(SubItemTerminalOutcome.Faulted, SubFlowType.SubProcess));
+
+        var result = await CreateGuard()
+            .ProbeAsync(_parentId, _subId, SubItemTerminalOutcome.Completed);
+
+        result.ShouldBe(SubItemTerminalProbe.Conflict);
+    }
+
+    [Fact]
+    public async Task ProbeAsync_BlockingSubFlow_WhenSameOutcomePersisted_ShouldStillProceedToLockedPath()
+    {
+        SetupSnapshot(CreateCorrelation(SubItemTerminalOutcome.Completed, SubFlowType.SubFlow));
+
+        var result = await CreateGuard()
+            .ProbeAsync(_parentId, _subId, SubItemTerminalOutcome.Completed);
+
+        // A blocking SubFlow marks the correlation terminal, releases the lock, and only then
+        // resumes the parent — reverting the correlation if that resume fails. Acknowledging here
+        // would consume a durable delivery whose work is about to be rolled back.
+        result.ShouldBe(SubItemTerminalProbe.Proceed);
+    }
+
+    [Fact]
+    public async Task ProbeAsync_BlockingSubFlow_WhenDifferentOutcomePersisted_ShouldStillProceedToLockedPath()
+    {
+        SetupSnapshot(CreateCorrelation(SubItemTerminalOutcome.Faulted, SubFlowType.SubFlow));
+
+        var result = await CreateGuard()
+            .ProbeAsync(_parentId, _subId, SubItemTerminalOutcome.Completed);
+
+        result.ShouldBe(SubItemTerminalProbe.Proceed);
+    }
+
+    [Fact]
+    public async Task ProbeAsync_WhenCorrelationStillOpen_ShouldProceedToLockedPath()
+    {
+        SetupSnapshot(CreateCorrelation(terminal: null));
+
+        var result = await CreateGuard()
+            .ProbeAsync(_parentId, _subId, SubItemTerminalOutcome.Completed);
+
+        result.ShouldBe(SubItemTerminalProbe.Proceed);
+    }
+
+    [Fact]
+    public async Task ProbeAsync_WhenCorrelationNotVisibleYet_ShouldProceedToLockedPath()
+    {
+        // The writer's transaction may still be open, so an absent snapshot must never be treated
+        // as "already done" — that would silently drop a delivery that still has work to do.
+        SetupSnapshot(null);
+
+        var result = await CreateGuard()
+            .ProbeAsync(_parentId, _subId, SubItemTerminalOutcome.Completed);
+
+        result.ShouldBe(SubItemTerminalProbe.Proceed);
+    }
+
+    [Fact]
+    public async Task ProbeAsync_WhenSnapshotReadThrows_ShouldFallBackToLockedPath()
+    {
+        _correlationRepository
+            .Setup(x => x.FindBySubInstanceIdAsReadOnlyAsync(_subId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("snapshot unavailable"));
+
+        var result = await CreateGuard()
+            .ProbeAsync(_parentId, _subId, SubItemTerminalOutcome.Completed);
+
+        // Correctness never depends on this optimisation succeeding.
+        result.ShouldBe(SubItemTerminalProbe.Proceed);
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/SubFlow/SubflowCancellationServiceTests.cs
+++ b/test/BBT.Workflow.Application.Tests/SubFlow/SubflowCancellationServiceTests.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using BBT.Aether.Results;
 using BBT.Aether.Uow;
+using BBT.Workflow.BackgroundJobs.Options;
 using BBT.Workflow.Caching;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.ExceptionHandling;
@@ -17,6 +18,7 @@ using BBT.Workflow.Instances.Events;
 using BBT.Workflow.Logging;
 using BBT.Workflow.SubFlow;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using Shouldly;
 using Xunit;
@@ -31,6 +33,7 @@ public sealed class SubflowCancellationServiceTests
     private readonly Mock<IInstanceRepository> _instanceRepository = new();
     private readonly Mock<IWorkflowExecutionService> _workflowExecution = new();
     private readonly Mock<ITransitionLockScopeFactory> _lockScopeFactory = new();
+    private readonly Mock<ISubItemTerminalGuard> _terminalGuard = new();
     private readonly Mock<ITransitionLockScope> _lockScope = new();
     private readonly Mock<ILogger<SubflowCancellationService>> _logger = new();
 
@@ -47,6 +50,17 @@ public sealed class SubflowCancellationServiceTests
         _lockScopeFactory
             .Setup(x => x.AcquireAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(_lockScope.Object);
+        _lockScopeFactory
+            .Setup(x => x.AcquireAsync(
+                It.IsAny<string>(), It.IsAny<LockAcquireWait>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_lockScope.Object);
+        // Default: the pre-lock probe finds nothing terminal, so every test exercises the
+        // authoritative locked path unless it explicitly overrides this.
+        _terminalGuard
+            .Setup(x => x.ProbeAsync(
+                It.IsAny<Guid>(), It.IsAny<Guid>(),
+                It.IsAny<SubItemTerminalOutcome>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubItemTerminalProbe.Proceed);
         _logger.Setup(x => x.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
     }
 
@@ -62,6 +76,7 @@ public sealed class SubflowCancellationServiceTests
         exception.Code.ShouldBe(WorkflowErrorCodes.SubflowTerminalLockNotAcquired);
         _lockScopeFactory.Verify(x => x.AcquireAsync(
             $"vnext:{input.Domain}:{input.Flow}:{input.InstanceId}:sub:{input.SubInstanceId:N}",
+            It.IsAny<LockAcquireWait>(),
             It.IsAny<CancellationToken>()), Times.Once);
         _instanceRepository.VerifyNoOtherCalls();
     }
@@ -308,6 +323,14 @@ public sealed class SubflowCancellationServiceTests
         terminalReload.Complete("bank");
         var order = new List<string>();
         var lockCall = 0;
+        // Main path takes the waiting overload; the compensation path still fails fast.
+        _lockScopeFactory
+            .Setup(x => x.AcquireAsync(
+                $"vnext:{input.Domain}:{input.Flow}:{input.InstanceId}:sub:{input.SubInstanceId:N}",
+                It.IsAny<LockAcquireWait>(),
+                It.IsAny<CancellationToken>()))
+            .Callback(() => order.Add($"lock-{++lockCall}"))
+            .ReturnsAsync(_lockScope.Object);
         _lockScopeFactory
             .Setup(x => x.AcquireAsync(
                 $"vnext:{input.Domain}:{input.Flow}:{input.InstanceId}:sub:{input.SubInstanceId:N}",
@@ -330,7 +353,10 @@ public sealed class SubflowCancellationServiceTests
         order.ShouldBe(["lock-1", "load-1", "resume", "lock-2", "load-2"]);
         terminalReload.FindCorrelationBySubInstanceId(subInstanceId)!.IsCompleted.ShouldBeTrue();
         _lockScopeFactory.Verify(x => x.AcquireAsync(
-            $"vnext:{input.Domain}:{input.Flow}:{input.InstanceId}:sub:{input.SubInstanceId:N}", CancellationToken.None), Times.Exactly(2));
+            $"vnext:{input.Domain}:{input.Flow}:{input.InstanceId}:sub:{input.SubInstanceId:N}",
+            It.IsAny<LockAcquireWait>(), CancellationToken.None), Times.Once);
+        _lockScopeFactory.Verify(x => x.AcquireAsync(
+            $"vnext:{input.Domain}:{input.Flow}:{input.InstanceId}:sub:{input.SubInstanceId:N}", CancellationToken.None), Times.Once);
         _instanceRepository.Verify(x => x.UpdateAsync(
             terminalReload, true, It.IsAny<CancellationToken>()), Times.Never);
     }
@@ -369,9 +395,13 @@ public sealed class SubflowCancellationServiceTests
         var failedLock = new Mock<ITransitionLockScope>();
         failedLock.SetupGet(x => x.IsAcquired).Returns(false);
         failedLock.Setup(x => x.DisposeAsync()).Returns(ValueTask.CompletedTask);
+        // Main path (waiting overload) acquires; the compensation path (fail-fast overload) does not.
         _lockScopeFactory
-            .SetupSequence(x => x.AcquireAsync(It.IsAny<string>(), CancellationToken.None))
-            .ReturnsAsync(_lockScope.Object)
+            .Setup(x => x.AcquireAsync(
+                It.IsAny<string>(), It.IsAny<LockAcquireWait>(), CancellationToken.None))
+            .ReturnsAsync(_lockScope.Object);
+        _lockScopeFactory
+            .Setup(x => x.AcquireAsync(It.IsAny<string>(), CancellationToken.None))
             .ReturnsAsync(failedLock.Object);
 
         var actual = await Should.ThrowAsync<InvalidOperationException>(
@@ -467,6 +497,8 @@ public sealed class SubflowCancellationServiceTests
         _instanceRepository.Object,
         _workflowExecution.Object,
         _lockScopeFactory.Object,
+        _terminalGuard.Object,
+        Options.Create(new WorkflowExecutionOptions()),
         _logger.Object);
 
     private void SetupBlockingParent(Instance parent)

--- a/test/BBT.Workflow.Application.Tests/SubFlow/SubflowCompletionServiceTests.cs
+++ b/test/BBT.Workflow.Application.Tests/SubFlow/SubflowCompletionServiceTests.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using BBT.Aether.Results;
 using BBT.Aether.Uow;
+using BBT.Workflow.BackgroundJobs.Options;
 using BBT.Workflow.Caching;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.ExceptionHandling;
@@ -18,6 +19,7 @@ using BBT.Workflow.Logging;
 using BBT.Workflow.Runtime;
 using BBT.Workflow.SubFlow;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using Shouldly;
 using Xunit;
@@ -34,6 +36,7 @@ public sealed class SubflowCompletionServiceTests
     private readonly Mock<IWorkflowExecutionService> _workflowExecutionService = new();
     private readonly Mock<ISubflowOutputMappingService> _outputMappingService = new();
     private readonly Mock<ITransitionLockScopeFactory> _lockScopeFactory = new();
+    private readonly Mock<ISubItemTerminalGuard> _terminalGuard = new();
     private readonly Mock<ITransitionLockScope> _lockScope = new();
     private readonly Mock<ILogger<SubflowCompletionService>> _logger = new();
 
@@ -52,6 +55,17 @@ public sealed class SubflowCompletionServiceTests
         _lockScopeFactory
             .Setup(x => x.AcquireAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(_lockScope.Object);
+        _lockScopeFactory
+            .Setup(x => x.AcquireAsync(
+                It.IsAny<string>(), It.IsAny<LockAcquireWait>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_lockScope.Object);
+        // Default: the pre-lock probe finds nothing terminal, so every test exercises the
+        // authoritative locked path unless it explicitly overrides this.
+        _terminalGuard
+            .Setup(x => x.ProbeAsync(
+                It.IsAny<Guid>(), It.IsAny<Guid>(),
+                It.IsAny<SubItemTerminalOutcome>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubItemTerminalProbe.Proceed);
         _logger.Setup(x => x.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
     }
 
@@ -67,8 +81,162 @@ public sealed class SubflowCompletionServiceTests
         exception.Code.ShouldBe(WorkflowErrorCodes.SubflowTerminalLockNotAcquired);
         _lockScopeFactory.Verify(x => x.AcquireAsync(
             $"vnext:{input.Domain}:{input.Flow}:{input.InstanceId}:sub:{input.SubInstanceId:N}",
+            It.IsAny<LockAcquireWait>(),
             It.IsAny<CancellationToken>()), Times.Once);
         _instanceRepository.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task CompletionAsync_WhenPreLockProbeReportsSettled_ShouldNoOpWithoutTakingLock()
+    {
+        var input = CreateInput(Guid.NewGuid(), Guid.NewGuid());
+        _terminalGuard
+            .Setup(x => x.ProbeAsync(
+                input.InstanceId, input.SubInstanceId,
+                SubItemTerminalOutcome.Completed, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubItemTerminalProbe.AlreadySettled);
+
+        await CreateService().CompletionAsync(input);
+
+        // The whole point of the pre-lock probe: a duplicate delivery must never contend on the
+        // distributed lock, and must never be reported as a transient failure.
+        _lockScopeFactory.VerifyNoOtherCalls();
+        _instanceRepository.VerifyNoOtherCalls();
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // The tests above stub ISubItemTerminalGuard, so they only prove how the service reacts to a
+    // probe result. The tests below wire the REAL guard against a correlation snapshot, which is
+    // what actually decides whether a durable delivery may be acknowledged without the lock.
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task CompletionAsync_BlockingSubFlowDuplicate_ShouldNotBeAcknowledgedByProbe()
+    {
+        // Phase 1 committed (correlation terminal) but the parent resume runs in a later phase and
+        // reverts the correlation if it fails. The probe must therefore refuse to settle this, and
+        // the delivery must reach the authoritative locked path instead.
+        var parent = CreateParentInstance(out var subInstanceId);
+        parent.CompleteCorrelation(subInstanceId, SubItemTerminalOutcome.Completed, DateTime.UtcNow);
+        SetupCompletedCorrelationPath(parent);
+        var service = CreateServiceWithRealGuard(
+            SnapshotOf(parent, subInstanceId, SubFlowType.SubFlow, SubItemTerminalOutcome.Completed));
+
+        await service.CompletionAsync(CreateInput(parent.Id, subInstanceId));
+
+        _lockScopeFactory.Verify(x => x.AcquireAsync(
+            It.IsAny<string>(), It.IsAny<LockAcquireWait>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _instanceRepository.Verify(x => x.FindWithAllCorrelationsAndDataAsync(
+            parent.Id, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CompletionAsync_BlockingSubFlowDuplicate_WhenOriginalHoldsLock_ShouldStayUnacknowledged()
+    {
+        // The original is still inside its transaction, so its write is invisible to the probe and
+        // the lock is held. The duplicate must be pushed back for broker re-delivery — never ACKed.
+        var parent = CreateParentInstance(out var subInstanceId);
+        parent.CompleteCorrelation(subInstanceId, SubItemTerminalOutcome.Completed, DateTime.UtcNow);
+        SetupCompletedCorrelationPath(parent);
+        _lockScope.SetupGet(x => x.IsAcquired).Returns(false);
+        var service = CreateServiceWithRealGuard(
+            SnapshotOf(parent, subInstanceId, SubFlowType.SubFlow, SubItemTerminalOutcome.Completed));
+
+        var exception = await Should.ThrowAsync<SubflowTerminalLockNotAcquiredException>(
+            () => service.CompletionAsync(CreateInput(parent.Id, subInstanceId)));
+
+        exception.Code.ShouldBe(WorkflowErrorCodes.SubflowTerminalLockNotAcquired);
+    }
+
+    [Fact]
+    public async Task CompletionAsync_SubProcessDuplicate_ShouldBeSettledWithoutTakingLock()
+    {
+        // A SubProcess commits its correlation and returns — there is no second phase to roll back,
+        // so a persisted terminal outcome really is final and the lock can be skipped entirely.
+        var parent = CreateParentInstance(out var subInstanceId);
+        parent.CompleteCorrelation(subInstanceId, SubItemTerminalOutcome.Completed, DateTime.UtcNow);
+        var service = CreateServiceWithRealGuard(
+            SnapshotOf(parent, subInstanceId, SubFlowType.SubProcess, SubItemTerminalOutcome.Completed));
+
+        await service.CompletionAsync(CreateInput(parent.Id, subInstanceId));
+
+        _lockScopeFactory.VerifyNoOtherCalls();
+        _instanceRepository.VerifyNoOtherCalls();
+    }
+
+    private SubflowCompletionService CreateServiceWithRealGuard(InstanceCorrelation? snapshot)
+    {
+        var correlationRepository = new Mock<IInstanceCorrelationRepository>();
+        correlationRepository
+            .Setup(x => x.FindBySubInstanceIdAsReadOnlyAsync(
+                It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(snapshot);
+
+        var guardLogger = new Mock<ILogger<SubItemTerminalGuard>>();
+        guardLogger.Setup(x => x.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
+
+        return new SubflowCompletionService(
+            _uowManager.Object,
+            _componentCacheStore.Object,
+            _instanceRepository.Object,
+            _runtimeInfoProvider.Object,
+            _workflowExecutionService.Object,
+            _outputMappingService.Object,
+            _lockScopeFactory.Object,
+            new SubItemTerminalGuard(correlationRepository.Object, guardLogger.Object),
+            Options.Create(new WorkflowExecutionOptions()),
+            _logger.Object);
+    }
+
+    /// <summary>
+    /// Builds the read-only correlation snapshot the real guard sees, independent of the tracked
+    /// aggregate the locked path loads.
+    /// </summary>
+    private static InstanceCorrelation SnapshotOf(
+        Instance parent,
+        Guid subInstanceId,
+        SubFlowType subFlowType,
+        SubItemTerminalOutcome outcome)
+    {
+        var snapshot = InstanceCorrelation.Create(
+            Guid.NewGuid(), parent.Id, "waiting-child", subInstanceId,
+            subFlowType.Code, "bank", "child-flow", "1.0.0");
+        snapshot.ApplyTerminalOutcome(outcome, DateTime.UtcNow);
+        return snapshot;
+    }
+
+    [Fact]
+    public async Task CompletionAsync_WhenPreLockProbeReportsConflict_ShouldNotReopenCorrelation()
+    {
+        var input = CreateInput(Guid.NewGuid(), Guid.NewGuid());
+        _terminalGuard
+            .Setup(x => x.ProbeAsync(
+                input.InstanceId, input.SubInstanceId,
+                SubItemTerminalOutcome.Completed, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubItemTerminalProbe.Conflict);
+
+        await CreateService().CompletionAsync(input);
+
+        _lockScopeFactory.VerifyNoOtherCalls();
+        _instanceRepository.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task CompletionAsync_ShouldAcquireTerminalLockWithBoundedWait()
+    {
+        var parent = CreateParentInstance(out var subInstanceId);
+        parent.CompleteCorrelation(subInstanceId, SubItemTerminalOutcome.Completed, DateTime.UtcNow);
+        SetupCompletedCorrelationPath(parent);
+
+        await CreateService().CompletionAsync(CreateInput(parent.Id, subInstanceId));
+
+        // Duplicates that collide with an in-flight original cannot see its pending write, so the
+        // acquisition must wait it out rather than fail fast into a broker re-delivery cycle.
+        _lockScopeFactory.Verify(x => x.AcquireAsync(
+            It.IsAny<string>(),
+            It.Is<LockAcquireWait>(w => w.MaxAttempts > 1 && w.Delay > TimeSpan.Zero),
+            It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -442,6 +610,14 @@ public sealed class SubflowCompletionServiceTests
         terminalReload.Complete("bank");
         var order = new List<string>();
         var lockCall = 0;
+        // Main path takes the waiting overload; the compensation path still fails fast.
+        _lockScopeFactory
+            .Setup(x => x.AcquireAsync(
+                $"vnext:{input.Domain}:{input.Flow}:{input.InstanceId}:sub:{input.SubInstanceId:N}",
+                It.IsAny<LockAcquireWait>(),
+                It.IsAny<CancellationToken>()))
+            .Callback(() => order.Add($"lock-{++lockCall}"))
+            .ReturnsAsync(_lockScope.Object);
         _lockScopeFactory
             .Setup(x => x.AcquireAsync(
                 $"vnext:{input.Domain}:{input.Flow}:{input.InstanceId}:sub:{input.SubInstanceId:N}",
@@ -478,7 +654,10 @@ public sealed class SubflowCompletionServiceTests
         order.ShouldBe(["lock-1", "load-1", "resume", "lock-2", "load-2"]);
         terminalReload.FindCorrelationBySubInstanceId(subInstanceId)!.IsCompleted.ShouldBeTrue();
         _lockScopeFactory.Verify(x => x.AcquireAsync(
-            $"vnext:{input.Domain}:{input.Flow}:{input.InstanceId}:sub:{input.SubInstanceId:N}", CancellationToken.None), Times.Exactly(2));
+            $"vnext:{input.Domain}:{input.Flow}:{input.InstanceId}:sub:{input.SubInstanceId:N}",
+            It.IsAny<LockAcquireWait>(), CancellationToken.None), Times.Once);
+        _lockScopeFactory.Verify(x => x.AcquireAsync(
+            $"vnext:{input.Domain}:{input.Flow}:{input.InstanceId}:sub:{input.SubInstanceId:N}", CancellationToken.None), Times.Once);
         _instanceRepository.Verify(x => x.UpdateAsync(
             terminalReload, true, It.IsAny<CancellationToken>()), Times.Never);
     }
@@ -542,6 +721,8 @@ public sealed class SubflowCompletionServiceTests
             _workflowExecutionService.Object,
             _outputMappingService.Object,
             _lockScopeFactory.Object,
+            _terminalGuard.Object,
+            Options.Create(new WorkflowExecutionOptions()),
             _logger.Object);
 
     private void SetupCompletedCorrelationPath(Instance parent)

--- a/test/BBT.Workflow.Application.Tests/SubFlow/SubflowFaultServiceTests.cs
+++ b/test/BBT.Workflow.Application.Tests/SubFlow/SubflowFaultServiceTests.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using BBT.Aether.Results;
 using BBT.Aether.Uow;
+using BBT.Workflow.BackgroundJobs.Options;
 using BBT.Workflow.Caching;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.ExceptionHandling;
@@ -19,6 +20,7 @@ using BBT.Workflow.Instances.Events;
 using BBT.Workflow.Logging;
 using BBT.Workflow.SubFlow;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using Shouldly;
 using Xunit;
@@ -34,6 +36,7 @@ public sealed class SubflowFaultServiceTests
     private readonly Mock<IWorkflowExecutionService> _workflowExecutionService = new();
     private readonly Mock<ISubflowOutputMappingService> _outputMappingService = new();
     private readonly Mock<ITransitionLockScopeFactory> _lockScopeFactory = new();
+    private readonly Mock<ISubItemTerminalGuard> _terminalGuard = new();
     private readonly Mock<ITransitionLockScope> _lockScope = new();
     private readonly Mock<ILogger<SubflowFaultService>> _logger = new();
 
@@ -61,6 +64,17 @@ public sealed class SubflowFaultServiceTests
         _lockScopeFactory
             .Setup(x => x.AcquireAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(_lockScope.Object);
+        _lockScopeFactory
+            .Setup(x => x.AcquireAsync(
+                It.IsAny<string>(), It.IsAny<LockAcquireWait>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_lockScope.Object);
+        // Default: the pre-lock probe finds nothing terminal, so every test exercises the
+        // authoritative locked path unless it explicitly overrides this.
+        _terminalGuard
+            .Setup(x => x.ProbeAsync(
+                It.IsAny<Guid>(), It.IsAny<Guid>(),
+                It.IsAny<SubItemTerminalOutcome>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubItemTerminalProbe.Proceed);
         _logger.Setup(x => x.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
     }
 
@@ -76,6 +90,7 @@ public sealed class SubflowFaultServiceTests
         exception.Code.ShouldBe(WorkflowErrorCodes.SubflowTerminalLockNotAcquired);
         _lockScopeFactory.Verify(x => x.AcquireAsync(
             $"vnext:{input.Domain}:{input.Flow}:{input.InstanceId}:sub:{input.SubInstanceId:N}",
+            It.IsAny<LockAcquireWait>(),
             It.IsAny<CancellationToken>()), Times.Once);
         _instanceRepository.VerifyNoOtherCalls();
     }
@@ -308,6 +323,14 @@ public sealed class SubflowFaultServiceTests
         terminalReload.Complete("bank");
         var order = new List<string>();
         var lockCall = 0;
+        // Main path takes the waiting overload; the compensation path still fails fast.
+        _lockScopeFactory
+            .Setup(x => x.AcquireAsync(
+                $"vnext:{input.Domain}:{input.Flow}:{input.InstanceId}:sub:{input.SubInstanceId:N}",
+                It.IsAny<LockAcquireWait>(),
+                It.IsAny<CancellationToken>()))
+            .Callback(() => order.Add($"lock-{++lockCall}"))
+            .ReturnsAsync(_lockScope.Object);
         _lockScopeFactory
             .Setup(x => x.AcquireAsync(
                 $"vnext:{input.Domain}:{input.Flow}:{input.InstanceId}:sub:{input.SubInstanceId:N}",
@@ -340,7 +363,10 @@ public sealed class SubflowFaultServiceTests
         order.ShouldBe(["lock-1", "load-1", "resume", "lock-2", "load-2"]);
         terminalReload.FindCorrelationBySubInstanceId(subInstanceId)!.IsCompleted.ShouldBeTrue();
         _lockScopeFactory.Verify(x => x.AcquireAsync(
-            $"vnext:{input.Domain}:{input.Flow}:{input.InstanceId}:sub:{input.SubInstanceId:N}", CancellationToken.None), Times.Exactly(2));
+            $"vnext:{input.Domain}:{input.Flow}:{input.InstanceId}:sub:{input.SubInstanceId:N}",
+            It.IsAny<LockAcquireWait>(), CancellationToken.None), Times.Once);
+        _lockScopeFactory.Verify(x => x.AcquireAsync(
+            $"vnext:{input.Domain}:{input.Flow}:{input.InstanceId}:sub:{input.SubInstanceId:N}", CancellationToken.None), Times.Once);
         _instanceRepository.Verify(x => x.UpdateAsync(
             terminalReload, true, It.IsAny<CancellationToken>()), Times.Never);
     }
@@ -632,6 +658,8 @@ public sealed class SubflowFaultServiceTests
             resolver,
             executor,
             _lockScopeFactory.Object,
+            _terminalGuard.Object,
+            Options.Create(new WorkflowExecutionOptions()),
             _logger.Object);
     }
 

--- a/test/BBT.Workflow.Infrastructure.Tests/Execution/Locks/TransitionLockScopeFactoryTests.cs
+++ b/test/BBT.Workflow.Infrastructure.Tests/Execution/Locks/TransitionLockScopeFactoryTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using BBT.Aether.DistributedLock;
@@ -51,6 +52,98 @@ public sealed class TransitionLockScopeFactoryTests
         await using var scope = await CreateFactory().AcquireAsync(key);
 
         scope.IsAcquired.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task AcquireAsync_WithoutWaitPolicy_ShouldNotRetry()
+    {
+        // The transition pipeline depends on fail-fast: a busy instance must surface immediately.
+        const string key = "vnext:bank:parent-flow:failfast";
+        _lockService.TryAcquireLockAsync(key, Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns((IDistributedLockHandle?)null);
+
+        await using var scope = await CreateFactory().AcquireAsync(key);
+
+        scope.IsAcquired.ShouldBeFalse();
+        await _lockService.Received(1)
+            .TryAcquireLockAsync(key, Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task AcquireAsync_WithWaitPolicy_ShouldRetryUntilLockIsReleased()
+    {
+        // A duplicate at-least-once delivery collides with the in-flight original; the original's
+        // critical section is one short transaction, so waiting it out must succeed.
+        const string key = "vnext:bank:parent-flow:contended-wait";
+        var handle = Substitute.For<IDistributedLockHandle>();
+        var attempts = 0;
+        _lockService.TryAcquireLockAsync(key, Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(_ => ++attempts < 3 ? null : handle);
+
+        await using var scope = await CreateFactory().AcquireAsync(
+            key,
+            new LockAcquireWait(4, TimeSpan.FromMilliseconds(1)));
+
+        scope.IsAcquired.ShouldBeTrue();
+        attempts.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task AcquireAsync_WithWaitPolicy_ShouldGiveUpAfterMaxAttempts()
+    {
+        const string key = "vnext:bank:parent-flow:contended-exhausted";
+        _lockService.TryAcquireLockAsync(key, Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns((IDistributedLockHandle?)null);
+
+        await using var scope = await CreateFactory().AcquireAsync(
+            key,
+            new LockAcquireWait(3, TimeSpan.FromMilliseconds(1)));
+
+        scope.IsAcquired.ShouldBeFalse();
+        await _lockService.Received(3)
+            .TryAcquireLockAsync(key, Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task LegacyImplementation_WithoutWaitOverload_ShouldStillSatisfyTheInterface()
+    {
+        // BBT.Workflow.Domain ships as a NuGet package, so an implementation written before the
+        // wait overload existed must keep compiling and keep its fail-fast behaviour. This test
+        // exists to fail at COMPILE time if the overload ever loses its default implementation.
+        ITransitionLockScopeFactory legacy = new LegacyLockScopeFactory();
+
+        var withoutWait = await legacy.AcquireAsync("vnext:bank:parent-flow:legacy");
+        var withWait = await legacy.AcquireAsync(
+            "vnext:bank:parent-flow:legacy",
+            new LockAcquireWait(5, TimeSpan.FromMilliseconds(50)));
+
+        withoutWait.IsAcquired.ShouldBeTrue();
+        withWait.IsAcquired.ShouldBeTrue();
+        ((LegacyLockScopeFactory)legacy).Calls.ShouldBe(2);
+    }
+
+    /// <summary>
+    /// Implements only the original member — deliberately does NOT override the wait overload.
+    /// </summary>
+    private sealed class LegacyLockScopeFactory : ITransitionLockScopeFactory
+    {
+        public int Calls { get; private set; }
+
+        public Task<ITransitionLockScope> AcquireAsync(
+            string lockKey,
+            CancellationToken cancellationToken = default)
+        {
+            Calls++;
+            return Task.FromResult<ITransitionLockScope>(new StubScope(lockKey));
+        }
+
+        private sealed class StubScope(string lockKey) : ITransitionLockScope
+        {
+            public bool IsAcquired => true;
+            public string LockKey => lockKey;
+            public Task<bool> ExtendAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
+            public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        }
     }
 
     [Fact]

--- a/workers/BBT.Workflow.DbMigrator/appsettings.json
+++ b/workers/BBT.Workflow.DbMigrator/appsettings.json
@@ -34,7 +34,7 @@
   },
   "Telemetry": {
     "ServiceName": "vnext-db-migrator",
-    "ServiceNamespace": "BBT.Workflow.DbMigrator",
+    "ServiceNamespace": "core",
     "ServiceVersion": "1.0.0",
     "TracingEnabled": true,
     "MetricsEnabled": true,

--- a/workers/BBT.Workflow.Workers.Inbox/appsettings.json
+++ b/workers/BBT.Workflow.Workers.Inbox/appsettings.json
@@ -34,7 +34,7 @@
   },
   "Telemetry": {
     "ServiceName": "vnext-inbox-worker",
-    "ServiceNamespace": "BBT.Workflow.Workers.Inbox",
+    "ServiceNamespace": "core",
     "ServiceVersion": "1.0.0",
     "TracingEnabled": false,
     "MetricsEnabled": false,

--- a/workers/BBT.Workflow.Workers.Outbox/appsettings.json
+++ b/workers/BBT.Workflow.Workers.Outbox/appsettings.json
@@ -28,7 +28,7 @@
   },
   "Telemetry": {
     "ServiceName": "vnext-worker-outbox",
-    "ServiceNamespace": "BBT.Workflow.Workers.Outbox",
+    "ServiceNamespace": "core",
     "ServiceVersion": "1.0.0",
     "TracingEnabled": false,
     "MetricsEnabled": false,


### PR DESCRIPTION
## Why

Terminal sub-item events (`instance.sub.completed` / `.faulted` / `.canceled`) are published with `EventHookMode.DurablePostCommit`. That mode publishes to the bus **unconditionally** and *also* runs the local hook, so every subflow completion is processed twice by design — once inline, once via the Inbox worker. In the 2026-07-29 onboarding × contract load test, **51 of 51** observed completions were dual-processed.

The idempotency check that recognises the duplicate sat **behind** the per-subInstance distributed lock, and that lock used a single `TryAcquire` with no wait. So a duplicate colliding with the in-flight original lost the lock, got a transient `503`, and waited a full broker re-delivery cycle — **~63 seconds** in the captured incident. The flow itself stayed correct (the local path won), but the failure produced real error noise and would degrade sharply under load: the inbox arrives a median 155 ms after the local hook, while the critical section is ~60 ms.

## What changed

Two layers, each fixing a **different** case — this distinction matters:

| Duplicate arrives | Probe | Bounded wait |
|---|---|---|
| SubProcess, after commit | ✅ skips the lock entirely | — |
| SubProcess, mid-transaction | ❌ can't see pending write | ✅ |
| **Blocking SubFlow (the observed incident)** | ❌ deliberately disabled | ✅ **this is the actual fix** |

**1. Pre-lock probe** — `ISubItemTerminalGuard` / `SubItemTerminalGuard`
Answers "already settled?" from a read-only correlation snapshot (`FindBySubInstanceIdAsReadOnlyAsync`) before any lock is taken.

Restricted to `SubFlowType.SubProcess`. A SubProcess commits its correlation and returns — no second phase, so the flag really is final. A blocking SubFlow commits, **releases the lock**, then resumes the parent in a second phase, and reverts the correlation via `RevertCorrelationInNewUowAsync` if that resume fails. A persisted terminal flag is therefore *not* proof of settlement there, and acknowledging from it would consume a durable message whose work is about to roll back. Verified in all three services: `SubflowCompletionService.cs:198-203`, `SubflowFaultService.cs:180-185`, `SubflowCancellationService.cs:188-191`.

An absent snapshot (writer's transaction still open) never counts as "done" — it returns `Proceed` so the authoritative locked path decides.

**2. Bounded lock wait** — `LockAcquireWait`
A duplicate arriving while the original is still inside its transaction cannot see the pending write, so the probe cannot help it. Waiting out the short critical section beats failing into a re-delivery cycle. Default `LockAcquireWait.None` preserves fail-fast for every existing caller — the transition pipeline relies on it to surface a busy instance immediately.

Lock-not-acquired still raises `SubflowTerminalLockNotAcquiredException` → 503 → re-delivery. Treating it as success would ack work that may still be reverted.

## Reviewer notes

**Interface compatibility.** `BBT.Workflow.Domain` ships as a NuGet package (`dotnet pack src/BBT.Workflow.Domain` in `build-and-publish-images.yml:748`), so adding an abstract member to `ITransitionLockScopeFactory` would break external implementations. The new overload has a **default interface implementation** delegating to the fail-fast overload — external implementors keep compiling and keep their original behaviour. `LegacyImplementation_WithoutWaitOverload_ShouldStillSatisfyTheInterface` locks this in at **compile time**.

**Configuration, not hardcoding.** The retry policy lives in `WorkflowExecutionOptions.SubItemTerminalLockRetry`, reusing the existing `LockConflictRetryOptions` type and the backoff pattern already used by `TransitionJobHandler` — rather than baking `4 × 120 ms` into the Domain layer.

**⚠️ Two unrelated changesets are bundled in here** (they were already in the working tree; included at the author's request):

1. **Telemetry / Dapr naming** — `Telemetry:ServiceNamespace` set to the domain (`"core"`) across orchestration, monitoring, DbMigrator, Inbox and Outbox; monitoring Dapr component names de-scoped (`vnext-execution-*` → `vnext-*`); monitoring tracing/metrics/logging enabled; pubsub env vars added to monitoring launchSettings. This makes `service.namespace` a single cross-signal filter for all components of a domain.
2. **`SubflowStateService.cs`** — the `correlation.IsCompleted` guard was **removed**. Not authored as part of this fix and flagged for explicit review: with it gone, an `instance.sub.state.changed` event arriving after the correlation is terminal can mutate the correlation. The timestamp-based out-of-order rejection still stands, but it guards a different case. **Please confirm this removal is intentional.**

## Known limitation (pre-existing, not introduced here)

Because resume runs outside the lock, a blocking-SubFlow duplicate arriving during the resume window still acquires the lock, sees `IsCompleted`, and acks — if the resume later fails and reverts, that delivery is lost. **This behaviour predates the change**: the in-lock branch (`SubflowCompletionService.cs:155-176`) also logged, committed and returned 200. Narrowing the fast path to SubProcess guarantees the change does not widen it. Closing it needs a durable settlement marker (`SettledAt` + EF migration across tenant schemas) or an `eventId`-based idempotency record — tracked as follow-up work.

## Testing

- **115** SubFlow tests, **9** lock-factory tests passing.
- New coverage: 7 probe cases (SubProcess settled/conflict, blocking SubFlow returning `Proceed` in **both** terminal states, open correlation, invisible correlation, snapshot read failure); three service-level tests using the **real** guard rather than a stub; retry-loop success and exhaustion; fail-fast default preserved; the legacy-implementation compile guard.
- **Regression check against a `HEAD` baseline in a separate worktree** — this repo has pre-existing failures, so counts alone are misleading and the failing *test-name sets* were diffed:
  - Application: 26 → 26 failures, **identical set**, +13 passing
  - Infrastructure: 13 → 12 (the difference is `DataSinkManagerTests…In_Parallel`, flaky), +5 passing
- `git diff --check` clean; full solution builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden subflow terminal handling by adding a lock-free terminal probe and configurable bounded lock retry, while aligning telemetry naming and enabling monitoring signals across components.

New Features:
- Introduce a lock-free sub-item terminal guard that short-circuits duplicate terminal subflow deliveries before acquiring the distributed lock when settlement is provably complete.
- Add configurable bounded-wait semantics for transition lock acquisition via LockAcquireWait and WorkflowExecutionOptions.SubItemTerminalLockRetry, preserving existing fail-fast behavior by default.

Bug Fixes:
- Prevent duplicate subflow terminal events from failing with transient lock errors by allowing retries on contended per-subInstance locks and skipping the lock when a settled outcome is already persisted.

Enhancements:
- Log additional diagnostics for terminal duplicate handling, settlement provability, probe failures, and transition lock retry scheduling.
- Adjust subflow state handling so that state change events are allowed after a correlation is marked completed, relying solely on timestamp-based out-of-order rejection.
- Register and wire the new sub-item terminal guard into subflow completion, fault, and cancellation services, with expanded test coverage for probe behavior and lock-wait semantics.

Deployment:
- Unify Dapr component names for monitoring and adjust telemetry ServiceNamespace to a shared "core" domain, while enabling tracing, metrics, and logging in the monitoring host configuration.

Tests:
- Extend subflow completion, fault, and cancellation service tests to cover pre-lock probing, bounded lock acquisition, and mixed overload usage during compensation paths.
- Add dedicated tests for SubItemTerminalGuard behavior across subflow types and correlation visibility cases, and for TransitionLockScopeFactory retry behavior and legacy interface compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved subflow completion and cancellation handling by detecting duplicate or conflicting terminal events earlier.
  * Added configurable lock retries with bounded waits and jittered backoff.
  * Enabled telemetry for tracing, metrics, and logging by default across monitored services.
  * Added launch configuration for Dapr pub/sub settings.

* **Bug Fixes**
  * Prevented settled workflows from being reopened by duplicate or conflicting events.
  * Ensured state updates continue through timestamp validation and propagation.

* **Refactor**
  * Standardized Dapr component names and telemetry service namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->