### PR TITLE
feat: view SDI/MDI display modes and function verb/schema/view contract

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,8 @@ describe the stable mental model, boundaries, failure modes, and change-safety r
 11. Read [Instance Filtering and Queries](runtime/instance-filtering-and-queries.md) before writing instance queries in mapping scripts (fluent `InstanceQuery`, operator reference, `GetInstancesTask` vs `DaprServiceTask`, migration from hand-written GraphQL filters).
 12. Read [GetInstance Task](runtime/get-instance-task.md) when a mapping needs a single instance's metadata **and** data in one call (task type `18`, local/remote response parity).
 13. Read [Script Related Instance Access](runtime/script-related-instance-access.md) before using or changing `context.Related` in mapping scripts (parent/correlation reads, unfiltered `x-roles` behavior, internal endpoint security posture).
+14. Read [View Display Modes](domain/view-display-modes.md) before changing a view's `display` declaration or how clients present views (SDI / MDI shapes, response `modes` contract).
+15. Read [Function Handler Architecture](domain/function-handler-architecture.md) § Custom Function Contract before declaring function `verbs` / input-output schemas and views, or changing verb enforcement.
 
 ## Documentation Rules
 

--- a/docs/contracts/api-and-service-contracts.md
+++ b/docs/contracts/api-and-service-contracts.md
@@ -32,6 +32,31 @@ contracts. Remote services call public runtime APIs rather than internal reposit
 | `GET /{domain}/workflows/{workflow}/instances/{instance}/functions/view` | Backend-driven view selection. |
 | `GET /{domain}/workflows/{workflow}/instances/{instance}/functions/schema` | Transition-aware schema. |
 | `POST /{domain}/workflows/{workflow}/instances/{instance}/transitions/{transition}` | Runs a transition sync or async. |
+| `GET /{domain}/functions` | Lists domain function definitions, including `verbs[]` and input/output schema and view references. |
+| `GET\|POST\|PATCH\|DELETE /{domain}/functions/{function}` | Invokes a custom domain function. `GET /{function}` invokes — it is not a metadata route. |
+| `GET\|POST\|PATCH\|DELETE /{domain}/workflows/{workflow}/instances/{instance}/functions/{function}` | Invokes a custom instance function. |
+
+### Custom function verbs and payload validation
+
+A custom function may declare `verbs[]` and an `inputSchema`. Both are opt-in — a function that
+declares neither accepts every routed verb and any body, which is the pre-existing behavior.
+
+| Condition | Response |
+| --- | --- |
+| Verb not in declared `verbs[]` | `405 Method Not Allowed` with an `Allow` header listing the declared verbs. |
+| Body present and fails `inputSchema` | `400` with field-level validation errors (same shape as transition schema validation). |
+| `outputSchema` | Never enforced; declarative contract for clients only. |
+
+The HTTP `QUERY` method is **not supported** — declaring it is a component validation error and no
+route accepts it. Surrounding tooling (Swagger/OpenAPI, gateways, client SDKs) does not handle an
+unrecognised method yet; model body-carrying reads as `POST`. See
+[Function Handler Architecture](../domain/function-handler-architecture.md) § Custom Function Contract.
+
+### View response: display modes
+
+The view response keeps `display` as the SDI (single-document) string and adds a `modes` object
+carrying `{ sdi, mdi }`. Clients predating MDI support keep reading `display` unchanged. See
+[View Display Modes](../domain/view-display-modes.md).
 
 ### State response: correlation lists
 

--- a/docs/domain/function-handler-architecture.md
+++ b/docs/domain/function-handler-architecture.md
@@ -36,6 +36,74 @@ Application services own domain behavior and result construction.
 | `hierarchy` | `HierarchyFunctionHandler` | Returns instance hierarchy. |
 | `humanTask` | `HumanTaskFunctionHandler` | Returns human task state for clients. |
 
+## Custom Function Contract (verbs, schemas, views)
+
+A custom function declares the contract its clients need in order to call it. Every part is
+optional, and a function that declares nothing behaves exactly as it did before this existed.
+
+| Attribute | Purpose |
+| --- | --- |
+| `verbs[]` | HTTP verbs the function accepts: `GET`, `POST`, `PATCH`, `DELETE`. Empty/absent means no restriction. |
+| `inputSchema` | `sys-schemas` reference describing the request body. Enforced at runtime. |
+| `outputSchema` | `sys-schemas` reference describing the response body. Declarative only. |
+| `inputView` | `sys-views` reference the client renders to collect input. |
+| `outputView` | `sys-views` reference the client renders to present output. |
+
+```jsonc
+"attributes": {
+  "scope": "D",
+  "verbs": ["POST"],
+  "inputSchema":  { "key": "search-request",  "domain": "core", "flow": "sys-schemas", "version": "1.0.0" },
+  "outputSchema": { "key": "search-response", "domain": "core", "flow": "sys-schemas", "version": "1.0.0" },
+  "inputView":    { "key": "search-form",     "domain": "core", "flow": "sys-views",   "version": "1.0.0" },
+  "task": { }
+}
+```
+
+### The QUERY verb (deferred, not supported)
+
+The HTTP `QUERY` method — a safe, idempotent read that carries a request body — is **deliberately
+not supported**. Declaring it is a component validation error and no route accepts it.
+
+.NET 10 does know the method at the HTTP layer (`HttpMethods.Query`, `HttpMethods.IsQuery`), and
+MVC's `HttpMethodAttribute` extension point makes routing it a few lines of work. The blocker is
+the surrounding ecosystem, not the runtime: Swagger/OpenAPI generation, gateways, WAFs and client
+SDKs do not handle an unrecognised method, so enabling it breaks tooling well before it buys
+anything. Revisit when that support lands.
+
+Until then, model body-carrying reads as `POST`.
+
+### Enforcement
+
+Both gates run inside `FunctionAppService.ExecuteFunctionAsync`, after scope enforcement and
+authorization and before any task executes. System functions (`state`, `view`, `data`, …) never
+reach this path — they are served by their own handlers — so they are unaffected.
+
+| Condition | Result |
+| --- | --- |
+| `verbs[]` empty or absent | Every routed verb accepted. |
+| Verb declared and matched | Request proceeds. |
+| Verb declared and not matched | `405 Method Not Allowed` + `Allow` header listing declared verbs. |
+| `inputSchema` absent | Body not validated. |
+| `inputSchema` set, no body (e.g. `GET`) | Body not validated. |
+| `inputSchema` set, body present | Validated via `IJsonSchemaValidator`; failure → `400` with field-level errors. |
+
+Comparison is case-insensitive and verbs are normalized to upper case, so `"post"` and `"POST"`
+are equivalent. `outputSchema` is never validated at runtime.
+
+Component validation rejects an unknown verb, a reference pointing at the wrong flow, and an
+`inputSchema` declared alongside verbs that can never carry a body (e.g. `verbs: ["GET"]` only),
+since the schema would be silently dead.
+
+### Discovery
+
+There is no dedicated contract endpoint. `GET {domain}/functions` already returns each function's
+full component definition, including `verbs[]` and the four reference fields, so a client reads the
+contract from the definition it already has and resolves the referenced schema/view components the
+same way it resolves any other reference.
+
+Note that `GET {domain}/functions/{function}` **invokes** the function — it is not a metadata route.
+
 ## State Alias (Role-Based State Visibility)
 
 A state may declare an `alias` array so the same internal state is presented under

--- a/docs/domain/view-display-modes.md
+++ b/docs/domain/view-display-modes.md
@@ -1,0 +1,90 @@
+# View Display Modes (SDI / MDI)
+
+## Purpose
+
+A view tells the client *how* it should be presented, not just what to render. Historically that
+was a single `display` string describing a single-document presentation — full page, popup,
+drawer. Client renderers also support a multi-document interface, where several documents are
+open side by side, and that layout needs its own answer: does this view open as a tab, a floating
+window, or a split pane?
+
+`display` therefore accepts a per-mode declaration while keeping the original string form working
+unchanged.
+
+## Authoring
+
+Both shapes are valid on `attributes.display` of a `sys-views` component.
+
+```jsonc
+"display": "popup"                          // legacy - means sdi: "popup"
+"display": { "sdi": "popup", "mdi": "tab" } // both modes
+"display": { "mdi": "window" }              // MDI only
+```
+
+At least one of `sdi` / `mdi` must carry a value; an empty object is rejected by component
+validation.
+
+### Vocabulary
+
+| Mode | Values |
+| --- | --- |
+| `sdi` | `full-page`, `popup`, `bottom-sheet`, `top-sheet`, `drawer`, `inline` |
+| `mdi` | `tab`, `window`, `split`, `inline` |
+
+The JSON schema constrains these values. The **runtime** does not: like `renderer`, the values are
+a documented vocabulary (`ViewDisplayMode.Sdi.*` / `ViewDisplayMode.Mdi.*`) and any non-blank
+string is accepted, so a domain can pilot a new value without a runtime release.
+
+## Runtime model
+
+`View.DisplayModes` (`ViewDisplay`) is the parsed declaration. Two accessors sit on top:
+
+| Member | Meaning |
+| --- | --- |
+| `View.Display` | The SDI value, or empty string. This is what every pre-existing call site reads. |
+| `View.MdiDisplay` | The MDI value, or null. |
+| `View.DisplayModes` | Both, or null when no display is declared. |
+
+`ViewDisplayJsonConverter` handles both input shapes, mirroring `ViewDefinitionJsonConverter`'s
+approach to the `view` / `views` back-compat pair. Writing mirrors the authored shape: an SDI-only
+declaration is written back as a bare string, anything declaring `mdi` as an object — so component
+JSON round-trips without churn.
+
+## Response contract
+
+The view response keeps `display` as the SDI string and adds `modes`:
+
+```jsonc
+{
+  "key": "customer-form",
+  "type": "Json",
+  "display": "popup",                       // SDI value; empty when only mdi is declared
+  "modes": { "sdi": "popup", "mdi": "tab" }, // null when no display is declared
+  "renderer": "pseudo-ui",
+  "content": { }
+}
+```
+
+Clients predating MDI support keep reading `display` and are unaffected. Clients that render both
+modes read `modes` and pick the value for the interface they are in.
+
+This applies to both resolution paths — local (`IComponentCacheStore`) and remote (another
+domain's instance read) — and to the function contract endpoint, which embeds the same view shape.
+
+## Monitoring
+
+The component summary projects `display` from either shape, reading `sdi` out of the object form,
+so the existing monitor display filter keeps matching regardless of how a view was authored.
+
+## Change safety
+
+- Adding `mdi` to an existing view is additive: `display` in the response is unchanged.
+- Moving a view to `mdi`-only empties the response `display` field — check consumers first.
+- Component validation requires at least one mode; it does not check membership in the vocabulary.
+
+## References
+
+- `src/BBT.Workflow.Domain/Definitions/Views/View.cs`
+- `src/BBT.Workflow.Domain/Definitions/Views/ViewDisplay.cs`, `ViewDisplayJsonConverter.cs`, `ViewEnums.cs`
+- `src/BBT.Workflow.Application/Instances/ViewContentResolutionService.cs`
+- `vnext-schema/schemas/view-definition.schema.json`

--- a/monitoring/BBT.Workflow.Monitor.Application/Components/MonitorComponentQueryService.cs
+++ b/monitoring/BBT.Workflow.Monitor.Application/Components/MonitorComponentQueryService.cs
@@ -558,7 +558,7 @@ public sealed class MonitorComponentQueryService(
                      : (JsonElement?)null;
 
         string? scope    = el.TryGetProperty("scope",    out var scopeEl)    && scopeEl.ValueKind    == JsonValueKind.String ? scopeEl.GetString()    : null;
-        string? display  = el.TryGetProperty("display",  out var displayEl)  && displayEl.ValueKind  == JsonValueKind.String ? displayEl.GetString()  : null;
+        string? display  = ExtractSdiDisplay(el);
         string? renderer = el.TryGetProperty("renderer", out var rendererEl) && rendererEl.ValueKind == JsonValueKind.String ? rendererEl.GetString() : null;
         string? name     = el.TryGetProperty("name",     out var nameEl)     && nameEl.ValueKind     == JsonValueKind.String ? nameEl.GetString()     : null;
         return new MonitorComponentSummaryItem
@@ -577,6 +577,25 @@ public sealed class MonitorComponentQueryService(
             Name        = componentType == MonitorComponentTypes.Mappings ? name : null,
             CreatedAt   = createdAt,
             ModifiedAt  = modifiedAt
+        };
+    }
+
+    /// <summary>
+    /// Reads the view's SDI display value. Views author <c>display</c> either as a bare string
+    /// (legacy, SDI-only) or as <c>{ "sdi": "...", "mdi": "..." }</c>; both shapes project to the
+    /// same summary field so existing display filters keep matching.
+    /// </summary>
+    private static string? ExtractSdiDisplay(JsonElement el)
+    {
+        if (!el.TryGetProperty("display", out var displayEl))
+            return null;
+
+        return displayEl.ValueKind switch
+        {
+            JsonValueKind.String => displayEl.GetString(),
+            JsonValueKind.Object when displayEl.TryGetProperty("sdi", out var sdiEl)
+                                      && sdiEl.ValueKind == JsonValueKind.String => sdiEl.GetString(),
+            _ => null
         };
     }
 

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs
@@ -83,7 +83,7 @@ public sealed class FunctionController(
 
         var result = await functionAppService.GetFunctionByInstanceAsync(
             function, workflow, domain, instance,
-            requestContext.Headers, requestContext.QueryParameters, null, cancellationToken);
+            requestContext.Headers, requestContext.QueryParameters, null, HttpContext.Request.Method, cancellationToken);
 
         return FunctionResponseActionResultMapper.ToActionResult(result, HttpContext);
     }
@@ -148,7 +148,7 @@ public sealed class FunctionController(
 
         var result = await functionAppService.GetFunctionByInstanceAsync(
             function, workflow, domain, instance,
-            requestContext.Headers, requestContext.QueryParameters, body, cancellationToken);
+            requestContext.Headers, requestContext.QueryParameters, body, HttpContext.Request.Method, cancellationToken);
 
         return FunctionResponseActionResultMapper.ToActionResult(result, HttpContext);
     }

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionResponseActionResultMapper.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionResponseActionResultMapper.cs
@@ -14,7 +14,7 @@ internal static class FunctionResponseActionResultMapper
         HttpContext httpContext)
     {
         if (!result.IsSuccess)
-            return result.ToActionResult(httpContext);
+            return MapFailure(result, httpContext);
 
         var output = result.Value!;
         ResponseOutputWriter.ApplyHeaders(output.Headers, httpContext);
@@ -28,6 +28,33 @@ internal static class FunctionResponseActionResultMapper
             StatusCode = output.StatusCode ?? StatusCodes.Status200OK,
             ContentType = ResponseOutputWriter.ResolveContentType(output.Headers),
             Content = SerializeContent(output.Data)
+        };
+    }
+
+    /// <summary>
+    /// Maps a failed function result to an action result. A rejected HTTP verb is the one failure the
+    /// generic Aether mapping cannot express: it must surface as 405 with an <c>Allow</c> header listing
+    /// the verbs the function declares. The allowed verbs travel in <c>Error.Target</c>.
+    /// </summary>
+    private static IActionResult MapFailure(
+        Result<FunctionResponseOutput> result,
+        HttpContext httpContext)
+    {
+        if (result.Error.Code != WorkflowErrorCodes.FunctionVerbNotAllowed)
+            return result.ToActionResult(httpContext);
+
+        if (!string.IsNullOrWhiteSpace(result.Error.Target))
+            httpContext.Response.Headers.Allow = result.Error.Target;
+
+        return new ObjectResult(new ProblemDetails
+        {
+            Status = StatusCodes.Status405MethodNotAllowed,
+            Title = "Method Not Allowed",
+            Detail = result.Error.Message,
+            Type = result.Error.Code
+        })
+        {
+            StatusCode = StatusCodes.Status405MethodNotAllowed
         };
     }
 

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/DefaultDomainFunctionHandler.cs
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/Handlers/DefaultDomainFunctionHandler.cs
@@ -22,6 +22,7 @@ public sealed class DefaultDomainFunctionHandler(
             request.Headers,
             request.QueryParameters,
             request.Body,
+            request.HttpContext.Request.Method,
             cancellationToken);
 
         return FunctionResponseActionResultMapper.ToActionResult(result, request.HttpContext);

--- a/src/BBT.Workflow.Application/Definitions/Validators/FunctionComponentValidator.cs
+++ b/src/BBT.Workflow.Application/Definitions/Validators/FunctionComponentValidator.cs
@@ -46,12 +46,83 @@ public sealed class FunctionComponentValidator : IComponentValidator
                 result.AddError("Function scope is required.", $"{nameof(Function)}.{nameof(Function.Scope)}");
             }
 
+            ValidateVerbs(function, result);
+            ValidateContractReferences(function, result);
+
             return result;
         }
         catch (JsonException ex)
         {
             result.AddError($"Invalid JSON format for function: {ex.Message}", nameof(Function));
             return result;
+        }
+    }
+
+    /// <summary>
+    /// Validates declared HTTP verbs. An empty list is valid and means "no restriction", so only the
+    /// contents of a non-empty declaration are checked.
+    /// </summary>
+    private static void ValidateVerbs(Function function, ComponentValidationResult result)
+    {
+        const string member = $"{nameof(Function)}.{nameof(Function.Verbs)}";
+
+        foreach (var verb in function.Verbs.Where(v => !FunctionVerb.IsKnown(v)))
+        {
+            result.AddError(
+                $"Function verb '{verb}' is not supported. Supported verbs: {string.Join(", ", FunctionVerb.All)}.",
+                member);
+        }
+
+        // An input schema describes the request body, so a function that only ever answers bodyless
+        // verbs can never apply it - the declaration would be silently dead.
+        if (function.InputSchema is not null &&
+            function.Verbs.Count > 0 &&
+            function.Verbs.All(v => !FunctionVerb.CarriesBody(v)))
+        {
+            result.AddError(
+                $"Function declares inputSchema but none of its verbs ({string.Join(", ", function.Verbs)}) " +
+                "carry a request body, so the schema would never be applied. Declare a body-carrying " +
+                $"verb ({FunctionVerb.Post}, {FunctionVerb.Patch} or {FunctionVerb.Delete}) or remove inputSchema.",
+                $"{nameof(Function)}.{nameof(Function.InputSchema)}");
+        }
+    }
+
+    /// <summary>
+    /// Validates that contract references point at the component type they are meant to describe.
+    /// </summary>
+    private static void ValidateContractReferences(Function function, ComponentValidationResult result)
+    {
+        ValidateReferenceFlow(function.InputSchema, RuntimeSysSchemaInfo.Schemas, nameof(Function.InputSchema), result);
+        ValidateReferenceFlow(function.OutputSchema, RuntimeSysSchemaInfo.Schemas, nameof(Function.OutputSchema), result);
+        ValidateReferenceFlow(function.InputView, RuntimeSysSchemaInfo.Views, nameof(Function.InputView), result);
+        ValidateReferenceFlow(function.OutputView, RuntimeSysSchemaInfo.Views, nameof(Function.OutputView), result);
+    }
+
+    private static void ValidateReferenceFlow(
+        Reference? reference,
+        string expectedFlow,
+        string propertyName,
+        ComponentValidationResult result)
+    {
+        if (reference is null)
+            return;
+
+        var member = $"{nameof(Function)}.{propertyName}";
+
+        if (string.IsNullOrWhiteSpace(reference.Key))
+            result.AddError($"Function {propertyName} reference requires a key.", member);
+
+        if (string.IsNullOrWhiteSpace(reference.Domain))
+            result.AddError($"Function {propertyName} reference requires a domain.", member);
+
+        if (string.IsNullOrWhiteSpace(reference.Version))
+            result.AddError($"Function {propertyName} reference requires a version.", member);
+
+        if (!string.Equals(reference.Flow, expectedFlow, StringComparison.OrdinalIgnoreCase))
+        {
+            result.AddError(
+                $"Function {propertyName} must reference the '{expectedFlow}' flow but references '{reference.Flow}'.",
+                member);
         }
     }
 }

--- a/src/BBT.Workflow.Application/Definitions/Validators/ViewComponentValidator.cs
+++ b/src/BBT.Workflow.Application/Definitions/Validators/ViewComponentValidator.cs
@@ -32,10 +32,13 @@ public sealed class ViewComponentValidator : IComponentValidator
                 result.AddError("View type is required.", $"{nameof(View)}.{nameof(View.Type)}");
             }
 
-            // Validate display
-            if (string.IsNullOrWhiteSpace(view.Display))
+            // Validate display - accepts the legacy string form (SDI) or the { sdi, mdi } object form,
+            // but at least one mode must declare a value.
+            if (view.DisplayModes is null || view.DisplayModes.IsEmpty)
             {
-                result.AddError("View display is required.", $"{nameof(View)}.{nameof(View.Display)}");
+                result.AddError(
+                    "View display is required (at least one of sdi/mdi).",
+                    $"{nameof(View)}.{nameof(View.DisplayModes)}");
             }
 
             if (!string.IsNullOrEmpty(view.Renderer) && view.Type != ViewType.Json)

--- a/src/BBT.Workflow.Application/Functions/FunctionAppService.cs
+++ b/src/BBT.Workflow.Application/Functions/FunctionAppService.cs
@@ -9,6 +9,7 @@ using BBT.Aether.Users;
 using BBT.Workflow.Authorization;
 using BBT.Workflow.Caching;
 using BBT.Workflow.Definitions;
+using BBT.Workflow.Functions.Validation;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Logging;
 using BBT.Workflow.Runtime;
@@ -37,7 +38,9 @@ public sealed class FunctionAppService(
     ITransitionAuthorizationManager transitionAuthorizationManager,
     IDynamicExpressoValueEvaluator keyEvaluator,
     IStateStoreCacheGateway cacheGateway,
-    IRemoteInvokerService remoteInvoker) : ApplicationService(serviceProvider), IFunctionAppService
+    IRemoteInvokerService remoteInvoker,
+    IFunctionRequestValidationService functionRequestValidationService)
+    : ApplicationService(serviceProvider), IFunctionAppService
 {
     /// <inheritdoc />
     public async Task<Result<FunctionResponseOutput>> GetFunctionByKeyAsync(
@@ -47,6 +50,7 @@ public sealed class FunctionAppService(
         Dictionary<string, string?>? headers = null,
         Dictionary<string, string?>? queryParameters = null,
         JsonElement? body = null,
+        string? httpMethod = null,
         CancellationToken cancellationToken = default)
     {
         runtimeInfoProvider.Check(domain);
@@ -55,7 +59,7 @@ public sealed class FunctionAppService(
             return await componentCacheStore
                 .GetFunctionAsync(domain, key, version, cancellationToken)
                 .BindAsync(function =>
-                    ExecuteFunctionAsync(function, null, null, headers, queryParameters, body, cancellationToken));
+                    ExecuteFunctionAsync(function, null, null, headers, queryParameters, body, httpMethod, cancellationToken));
         }
     }
 
@@ -68,6 +72,7 @@ public sealed class FunctionAppService(
         Dictionary<string, string?>? headers = null,
         Dictionary<string, string?>? queryParameters = null,
         JsonElement? body = null,
+        string? httpMethod = null,
         CancellationToken cancellationToken = default)
     {
         runtimeInfoProvider.Check(domain);
@@ -87,7 +92,7 @@ public sealed class FunctionAppService(
             return await componentCacheStore
                 .GetFlowAsync(domain, flow, instance.FlowVersion, cancellationToken)
                 .BindAsync(workflow =>
-                    ResolveFunctionAndExecuteAsync(domain, key, instance, workflow, headers, queryParameters, body, cancellationToken));
+                    ResolveFunctionAndExecuteAsync(domain, key, instance, workflow, headers, queryParameters, body, httpMethod, cancellationToken));
         }
     }
 
@@ -116,13 +121,14 @@ public sealed class FunctionAppService(
         Dictionary<string, string?>? headers,
         Dictionary<string, string?>? queryParameters,
         JsonElement? body,
+        string? httpMethod,
         CancellationToken cancellationToken)
     {
         var functionReference = workflow.FindFunction(key);
         return componentCacheStore
             .GetFunctionAsync(domain, key, functionReference?.Version, cancellationToken)
             .BindAsync(function =>
-                ExecuteFunctionAsync(function, instance, workflow, headers, queryParameters, body, cancellationToken));
+                ExecuteFunctionAsync(function, instance, workflow, headers, queryParameters, body, httpMethod, cancellationToken));
     }
 
     /// <summary>
@@ -135,6 +141,7 @@ public sealed class FunctionAppService(
         Dictionary<string, string?>? headers,
         Dictionary<string, string?>? queryParameters,
         JsonElement? body,
+        string? httpMethod,
         CancellationToken cancellationToken)
     {
         // Scope enforcement. Domain is exempt; Instance/Flow require an instance;
@@ -166,6 +173,22 @@ public sealed class FunctionAppService(
             if (!allowed)
                 return Result<FunctionResponseOutput>.Fail(WorkflowErrors.FunctionAccessDenied(function.Key));
         }
+
+        // Contract enforcement. Both gates are opt-in: a function that declares no verbs accepts every
+        // verb, and one that declares no input schema accepts any body - so definitions authored before
+        // contract declaration behave exactly as before. Runs after authorization so an unauthorized
+        // caller learns nothing about the function's shape.
+        if (!function.SupportsVerb(httpMethod))
+        {
+            Logger.FunctionVerbRejected(function.Key, httpMethod!, string.Join(", ", function.Verbs));
+            return Result<FunctionResponseOutput>.Fail(
+                WorkflowErrors.FunctionVerbNotAllowed(function.Key, httpMethod!, function.Verbs));
+        }
+
+        var inputValidation = await functionRequestValidationService.ValidateRequestAsync(
+            function, body, headers, cancellationToken);
+        if (!inputValidation.IsSuccess)
+            return Result<FunctionResponseOutput>.Fail(inputValidation.Error);
 
         object scriptBody = body.HasValue
             ? (object)body.Value

--- a/src/BBT.Workflow.Application/Functions/IFunctionAppService.cs
+++ b/src/BBT.Workflow.Application/Functions/IFunctionAppService.cs
@@ -18,6 +18,7 @@ public interface IFunctionAppService : IApplicationService
     /// <param name="version">Request Version</param>
     /// <param name="headers">Request Headers</param>
     /// <param name="queryParameters">Request Query Params</param>
+    /// <param name="httpMethod">Request HTTP method, checked against the function's declared verbs. Null skips the check.</param>
     /// <param name="cancellationToken">Cancellation Token</param>
     Task<Result<FunctionResponseOutput>> GetFunctionByKeyAsync(
         string key,
@@ -26,6 +27,7 @@ public interface IFunctionAppService : IApplicationService
         Dictionary<string, string?>? headers = null,
         Dictionary<string, string?>? queryParameters = null,
         JsonElement? body = null,
+        string? httpMethod = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -37,6 +39,7 @@ public interface IFunctionAppService : IApplicationService
     /// <param name="instance">Instance Identifier</param>
     /// <param name="headers">Request Headers</param>
     /// <param name="queryParameters">Request Query Params</param>
+    /// <param name="httpMethod">Request HTTP method, checked against the function's declared verbs. Null skips the check.</param>
     /// <param name="cancellationToken">Cancellation Token</param>
     Task<Result<FunctionResponseOutput>> GetFunctionByInstanceAsync(
         string key,
@@ -46,6 +49,7 @@ public interface IFunctionAppService : IApplicationService
         Dictionary<string, string?>? headers = null,
         Dictionary<string, string?>? queryParameters = null,
         JsonElement? body = null,
+        string? httpMethod = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/BBT.Workflow.Application/Functions/Validation/FunctionRequestValidationService.cs
+++ b/src/BBT.Workflow.Application/Functions/Validation/FunctionRequestValidationService.cs
@@ -1,0 +1,60 @@
+using System.Text.Json;
+using BBT.Aether.Results;
+using BBT.Workflow.Caching;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Logging;
+using BBT.Workflow.Shared;
+using BBT.Workflow.Validation;
+using Microsoft.Extensions.Logging;
+
+namespace BBT.Workflow.Functions.Validation;
+
+/// <summary>
+/// Validates function request bodies against the function's declared input schema.
+/// Mirrors the transition-level schema gate (<c>TransitionValidationService</c>) and reuses the same
+/// collaborators, so functions and transitions report schema violations identically.
+/// </summary>
+public sealed class FunctionRequestValidationService(
+    IJsonSchemaValidator schemaValidator,
+    IComponentCacheStore componentCacheStore,
+    ILogger<FunctionRequestValidationService> logger) : IFunctionRequestValidationService
+{
+    /// <inheritdoc />
+    public async Task<Result> ValidateRequestAsync(
+        Function function,
+        JsonElement? body,
+        IReadOnlyDictionary<string, string?>? headers = null,
+        CancellationToken cancellationToken = default)
+    {
+        // Guard: no declared input contract - behave exactly as before contract declaration existed.
+        if (function.InputSchema is null)
+            return Result.Ok();
+
+        // Guard: no body to validate. Bodyless verbs (GET) and empty payloads are not the schema's concern;
+        // a function that must receive a body should declare it required in the schema of a body-carrying verb.
+        if (!body.HasValue || body.Value.ValueKind is JsonValueKind.Undefined or JsonValueKind.Null)
+            return Result.Ok();
+
+        var schemaResult = await componentCacheStore.GetSchemaAsync(function.InputSchema, cancellationToken);
+        if (!schemaResult.IsSuccess)
+            return Result.Fail(schemaResult.Error);
+
+        var validationResult = schemaValidator.Validate(
+            schemaResult.Value!.Schema,
+            body,
+            CreateSchemaValidationOptions(headers));
+
+        if (!validationResult.IsSuccess)
+            logger.FunctionInputSchemaValidationFailed(function.Key, function.InputSchema.Key);
+
+        return validationResult;
+    }
+
+    private static SchemaValidationOptions CreateSchemaValidationOptions(IReadOnlyDictionary<string, string?>? headers)
+    {
+        return new SchemaValidationOptions(
+            Culture: LanguageResolver.ResolveCulture(headers),
+            IncludeVocabularyDetails: true,
+            CustomValidationEnabled: true);
+    }
+}

--- a/src/BBT.Workflow.Application/Functions/Validation/IFunctionRequestValidationService.cs
+++ b/src/BBT.Workflow.Application/Functions/Validation/IFunctionRequestValidationService.cs
@@ -1,0 +1,26 @@
+using System.Text.Json;
+using BBT.Aether.Results;
+using BBT.Workflow.Definitions;
+
+namespace BBT.Workflow.Functions.Validation;
+
+/// <summary>
+/// Validates an incoming function request against the contract the function declares.
+/// </summary>
+public interface IFunctionRequestValidationService
+{
+    /// <summary>
+    /// Validates the request body against the function's declared <c>inputSchema</c>.
+    /// Returns success when the function declares no input schema or the request carries no body,
+    /// so functions authored before contract declaration keep their current behaviour.
+    /// </summary>
+    /// <param name="function">The resolved function definition.</param>
+    /// <param name="body">The request body, if any.</param>
+    /// <param name="headers">Request headers, used to resolve the validation culture.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<Result> ValidateRequestAsync(
+        Function function,
+        JsonElement? body,
+        IReadOnlyDictionary<string, string?>? headers = null,
+        CancellationToken cancellationToken = default);
+}

--- a/src/BBT.Workflow.Application/Instances/DTOs/GetViewOutput.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/GetViewOutput.cs
@@ -21,9 +21,15 @@ public sealed class GetViewOutput
     public string Type { get; set; }
 
     /// <summary>
-    /// Display mode
+    /// Display mode for SDI (single-document interface) clients. Preserved for clients predating
+    /// MDI support; equivalent to <c>Modes.Sdi</c>. Empty when the view only declares an MDI display.
     /// </summary>
     public string Display { get; set; }
+
+    /// <summary>
+    /// Per-client-mode display declaration. Null when the view declares no display.
+    /// </summary>
+    public ViewDisplayModesDto? Modes { get; set; }
 
     /// <summary>
     /// Localization label

--- a/src/BBT.Workflow.Application/Instances/DTOs/ViewDisplayModesDto.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/ViewDisplayModesDto.cs
@@ -1,0 +1,19 @@
+namespace BBT.Workflow.Instances;
+
+/// <summary>
+/// Per-client-mode display declaration returned alongside a view.
+/// </summary>
+public sealed class ViewDisplayModesDto
+{
+    /// <summary>
+    /// Display value for SDI (single-document interface) clients, e.g. <c>full-page</c>, <c>popup</c>.
+    /// Null when the view only declares an MDI display.
+    /// </summary>
+    public string? Sdi { get; set; }
+
+    /// <summary>
+    /// Display value for MDI (multi-document interface) clients, e.g. <c>tab</c>, <c>window</c>.
+    /// Null when the view declares no MDI presentation.
+    /// </summary>
+    public string? Mdi { get; set; }
+}

--- a/src/BBT.Workflow.Application/Instances/DTOs/ViewInstanceAttributesDto.cs
+++ b/src/BBT.Workflow.Application/Instances/DTOs/ViewInstanceAttributesDto.cs
@@ -22,10 +22,12 @@ public sealed class ViewInstanceAttributesDto
     public ViewType? Type { get; set; }
 
     /// <summary>
-    /// Display mode.
+    /// Per-client-mode display declaration. Accepts both the legacy string form (SDI-only) and the
+    /// object form via <see cref="ViewDisplayJsonConverter"/>.
     /// </summary>
     [JsonPropertyName("display")]
-    public string? Display { get; set; }
+    [JsonConverter(typeof(ViewDisplayJsonConverter))]
+    public ViewDisplay? Display { get; set; }
 
     /// <summary>
     /// Localization label.

--- a/src/BBT.Workflow.Application/Instances/ViewContentResolutionService.cs
+++ b/src/BBT.Workflow.Application/Instances/ViewContentResolutionService.cs
@@ -106,6 +106,7 @@ public sealed class ViewContentResolutionService(
             Content = content,
             Type = view.Type.ToString(),
             Display = view.Display,
+            Modes = MapDisplayModes(view.DisplayModes),
             Label = string.Empty,
             Renderer = view.Renderer
         };
@@ -128,9 +129,26 @@ public sealed class ViewContentResolutionService(
             Key = instanceOutput.Key ?? viewKey,
             Content = contentTyped,
             Type = viewType.ToString(),
-            Display = attrs?.Display ?? string.Empty,
+            Display = attrs?.Display?.Sdi ?? string.Empty,
+            Modes = MapDisplayModes(attrs?.Display),
             Label = attrs?.Label ?? string.Empty,
             Renderer = attrs?.Renderer
+        };
+    }
+
+    /// <summary>
+    /// Maps the domain display declaration to its response DTO. Returns null when the view declares
+    /// no display, so the field is omitted rather than emitted as an empty object.
+    /// </summary>
+    private static ViewDisplayModesDto? MapDisplayModes(ViewDisplay? display)
+    {
+        if (display is null || display.IsEmpty)
+            return null;
+
+        return new ViewDisplayModesDto
+        {
+            Sdi = display.Sdi,
+            Mdi = display.Mdi
         };
     }
 

--- a/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
@@ -17,6 +17,7 @@ using BBT.Workflow.Authorization;
 using BBT.Workflow.BackgroundJobs;
 using BBT.Workflow.Events;
 using BBT.Workflow.Functions;
+using BBT.Workflow.Functions.Validation;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
@@ -83,6 +84,7 @@ public static class WorkflowApplicationModuleServiceCollectionExtensions
         services.AddScoped<IViewContentResolutionService, ViewContentResolutionService>();
         services.AddScoped<IInstanceRetryAppService, InstanceRetryAppService>();
         services.AddScoped<IStateStoreCacheGateway, StateStoreCacheGateway>();
+        services.AddScoped<IFunctionRequestValidationService, FunctionRequestValidationService>();
         services.AddScoped<IFunctionAppService, FunctionAppService>();
         services.AddScoped<IEventAppService, EventAppService>();
         services.AddScoped<IInstanceSelectorResolver, InstanceSelectorResolver>();

--- a/src/BBT.Workflow.Domain/Definitions/Functions/Function.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Functions/Function.cs
@@ -23,7 +23,12 @@ public sealed class Function : IDomainEntity, IFunctionReference, IReferenceSett
         ScriptCode? output = null,
         List<RoleGrant>? roles = null,
         bool rawResponse = false,
-        FunctionCache? cache = null
+        FunctionCache? cache = null,
+        List<string>? verbs = null,
+        Reference? inputSchema = null,
+        Reference? outputSchema = null,
+        Reference? inputView = null,
+        Reference? outputView = null
     ) : this()
     {
         Scope = scope;
@@ -33,6 +38,11 @@ public sealed class Function : IDomainEntity, IFunctionReference, IReferenceSett
         this.roles = roles ?? [];
         RawResponse = rawResponse;
         Cache = cache;
+        this.verbs = NormalizeVerbs(verbs);
+        InputSchema = inputSchema;
+        OutputSchema = outputSchema;
+        InputView = inputView;
+        OutputView = outputView;
     }
 
     /// <summary>
@@ -91,6 +101,45 @@ public sealed class Function : IDomainEntity, IFunctionReference, IReferenceSett
     [JsonInclude] [JsonPropertyName("cache")]
     public FunctionCache? Cache { get; private set; }
 
+    [JsonInclude] [JsonPropertyName("verbs")]
+    private List<string> verbs = [];
+
+    /// <summary>
+    /// HTTP verbs this function supports, normalized to upper case.
+    /// Empty means no verb restriction is applied, preserving the behaviour of definitions authored
+    /// before verb declaration existed. Well-known values are defined in <see cref="FunctionVerb"/>.
+    /// </summary>
+    [JsonIgnore]
+    public IReadOnlyCollection<string> Verbs => verbs.AsReadOnly();
+
+    /// <summary>
+    /// Optional reference to the <c>sys-schemas</c> component describing this function's request body.
+    /// When set, the runtime validates the request body against it before executing any task.
+    /// </summary>
+    [JsonInclude] [JsonPropertyName("inputSchema")]
+    public Reference? InputSchema { get; private set; }
+
+    /// <summary>
+    /// Optional reference to the <c>sys-schemas</c> component describing this function's response body.
+    /// Declarative only - the runtime does not validate responses against it.
+    /// </summary>
+    [JsonInclude] [JsonPropertyName("outputSchema")]
+    public Reference? OutputSchema { get; private set; }
+
+    /// <summary>
+    /// Optional reference to the <c>sys-views</c> component the client renders to collect this
+    /// function's input.
+    /// </summary>
+    [JsonInclude] [JsonPropertyName("inputView")]
+    public Reference? InputView { get; private set; }
+
+    /// <summary>
+    /// Optional reference to the <c>sys-views</c> component the client renders to present this
+    /// function's output.
+    /// </summary>
+    [JsonInclude] [JsonPropertyName("outputView")]
+    public Reference? OutputView { get; private set; }
+
     [JsonInclude] [JsonPropertyName("roles")]
     private List<RoleGrant> roles = new();
 
@@ -120,6 +169,36 @@ public sealed class Function : IDomainEntity, IFunctionReference, IReferenceSett
 
     public List<OnExecuteTask> GetExecuteTasks() =>
         onExecutionTasks.Count > 0 ? onExecutionTasks : [Task!];
+
+    /// <summary>
+    /// True when this function accepts the given HTTP verb. A function that declares no verbs
+    /// accepts every verb, so existing definitions keep their current behaviour.
+    /// </summary>
+    /// <param name="httpMethod">The incoming HTTP method. A null or blank value is treated as unrestricted.</param>
+    public bool SupportsVerb(string? httpMethod)
+    {
+        if (verbs.Count == 0 || string.IsNullOrWhiteSpace(httpMethod))
+            return true;
+
+        var normalized = FunctionVerb.Normalize(httpMethod);
+        return verbs.Contains(normalized, StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Trims, upper-cases and de-duplicates authored verbs so comparison and the <c>Allow</c> header
+    /// are stable regardless of how the component JSON was written.
+    /// </summary>
+    private static List<string> NormalizeVerbs(List<string>? authored)
+    {
+        if (authored is null || authored.Count == 0)
+            return [];
+
+        return authored
+            .Where(v => !string.IsNullOrWhiteSpace(v))
+            .Select(FunctionVerb.Normalize)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+    }
 
     public void SetReference(IReference reference)
     {

--- a/src/BBT.Workflow.Domain/Definitions/Functions/FunctionVerb.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Functions/FunctionVerb.cs
@@ -1,0 +1,61 @@
+namespace BBT.Workflow.Definitions;
+
+/// <summary>
+/// HTTP verbs a <see cref="Function"/> can declare support for.
+/// A function that declares no verbs accepts every verb the runtime routes, preserving the
+/// behaviour of definitions authored before verb declaration existed.
+/// </summary>
+public static class FunctionVerb
+{
+    /// <summary>
+    /// Read without a request body.
+    /// </summary>
+    public const string Get = "GET";
+
+    /// <summary>
+    /// Create or invoke with a request body.
+    /// </summary>
+    public const string Post = "POST";
+
+    /// <summary>
+    /// Partial update with a request body.
+    /// </summary>
+    public const string Patch = "PATCH";
+
+    /// <summary>
+    /// Delete.
+    /// </summary>
+    public const string Delete = "DELETE";
+
+    // The HTTP QUERY method (a safe, idempotent read carrying a request body) is deliberately not
+    // supported yet: the surrounding tooling - Swagger/OpenAPI generation, gateways, client SDKs -
+    // does not handle an unrecognised method. Revisit once that ecosystem catches up.
+
+    /// <summary>
+    /// Every verb the runtime recognises, in declaration order.
+    /// </summary>
+    public static readonly IReadOnlyList<string> All = [Get, Post, Patch, Delete];
+
+    /// <summary>
+    /// True when <paramref name="verb"/> is a recognised verb, ignoring case and surrounding space.
+    /// </summary>
+    public static bool IsKnown(string? verb)
+    {
+        if (string.IsNullOrWhiteSpace(verb))
+            return false;
+
+        var normalized = Normalize(verb);
+        return All.Any(v => string.Equals(v, normalized, StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Normalizes a verb for comparison: trimmed and upper-cased.
+    /// </summary>
+    public static string Normalize(string verb) => verb.Trim().ToUpperInvariant();
+
+    /// <summary>
+    /// True when the verb carries a request body the runtime can validate against an input schema.
+    /// </summary>
+    public static bool CarriesBody(string? verb) =>
+        Normalize(verb ?? string.Empty) is Post or Patch or Delete;
+}

--- a/src/BBT.Workflow.Domain/Definitions/Views/View.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Views/View.cs
@@ -21,13 +21,13 @@ public sealed class View : IDomainEntity, IViewReference, IReferenceSetter
     private View(
         ViewType type,
         object content,
-        string display,
+        ViewDisplay? display,
         LanguageLabel[]? labels,
         string? renderer) : this()
     {
         Type = type;
         Content = content;
-        Display = display;
+        this.display = display;
         Labels = labels ?? [];
         Renderer = renderer;
     }
@@ -67,11 +67,33 @@ public sealed class View : IDomainEntity, IViewReference, IReferenceSetter
     /// </summary>
     public object Content { get; private set; } = string.Empty;
     
+    [JsonInclude]
+    [JsonPropertyName("display")]
+    [JsonConverter(typeof(ViewDisplayJsonConverter))]
+    private ViewDisplay? display;
+
     /// <summary>
-    /// Display
+    /// Per-client-mode display declaration. Authored either as a bare string (legacy, SDI-only) or as
+    /// <c>{ "sdi": "...", "mdi": "..." }</c>. Null when the view declares no display.
     /// </summary>
-    public string Display { get; private set; } = string.Empty;
-    
+    [JsonIgnore]
+    public ViewDisplay? DisplayModes => display;
+
+    /// <summary>
+    /// SDI (single-document interface) display value. This is what the legacy string-form
+    /// <c>display</c> declaration maps to, and what clients predating MDI support consume.
+    /// Empty when the view only declares an MDI display.
+    /// </summary>
+    [JsonIgnore]
+    public string Display => display?.Sdi ?? string.Empty;
+
+    /// <summary>
+    /// MDI (multi-document interface) display value. Null when the view declares no MDI presentation.
+    /// </summary>
+    [JsonIgnore]
+    public string? MdiDisplay => display?.Mdi;
+
+
     /// <summary>
     /// Localization labels
     /// </summary>

--- a/src/BBT.Workflow.Domain/Definitions/Views/ViewDisplay.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Views/ViewDisplay.cs
@@ -1,0 +1,54 @@
+using System.Text.Json.Serialization;
+
+namespace BBT.Workflow.Definitions;
+
+/// <summary>
+/// Per-client-mode display declaration for a <see cref="View"/>.
+/// A view may declare a display hint for SDI (single-document interface) clients,
+/// for MDI (multi-document interface) clients, or both.
+/// </summary>
+/// <remarks>
+/// In component JSON this is authored either as a bare string (legacy shape, interpreted as
+/// <see cref="Sdi"/>) or as an object <c>{ "sdi": "...", "mdi": "..." }</c>.
+/// <see cref="ViewDisplayJsonConverter"/> handles both shapes.
+/// Well-known values are listed in <see cref="ViewDisplayMode"/>.
+/// </remarks>
+public sealed class ViewDisplay
+{
+    /// <summary>
+    /// Creates a display declaration.
+    /// </summary>
+    /// <param name="sdi">Display hint for SDI clients. Well-known values in <see cref="ViewDisplayMode.Sdi"/>.</param>
+    /// <param name="mdi">Display hint for MDI clients. Well-known values in <see cref="ViewDisplayMode.Mdi"/>.</param>
+    [JsonConstructor]
+    public ViewDisplay(string? sdi, string? mdi)
+    {
+        Sdi = sdi;
+        Mdi = mdi;
+    }
+
+    /// <summary>
+    /// Display hint for SDI (single-document interface) clients, e.g. <c>full-page</c>, <c>popup</c>.
+    /// This is the value legacy string-form <c>display</c> declarations map to.
+    /// </summary>
+    [JsonPropertyName("sdi")]
+    public string? Sdi { get; }
+
+    /// <summary>
+    /// Display hint for MDI (multi-document interface) clients, e.g. <c>tab</c>, <c>window</c>.
+    /// Null when the view does not declare an MDI presentation.
+    /// </summary>
+    [JsonPropertyName("mdi")]
+    public string? Mdi { get; }
+
+    /// <summary>
+    /// True when neither mode declares a display hint.
+    /// </summary>
+    [JsonIgnore]
+    public bool IsEmpty => string.IsNullOrWhiteSpace(Sdi) && string.IsNullOrWhiteSpace(Mdi);
+
+    /// <summary>
+    /// Creates a declaration from a legacy string display value, which is always an SDI hint.
+    /// </summary>
+    public static ViewDisplay FromSdi(string? sdi) => new(sdi, null);
+}

--- a/src/BBT.Workflow.Domain/Definitions/Views/ViewDisplayJsonConverter.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Views/ViewDisplayJsonConverter.cs
@@ -1,0 +1,92 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace BBT.Workflow.Definitions;
+
+/// <summary>
+/// Custom JSON converter for <see cref="ViewDisplay"/> that supports both the legacy string format
+/// (<c>"display": "popup"</c>, interpreted as an SDI hint) and the object format
+/// (<c>"display": { "sdi": "popup", "mdi": "tab" }</c>).
+/// This ensures backward compatibility with existing view components.
+/// </summary>
+/// <remarks>
+/// Writing mirrors the authored shape: a declaration carrying only an SDI hint is written back as a
+/// bare string so component JSON round-trips unchanged; anything declaring an MDI hint is written as
+/// an object.
+/// </remarks>
+public sealed class ViewDisplayJsonConverter : JsonConverter<ViewDisplay>
+{
+    /// <inheritdoc />
+    public override ViewDisplay? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        // Handle null
+        if (reader.TokenType == JsonTokenType.Null)
+            return null;
+
+        // Handle legacy string format - the value is an SDI display hint
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            var display = reader.GetString();
+            return string.IsNullOrWhiteSpace(display) ? null : ViewDisplay.FromSdi(display);
+        }
+
+        // Handle object format - explicit per-mode declaration
+        if (reader.TokenType == JsonTokenType.StartObject)
+        {
+            using var doc = JsonDocument.ParseValue(ref reader);
+            var root = doc.RootElement;
+
+            var sdi = ReadModeValue(root, "sdi", options.PropertyNameCaseInsensitive);
+            var mdi = ReadModeValue(root, "mdi", options.PropertyNameCaseInsensitive);
+
+            var display = new ViewDisplay(sdi, mdi);
+            return display.IsEmpty ? null : display;
+        }
+
+        // Unknown format - treat as absent instead of throwing, consistent with ViewDefinitionJsonConverter
+        return null;
+    }
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, ViewDisplay value, JsonSerializerOptions options)
+    {
+        if (value == null || value.IsEmpty)
+        {
+            writer.WriteNullValue();
+            return;
+        }
+
+        // SDI-only declarations round-trip as the legacy string shape
+        if (string.IsNullOrWhiteSpace(value.Mdi))
+        {
+            writer.WriteStringValue(value.Sdi);
+            return;
+        }
+
+        writer.WriteStartObject();
+        if (!string.IsNullOrWhiteSpace(value.Sdi))
+            writer.WriteString("sdi", value.Sdi);
+        writer.WriteString("mdi", value.Mdi);
+        writer.WriteEndObject();
+    }
+
+    private static string? ReadModeValue(JsonElement root, string propertyName, bool caseInsensitive)
+    {
+        if (root.TryGetProperty(propertyName, out var element))
+            return element.ValueKind == JsonValueKind.String ? element.GetString() : null;
+
+        if (!caseInsensitive)
+            return null;
+
+        foreach (var property in root.EnumerateObject())
+        {
+            if (property.NameEquals(propertyName) ||
+                string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+            {
+                return property.Value.ValueKind == JsonValueKind.String ? property.Value.GetString() : null;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/BBT.Workflow.Domain/Definitions/Views/ViewEnums.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Views/ViewEnums.cs
@@ -83,3 +83,76 @@ public static class ViewRenderer
     /// </summary>
     public const string NativeAndroid = "native-android";
 }
+
+/// <summary>
+/// Well-known display values for <see cref="ViewDisplay"/>, grouped by client interface mode.
+/// Used as values for <see cref="View.DisplayModes"/> to indicate how the client should present
+/// the view. Like <see cref="ViewRenderer"/>, these are a documented vocabulary rather than an
+/// enforced enum — the runtime accepts any non-blank value.
+/// </summary>
+public static class ViewDisplayMode
+{
+    /// <summary>
+    /// Display values for SDI (single-document interface) clients. This is the vocabulary the
+    /// legacy string-form <c>display</c> declaration uses.
+    /// </summary>
+    public static class Sdi
+    {
+        /// <summary>
+        /// Full page display
+        /// </summary>
+        public const string FullPage = "full-page";
+
+        /// <summary>
+        /// Popup/modal display
+        /// </summary>
+        public const string Popup = "popup";
+
+        /// <summary>
+        /// Bottom sheet display
+        /// </summary>
+        public const string BottomSheet = "bottom-sheet";
+
+        /// <summary>
+        /// Top sheet display
+        /// </summary>
+        public const string TopSheet = "top-sheet";
+
+        /// <summary>
+        /// Drawer/side menu display
+        /// </summary>
+        public const string Drawer = "drawer";
+
+        /// <summary>
+        /// Inline display within the page
+        /// </summary>
+        public const string Inline = "inline";
+    }
+
+    /// <summary>
+    /// Display values for MDI (multi-document interface) clients, where several documents are open
+    /// side by side and the view has to declare where it lands.
+    /// </summary>
+    public static class Mdi
+    {
+        /// <summary>
+        /// Opens as a tab in the document area
+        /// </summary>
+        public const string Tab = "tab";
+
+        /// <summary>
+        /// Opens as a floating/detached window
+        /// </summary>
+        public const string Window = "window";
+
+        /// <summary>
+        /// Opens in a split pane next to the active document
+        /// </summary>
+        public const string Split = "split";
+
+        /// <summary>
+        /// Inline display within the active document
+        /// </summary>
+        public const string Inline = "inline";
+    }
+}

--- a/src/BBT.Workflow.Domain/Logging/WorkflowErrors.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowErrors.cs
@@ -463,6 +463,26 @@ public static class WorkflowErrors
             WorkflowErrorCodes.FunctionScopeNotSatisfied,
             $"Function '{functionKey}' with scope '{scope}' cannot be invoked in this context.");
 
+    /// <summary>
+    /// The function declares a set of supported HTTP verbs and the request's verb is not among them.
+    /// Maps to HTTP 405; the allowed verbs travel in <c>Error.Target</c> so the HTTP layer can emit
+    /// the <c>Allow</c> response header without re-reading the definition.
+    /// </summary>
+    /// <param name="functionKey">The key of the function that was invoked.</param>
+    /// <param name="httpMethod">The rejected HTTP method.</param>
+    /// <param name="allowedVerbs">The verbs the function declares support for.</param>
+    public static Error FunctionVerbNotAllowed(
+        string functionKey,
+        string httpMethod,
+        IEnumerable<string> allowedVerbs)
+    {
+        var allowed = string.Join(", ", allowedVerbs);
+        return Error.Validation(
+            WorkflowErrorCodes.FunctionVerbNotAllowed,
+            $"Function '{functionKey}' does not support HTTP {httpMethod}. Allowed: {allowed}.",
+            target: allowed);
+    }
+
     #endregion
 
     #region Authorization Errors

--- a/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
@@ -3088,4 +3088,33 @@ public static partial class WorkflowLogs
         string reason);
 
     #endregion
+
+    #region Function Contract (800xx)
+
+    /// <summary>
+    /// Logs when a request is rejected because the function does not declare support for its HTTP verb.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 80001,
+        Level = LogLevel.Warning,
+        Message = "Function {FunctionKey} rejected HTTP {HttpMethod}; declared verbs: {AllowedVerbs}")]
+    public static partial void FunctionVerbRejected(
+        this ILogger logger,
+        string functionKey,
+        string httpMethod,
+        string allowedVerbs);
+
+    /// <summary>
+    /// Logs when a request body fails validation against the function's declared input schema.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 80002,
+        Level = LogLevel.Warning,
+        Message = "Function {FunctionKey} input schema validation failed against {SchemaKey}")]
+    public static partial void FunctionInputSchemaValidationFailed(
+        this ILogger logger,
+        string functionKey,
+        string schemaKey);
+
+    #endregion
 }

--- a/src/BBT.Workflow.Domain/WorkflowErrorCodes.cs
+++ b/src/BBT.Workflow.Domain/WorkflowErrorCodes.cs
@@ -132,6 +132,9 @@ public static class WorkflowErrorCodes
     public const string FunctionNotInWorkflow = "Function:800001";
     public const string FunctionScopeNotSatisfied = "Function:800002";
 
+    /// <summary>The function does not declare support for the request's HTTP verb. Maps to HTTP 405.</summary>
+    public const string FunctionVerbNotAllowed = "Function:800003";
+
     #endregion
 
     #region Authorization Errors (110xxx)

--- a/test/BBT.Workflow.Application.Tests/Definitions/Validators/FunctionComponentValidatorTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Definitions/Validators/FunctionComponentValidatorTests.cs
@@ -97,4 +97,131 @@ public class FunctionComponentValidatorTests
         // Assert
         result.IsValid.ShouldBeFalse();
     }
+
+    // ── verbs / contract references ──────────────────────────────────────────
+
+    private static JsonElement FunctionWith(string extraAttributes) =>
+        JsonDocument.Parse($$"""
+        {
+            "scope": "F",
+            "task": {
+                "type": "6",
+                "config": { "url": "https://example.com", "method": "GET" }
+            }{{extraAttributes}}
+        }
+        """).RootElement;
+
+    [Fact]
+    public void Validate_ShouldReturnSuccess_WhenNoVerbsDeclared()
+    {
+        var result = _validator.Validate(FunctionWith(string.Empty));
+
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_ShouldReturnSuccess_ForAllKnownVerbs()
+    {
+        var result = _validator.Validate(
+            FunctionWith(""", "verbs": ["GET", "POST", "PATCH", "DELETE"]"""));
+
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_ShouldReturnError_ForQueryVerb_NotSupportedYet()
+    {
+        // QUERY is intentionally unsupported until Swagger/gateway tooling handles it.
+        var result = _validator.Validate(FunctionWith(""", "verbs": ["QUERY"]"""));
+
+        result.IsValid.ShouldBeFalse();
+        result.ValidationErrors.ShouldContain(e => e.MemberNames.Contains("Function.Verbs"));
+    }
+
+    [Fact]
+    public void Validate_ShouldReturnError_ForUnknownVerb()
+    {
+        var result = _validator.Validate(FunctionWith(""", "verbs": ["PUT"]"""));
+
+        result.IsValid.ShouldBeFalse();
+        result.ValidationErrors.ShouldContain(e => e.MemberNames.Contains("Function.Verbs"));
+    }
+
+    [Fact]
+    public void Validate_ShouldNormalizeVerbCasing()
+    {
+        var result = _validator.Validate(FunctionWith(""", "verbs": ["post", " patch "]"""));
+
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_ShouldReturnSuccess_ForWellFormedContractReferences()
+    {
+        var result = _validator.Validate(FunctionWith("""
+        , "verbs": ["POST"]
+        , "inputSchema":  { "key": "in",  "domain": "d", "flow": "sys-schemas", "version": "1.0.0" }
+        , "outputSchema": { "key": "out", "domain": "d", "flow": "sys-schemas", "version": "1.0.0" }
+        , "inputView":    { "key": "vin", "domain": "d", "flow": "sys-views",   "version": "1.0.0" }
+        , "outputView":   { "key": "vout","domain": "d", "flow": "sys-views",   "version": "1.0.0" }
+        """));
+
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_ShouldReturnError_WhenInputSchemaReferencesWrongFlow()
+    {
+        var result = _validator.Validate(FunctionWith("""
+        , "verbs": ["POST"]
+        , "inputSchema": { "key": "in", "domain": "d", "flow": "sys-views", "version": "1.0.0" }
+        """));
+
+        result.IsValid.ShouldBeFalse();
+        result.ValidationErrors.ShouldContain(e => e.MemberNames.Contains("Function.InputSchema"));
+    }
+
+    [Fact]
+    public void Validate_ShouldReturnError_WhenInputViewReferencesWrongFlow()
+    {
+        var result = _validator.Validate(FunctionWith("""
+        , "inputView": { "key": "vin", "domain": "d", "flow": "sys-schemas", "version": "1.0.0" }
+        """));
+
+        result.IsValid.ShouldBeFalse();
+        result.ValidationErrors.ShouldContain(e => e.MemberNames.Contains("Function.InputView"));
+    }
+
+    [Fact]
+    public void Validate_ShouldReturnError_WhenInputSchemaDeclaredButNoVerbCarriesABody()
+    {
+        var result = _validator.Validate(FunctionWith("""
+        , "verbs": ["GET"]
+        , "inputSchema": { "key": "in", "domain": "d", "flow": "sys-schemas", "version": "1.0.0" }
+        """));
+
+        result.IsValid.ShouldBeFalse();
+        result.ValidationErrors.ShouldContain(e => e.MemberNames.Contains("Function.InputSchema"));
+    }
+
+    [Fact]
+    public void Validate_ShouldAllowInputSchema_WhenABodyCarryingVerbAccompaniesGet()
+    {
+        var result = _validator.Validate(FunctionWith("""
+        , "verbs": ["GET", "POST"]
+        , "inputSchema": { "key": "in", "domain": "d", "flow": "sys-schemas", "version": "1.0.0" }
+        """));
+
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_ShouldAllowInputSchema_WhenNoVerbsDeclared()
+    {
+        var result = _validator.Validate(FunctionWith("""
+        , "inputSchema": { "key": "in", "domain": "d", "flow": "sys-schemas", "version": "1.0.0" }
+        """));
+
+        result.IsValid.ShouldBeTrue();
+    }
 }

--- a/test/BBT.Workflow.Application.Tests/Definitions/Validators/ViewComponentValidatorTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Definitions/Validators/ViewComponentValidatorTests.cs
@@ -197,4 +197,64 @@ public class ViewComponentValidatorTests
         // Assert
         result.IsValid.ShouldBeTrue();
     }
+
+    // ── display: SDI / MDI modes ─────────────────────────────────────────────
+
+    private static JsonElement ViewWithDisplay(string displayJson) =>
+        JsonDocument.Parse($$"""
+        {
+            "type": "json",
+            "content": "{\"test\": \"content\"}",
+            "display": {{displayJson}}
+        }
+        """).RootElement;
+
+    [Fact]
+    public void Validate_ShouldReturnSuccess_ForLegacyStringDisplay()
+    {
+        var result = _validator.Validate(ViewWithDisplay("\"popup\""));
+
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_ShouldReturnSuccess_ForDisplayWithBothModes()
+    {
+        var result = _validator.Validate(ViewWithDisplay("""{"sdi": "popup", "mdi": "tab"}"""));
+
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_ShouldReturnSuccess_ForDisplayWithMdiOnly()
+    {
+        var result = _validator.Validate(ViewWithDisplay("""{"mdi": "window"}"""));
+
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_ShouldReturnError_ForMissingDisplay()
+    {
+        var attributes = JsonDocument.Parse("""
+        {
+            "type": "json",
+            "content": "{\"test\": \"content\"}"
+        }
+        """).RootElement;
+
+        var result = _validator.Validate(attributes);
+
+        result.IsValid.ShouldBeFalse();
+        result.ValidationErrors.ShouldContain(e => e.MemberNames.Contains("View.DisplayModes"));
+    }
+
+    [Fact]
+    public void Validate_ShouldReturnError_ForEmptyDisplayObject()
+    {
+        var result = _validator.Validate(ViewWithDisplay("{}"));
+
+        result.IsValid.ShouldBeFalse();
+        result.ValidationErrors.ShouldContain(e => e.MemberNames.Contains("View.DisplayModes"));
+    }
 }

--- a/test/BBT.Workflow.Application.Tests/Functions/FunctionAppServiceScopeTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Functions/FunctionAppServiceScopeTests.cs
@@ -11,6 +11,7 @@ using BBT.Aether.Users;
 using BBT.Workflow.Authorization;
 using BBT.Workflow.Caching;
 using BBT.Workflow.Definitions;
+using BBT.Workflow.Functions.Validation;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Runtime;
 using BBT.Workflow.Scripting;
@@ -47,6 +48,7 @@ public sealed class FunctionAppServiceScopeTests : IDisposable
     private readonly ITaskCoordinator _taskCoordinator;
     private readonly IStateStoreCacheGateway _cacheGateway;
     private readonly IDynamicExpressoValueEvaluator _keyEvaluator;
+    private readonly IFunctionRequestValidationService _functionRequestValidationService;
     private readonly FunctionAppService _service;
 
     private readonly IServiceProvider _ambientServiceProvider;
@@ -59,6 +61,14 @@ public sealed class FunctionAppServiceScopeTests : IDisposable
         _taskCoordinator = Substitute.For<ITaskCoordinator>();
         _cacheGateway = Substitute.For<IStateStoreCacheGateway>();
         _keyEvaluator = Substitute.For<IDynamicExpressoValueEvaluator>();
+        _functionRequestValidationService = Substitute.For<IFunctionRequestValidationService>();
+        _functionRequestValidationService
+            .ValidateRequestAsync(
+                Arg.Any<Function>(),
+                Arg.Any<JsonElement?>(),
+                Arg.Any<IReadOnlyDictionary<string, string?>?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Result.Ok());
 
         // Ambient provider needed by PostSharp UnitOfWork interception.
         var mockUoW = Substitute.For<IUnitOfWork>();
@@ -113,7 +123,8 @@ public sealed class FunctionAppServiceScopeTests : IDisposable
             transitionAuthorizationManager: Substitute.For<ITransitionAuthorizationManager>(),
             keyEvaluator: _keyEvaluator,
             cacheGateway: _cacheGateway,
-            remoteInvoker: Substitute.For<IRemoteInvokerService>());
+            remoteInvoker: Substitute.For<IRemoteInvokerService>(),
+            functionRequestValidationService: _functionRequestValidationService);
     }
 
     public void Dispose()
@@ -154,6 +165,86 @@ public sealed class FunctionAppServiceScopeTests : IDisposable
 
         result.IsSuccess.ShouldBeFalse();
         result.Error.Code.ShouldBe(WorkflowErrorCodes.FunctionScopeNotSatisfied);
+    }
+
+    // ─── Verb enforcement ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ByKey_NoVerbsDeclared_AcceptsAnyVerb()
+    {
+        SetupFunction(TaskScope.Domain);
+
+        var result = await _service.GetFunctionByKeyAsync(FunctionKey, TestDomain, httpMethod: "DELETE");
+
+        result.IsSuccess.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ByKey_NullHttpMethod_SkipsVerbCheck()
+    {
+        SetupFunction(TaskScope.Domain, verbs: ["POST"]);
+
+        var result = await _service.GetFunctionByKeyAsync(FunctionKey, TestDomain, httpMethod: null);
+
+        result.IsSuccess.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ByKey_DeclaredVerb_Succeeds()
+    {
+        SetupFunction(TaskScope.Domain, verbs: ["POST", "PATCH"]);
+
+        var result = await _service.GetFunctionByKeyAsync(FunctionKey, TestDomain, httpMethod: "PATCH");
+
+        result.IsSuccess.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ByKey_UndeclaredVerb_Returns405Error()
+    {
+        SetupFunction(TaskScope.Domain, verbs: ["POST", "PATCH"]);
+
+        var result = await _service.GetFunctionByKeyAsync(FunctionKey, TestDomain, httpMethod: "DELETE");
+
+        result.IsSuccess.ShouldBeFalse();
+        result.Error.Code.ShouldBe(WorkflowErrorCodes.FunctionVerbNotAllowed);
+        // Target carries the Allow header value.
+        result.Error.Target.ShouldBe("POST, PATCH");
+    }
+
+    [Fact]
+    public async Task ByKey_VerbComparisonIsCaseInsensitive()
+    {
+        SetupFunction(TaskScope.Domain, verbs: ["post"]);
+
+        var result = await _service.GetFunctionByKeyAsync(FunctionKey, TestDomain, httpMethod: "POST");
+
+        result.IsSuccess.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ByKey_InputSchemaValidationFailure_ShortCircuitsBeforeTasks()
+    {
+        SetupFunction(TaskScope.Domain);
+        _functionRequestValidationService
+            .ValidateRequestAsync(
+                Arg.Any<Function>(),
+                Arg.Any<JsonElement?>(),
+                Arg.Any<IReadOnlyDictionary<string, string?>?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Result.Fail(Error.Validation("schema.invalid", "body does not match schema")));
+
+        var result = await _service.GetFunctionByKeyAsync(FunctionKey, TestDomain, httpMethod: "POST");
+
+        result.IsSuccess.ShouldBeFalse();
+        result.Error.Code.ShouldBe("schema.invalid");
+        await _taskCoordinator.DidNotReceive().ExecuteAsync(
+            Arg.Any<IEnumerable<OnExecuteTask>>(),
+            Arg.Any<Guid?>(),
+            Arg.Any<TaskTrigger>(),
+            Arg.Any<TaskExecutionOrigin>(),
+            Arg.Any<ScriptContext>(),
+            Arg.Any<CancellationToken>());
     }
 
     // ─── Instance-level endpoint (GetFunctionByInstanceAsync) ───────────────────
@@ -341,13 +432,13 @@ public sealed class FunctionAppServiceScopeTests : IDisposable
             .Returns(Result<Function>.Ok(function));
     }
 
-    private void SetupFunction(TaskScope scope)
+    private void SetupFunction(TaskScope scope, List<string>? verbs = null)
     {
         var task = OnExecuteTask.Create(
             1,
             new Reference("my-task", TestDomain, "sys-tasks", TestVersion),
             ScriptCode.FromNative(string.Empty));
-        var function = new Function(scope, task);
+        var function = new Function(scope, task, verbs: verbs);
         function.SetReference(new Reference(FunctionKey, TestDomain, "sys-functions", TestVersion));
 
         _componentCacheStore

--- a/test/BBT.Workflow.Application.Tests/Functions/FunctionRequestValidationServiceTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Functions/FunctionRequestValidationServiceTests.cs
@@ -1,0 +1,160 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.Results;
+using BBT.Workflow.Caching;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Functions.Validation;
+using BBT.Workflow.Validation;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Functions;
+
+/// <summary>
+/// Unit tests for <see cref="FunctionRequestValidationService"/>: the request body is only validated
+/// when the function declares an input schema and the request actually carries a body, so functions
+/// authored before contract declaration are unaffected.
+/// </summary>
+public sealed class FunctionRequestValidationServiceTests
+{
+    private const string TestDomain = "test-domain";
+    private const string TestVersion = "1.0.0";
+
+    private readonly IJsonSchemaValidator _schemaValidator = Substitute.For<IJsonSchemaValidator>();
+    private readonly IComponentCacheStore _componentCacheStore = Substitute.For<IComponentCacheStore>();
+    private readonly FunctionRequestValidationService _service;
+
+    public FunctionRequestValidationServiceTests()
+    {
+        _service = new FunctionRequestValidationService(
+            _schemaValidator,
+            _componentCacheStore,
+            NullLogger<FunctionRequestValidationService>.Instance);
+    }
+
+    [Fact]
+    public async Task NoInputSchema_ReturnsOk_WithoutTouchingTheCache()
+    {
+        var function = CreateFunction(inputSchema: null);
+
+        var result = await _service.ValidateRequestAsync(function, ParseBody("""{"a":1}"""));
+
+        result.IsSuccess.ShouldBeTrue();
+        await _componentCacheStore.DidNotReceiveWithAnyArgs()
+            .GetSchemaAsync(default!, default!, default, default);
+    }
+
+    [Fact]
+    public async Task NoBody_ReturnsOk_WithoutTouchingTheCache()
+    {
+        var function = CreateFunction(SchemaRef());
+
+        var result = await _service.ValidateRequestAsync(function, body: null);
+
+        result.IsSuccess.ShouldBeTrue();
+        await _componentCacheStore.DidNotReceiveWithAnyArgs()
+            .GetSchemaAsync(default!, default!, default, default);
+    }
+
+    [Fact]
+    public async Task NullJsonBody_ReturnsOk()
+    {
+        var function = CreateFunction(SchemaRef());
+
+        var result = await _service.ValidateRequestAsync(function, ParseBody("null"));
+
+        result.IsSuccess.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task UnresolvableSchema_Fails()
+    {
+        var function = CreateFunction(SchemaRef());
+        _componentCacheStore
+            .GetSchemaAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(Result<SchemaDefinition>.Fail(Error.NotFound("schema.notfound", "missing")));
+
+        var result = await _service.ValidateRequestAsync(function, ParseBody("""{"a":1}"""));
+
+        result.IsSuccess.ShouldBeFalse();
+        result.Error.Code.ShouldBe("schema.notfound");
+    }
+
+    [Fact]
+    public async Task ValidBody_ReturnsOk()
+    {
+        var function = CreateFunction(SchemaRef());
+        SetupSchema();
+        _schemaValidator
+            .Validate(Arg.Any<JsonElement>(), Arg.Any<JsonElement?>(), Arg.Any<SchemaValidationOptions>())
+            .Returns(Result.Ok());
+
+        var result = await _service.ValidateRequestAsync(function, ParseBody("""{"a":1}"""));
+
+        result.IsSuccess.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task InvalidBody_SurfacesTheValidatorFailure()
+    {
+        var function = CreateFunction(SchemaRef());
+        SetupSchema();
+        _schemaValidator
+            .Validate(Arg.Any<JsonElement>(), Arg.Any<JsonElement?>(), Arg.Any<SchemaValidationOptions>())
+            .Returns(Result.Fail(Error.Validation("schema.invalid", "a is required")));
+
+        var result = await _service.ValidateRequestAsync(function, ParseBody("""{"b":1}"""));
+
+        result.IsSuccess.ShouldBeFalse();
+        result.Error.Code.ShouldBe("schema.invalid");
+    }
+
+    [Fact]
+    public async Task ResolvesCultureFromAcceptLanguageHeader()
+    {
+        var function = CreateFunction(SchemaRef());
+        SetupSchema();
+        _schemaValidator
+            .Validate(Arg.Any<JsonElement>(), Arg.Any<JsonElement?>(), Arg.Any<SchemaValidationOptions>())
+            .Returns(Result.Ok());
+
+        var headers = new Dictionary<string, string?> { ["Accept-Language"] = "tr-TR" };
+        await _service.ValidateRequestAsync(function, ParseBody("""{"a":1}"""), headers);
+
+        _schemaValidator.Received(1).Validate(
+            Arg.Any<JsonElement>(),
+            Arg.Any<JsonElement?>(),
+            Arg.Is<SchemaValidationOptions>(o => o.Culture == "tr-TR"));
+    }
+
+    private static Reference SchemaRef() => new("in-schema", TestDomain, "sys-schemas", TestVersion);
+
+    private static JsonElement ParseBody(string json) => JsonDocument.Parse(json).RootElement.Clone();
+
+    private static Function CreateFunction(Reference? inputSchema)
+    {
+        var task = OnExecuteTask.Create(
+            1,
+            new Reference("my-task", TestDomain, "sys-tasks", TestVersion),
+            ScriptCode.FromNative(string.Empty));
+        var function = new Function(TaskScope.Domain, task, inputSchema: inputSchema);
+        function.SetReference(new Reference("my-fn", TestDomain, "sys-functions", TestVersion));
+        return function;
+    }
+
+    private void SetupSchema()
+    {
+        var schema = JsonSerializer.Deserialize<SchemaDefinition>(
+            """{"type":"json","schema":{"type":"object"}}""",
+            JsonSerializerConstants.JsonOptions)!;
+        schema.SetReference(SchemaRef());
+
+        _componentCacheStore
+            .GetSchemaAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(Result<SchemaDefinition>.Ok(schema));
+    }
+}

--- a/test/BBT.Workflow.Domain.Tests/Definitions/Views/ViewDisplayJsonConverterTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Definitions/Views/ViewDisplayJsonConverterTests.cs
@@ -1,0 +1,220 @@
+using System.Text.Json;
+using BBT.Workflow.Definitions;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Domain.Tests.Definitions.Views;
+
+/// <summary>
+/// Unit tests for <see cref="ViewDisplayJsonConverter"/> and the <see cref="View"/> display accessors.
+/// Covers the backward-compatible string form (SDI-only) alongside the { sdi, mdi } object form.
+/// </summary>
+public class ViewDisplayJsonConverterTests
+{
+    /// <summary>
+    /// Options carrying the converter directly, used to exercise it in isolation. Serializing a whole
+    /// <see cref="View"/> is not usable here because <c>View.SemanticVersion</c> requires a version,
+    /// which component JSON only carries at the envelope level.
+    /// </summary>
+    private static readonly JsonSerializerOptions ConverterOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new ViewDisplayJsonConverter() }
+    };
+
+    private static View DeserializeView(string displayJson)
+    {
+        var json = $$"""{"type": 1, "content": "{}", "display": {{displayJson}}}""";
+        var view = JsonSerializer.Deserialize<View>(json, JsonSerializerConstants.JsonOptions);
+        view.ShouldNotBeNull();
+        return view;
+    }
+
+    private static JsonElement SerializeDisplay(ViewDisplay? display)
+    {
+        var json = JsonSerializer.Serialize(display, ConverterOptions);
+        return JsonDocument.Parse(json).RootElement.Clone();
+    }
+
+    // ── Reading: legacy string form ──────────────────────────────────────────
+
+    [Fact]
+    public void Read_LegacyStringForm_MapsToSdi()
+    {
+        var view = DeserializeView("\"popup\"");
+
+        view.DisplayModes.ShouldNotBeNull();
+        view.DisplayModes.Sdi.ShouldBe("popup");
+        view.DisplayModes.Mdi.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Read_LegacyStringForm_LegacyDisplayAccessorReturnsSameValue()
+    {
+        var view = DeserializeView($"\"{ViewDisplayMode.Sdi.FullPage}\"");
+
+        view.Display.ShouldBe(ViewDisplayMode.Sdi.FullPage);
+        view.MdiDisplay.ShouldBeNull();
+    }
+
+    // ── Reading: object form ─────────────────────────────────────────────────
+
+    [Fact]
+    public void Read_ObjectForm_WithBothModes_MapsBoth()
+    {
+        var view = DeserializeView("""{"sdi": "popup", "mdi": "tab"}""");
+
+        view.Display.ShouldBe("popup");
+        view.MdiDisplay.ShouldBe("tab");
+        view.DisplayModes!.Sdi.ShouldBe("popup");
+        view.DisplayModes.Mdi.ShouldBe("tab");
+    }
+
+    [Fact]
+    public void Read_ObjectForm_MdiOnly_LeavesLegacyDisplayEmpty()
+    {
+        var view = DeserializeView("""{"mdi": "window"}""");
+
+        view.Display.ShouldBe(string.Empty);
+        view.MdiDisplay.ShouldBe("window");
+        view.DisplayModes!.Sdi.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Read_ObjectForm_SdiOnly_BehavesLikeLegacyString()
+    {
+        var view = DeserializeView("""{"sdi": "drawer"}""");
+
+        view.Display.ShouldBe("drawer");
+        view.MdiDisplay.ShouldBeNull();
+    }
+
+    // ── Reading: absent / empty ──────────────────────────────────────────────
+
+    [Fact]
+    public void Read_Null_YieldsNoDisplayModes()
+    {
+        var view = DeserializeView("null");
+
+        view.DisplayModes.ShouldBeNull();
+        view.Display.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void Read_EmptyString_YieldsNoDisplayModes()
+    {
+        var view = DeserializeView("\"\"");
+
+        view.DisplayModes.ShouldBeNull();
+        view.Display.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void Read_EmptyObject_YieldsNoDisplayModes()
+    {
+        var view = DeserializeView("{}");
+
+        view.DisplayModes.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Read_MissingDisplayProperty_YieldsNoDisplayModes()
+    {
+        var json = """{"type": 1, "content": "{}"}""";
+        var view = JsonSerializer.Deserialize<View>(json, JsonSerializerConstants.JsonOptions);
+
+        view.ShouldNotBeNull();
+        view.DisplayModes.ShouldBeNull();
+        view.Display.ShouldBe(string.Empty);
+    }
+
+    // ── Writing: round-trip ──────────────────────────────────────────────────
+
+    [Fact]
+    public void Write_SdiOnly_RoundTripsAsBareString()
+    {
+        var display = SerializeDisplay(DeserializeView("\"popup\"").DisplayModes);
+
+        display.ValueKind.ShouldBe(JsonValueKind.String);
+        display.GetString().ShouldBe("popup");
+    }
+
+    [Fact]
+    public void Write_WithMdi_RoundTripsAsObject()
+    {
+        var display = SerializeDisplay(DeserializeView("""{"sdi": "popup", "mdi": "tab"}""").DisplayModes);
+
+        display.ValueKind.ShouldBe(JsonValueKind.Object);
+        display.GetProperty("sdi").GetString().ShouldBe("popup");
+        display.GetProperty("mdi").GetString().ShouldBe("tab");
+    }
+
+    [Fact]
+    public void Write_MdiOnly_OmitsSdi()
+    {
+        var display = SerializeDisplay(DeserializeView("""{"mdi": "window"}""").DisplayModes);
+
+        display.ValueKind.ShouldBe(JsonValueKind.Object);
+        display.TryGetProperty("sdi", out _).ShouldBeFalse();
+        display.GetProperty("mdi").GetString().ShouldBe("window");
+    }
+
+    [Fact]
+    public void Write_Empty_WritesNull()
+    {
+        SerializeDisplay(null).ValueKind.ShouldBe(JsonValueKind.Null);
+        SerializeDisplay(new ViewDisplay(null, null)).ValueKind.ShouldBe(JsonValueKind.Null);
+    }
+
+    [Fact]
+    public void RoundTrip_ObjectForm_PreservesBothModes()
+    {
+        var original = DeserializeView("""{"sdi": "bottom-sheet", "mdi": "split"}""").DisplayModes;
+
+        var json = JsonSerializer.Serialize(original, ConverterOptions);
+        var reparsed = JsonSerializer.Deserialize<ViewDisplay>(json, ConverterOptions);
+
+        reparsed.ShouldNotBeNull();
+        reparsed.Sdi.ShouldBe("bottom-sheet");
+        reparsed.Mdi.ShouldBe("split");
+    }
+
+    [Fact]
+    public void RoundTrip_LegacyStringForm_StaysAStringAndReparsesToSdi()
+    {
+        var original = DeserializeView("\"drawer\"").DisplayModes;
+
+        var json = JsonSerializer.Serialize(original, ConverterOptions);
+        json.ShouldBe("\"drawer\"");
+
+        var reparsed = JsonSerializer.Deserialize<ViewDisplay>(json, ConverterOptions);
+        reparsed.ShouldNotBeNull();
+        reparsed.Sdi.ShouldBe("drawer");
+        reparsed.Mdi.ShouldBeNull();
+    }
+
+    // ── ViewDisplay value object ─────────────────────────────────────────────
+
+    [Fact]
+    public void IsEmpty_WhenBothModesBlank_IsTrue()
+    {
+        new ViewDisplay(null, null).IsEmpty.ShouldBeTrue();
+        new ViewDisplay("  ", "").IsEmpty.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsEmpty_WhenEitherModeSet_IsFalse()
+    {
+        new ViewDisplay("popup", null).IsEmpty.ShouldBeFalse();
+        new ViewDisplay(null, "tab").IsEmpty.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void FromSdi_SetsOnlySdi()
+    {
+        var display = ViewDisplay.FromSdi("inline");
+
+        display.Sdi.ShouldBe("inline");
+        display.Mdi.ShouldBeNull();
+    }
+}

--- a/vnext-meta/features.json
+++ b/vnext-meta/features.json
@@ -55,6 +55,21 @@
       "status": "stable",
       "description": "Built-in StateStoreTask (TaskType=17, discriminator 'statestore') that reads and writes a Dapr state store component from the workflow/function pipeline. When the task config omits storeName, the store is resolved from the executing runtime's DAPR_STATE_STORE_NAME configuration value, so each runtime targets its own component with no hard-coded name. Runs through the Execution API like the other Dapr tasks: the StateStoreTaskExecutor performs input/output mapping and delegates a TaskEnvelope to the StateStoreTaskInvoker, which uses DaprClient. Command names mirror the Dapr state API verbs: get (GetStateAndETagAsync; a cache miss returns success with metadata Found=false and null data, so the error boundary is not tripped), set (SaveStateAsync / TrySaveStateAsync when an ETag is supplied, with optional ttlInSeconds TTL, and StateOptions concurrency FirstWrite/LastWrite + consistency Eventual/Strong), and delete (single key via DeleteStateAsync, key list via DeleteBulkStateAsync, or tag/pattern via the Dapr state Query API which requires a query-capable state store). An explicit storeName must be exposed by the Execution sidecar; the repo ships a 'vnext-state' component there for that purpose. All task-supplied keys are stored under the fixed 'custom:' prefix to namespace task-written entries away from engine-owned cache keys sharing the same store.",
       "schemaPath": "task.type=17"
+    },
+    "viewDisplayModes": {
+      "since": "0.0.79",
+      "status": "stable",
+      "description": "A view declares its display per client interface mode. attributes.display accepts the existing bare string (full-page | popup | bottom-sheet | top-sheet | drawer | inline), which continues to mean the SDI (single-document interface) display, or an object { sdi, mdi } where mdi carries the multi-document display (tab | window | split | inline) for clients that render several documents side by side. At least one mode must be present. The runtime keeps the legacy string in the view response's display field, so clients predating MDI support are unaffected, and adds a modes object carrying both values; a view declaring only mdi returns an empty display. Component JSON round-trips in the shape it was authored: an SDI-only declaration is written back as a bare string, anything declaring mdi as an object. Values are a documented vocabulary (ViewDisplayMode), not an enforced enum — the runtime accepts any non-blank value, the same way renderer is treated.",
+      "schemaPath": "view.attributes.display",
+      "apiEndpoints": [
+        "GET {domain}/workflows/{workflow}/instances/{instance}/functions/view"
+      ]
+    },
+    "functionContract": {
+      "since": "0.0.79",
+      "status": "stable",
+      "description": "A function declares the contract clients need in order to call it: attributes.verbs[] lists the supported HTTP verbs (GET, POST, PATCH, DELETE), and inputSchema/outputSchema (sys-schemas references) plus inputView/outputView (sys-views references) describe its payloads and screens. Both gates are opt-in: a function declaring no verbs accepts every routed verb, and one declaring no inputSchema accepts any body, so definitions authored before contract declaration are unaffected. When verbs are declared, an undeclared verb is rejected with HTTP 405 and an Allow response header listing the declared verbs; when inputSchema is declared, a request that carries a body is validated against it before any task runs, using the same JSON-schema validator and localization as transition schema validation. outputSchema is declarative only and is not enforced. Component validation also rejects an unknown verb, a reference pointing at the wrong flow, and an inputSchema declared alongside verbs that can never carry a body. The HTTP QUERY method is deliberately not supported yet — .NET 10 exposes it at the HTTP layer (HttpMethods.Query) and MVC's HttpMethodAttribute makes routing it trivial, but Swagger/OpenAPI generation, gateways and client SDKs do not handle an unrecognised method, so body-carrying reads should be modelled as POST for now. No dedicated contract endpoint exists: GET {domain}/functions already returns each function's full definition including verbs and the four reference fields.",
+      "schemaPath": "function.attributes.verbs"
     }
   }
 }


### PR DESCRIPTION
Runtime side of the two client-contract gaps. Consumes the schema change in burgan-tech/vnext-schema#128 — **merge that first**.

## Why

1. **View** exposed a single `display` string (`full-page`, `popup`, `drawer`, …). Those values only describe a **single-document (SDI)** presentation. Client renderers also support **MDI**, where several documents are open side by side, and a view had no way to say whether it lands as a tab, a window, or a split pane.
2. **Function** declared no contract at all — no request/response schema, no input/output view, and no indication of which HTTP verbs it accepts. Worse, `FunctionController` folded POST/PATCH/DELETE into a single action and **never read the verb**, so any of them silently executed the function.

## What changed

### View display modes

`attributes.display` now parses either the legacy bare string or `{ sdi, mdi }`. The string form keeps its exact meaning — the SDI value.

- `ViewDisplay` + `ViewDisplayJsonConverter` handle both shapes, mirroring how `ViewDefinitionJsonConverter` handles the existing `view`/`views` back-compat pair. Writing mirrors the authored shape, so SDI-only round-trips to a bare string and component JSON doesn't churn.
- `View.Display` still returns a string (the SDI value) — **no existing call site changed**. `View.MdiDisplay` / `View.DisplayModes` are additive.
- View response keeps `display` and gains `modes`, on both the local and remote resolution paths.
- Fixed in passing: `ViewInstanceAttributesDto.Display` was a plain `string?` and would have silently dropped the object form on the remote path.
- Monitor summary reads `sdi` out of the object form, so the existing display filter keeps matching either shape.

### Function contract

`Function` gains `Verbs` plus `InputSchema` / `OutputSchema` / `InputView` / `OutputView`, using the same `Reference` type and pattern as `Transition.Schema`.

Enforcement sits in `FunctionAppService.ExecuteFunctionAsync` — the single funnel for both the domain and instance paths. It runs **after** scope and role checks (an unauthorized caller learns nothing about the function's shape) and **before** any task executes. System functions (`state`, `view`, `data`, …) use their own handlers and never reach this path.

| Condition | Result |
| --- | --- |
| `verbs[]` absent/empty | Every routed verb accepted (pre-existing behavior) |
| Verb declared, not matched | `405` + `Allow` header listing declared verbs |
| `inputSchema` absent, or no body | Not validated |
| `inputSchema` set, body present | Validated; failure → `400` with field-level errors |
| `outputSchema` | Never validated — declarative only |

`FunctionRequestValidationService` reuses `IJsonSchemaValidator` and `IComponentCacheStore` exactly as `TransitionValidationService` does, including culture resolution, so functions and transitions report schema violations identically.

**No new endpoints.** `GET {domain}/functions` already returns each function's full definition, so the contract is discoverable from data clients already fetch.

## Backward compatibility

Both gates are opt-in — a function declaring no verbs accepts every verb, one declaring no input schema accepts any body — and the legacy `display` string is still first-class. Existing components and clients are unaffected.

## Notes for reviewers

**No QUERY verb.** An earlier revision routed it via a custom `HttpQueryAttribute`. Removed deliberately: .NET 10 exposes the method at the HTTP layer and routing it is trivial, but Swagger/OpenAPI generation, gateways and client SDKs don't handle an unrecognised method, so it breaks tooling before delivering value. Declaring it is now a validation error; model body-carrying reads as `POST`. Revisit when the ecosystem catches up.

**One deviation from plan.** The plan called for a *warning* when `inputSchema` is declared alongside verbs that can never carry a body (e.g. `verbs: ["GET"]` only). `ComponentValidationResult` has no warning channel, so it's an **error**, narrowed to that provably-dead case. These are new fields, so nothing existing breaks — happy to drop the check if you'd rather.

**405 mapping.** `FunctionResponseActionResultMapper` special-cases this one error code, since the generic Aether result mapping can't express 405 + `Allow`. The verb list travels in `Error.Target`.

## Verification

- Build clean.
- ~45 new tests; function tests 143/143, view-display tests 18/18.
- **Full suite: failing-test names are byte-identical to the `master` baseline** (191 pre-existing failures, mostly `AmbientServiceProvider` parallel-collection leakage) — verified by diffing failing test names before and after with the branch stashed. Zero regressions.
- QUERY's absence and the route surface verified against the **real MVC action-descriptor table**, not just attribute inspection: the two invoke routes carry exactly POST/PATCH/DELETE, no endpoint advertises QUERY.

**Not verified:** the 405/`Allow` response over the wire — that needs running infra plus a seeded domain component. The service-layer error and the mapper are unit-covered; the HTTP hop is not.

**Open question:** the MDI vocabulary (`tab` / `window` / `split` / `inline`) is a proposal and needs client-renderer team sign-off. Changing it touches only the schema enum and the `ViewDisplayMode.Mdi` constants — the runtime accepts any non-blank value, same as `renderer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce view SDI/MDI display mode support and add declarative HTTP verb and schema/view contracts for custom functions with enforcement at runtime.

New Features:
- Allow views to declare per-mode display settings for SDI and MDI clients while preserving the legacy single-string display field.
- Expose function-level contract metadata including supported HTTP verbs and input/output schema and view references, and enforce these contracts on function invocation.

Enhancements:
- Validate function verb declarations and contract references at definition time, rejecting unsupported verbs, mismatched flows, and dead input schema configurations.
- Enforce function verb whitelists and request body schema validation in FunctionAppService, returning 405 with Allow headers for disallowed verbs and 400 for schema violations.
- Extend view response DTOs and monitor summaries to surface per-mode display information without breaking existing clients.
- Register and wire a dedicated function request validation service that reuses existing schema validation infrastructure and logging.
- Document the new function contract and view display mode semantics in API and domain documentation and cross-link them from the docs index.

Tests:
- Add unit tests for function component validation covering verbs, contract references, and body-carrying verb rules.
- Add tests for function request validation behavior and for new FunctionAppService verb and schema enforcement paths.
- Add tests for view component validation and ViewDisplayJsonConverter to ensure SDI/MDI display parsing and serialization behave as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SDI and MDI view display modes, while preserving support for legacy display values.
  * Added function contracts with supported HTTP verbs, input/output schemas, and views.
  * Added request validation against declared input schemas.
* **Bug Fixes**
  * Unsupported function verbs now return HTTP 405 responses with allowed methods.
  * View summaries and remote mappings now correctly expose display modes.
* **Documentation**
  * Added guidance for view modes, function contracts, validation, and endpoint behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->