### PR TITLE
feat(state-function): return completed child correlations

### DIFF
--- a/docs/contracts/api-and-service-contracts.md
+++ b/docs/contracts/api-and-service-contracts.md
@@ -27,11 +27,27 @@ contracts. Remote services call public runtime APIs rather than internal reposit
 
 | Endpoint family | Behavior |
 | --- | --- |
-| `GET /{domain}/workflows/{workflow}/instances/{instance}/functions/state` | Conditional state response, available transitions, role filtering, ETag. |
+| `GET /{domain}/workflows/{workflow}/instances/{instance}/functions/state` | Conditional state response, available transitions, role filtering, ETag, child correlations. |
 | `GET /{domain}/workflows/{workflow}/instances/{instance}/functions/data` | Latest data, optional extensions, ETag. |
 | `GET /{domain}/workflows/{workflow}/instances/{instance}/functions/view` | Backend-driven view selection. |
 | `GET /{domain}/workflows/{workflow}/instances/{instance}/functions/schema` | Transition-aware schema. |
 | `POST /{domain}/workflows/{workflow}/instances/{instance}/transitions/{transition}` | Runs a transition sync or async. |
+
+### State response: correlation lists
+
+The state response exposes child correlations through two lists, and clients must pick the one
+matching their intent:
+
+| Field | Contents |
+| --- | --- |
+| `activeCorrelations` | Open correlations only. Stable, long-standing semantics — safe for "is a sub item still running". |
+| `correlations` | Full set, active **and** completed, ordered by `createdAt` ascending. Each entry carries `isCompleted`, `completedAt`, `terminalOutcome` (`completed` / `faulted` / `canceled`), `currentState`, `stateChangedAt`. Use this to reconstruct which sub items ran and how each ended. |
+
+Both merge the active subflow's own corresponding list when the parent is inside a subflow, so a
+nested chain stays consistent. `correlations` is read through a dedicated query, so under
+concurrent completion its active subset can be a moment fresher than `activeCorrelations`.
+Changes to the correlation set participate in the state ETag — see
+[state-function cache and fingerprint ETag](../runtime/state-function-cache-and-etag.md).
 
 ## Sync and Async Semantics
 

--- a/docs/runtime/state-function-cache-and-etag.md
+++ b/docs/runtime/state-function-cache-and-etag.md
@@ -44,7 +44,11 @@ aggregate materialization:
 
 ```
 SELECT Id, Key, EffectiveState, Status, FlowVersion,
-       EXISTS(active SubFlow correlation) AS HasActiveSubFlow
+       EXISTS(active SubFlow correlation)      AS HasActiveSubFlow,
+       COUNT(correlations)                     AS CorrelationCount,
+       COUNT(correlations WHERE IsCompleted)   AS CompletedCorrelationCount,
+       MAX(correlations.CompletedAt)           AS LastCorrelationCompletedAt,
+       MAX(correlations.SubFlowStateChangedAt) AS LastSubFlowStateChangedAt
 ```
 
 - Identifier resolution mirrors `FindByIdentifierAsReadOnlyAsync`: id first, then the most
@@ -54,13 +58,31 @@ SELECT Id, Key, EffectiveState, Status, FlowVersion,
   AND SubFlowType = 'S'`) — a single B-tree probe, not a correlation load.
 - `EffectiveState` (not `CurrentState`) is used because subflow state changes are propagated
   upward into the parent's `EffectiveState` column.
+- The four **correlation aggregates** exist because the response body carries the full
+  `correlations` list (active *and* completed). They run over the unfiltered correlation set and
+  are served by `IX_InstancesCorrelations_ByParent` (`ParentInstanceId`, no filter) — the two
+  partial indexes cannot serve them, since both exclude exactly the completed rows involved.
+  Each mutation of the set moves at least one aggregate: a sub item starting moves
+  `CorrelationCount`, terminating (or a revert) moves `CompletedCorrelationCount`, a
+  revert-then-recomplete that restores both counts moves `LastCorrelationCompletedAt`, and a sub
+  item advancing its own state moves `LastSubFlowStateChangedAt`.
+
+> **Invariant — the two build paths must agree.** The fast path fingerprints via this projection;
+> the full-build path uses `InstanceStateFingerprint.FromInstance(instance, allCorrelations)`.
+> The aggregate's own `ChildCorrelations` is loaded with an active-only filtered include, so it
+> must never feed the aggregates — hence `allCorrelations` is a required argument rather than
+> read off the instance. If the two disagree on one member, the full-path ETag never matches the
+> one the fast path validates and every poll rebuilds the response. Guarded by
+> `InstanceStateFingerprintQueryTests.ProjectionAndFromInstance_ProduceIdenticalFingerprints`.
 
 ### ETag
 
 Computed by `IStateFunctionCache.ComputeEtag` — a deterministic SHA-256 hash (32 hex chars):
 
 ```
-etag = h(instanceId | effectiveState | status | flowVersion | callerHash)
+etag = h(instanceId | effectiveState | status | flowVersion | callerHash
+         | correlationCount | completedCorrelationCount
+         | lastCorrelationCompletedAt | lastSubFlowStateChangedAt)
 ```
 
 - **Deterministic across pods**: any instance of the service computes the same ETag for the
@@ -73,6 +95,10 @@ etag = h(instanceId | effectiveState | status | flowVersion | callerHash)
   `h(... | displayedState | displayedStatus)`. The parent row alone cannot see
   subflow-internal Busy/Active flips (`PropagateEffectiveStateToParent` updates only
   `EffectiveState`, never `Status`, and is asynchronous via the Inbox worker).
+- **Correlation members are in the hash** because the body exposes the full `correlations` list:
+  a sub item starting, terminating or advancing its state changes the body without touching the
+  instance's own state or status, and a long-polling client would otherwise keep getting 304 and
+  never observe it.
 - The ETag intentionally does **not** track instance-data-only changes: the state function
   signals state/status transitions, not data versions. `X-Entity-ETag` served from cache may
   lag data-only updates until the next state/status change (accepted by design — the data

--- a/src/BBT.Workflow.Application/Instances/Caching/StateFunctionCache.cs
+++ b/src/BBT.Workflow.Application/Instances/Caching/StateFunctionCache.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 using BBT.Aether.DistributedCache;
@@ -52,6 +53,9 @@ public sealed class StateFunctionCache(
         string? displayedState,
         string? displayedStatus)
     {
+        // The correlation members participate because the response body carries the full correlation
+        // set: a sub item starting, terminating or advancing its state changes the body without
+        // touching the instance's own state or status, and must still invalidate the caller's ETag.
         var material = string.Join('|',
             fingerprint.Id,
             fingerprint.EffectiveState ?? string.Empty,
@@ -59,11 +63,23 @@ public sealed class StateFunctionCache(
             fingerprint.FlowVersion ?? string.Empty,
             BuildCallerHash(input),
             displayedState ?? string.Empty,
-            displayedStatus ?? string.Empty);
+            displayedStatus ?? string.Empty,
+            fingerprint.CorrelationCount,
+            fingerprint.CompletedCorrelationCount,
+            FormatTimestamp(fingerprint.LastCorrelationCompletedAt),
+            FormatTimestamp(fingerprint.LastSubFlowStateChangedAt));
 
         return Convert.ToHexStringLower(
             SHA256.HashData(Encoding.UTF8.GetBytes(material)))[..EtagLength];
     }
+
+    /// <summary>
+    /// Round-trip ("O") rendering of a fingerprint timestamp, or the empty string for null. Both
+    /// fingerprint paths read their timestamps from the database, so precision and
+    /// <see cref="DateTimeKind"/> match and the rendered material is stable.
+    /// </summary>
+    private static string FormatTimestamp(DateTime? value) =>
+        value?.ToString("O", CultureInfo.InvariantCulture) ?? string.Empty;
 
     private string BuildCallerHash(GetInstanceStateInput input) =>
         CallerScopeHash.Compute(currentUser, input.Role, input.Roles, input.Extensions, input.Headers, input.Version);

--- a/src/BBT.Workflow.Application/Instances/DTOs/GetInstanceStateOutput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/GetInstanceStateOutput.cs
@@ -44,6 +44,16 @@ public sealed class GetInstanceStateOutput
     public List<ActiveCorrelationHref> ActiveCorrelations { get; set; } = [];
 
     /// <summary>
+    /// Full child correlation set — active and completed — ordered by creation time ascending.
+    /// Clients that need the sub item history (which subflows ran and how they terminated) read this
+    /// list and filter on <see cref="ActiveCorrelationHref.IsCompleted"/>;
+    /// <see cref="ActiveCorrelations"/> keeps its active-only semantics.
+    /// Read from a dedicated query, so under concurrent completion its active subset can be a moment
+    /// fresher than <see cref="ActiveCorrelations"/>.
+    /// </summary>
+    public List<ActiveCorrelationHref> Correlations { get; set; } = [];
+
+    /// <summary>
     /// Available transition items with href links
     /// </summary>
     public List<TransitionItem> Transitions { get; set; } = [];

--- a/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
+++ b/src/BBT.Workflow.Application/Instances/InstanceQueryAppService.cs
@@ -336,6 +336,62 @@ public sealed class InstanceQueryAppService(
     }
 
     /// <summary>
+    /// Data-function href for a correlation's sub item, carrying the caller's extensions when present.
+    /// </summary>
+    private string BuildCorrelationDataHref(
+        string subFlowDomain, string subFlowName, Guid subFlowInstanceId, string[] allExtensions) =>
+        allExtensions.Length > 0
+            ? urlTemplateBuilder.BuildDataWithExtensionsUrl(
+                subFlowDomain, subFlowName, subFlowInstanceId.ToString(), allExtensions)
+            : urlTemplateBuilder.BuildDataUrl(
+                subFlowDomain, subFlowName, subFlowInstanceId.ToString());
+
+    /// <summary>
+    /// Maps an active-correlation projection onto its response entry — the <c>activeCorrelations</c>
+    /// list. Terminal and state-tracking details are absent from the projection and stay unset; they
+    /// are meaningless for an active correlation anyway.
+    /// </summary>
+    private ActiveCorrelationHref BuildCorrelationHref(InstanceCorrelationInfo correlation, string[] allExtensions) =>
+        new()
+        {
+            CorrelationId = correlation.CorrelationId,
+            ParentState = correlation.ParentState,
+            SubFlowInstanceId = correlation.SubFlowInstanceId,
+            SubFlowType = correlation.SubFlowType,
+            SubFlowDomain = correlation.SubFlowDomain,
+            SubFlowName = correlation.SubFlowName,
+            SubFlowVersion = correlation.SubFlowVersion,
+            IsCompleted = correlation.IsCompleted,
+            Href = BuildCorrelationDataHref(
+                correlation.SubFlowDomain, correlation.SubFlowName, correlation.SubFlowInstanceId, allExtensions)
+        };
+
+    /// <summary>
+    /// Maps a correlation entity onto its response entry — the full <c>correlations</c> list. Carries the
+    /// terminal details (<c>completedAt</c>, <c>terminalOutcome</c>) and the tracked sub-item state that
+    /// let a client reconstruct which sub items ran and how each one ended.
+    /// </summary>
+    private ActiveCorrelationHref BuildCorrelationHref(InstanceCorrelation correlation, string[] allExtensions) =>
+        new()
+        {
+            CorrelationId = correlation.Id,
+            ParentState = correlation.ParentState,
+            SubFlowInstanceId = correlation.SubFlowInstanceId,
+            SubFlowType = correlation.SubFlowType,
+            SubFlowDomain = correlation.SubFlowDomain,
+            SubFlowName = correlation.SubFlowName,
+            SubFlowVersion = correlation.SubFlowVersion,
+            IsCompleted = correlation.IsCompleted,
+            CompletedAt = correlation.CompletedAt,
+            TerminalOutcome = correlation.TerminalOutcome,
+            CreatedAt = correlation.CreatedAt,
+            CurrentState = correlation.SubFlowCurrentState,
+            StateChangedAt = correlation.SubFlowStateChangedAt,
+            Href = BuildCorrelationDataHref(
+                correlation.SubFlowDomain, correlation.SubFlowName, correlation.SubFlowInstanceId, allExtensions)
+        };
+
+    /// <summary>
     /// Gets available transitions and state information from a remote SubFlow instance.
     /// Includes view extensions and active correlations from the SubFlow.
     /// </summary>
@@ -398,6 +454,7 @@ public sealed class InstanceQueryAppService(
                     SubFlowData: subFlowValue.Data,
                     SubFlowView: subFlowValue.View,
                     SubFlowActiveCorrelations: subFlowValue.ActiveCorrelations,
+                    SubFlowCorrelations: subFlowValue.Correlations,
                     SubFlowTransitionItems: subFlowValue.Transitions,
                     // Bubble the (possibly deeper) subflow's long-poll termination signal up the chain.
                     Interaction: subFlowValue.Interaction);
@@ -864,7 +921,18 @@ public sealed class InstanceQueryAppService(
                     if (!await IsInstanceQueryAllowedAsync(data.workflow, data.instance, input.Roles, input.Headers, input.QueryParams, cancellationToken))
                         return ConditionalResult<GetInstanceStateOutput>.Fail(WorkflowErrors.QueryAccessDenied(data.instance.GetEffectiveState));
 
-                    var buildResult = await BuildInstanceStateOutputAsync(data.instance, data.workflow, input, cancellationToken);
+                    // Full correlation set (active + completed), ordered by creation time. The aggregate's
+                    // own ChildCorrelations collection is loaded with an active-only filtered include, so
+                    // the completed rows the response exposes require this dedicated read. Ordering is
+                    // applied here rather than in the shared repository method, whose ParentState ordering
+                    // the hierarchy and monitor consumers already depend on.
+                    var allCorrelations = (await instanceCorrelationRepository
+                            .GetByParentAsync(data.instance.Id, cancellationToken))
+                        .OrderBy(c => c.CreatedAt)
+                        .ToList();
+
+                    var buildResult = await BuildInstanceStateOutputAsync(
+                        data.instance, data.workflow, input, allCorrelations, cancellationToken);
                     if (!buildResult.IsSuccess)
                         return ConditionalResult<GetInstanceStateOutput>.Fail(buildResult.Error);
 
@@ -872,10 +940,12 @@ public sealed class InstanceQueryAppService(
                     var entityEtag = data.instance.LatestData?.ETag ?? string.Empty;
                     output.EntityEtag = entityEtag;
 
-                    // Same fingerprint-ETag the fast path computes from the projection query.
+                    // Same fingerprint-ETag the fast path computes from the projection query. The
+                    // correlation members must come from allCorrelations, not from the aggregate, so both
+                    // paths hash the same set — see InstanceStateFingerprint.FromInstance.
                     // Active-subflow responses fold the live displayed state/status into the hash:
                     // the parent row alone cannot see subflow-internal Busy/Active flips.
-                    var fingerprint = InstanceStateFingerprint.FromInstance(data.instance);
+                    var fingerprint = InstanceStateFingerprint.FromInstance(data.instance, allCorrelations);
                     var etag = data.instance.HasActiveSubFlow
                         ? stateFunctionCache.ComputeEtag(input, fingerprint, output)
                         : stateFunctionCache.ComputeEtag(input, fingerprint);
@@ -957,10 +1027,18 @@ public sealed class InstanceQueryAppService(
     /// Builds the complete instance state output including transitions, correlations, and view information.
     /// When there's an active SubFlow, includes the SubFlow's view extensions in data href and merges active correlations.
     /// </summary>
+    /// <param name="instance">The loaded instance aggregate (child correlations active-only).</param>
+    /// <param name="currentWorkflow">The workflow definition bound to the instance.</param>
+    /// <param name="input">The state request.</param>
+    /// <param name="allCorrelations">Full child correlation set (active + completed), CreatedAt ascending.
+    /// Feeds the <c>correlations</c> response list only — the active-subflow detection below deliberately
+    /// keeps using the aggregate, whose active set drives Busy/settlement semantics.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     private async Task<Result<GetInstanceStateOutput>> BuildInstanceStateOutputAsync(
         Instance instance,
         Definitions.Workflow currentWorkflow,
         GetInstanceStateInput input,
+        IReadOnlyCollection<InstanceCorrelation> allCorrelations,
         CancellationToken cancellationToken)
     {
         // Build instance transition information using shared logic (no DB call - uses instance.ActiveCorrelations)
@@ -1184,26 +1262,21 @@ public sealed class InstanceQueryAppService(
         {
             Href = urlTemplateBuilder.BuildMasterUrl(input.Domain, input.Workflow, instance.Id.ToString())
         };
-        var mainFlowCorrelationHrefs = transitionInfo.ActiveCorrelations.Select(correlation =>
-            new ActiveCorrelationHref
-            {
-                CorrelationId = correlation.CorrelationId,
-                ParentState = correlation.ParentState,
-                SubFlowInstanceId = correlation.SubFlowInstanceId,
-                SubFlowType = correlation.SubFlowType,
-                SubFlowDomain = correlation.SubFlowDomain,
-                SubFlowName = correlation.SubFlowName,
-                SubFlowVersion = correlation.SubFlowVersion,
-                IsCompleted = correlation.IsCompleted,
-                Href = allExtensions.Length > 0
-                    ? urlTemplateBuilder.BuildDataWithExtensionsUrl(correlation.SubFlowDomain, correlation.SubFlowName,
-                        correlation.SubFlowInstanceId.ToString(), allExtensions)
-                    : urlTemplateBuilder.BuildDataUrl(correlation.SubFlowDomain, correlation.SubFlowName,
-                        correlation.SubFlowInstanceId.ToString())
-            }).ToList();
+        var mainFlowCorrelationHrefs = transitionInfo.ActiveCorrelations
+            .Select(correlation => BuildCorrelationHref(correlation, allExtensions))
+            .ToList();
         var allActiveCorrelations = subFlowStateInfo.SubFlowActiveCorrelations != null
             ? mainFlowCorrelationHrefs.Concat(subFlowStateInfo.SubFlowActiveCorrelations).ToList()
             : mainFlowCorrelationHrefs;
+
+        // Full set (active + completed) for clients that need the sub item history. Merged with the
+        // subflow's own full set exactly as the active list is, so a nested chain stays consistent.
+        var fullCorrelationHrefs = allCorrelations
+            .Select(correlation => BuildCorrelationHref(correlation, allExtensions))
+            .ToList();
+        var allCorrelationHrefs = subFlowStateInfo.SubFlowCorrelations != null
+            ? fullCorrelationHrefs.Concat(subFlowStateInfo.SubFlowCorrelations).ToList()
+            : fullCorrelationHrefs;
 
         // Role-aware state alias: when the displayed state is the main-flow current state and that
         // state defines aliases, return the role-resolved alias (localized label, else name) instead
@@ -1257,6 +1330,7 @@ public sealed class InstanceQueryAppService(
                 : subFlowStateInfo.StateType!,
             Status = subFlowStateInfo.Status,
             ActiveCorrelations = allActiveCorrelations,
+            Correlations = allCorrelationHrefs,
             Transitions = transitionItems,
             Interaction = interaction
         });
@@ -2440,6 +2514,7 @@ public sealed class InstanceQueryAppService(
     /// <param name="SubFlowData">Data href from SubFlow (contains extensions info) - null for main flow</param>
     /// <param name="SubFlowView">View href from SubFlow - null for main flow</param>
     /// <param name="SubFlowActiveCorrelations">Active correlations from SubFlow - empty for main flow</param>
+    /// <param name="SubFlowCorrelations">Full correlation set (active + completed) from SubFlow - empty for main flow</param>
     /// <param name="SubFlowTransitionItems">Transition items from SubFlow (includes HasView) - null for main flow</param>
     private sealed record SubFlowStateInfo(
         List<string> AvailableTransitions,
@@ -2449,6 +2524,7 @@ public sealed class InstanceQueryAppService(
         DataHref? SubFlowData = null,
         ViewHref? SubFlowView = null,
         List<ActiveCorrelationHref>? SubFlowActiveCorrelations = null,
+        List<ActiveCorrelationHref>? SubFlowCorrelations = null,
         List<TransitionItem>? SubFlowTransitionItems = null,
         InstanceInteractionOutput? Interaction = null);
 

--- a/src/BBT.Workflow.Domain/Instances/InstanceStateFingerprint.cs
+++ b/src/BBT.Workflow.Domain/Instances/InstanceStateFingerprint.cs
@@ -14,23 +14,57 @@ namespace BBT.Workflow.Instances;
 /// without a state or status change.</param>
 /// <param name="HasActiveSubFlow">True when an open SubFlow-type correlation exists. The state
 /// response is then built from a live subflow call, so it must not be served from cache.</param>
+/// <param name="CorrelationCount">Total child correlations, active and completed. The state response
+/// carries the full correlation set, so a newly started sub item must invalidate the cached body even
+/// when state and status are unchanged.</param>
+/// <param name="CompletedCorrelationCount">Completed child correlations. Moves when a sub item
+/// terminates and moves back when a completion is reverted — neither changes the total count.</param>
+/// <param name="LastCorrelationCompletedAt">Newest completion timestamp across child correlations,
+/// or null when none has completed. Distinguishes a revert-and-recomplete that leaves both counts at
+/// their original values.</param>
+/// <param name="LastSubFlowStateChangedAt">Newest sub-item state-change timestamp across child
+/// correlations, or null when none has reported a state. A sub item advancing its own state changes
+/// neither count.</param>
+/// <remarks>
+/// The four correlation members must be computed over the <em>full</em> correlation set — active and
+/// completed. See <see cref="FromInstance"/>: the aggregate's own collection is loaded with an
+/// active-only filtered include, so it must never be the source, or the full-build ETag would never
+/// match the one the projection query computes and the cache would invalidate on every poll.
+/// Each member is expressed so that LINQ-to-Objects and SQL agree exactly: <c>Count</c> maps to
+/// <c>COUNT</c>, and <c>Max</c> over a nullable projection ignores nulls and yields null for an
+/// all-null (or empty) set in both.
+/// </remarks>
 public sealed record InstanceStateFingerprint(
     Guid Id,
     string? Key,
     string? EffectiveState,
     InstanceStatus Status,
     string? FlowVersion,
-    bool HasActiveSubFlow)
+    bool HasActiveSubFlow,
+    int CorrelationCount,
+    int CompletedCorrelationCount,
+    DateTime? LastCorrelationCompletedAt,
+    DateTime? LastSubFlowStateChangedAt)
 {
     /// <summary>
     /// Builds the fingerprint from an already-loaded aggregate — the full-build path uses this
     /// so its ETag is computed from exactly the same values the projection query would return.
     /// </summary>
-    public static InstanceStateFingerprint FromInstance(Instance instance) =>
+    /// <param name="instance">The loaded instance aggregate.</param>
+    /// <param name="allCorrelations">The instance's child correlations, active <em>and</em> completed,
+    /// read separately. Required as an explicit argument precisely because
+    /// <c>instance.ChildCorrelations</c> is loaded active-only on the state path.</param>
+    public static InstanceStateFingerprint FromInstance(
+        Instance instance,
+        IReadOnlyCollection<InstanceCorrelation> allCorrelations) =>
         new(instance.Id,
             instance.Key,
             instance.EffectiveState,
             instance.Status,
             instance.FlowVersion,
-            instance.HasActiveSubFlow);
+            instance.HasActiveSubFlow,
+            allCorrelations.Count,
+            allCorrelations.Count(c => c.IsCompleted),
+            allCorrelations.Select(c => c.CompletedAt).Max(),
+            allCorrelations.Select(c => c.SubFlowStateChangedAt).Max());
 }

--- a/src/BBT.Workflow.Domain/Shared/HrefBase.cs
+++ b/src/BBT.Workflow.Domain/Shared/HrefBase.cs
@@ -96,7 +96,9 @@ public sealed class ViewHref : HrefBase
 }
 
 /// <summary>
-/// Active correlation with href link and additional properties
+/// Child correlation with href link and additional properties. Used for both the active-only
+/// <c>activeCorrelations</c> list and the full <c>correlations</c> list (active + completed);
+/// <see cref="IsCompleted"/> distinguishes the two within the full list.
 /// </summary>
 public sealed class ActiveCorrelationHref : HrefBase
 {
@@ -141,12 +143,35 @@ public sealed class ActiveCorrelationHref : HrefBase
     public bool IsCompleted { get; set; }
 
     /// <summary>
-    /// Status of the correlation (optional)
+    /// When the correlation was completed; null while it is still active.
+    /// </summary>
+    public DateTime? CompletedAt { get; set; }
+
+    /// <summary>
+    /// How the sub item terminated (Completed / Faulted / Canceled). Null while the correlation is
+    /// active, and also null for legacy rows completed before the outcome was recorded.
+    /// </summary>
+    public SubItemTerminalOutcome? TerminalOutcome { get; set; }
+
+    /// <summary>
+    /// When the correlation was created — the stable ordering key for the full correlation list.
+    /// </summary>
+    public DateTime CreatedAt { get; set; }
+
+    /// <summary>
+    /// Reserved for the sub item's instance status. Not populated today — use the sub item's own
+    /// state endpoint (see <see cref="HrefBase.Href"/>) when the live status is required.
     /// </summary>
     public InstanceStatus? Status { get; set; }
 
     /// <summary>
-    /// Current state of the correlation (optional)
+    /// Last known state of the sub item, tracked on the parent correlation so the parent does not
+    /// need a cross-domain query. Null until the sub item reports its first state change.
     /// </summary>
     public string? CurrentState { get; set; }
+
+    /// <summary>
+    /// When <see cref="CurrentState"/> was last updated.
+    /// </summary>
+    public DateTime? StateChangedAt { get; set; }
 }

--- a/src/BBT.Workflow.Infrastructure/Data/InstancesModelCreatingExtensions.cs
+++ b/src/BBT.Workflow.Infrastructure/Data/InstancesModelCreatingExtensions.cs
@@ -224,6 +224,12 @@ public static class InstancesModelCreatingExtensions
             b.HasIndex(new[] { nameof(InstanceCorrelation.ParentInstanceId) }, "IX_InstancesCorrelations_ActiveBlockingSubFlow")
                 .HasFilter("\"IsCompleted\" = false AND \"SubFlowType\" = 'S'");
 
+            // Unfiltered counterpart for the reads that must see completed rows too: GetByParentAsync
+            // (state-function correlation list, hierarchy tree, monitor) and the correlation aggregates
+            // in ProjectStateFingerprint. Neither partial index above can serve those — both exclude
+            // exactly the completed rows these reads are after.
+            b.HasIndex(new[] { nameof(InstanceCorrelation.ParentInstanceId) }, "IX_InstancesCorrelations_ByParent");
+
             // SubFlowInstanceId is 1-1 with the started SubFlow instance (subflow start is
             // unique per parent state). UNIQUE both enforces this invariant and gives the
             // hot SubFlow-completion lookup (FindBySubInstanceIdAsync) a direct B-tree probe.

--- a/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceRepository.cs
+++ b/src/BBT.Workflow.Infrastructure/Instances/EfCoreInstanceRepository.cs
@@ -373,6 +373,13 @@ public sealed class EfCoreInstanceRepository(
             .FirstOrDefaultAsync(cancellationToken);
     }
 
+    /// <remarks>
+    /// The correlation members deliberately run over the unfiltered <c>ChildCorrelations</c> set: the
+    /// state response carries the full correlation list, so completed rows must take part in cache
+    /// validation. They mirror <see cref="InstanceStateFingerprint.FromInstance"/> term for term —
+    /// the full-build path must produce a byte-identical fingerprint or the cache invalidates on every
+    /// poll. Served by IX_InstancesCorrelations_ByParent (unfiltered, on ParentInstanceId).
+    /// </remarks>
     private static IQueryable<InstanceStateFingerprint> ProjectStateFingerprint(IQueryable<Instance> query) =>
         query.Select(i => new InstanceStateFingerprint(
             i.Id,
@@ -380,7 +387,11 @@ public sealed class EfCoreInstanceRepository(
             i.EffectiveState,
             i.Status,
             i.FlowVersion,
-            i.ChildCorrelations.Any(c => !c.IsCompleted && c.SubFlowType == SubFlowType.SubFlow)));
+            i.ChildCorrelations.Any(c => !c.IsCompleted && c.SubFlowType == SubFlowType.SubFlow),
+            i.ChildCorrelations.Count,
+            i.ChildCorrelations.Count(c => c.IsCompleted),
+            i.ChildCorrelations.Select(c => c.CompletedAt).Max(),
+            i.ChildCorrelations.Select(c => c.SubFlowStateChangedAt).Max()));
 
     /// <inheritdoc />
     public async Task<InstanceDataFingerprint?> GetDataFingerprintAsync(

--- a/src/BBT.Workflow.Infrastructure/Migrations/20260731193117_InstanceCorrelationByParentIndex.Designer.cs
+++ b/src/BBT.Workflow.Infrastructure/Migrations/20260731193117_InstanceCorrelationByParentIndex.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using BBT.Workflow.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BBT.Workflow.Migrations
 {
     [DbContext(typeof(WorkflowDbContext))]
-    partial class WorkflowDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260731193117_InstanceCorrelationByParentIndex")]
+    partial class InstanceCorrelationByParentIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/BBT.Workflow.Infrastructure/Migrations/20260731193117_InstanceCorrelationByParentIndex.cs
+++ b/src/BBT.Workflow.Infrastructure/Migrations/20260731193117_InstanceCorrelationByParentIndex.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BBT.Workflow.Migrations
+{
+    /// <inheritdoc />
+    public partial class InstanceCorrelationByParentIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_InstancesCorrelations_ByParent",
+                schema: "public",
+                table: "InstancesCorrelations",
+                column: "ParentInstanceId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_InstancesCorrelations_ByParent",
+                schema: "public",
+                table: "InstancesCorrelations");
+        }
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/Instances/Caching/StateFunctionCacheTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/Caching/StateFunctionCacheTests.cs
@@ -232,6 +232,76 @@ public class StateFunctionCacheTests
         sut.ComputeEtag(input, fingerprint with { FlowVersion = "2.0.0" }).ShouldNotBe(baseline);
     }
 
+    /// <summary>
+    /// The response body carries the full correlation set, so every way that set can change must move the
+    /// ETag even though the instance's own state, status and flow version are untouched. Without this a
+    /// long-polling client would keep receiving 304 and never see a sub item start, finish or advance.
+    /// </summary>
+    [Fact]
+    public void ComputeEtag_ChangesWithEveryCorrelationSetMutation()
+    {
+        var sut = CreateSut();
+        var input = CreateInput();
+        var fingerprint = CreateFingerprint(
+            correlationCount: 2,
+            completedCorrelationCount: 1,
+            lastCorrelationCompletedAt: new DateTime(2026, 4, 5, 6, 7, 8, DateTimeKind.Utc),
+            lastSubFlowStateChangedAt: new DateTime(2026, 4, 5, 6, 7, 7, DateTimeKind.Utc));
+        var baseline = sut.ComputeEtag(input, fingerprint);
+
+        // A new sub item started.
+        sut.ComputeEtag(input, fingerprint with { CorrelationCount = 3 }).ShouldNotBe(baseline);
+        // A sub item terminated (or a completion was reverted) without changing the total.
+        sut.ComputeEtag(input, fingerprint with { CompletedCorrelationCount = 2 }).ShouldNotBe(baseline);
+        // Revert-then-recomplete leaves both counts as they were; the timestamp separates them.
+        sut.ComputeEtag(input, fingerprint with
+        {
+            LastCorrelationCompletedAt = new DateTime(2026, 4, 5, 6, 7, 9, DateTimeKind.Utc)
+        }).ShouldNotBe(baseline);
+        // A sub item advanced its own state — no count moves.
+        sut.ComputeEtag(input, fingerprint with
+        {
+            LastSubFlowStateChangedAt = new DateTime(2026, 4, 5, 6, 7, 10, DateTimeKind.Utc)
+        }).ShouldNotBe(baseline);
+    }
+
+    /// <summary>
+    /// The counterpart guarantee: an unchanged correlation set must reproduce the same ETag, so a quiet
+    /// instance keeps answering 304 instead of re-sending the body on every poll.
+    /// </summary>
+    [Fact]
+    public void ComputeEtag_IsStableForAnUnchangedCorrelationSet()
+    {
+        var sut = CreateSut();
+        var input = CreateInput();
+        var completedAt = new DateTime(2026, 4, 5, 6, 7, 8, DateTimeKind.Utc);
+
+        var first = sut.ComputeEtag(input, CreateFingerprint(
+            correlationCount: 2, completedCorrelationCount: 1, lastCorrelationCompletedAt: completedAt));
+        var second = sut.ComputeEtag(input, CreateFingerprint(
+            correlationCount: 2, completedCorrelationCount: 1, lastCorrelationCompletedAt: completedAt));
+
+        second.ShouldBe(first);
+    }
+
+    /// <summary>
+    /// Counts must not collapse into one another in the hash material: 2 total / 1 completed must never
+    /// hash the same as 1 total / 2 completed (a naive concatenation would let "21" collide with "12").
+    /// </summary>
+    [Fact]
+    public void ComputeEtag_DoesNotConflateCorrelationCounts()
+    {
+        var sut = CreateSut();
+        var input = CreateInput();
+
+        var twoOfOne = sut.ComputeEtag(input,
+            CreateFingerprint(correlationCount: 21, completedCorrelationCount: 1));
+        var oneOfTwo = sut.ComputeEtag(input,
+            CreateFingerprint(correlationCount: 2, completedCorrelationCount: 11));
+
+        oneOfTwo.ShouldNotBe(twoOfOne);
+    }
+
     [Fact]
     public void ComputeEtag_ChangesWithCallerScope()
     {
@@ -272,7 +342,15 @@ public class StateFunctionCacheTests
         subFlowBusy.ShouldNotBe(subFlowActive);
     }
 
-    private static InstanceStateFingerprint CreateFingerprint() =>
+    private static InstanceStateFingerprint CreateFingerprint(
+        int correlationCount = 0,
+        int completedCorrelationCount = 0,
+        DateTime? lastCorrelationCompletedAt = null,
+        DateTime? lastSubFlowStateChangedAt = null) =>
         new(Guid.Parse("11111111-1111-1111-1111-111111111111"), "test-key", "review",
-            InstanceStatus.Active, "1.0.0", HasActiveSubFlow: false);
+            InstanceStatus.Active, "1.0.0", HasActiveSubFlow: false,
+            CorrelationCount: correlationCount,
+            CompletedCorrelationCount: completedCorrelationCount,
+            LastCorrelationCompletedAt: lastCorrelationCompletedAt,
+            LastSubFlowStateChangedAt: lastSubFlowStateChangedAt);
 }

--- a/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceStateTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/InstanceQueryAppServiceStateTests.cs
@@ -44,6 +44,7 @@ public class InstanceQueryAppServiceStateTests : IDisposable
     private readonly IUrlTemplateBuilder _urlTemplateBuilder;
     private readonly IViewContentResolutionService _viewContentResolutionService;
     private readonly ITransitionAuthorizationManager _transitionAuthorizationManager;
+    private readonly IInstanceCorrelationRepository _instanceCorrelationRepository;
     private readonly Caching.IStateFunctionCache _stateFunctionCache;
     private readonly InstanceQueryAppService _service;
     private readonly IServiceProvider _ambientServiceProvider;
@@ -64,6 +65,7 @@ public class InstanceQueryAppServiceStateTests : IDisposable
         _urlTemplateBuilder = Substitute.For<IUrlTemplateBuilder>();
         _viewContentResolutionService = Substitute.For<IViewContentResolutionService>();
         _transitionAuthorizationManager = Substitute.For<ITransitionAuthorizationManager>();
+        _instanceCorrelationRepository = Substitute.For<IInstanceCorrelationRepository>();
         // Enabled defaults to false so existing tests exercise the full build path;
         // cache-specific tests opt in explicitly.
         _stateFunctionCache = Substitute.For<Caching.IStateFunctionCache>();
@@ -88,7 +90,7 @@ public class InstanceQueryAppServiceStateTests : IDisposable
             componentCacheStore: _componentCacheStore,
             instanceRepository: _instanceRepository,
             instanceTransitionRepository: Substitute.For<IInstanceTransitionRepository>(),
-            instanceCorrelationRepository: Substitute.For<IInstanceCorrelationRepository>(),
+            instanceCorrelationRepository: _instanceCorrelationRepository,
             instanceExtensionService: Substitute.For<IInstanceExtensionService>(),
             scriptContextFactory: Substitute.For<IScriptContextFactory>(),
             instanceQueryGateway: _instanceQueryGateway,
@@ -112,6 +114,87 @@ public class InstanceQueryAppServiceStateTests : IDisposable
     {
         AmbientServiceProvider.Current = _previousAmbientServiceProvider;
         (_ambientServiceProvider as IDisposable)?.Dispose();
+    }
+
+    /// <summary>
+    /// The full <c>correlations</c> list carries completed correlations with their terminal details,
+    /// while <c>activeCorrelations</c> keeps its active-only semantics — the compatibility contract for
+    /// clients already reading the active list.
+    /// </summary>
+    [Fact]
+    public async Task GetInstanceStateAsync_ReturnsCompletedCorrelations_WithoutWideningActiveCorrelations()
+    {
+        // Arrange — one still-active correlation (from the fixture) plus one that already faulted
+        var (instance, workflow) = CreateParentWithActiveSubFlow();
+        SetupCommonMocks(instance, workflow);
+        SetupSubFlowGateway(InstanceStatus.Active, "sub-review");
+
+        var activeCorrelation = instance.ChildCorrelations.Single();
+        var completedAt = new DateTime(2026, 6, 7, 8, 9, 10, DateTimeKind.Utc);
+        // Pinned older than the fixture's active correlation so the expected CreatedAt order is explicit.
+        var completedCorrelation = CreateCorrelation(
+            instance.Id, "earlier-sub-flow", SubItemTerminalOutcome.Faulted, completedAt, "child-error",
+            createdAt: activeCorrelation.CreatedAt.AddMinutes(-5));
+        SetupFullCorrelations(instance.Id, [completedCorrelation, activeCorrelation]);
+
+        // Act
+        var result = await _service.GetInstanceStateAsync(
+            CreateInput(instance.Id.ToString()), CancellationToken.None);
+
+        // Assert
+        result.Result.IsSuccess.ShouldBeTrue();
+        var output = result.Result.Value!;
+
+        output.ActiveCorrelations.Select(c => c.CorrelationId)
+            .ShouldBe([activeCorrelation.Id]);
+
+        output.Correlations.Select(c => c.CorrelationId)
+            .ShouldBe([completedCorrelation.Id, activeCorrelation.Id]);
+
+        var completedEntry = output.Correlations.Single(c => c.CorrelationId == completedCorrelation.Id);
+        completedEntry.IsCompleted.ShouldBeTrue();
+        completedEntry.CompletedAt.ShouldBe(completedAt);
+        completedEntry.TerminalOutcome.ShouldBe(SubItemTerminalOutcome.Faulted);
+        completedEntry.CurrentState.ShouldBe("child-error");
+        completedEntry.StateChangedAt.ShouldNotBeNull();
+        completedEntry.SubFlowName.ShouldBe("earlier-sub-flow");
+        completedEntry.Href.ShouldBe("https://data-url");
+
+        var activeEntry = output.Correlations.Single(c => c.CorrelationId == activeCorrelation.Id);
+        activeEntry.IsCompleted.ShouldBeFalse();
+        activeEntry.CompletedAt.ShouldBeNull();
+        activeEntry.TerminalOutcome.ShouldBeNull();
+    }
+
+    /// <summary>
+    /// The full list is ordered by creation time ascending regardless of the order the read returns,
+    /// so a client can replay sub items in the order the parent started them.
+    /// </summary>
+    [Fact]
+    public async Task GetInstanceStateAsync_OrdersCorrelationsByCreatedAtAscending()
+    {
+        // Arrange — supplied newest-first to prove the service re-orders
+        var (instance, workflow) = CreateParentWithActiveSubFlow();
+        SetupCommonMocks(instance, workflow);
+        SetupSubFlowGateway(InstanceStatus.Active, "sub-review");
+
+        var newest = CreateCorrelation(instance.Id, "third", SubItemTerminalOutcome.Completed,
+            createdAt: new DateTime(2026, 1, 3, 0, 0, 0, DateTimeKind.Utc));
+        var middle = CreateCorrelation(instance.Id, "second", SubItemTerminalOutcome.Completed,
+            createdAt: new DateTime(2026, 1, 2, 0, 0, 0, DateTimeKind.Utc));
+        var oldest = CreateCorrelation(instance.Id, "first", SubItemTerminalOutcome.Completed,
+            createdAt: new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        SetupFullCorrelations(instance.Id, [newest, middle, oldest]);
+
+        // Act
+        var result = await _service.GetInstanceStateAsync(
+            CreateInput(instance.Id.ToString()), CancellationToken.None);
+
+        // Assert
+        result.Result.IsSuccess.ShouldBeTrue();
+        result.Result.Value!.Correlations.Select(c => c.SubFlowName)
+            .ShouldBe(["first", "second", "third"]);
     }
 
     /// <summary>
@@ -1056,7 +1139,9 @@ public class InstanceQueryAppServiceStateTests : IDisposable
         _instanceRepository
             .GetStateFingerprintAsync(instance.Id.ToString(), Arg.Any<CancellationToken>())
             .Returns(new InstanceStateFingerprint(instance.Id, "test-key", TestState, InstanceStatus.Busy,
-                TestVersion, HasActiveSubFlow: true));
+                TestVersion, HasActiveSubFlow: true,
+                CorrelationCount: 1, CompletedCorrelationCount: 0,
+                LastCorrelationCompletedAt: null, LastSubFlowStateChangedAt: null));
 
         // Act
         var result = await _service.GetInstanceStateAsync(CreateInput(instance.Id.ToString()), CancellationToken.None);
@@ -1114,7 +1199,9 @@ public class InstanceQueryAppServiceStateTests : IDisposable
         _instanceRepository
             .GetStateFingerprintAsync(instanceId.ToString(), Arg.Any<CancellationToken>())
             .Returns(new InstanceStateFingerprint(instanceId, "test-key", TestState, InstanceStatus.Active,
-                TestVersion, HasActiveSubFlow: false));
+                TestVersion, HasActiveSubFlow: false,
+                CorrelationCount: 0, CompletedCorrelationCount: 0,
+                LastCorrelationCompletedAt: null, LastSubFlowStateChangedAt: null));
 
     private void SetupCachedEntry(out Caching.StateFunctionCacheEntry entry, string etag = "etag-current")
     {
@@ -1233,6 +1320,11 @@ public class InstanceQueryAppServiceStateTests : IDisposable
 
         _representationEtagService.Generate(Arg.Any<object>()).Returns((string?)null);
 
+        // Full correlation set for the `correlations` response list and the fingerprint. Defaults to
+        // the aggregate's own (active) correlations so tests that do not care about completed rows
+        // see a consistent picture; SetupFullCorrelations overrides it.
+        SetupFullCorrelations(instance.Id, [.. instance.ChildCorrelations]);
+
         // Default: queryRoles visibility allowed (specific tests override to false to assert 403).
         _transitionAuthorizationManager
             .IsQueryAllowedAsync(
@@ -1243,6 +1335,59 @@ public class InstanceQueryAppServiceStateTests : IDisposable
                 Arg.Any<CancellationToken>())
             .Returns(true);
     }
+
+    /// <summary>
+    /// Stubs the dedicated full-correlation read (active + completed) the state path performs, since the
+    /// aggregate's own collection is loaded active-only in production.
+    /// </summary>
+    private void SetupFullCorrelations(Guid instanceId, List<InstanceCorrelation> correlations) =>
+        _instanceCorrelationRepository
+            .GetByParentAsync(instanceId, Arg.Any<CancellationToken>())
+            .Returns(correlations);
+
+    /// <summary>
+    /// Builds a correlation for <paramref name="parentInstanceId"/>, optionally already terminated.
+    /// </summary>
+    private static InstanceCorrelation CreateCorrelation(
+        Guid parentInstanceId,
+        string subFlowName,
+        SubItemTerminalOutcome? outcome = null,
+        DateTime? completedAt = null,
+        string? subFlowCurrentState = null,
+        DateTime? createdAt = null)
+    {
+        var correlation = InstanceCorrelation.Create(
+            id: Guid.NewGuid(),
+            instanceId: parentInstanceId,
+            parentState: TestState,
+            subFlowInstanceId: Guid.NewGuid(),
+            subFlowType: "S",
+            subFlowDomain: "sub-domain",
+            subFlowName: subFlowName,
+            subFlowVersion: "1.0.0");
+
+        if (subFlowCurrentState is not null)
+            correlation.UpdateSubFlowState(subFlowCurrentState, new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc));
+
+        if (outcome is not null)
+            correlation.ApplyTerminalOutcome(outcome.Value,
+                completedAt ?? new DateTime(2026, 1, 2, 3, 4, 6, DateTimeKind.Utc));
+
+        if (createdAt is not null)
+            PinCreatedAt(correlation, createdAt.Value);
+
+        return correlation;
+    }
+
+    /// <summary>
+    /// Pins a correlation's <c>CreatedAt</c>. The audit base exposes only a protected setter (production
+    /// stamps it on save), so ordering assertions have to reach it reflectively.
+    /// </summary>
+    private static void PinCreatedAt(InstanceCorrelation correlation, DateTime createdAt) =>
+        typeof(InstanceCorrelation)
+            .GetProperty(nameof(InstanceCorrelation.CreatedAt))!
+            .GetSetMethod(nonPublic: true)!
+            .Invoke(correlation, [createdAt]);
 
     private void SetupSubFlowGateway(InstanceStatus subFlowStatus, string subFlowState,
         InstanceInteractionOutput? interaction = null)

--- a/test/BBT.Workflow.Infrastructure.Tests/Domains/Instances/InstanceStateFingerprintQueryTests.cs
+++ b/test/BBT.Workflow.Infrastructure.Tests/Domains/Instances/InstanceStateFingerprintQueryTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using BBT.Aether.MultiSchema;
@@ -115,6 +116,113 @@ public sealed class InstanceStateFingerprintQueryTests : IAsyncLifetime
 
         fingerprint.ShouldNotBeNull();
         fingerprint!.HasActiveSubFlow.ShouldBeFalse();
+    }
+
+    /// <summary>
+    /// The correlation aggregates must count the full set — active and completed — and must translate to
+    /// SQL (COUNT / COUNT-with-predicate / MAX over nullable timestamp columns).
+    /// </summary>
+    [Fact]
+    public async Task ProjectsCorrelationAggregatesOverActiveAndCompletedRows()
+    {
+        var instance = Instance.Create(Guid.NewGuid(), Flow, FlowVersion, "fp-correlation-aggregates");
+        instance.SetEffectiveState("review");
+
+        var completedAt = new DateTime(2026, 3, 4, 5, 6, 7, DateTimeKind.Utc);
+        var stateChangedAt = new DateTime(2026, 3, 4, 5, 6, 6, DateTimeKind.Utc);
+
+        var completed = CreateCorrelation(instance.Id, subFlowType: "S");
+        completed.ApplyTerminalOutcome(SubItemTerminalOutcome.Completed, completedAt);
+        instance.AddCorrelation(completed);
+
+        var active = CreateCorrelation(instance.Id, subFlowType: "S");
+        active.UpdateSubFlowState("sub-review", stateChangedAt);
+        instance.AddCorrelation(active);
+
+        await SeedAsync(instance);
+
+        await using var ctx = CreateContext();
+        var fingerprint = await QueryAsync(ctx, instance.Id.ToString());
+
+        fingerprint.ShouldNotBeNull();
+        fingerprint!.CorrelationCount.ShouldBe(2);
+        fingerprint.CompletedCorrelationCount.ShouldBe(1);
+        fingerprint.LastCorrelationCompletedAt.ShouldBe(completedAt);
+        fingerprint.LastSubFlowStateChangedAt.ShouldBe(stateChangedAt);
+    }
+
+    /// <summary>
+    /// No correlations at all must yield zero counts and null timestamps — SQL <c>MAX</c> over an empty
+    /// set and LINQ-to-Objects <c>Max</c> over a nullable sequence must agree on null rather than one
+    /// throwing or returning a default.
+    /// </summary>
+    [Fact]
+    public async Task WithoutCorrelations_ProjectsZeroCountsAndNullTimestamps()
+    {
+        var instance = Instance.Create(Guid.NewGuid(), Flow, FlowVersion, "fp-no-correlations");
+        instance.SetEffectiveState("review");
+        await SeedAsync(instance);
+
+        await using var ctx = CreateContext();
+        var fingerprint = await QueryAsync(ctx, instance.Id.ToString());
+
+        fingerprint.ShouldNotBeNull();
+        fingerprint!.CorrelationCount.ShouldBe(0);
+        fingerprint.CompletedCorrelationCount.ShouldBe(0);
+        fingerprint.LastCorrelationCompletedAt.ShouldBeNull();
+        fingerprint.LastSubFlowStateChangedAt.ShouldBeNull();
+    }
+
+    /// <summary>
+    /// Regression guard for endless cache invalidation. The long-poll fast path builds the fingerprint
+    /// from the projection query while the full-build path builds it from the loaded aggregate plus the
+    /// separately-read correlation list. If the two disagree on a single member, the ETag computed on the
+    /// full path never matches the one the fast path validates against and every poll re-builds.
+    /// Runs with a mixed correlation set (active, completed, state-advanced) to exercise every member.
+    /// </summary>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ProjectionAndFromInstance_ProduceIdenticalFingerprints(bool withCorrelations)
+    {
+        var instance = Instance.Create(Guid.NewGuid(), Flow, FlowVersion, $"fp-parity-{withCorrelations}");
+        instance.SetEffectiveState("review");
+
+        if (withCorrelations)
+        {
+            var completed = CreateCorrelation(instance.Id, subFlowType: "S");
+            completed.ApplyTerminalOutcome(
+                SubItemTerminalOutcome.Faulted, new DateTime(2026, 5, 6, 7, 8, 9, DateTimeKind.Utc));
+            instance.AddCorrelation(completed);
+
+            var advanced = CreateCorrelation(instance.Id, subFlowType: "P");
+            advanced.UpdateSubFlowState("child-state", new DateTime(2026, 5, 6, 7, 8, 10, DateTimeKind.Utc));
+            instance.AddCorrelation(advanced);
+
+            instance.AddCorrelation(CreateCorrelation(instance.Id, subFlowType: "S"));
+        }
+
+        await SeedAsync(instance);
+
+        await using var ctx = CreateContext();
+        var projected = await QueryAsync(ctx, instance.Id.ToString());
+
+        // Mirror the production full-build path: aggregate loaded with the active-only filtered include,
+        // full correlation set read separately.
+        var loaded = await ctx.Instances
+            .AsNoTracking()
+            .Include(i => i.DataList)
+            .Include(i => i.ChildCorrelations.Where(c => !c.IsCompleted))
+            .FirstAsync(i => i.Id == instance.Id);
+        var allCorrelations = await ctx.Set<InstanceCorrelation>()
+            .AsNoTracking()
+            .Where(c => c.ParentInstanceId == instance.Id)
+            .ToListAsync();
+
+        var fromInstance = InstanceStateFingerprint.FromInstance(loaded, allCorrelations);
+
+        projected.ShouldNotBeNull();
+        fromInstance.ShouldBe(projected);
     }
 
     [Fact]

--- a/vnext-meta/features.json
+++ b/vnext-meta/features.json
@@ -24,6 +24,14 @@
         "POST {domain}/workflows/{workflow}/instances/{instance}/longpoll/ack"
       ]
     },
+    "stateCorrelationHistory": {
+      "since": "0.0.77",
+      "status": "stable",
+      "description": "The State (long-poll) function returns the full child-correlation set, not just the open ones. The existing activeCorrelations field keeps its active-only semantics, and a new correlations field carries every correlation — active and completed — ordered by createdAt ascending. Each entry adds isCompleted, completedAt, terminalOutcome (completed/faulted/canceled), currentState and stateChangedAt, so a client workflow manager can reconstruct which sub items ran and how each one ended without extra queries. Both lists merge the active subflow's corresponding list when the parent is inside a subflow. The completed rows come from a dedicated read because the instance aggregate is loaded with an active-only filtered include; correlation-set changes (a sub item starting, terminating, being reverted, or advancing its own state) now participate in the state fingerprint ETag, so a long-polling client is no longer served 304 while the set changes underneath it.",
+      "apiEndpoints": [
+        "GET {domain}/workflows/{workflow}/instances/{instance}/functions/state"
+      ]
+    },
     "stateNotification": {
       "since": "0.0.63",
       "status": "stable",


### PR DESCRIPTION
## Why

The State (long-poll) function only exposed **open** child correlations. The client workflow manager needs the closed ones too — to know which sub items ran and how each one ended — and that information was simply absent from the response.

## What changed

### Response shape

| Field | Contents |
| --- | --- |
| `activeCorrelations` | **Unchanged** — open correlations only. Existing clients are unaffected. |
| `correlations` (new) | Full set, active **and** completed, `createdAt` ascending. Each entry adds `isCompleted`, `completedAt`, `terminalOutcome` (`completed`/`faulted`/`canceled`), `currentState`, `stateChangedAt`, `createdAt`. |

Both lists merge the active subflow's corresponding list, so a nested chain stays consistent. `terminalOutcome` serializes as a camelCase string and round-trips through the subflow gateway (same `JsonSerializerConstants.JsonOptions` on both ends).

### Why not just widen the include

`WithDetailsAsync()` loads `ChildCorrelations` with a filtered include (`!IsCompleted`). Widening it would have broken two things:

- The partial covering index `IX_InstancesCorrelations_ActiveByParent_Covering` (`HasFilter("IsCompleted = false")`) is tuned to match that include exactly and serves the transition hot path as an index-only scan.
- `Instance.ActiveCorrelations` / `Subflow` / `HasActiveSubFlow`, `TransitionSettlement` and `InstanceBusyManager` all depend on that set being genuinely active.

So completed rows come from a dedicated `IInstanceCorrelationRepository.GetByParentAsync` read (already used by the hierarchy and monitor paths — no new repository method), and **the active-subflow detection path is left untouched**. Ordering is applied in the app service rather than changing the shared method's `ORDER BY`, which those other consumers depend on.

One consequence, documented in the DTO and the contract doc: under concurrent completion the active subset of `correlations` can be a moment fresher than `activeCorrelations`.

### ETag correctness (the subtle part)

`InstanceStateFingerprint` previously derived only `HasActiveSubFlow` from correlations. A correlation closing without a state/status change would leave the ETag unmoved and a long-polling client would receive 304 forever, never seeing the updated list. Four members now participate:

`CorrelationCount` · `CompletedCorrelationCount` · `LastCorrelationCompletedAt` · `LastSubFlowStateChangedAt`

Each covers a distinct mutation: a sub item starting, terminating (or a revert), a revert-then-recomplete that restores both counts, and a sub item advancing its own state.

> **Reviewer note — the trap this guards.** The fast path fingerprints via a projection query; the full-build path uses `FromInstance`. If the two disagree on one member, the full-path ETag never matches the one the fast path validates and **every poll rebuilds the response**. `Count`/`Max` are used because they translate term-for-term between SQL and LINQ-to-Objects (a coalesced-timestamp expression does not — null semantics differ), and relying on audit `ModifiedAt` would have been unverified. `FromInstance` now *requires* the full correlation list as an argument and the single-arg overload is gone, so passing the active-only include is no longer expressible. A parity test asserts the two are byte-identical against real Postgres.

### Index

Neither existing index on `ParentInstanceId` is usable here — both are partial on `IsCompleted = false`, excluding exactly the rows these reads want. Adds `IX_InstancesCorrelations_ByParent` (unfiltered) + migration `20260731193117`. The two partial indexes are untouched.

The migration was generated with `dotnet ef` by temporarily adding the Design package (no project referenced it), then reverting the csproj. It contains only the index; the snapshot diff is 3 lines plus an incidental `ProductVersion` annotation bump (10.0.4 → 10.0.10, the tooling's runtime).

### Performance

The extra query runs **only on the full-build path** (cache miss / ETag mismatch). The long-poll fast path adds no round trip — just scalar subqueries on the projection it already issues.

## Verification

| Suite | Branch | Master | Delta |
| --- | --- | --- | --- |
| `Application.Tests` (full) | 26 F / 918 P | 26 F / 913 P | identical failure **names**; +5 = the 5 new tests |
| `Domain.Tests` (correlation/instance) | 35 F / 91 P | 35 F / 91 P | identical names, zero regressions |
| `Infrastructure.Tests` (correlation + fingerprint) | 7 F / 14 P | 7 F / 10 P | same 7 failures; +4 = the 4 new cases |

Baselines were measured on a `master` worktree, not assumed. All pre-existing failures are unrelated: the `Application`/`Domain` ones are the known `AmbientServiceProvider` parallel-collection leakage; the 7 `Infrastructure` ones are a `BackgroundJobInfo.Payload` JsonElement→jsonb mapping error reproduced identically on `master`.

New tests: completed-vs-active list separation with terminal details, `createdAt` ordering, ETag moves on every correlation mutation, ETag stable for an unchanged set, counts not conflated in the hash material, SQL translation of the new aggregates, empty-set null handling, and the projection-vs-`FromInstance` parity theory (real Postgres via Testcontainers).

**Not run:** the end-to-end Docker scenario and `EXPLAIN ANALYZE` index confirmation — both need the full infrastructure stack up. Worth doing before merge if you want the index plan confirmed on real data volumes.

## Docs / meta

- `docs/runtime/state-function-cache-and-etag.md` — new fingerprint columns, ETag material, and the two-build-paths-must-agree invariant.
- `docs/contracts/api-and-service-contracts.md` — a table telling clients which correlation list to use.
- `vnext-meta/features.json` — `engine.stateCorrelationHistory`, `since: 0.0.77`.

Deliberately **not** touched: `docs/monitoring/endpoints/vnext-monitor-api-reference.md` and the subflow tutorial. Both document different DTOs (monitor API, plain instance GET) that this change does not affect.

Running the meta validator surfaced pre-existing drift that is **not** addressed here, since each is a release-management call: `common.props` 0.0.26 vs `package.json` 0.0.53 vs `runtimeVersion` 0.0.61 vs manifest tip 0.0.76, an empty `component-registry.json`, and no `features.json` entries for 0.0.65–0.0.76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Expose full child correlation history in the instance state response while keeping existing active-only semantics and ensure cache/ETag correctness based on correlation changes.

New Features:
- Add a full `correlations` list to the state function response including active and completed child correlations with terminal details and creation-time ordering.
- Extend correlation DTOs to carry completion timestamps, terminal outcomes, creation time, and last known sub-item state metadata.

Enhancements:
- Refine instance state building to fetch and merge full correlation sets, reusing active-only correlations for behavior that depends on live subflows.
- Update `InstanceStateFingerprint` and its EF projection to include correlation-count and timestamp aggregates so cache ETags track correlation set changes.
- Centralize correlation href construction for both active-only and full correlation lists.
- Add an unfiltered index on `ParentInstanceId` to efficiently serve full correlation and fingerprint queries over active and completed correlations.

Documentation:
- Update runtime caching/ETag documentation to describe correlation aggregates and their role in fingerprinting.
- Extend API/service contract docs for the state endpoint to document `activeCorrelations` vs full `correlations` usage.

Tests:
- Add application tests covering separation of active vs full correlation lists and ordering by creation time.
- Add infrastructure tests validating correlation aggregates in the fingerprint projection, empty-set handling, and parity between projection- and instance-based fingerprints.
- Extend cache tests to assert ETag changes for all correlation mutations, stability for unchanged sets, and non-conflation of correlation counts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * State responses now include both active and completed child-correlation history, ordered by creation time.
  * Correlation details include completion status, outcomes, creation times, and state-change timestamps.
  * Nested subflow responses now include the complete correlation history.

* **Bug Fixes**
  * Conditional responses now refresh correctly when correlation data changes.
  * Improved state lookups for instances with completed correlations.

* **Documentation**
  * Documented correlation history, freshness behavior, and caching updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->