### PR TITLE
fix(cache): scope component version resolutions to a generation token

### DIFF
--- a/src/BBT.Workflow.Application/Caching/CacheActivityHelper.cs
+++ b/src/BBT.Workflow.Application/Caching/CacheActivityHelper.cs
@@ -21,10 +21,14 @@ public static class CacheActivityHelper
     public const string OperationSet = "Cache.Set";
     public const string OperationRemove = "Cache.Remove";
     public const string OperationWarmup = "Cache.Warmup";
-    public const string OperationVersionIndex = "Cache.VersionIndex";
+    public const string OperationGenerationGet = "Cache.GenerationGet";
+    public const string OperationGenerationSet = "Cache.GenerationSet";
 
     private const string TagCacheKey = "cache.key";
     private const string TagCacheHit = "cache.hit";
+    private const string TagCacheNegative = "cache.negative";
+    private const string TagCacheCoalesced = "cache.coalesced";
+    private const string TagCacheGeneration = "cache.generation";
     private const string TagCacheStore = "cache.store";
     private const string TagCacheItemCount = "cache.item_count";
     private const string TagComponentType = "cache.component_type";
@@ -69,6 +73,32 @@ public static class CacheActivityHelper
     public static void SetItemCount(Activity? activity, int count)
     {
         activity?.SetTag(TagCacheItemCount, count);
+    }
+
+    /// <summary>
+    /// Records that the hit was a negative (no matching version) entry rather than a component body.
+    /// </summary>
+    public static void SetNegative(Activity? activity, bool negative)
+    {
+        activity?.SetTag(TagCacheNegative, negative);
+    }
+
+    /// <summary>
+    /// Records that this call waited on a resolution already in flight instead of loading from the
+    /// backend itself.
+    /// </summary>
+    public static void SetCoalesced(Activity? activity, bool coalesced)
+    {
+        activity?.SetTag(TagCacheCoalesced, coalesced);
+    }
+
+    /// <summary>
+    /// Records the generation token a version resolution was scoped to.
+    /// </summary>
+    public static void SetGeneration(Activity? activity, string? generation)
+    {
+        if (activity is not null && !string.IsNullOrEmpty(generation))
+            activity.SetTag(TagCacheGeneration, generation);
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Application/Caching/CacheEnvelope.cs
+++ b/src/BBT.Workflow.Application/Caching/CacheEnvelope.cs
@@ -14,4 +14,14 @@ public sealed class CacheEnvelope<T> where T : class
     public string Version { get; set; } = string.Empty;
     public string Flow { get; set; } = string.Empty;
     public T? Entity { get; set; }
+
+    /// <summary>
+    /// Marks the envelope as a cached "no version matched this request" answer.
+    /// </summary>
+    /// <remarks>
+    /// A negative answer has to be distinguishable from a missing entry: without this flag an envelope
+    /// carrying no entity is indistinguishable from a cache miss, so every request for a version that
+    /// does not exist would reach the database again.
+    /// </remarks>
+    public bool IsNegative { get; set; }
 }

--- a/src/BBT.Workflow.Application/Caching/CacheSet.cs
+++ b/src/BBT.Workflow.Application/Caching/CacheSet.cs
@@ -1,7 +1,11 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
 using BBT.Aether.DistributedCache;
 using BBT.Aether.Results;
 using BBT.Workflow.Instances;
+using BBT.Workflow.Logging;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace BBT.Workflow.Caching;
 
@@ -9,16 +13,45 @@ namespace BBT.Workflow.Caching;
 /// Redis-first cache implementation with DB fallback. No in-memory snapshot.
 /// All pods share the same Redis instance, so writes are immediately visible cluster-wide.
 /// </summary>
+/// <remarks>
+/// Two kinds of entry are stored, and the difference between them is the whole design:
+/// <list type="bullet">
+///     <item><description>
+///         <c>full:{canonicalVersion}</c> — a component body keyed by its full version. A full version
+///         names one revision forever, so this may be written unconditionally and reused indefinitely.
+///     </description></item>
+///     <item><description>
+///         <c>res:{generation}:{spelling}</c> — the answer to a version <i>request</i>
+///         (<c>latest</c>, <c>1</c>, <c>1.2</c>, <c>2.3.5</c>). Its value depends on the set of
+///         published versions, not on one revision, so publishing or deactivating anything can change
+///         it. These are never written as though the published entity wins the range; instead they are
+///         scoped to a generation token that is replaced whenever the published set changes.
+///     </description></item>
+/// </list>
+/// Keying resolutions under a generation is what makes invalidation complete. A publish cannot enumerate
+/// which request spellings its component participates in — <see cref="InstanceDataVersionComparer.FindBestMatch"/>
+/// also accepts leading-zero package-version aliases, and could accept more forms later — so instead of
+/// listing them, replacing the token makes all of them unreachable at once.
+/// </remarks>
 /// <typeparam name="T">The type of entity to cache</typeparam>
 public class CacheSet<T>(
     IDistributedCacheService distributedCache,
     ICacheBackend<T> backend,
+    IComponentGenerationProvider generationProvider,
+    IOptions<ComponentCacheOptions> options,
+    TimeProvider timeProvider,
     ILogger<CacheSet<T>> logger)
     : ICacheSet<T>
     where T : class, IDomainEntity, IReferenceSetter
 {
     private static readonly string ComponentKeyName = T.ComponentTypeKey;
-    private static readonly TimeSpan FullVersionTtl = TimeSpan.FromMinutes(30);
+
+    /// <summary>
+    /// Resolutions in flight, so concurrent misses for the same component and spelling share one
+    /// backend load instead of each issuing their own. Misses cluster immediately after a publish, which
+    /// is exactly when a hot component would otherwise stampede the database.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, Lazy<Task<Result<T>>>> _inFlightResolutions = new();
 
     public Type EntityType => typeof(T);
 
@@ -29,13 +62,10 @@ public class CacheSet<T>(
         string? version,
         CancellationToken cancellationToken = default)
     {
-        if (InstanceDataVersionComparer.IsRequestingLatest(version))
-            return await GetLatestAsync(domain, key, cancellationToken);
-
         if (InstanceDataVersionComparer.IsFullVersion(version))
             return await GetFullVersionAsync(domain, key, version!, cancellationToken);
 
-        return await GetArtifactVersionAsync(domain, key, version!, cancellationToken);
+        return await GetResolvedAsync(domain, key, version, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -44,7 +74,7 @@ public class CacheSet<T>(
         string name,
         CancellationToken cancellationToken = default)
     {
-        return await GetLatestAsync(domain, name, cancellationToken);
+        return await GetResolvedAsync(domain, name, InstanceDataVersionComparer.LatestKeyword, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -56,42 +86,30 @@ public class CacheSet<T>(
         var domain = entity.Domain;
         var key = entity.Key;
         var fullVersion = entity.Version;
-        var artifactVersion = InstanceDataVersionComparer.GetArtifactVersion(fullVersion);
 
         using var activity = CacheActivityHelper.StartActivity(
             CacheActivityHelper.OperationSet, CreateFullKey(domain, key, fullVersion), ComponentKeyName);
 
-        try
-        {
-            var envelope = CreateEnvelope(entity);
+        // 1) The body under its immutable full-version key. Safe to overwrite: the key names this exact
+        //    revision, so the only thing an overwrite can change is a re-published body.
+        await TryWriteAsync(
+            CreateFullKey(domain, key, fullVersion),
+            CreateEnvelope(entity),
+            FullEntryOptions(),
+            cancellationToken);
 
-            // 1) Write the full version body (short TTL -- rare access pattern)
-            await distributedCache.SetAsync(
-                CreateFullKey(domain, key, fullVersion),
-                envelope,
-                new DistributedCacheEntryOptions { AbsoluteExpiration = DateTimeOffset.UtcNow.Add(FullVersionTtl) },
-                cancellationToken);
+        // 2) Invalidate every cached version resolution for this component. Not just the ones derivable
+        //    from this version: adding a version can change what any request resolves to, and this
+        //    publish may well be a lower version than what is already stored.
+        var generation = await generationProvider.BumpAsync(ComponentKeyName, domain, key, cancellationToken);
+        CacheActivityHelper.SetGeneration(activity, generation);
 
-            // 2) Overwrite the latest key with the new entity (no TTL)
-            await distributedCache.SetAsync(
-                CreateLatestKey(domain, key),
-                envelope,
-                cancellationToken: cancellationToken);
+        // 3) Re-resolve the common spellings and cache them under the new generation, so a deploy does
+        //    not leave every hot component to be resolved by whichever request arrives first.
+        await WarmResolutionsAsync(domain, key, entity, generation, activity, cancellationToken);
 
-            // 3) Overwrite the artifact key with the new entity (no TTL)
-            if (!string.IsNullOrEmpty(artifactVersion))
-            {
-                await distributedCache.SetAsync(
-                    CreateArtifactKey(domain, key, artifactVersion),
-                    envelope,
-                    cancellationToken: cancellationToken);
-            }
-        }
-        catch (Exception ex)
-        {
-            CacheActivityHelper.SetError(activity, ex);
-            logger.LogError(ex, "Error writing to distributed cache for {Domain}/{Key}@{Version}", domain, key, fullVersion);
-        }
+        if (options.Value.PurgeLegacyKeysOnPublish)
+            await PurgeLegacyKeysAsync(domain, key, fullVersion, cancellationToken);
 
         return Result.Ok();
     }
@@ -99,26 +117,20 @@ public class CacheSet<T>(
     /// <inheritdoc />
     public async Task<Result> InvalidateAsync(string domain, string key, string version, CancellationToken cancellationToken = default)
     {
-        var artifactVersion = InstanceDataVersionComparer.GetArtifactVersion(version);
-
         using var activity = CacheActivityHelper.StartActivity(
             CacheActivityHelper.OperationRemove, CreateFullKey(domain, key, version), ComponentKeyName);
 
-        try
-        {
-            await distributedCache.RemoveAsync(CreateLatestKey(domain, key), cancellationToken);
+        // A full version identifies one revision, so its body is the only body worth dropping.
+        if (InstanceDataVersionComparer.IsFullVersion(version))
+            await TryRemoveAsync(CreateFullKey(domain, key, version), cancellationToken);
 
-            if (!string.IsNullOrEmpty(artifactVersion))
-                await distributedCache.RemoveAsync(CreateArtifactKey(domain, key, artifactVersion), cancellationToken);
+        // Deliberately not warmed: the version may have been deactivated or deleted, so the correct
+        // winner is whatever the database says on the next read.
+        var generation = await generationProvider.BumpAsync(ComponentKeyName, domain, key, cancellationToken);
+        CacheActivityHelper.SetGeneration(activity, generation);
 
-            if (InstanceDataVersionComparer.IsFullVersion(version))
-                await distributedCache.RemoveAsync(CreateFullKey(domain, key, version), cancellationToken);
-        }
-        catch (Exception ex)
-        {
-            CacheActivityHelper.SetError(activity, ex);
-            logger.LogError(ex, "Error removing from distributed cache for {Domain}/{Key}@{Version}", domain, key, version);
-        }
+        if (options.Value.PurgeLegacyKeysOnPublish)
+            await PurgeLegacyKeysAsync(domain, key, version, cancellationToken);
 
         return Result.Ok();
     }
@@ -131,150 +143,326 @@ public class CacheSet<T>(
     // Private: read paths
     // ────────────────────────────────────────────────────────────────────
 
-    private async Task<Result<T>> GetLatestAsync(string domain, string key, CancellationToken cancellationToken)
+    private async Task<Result<T>> GetResolvedAsync(
+        string domain,
+        string key,
+        string? requested,
+        CancellationToken cancellationToken)
     {
-        var redisKey = CreateLatestKey(domain, key);
+        var spelling = InstanceDataVersionComparer.NormalizeRequest(requested);
+        var generation = await generationProvider.GetAsync(ComponentKeyName, domain, key, cancellationToken);
+        var redisKey = CreateResolutionKey(domain, key, generation, spelling);
 
         using var activity = CacheActivityHelper.StartActivity(
             CacheActivityHelper.OperationGet, redisKey, ComponentKeyName);
+        CacheActivityHelper.SetGeneration(activity, generation);
 
-        // 1) Try Redis
-        var entity = await TryGetFromRedisAsync(redisKey, activity, cancellationToken);
-        if (entity is not null)
-            return Result<T>.Ok(entity);
+        var envelope = await TryGetEnvelopeAsync(redisKey, activity, cancellationToken);
+        if (envelope is not null)
+        {
+            CacheActivityHelper.SetCacheHit(activity, true);
+
+            if (envelope.IsNegative)
+            {
+                CacheActivityHelper.SetNegative(activity, true);
+                return Result<T>.Fail(CacheErrors.ItemNotFoundInBackend<T>(domain, key, requested));
+            }
+
+            if (envelope.Entity is not null)
+            {
+                HydrateReference(envelope);
+                return Result<T>.Ok(envelope.Entity);
+            }
+        }
 
         CacheActivityHelper.SetCacheHit(activity, false);
 
-        // 2) Fallback to DB: load all versions for the key, find latest
-        var allResult = await backend.LoadAllByKeyAsync(domain, key, cancellationToken);
-        if (!allResult.IsSuccess || allResult.Value!.Count == 0)
-            return Result<T>.Fail(CacheErrors.ItemNotFoundInBackend<T>(domain, key, null));
-
-        var allVersions = allResult.Value!;
-        var latestVersion = InstanceDataVersionComparer.FindBestMatch(
-            allVersions.Select(e => e.Version), null);
-
-        var latest = allVersions.FirstOrDefault(e =>
-            string.Equals(e.Version, latestVersion, StringComparison.OrdinalIgnoreCase));
-
-        if (latest is null)
-            return Result<T>.Fail(CacheErrors.ItemNotFoundInBackend<T>(domain, key, null));
-
-        // Populate Redis for future reads
-        _ = PopulateCacheAsync(latest, cancellationToken);
-
-        return Result<T>.Ok(latest);
+        return await ResolveCoalescedAsync(domain, key, requested, spelling, redisKey, activity, cancellationToken);
     }
 
-    private async Task<Result<T>> GetArtifactVersionAsync(string domain, string key, string artifactVersion, CancellationToken cancellationToken)
+    /// <summary>
+    /// Shares one backend resolution between all callers currently missing the same resolution key.
+    /// </summary>
+    /// <remarks>
+    /// The shared load runs on the first caller's cancellation token. If that caller disappears the
+    /// waiters observe the cancellation and resolve again on their next request; the alternative — an
+    /// unbounded token — would keep loading for callers that have already gone away. The window is
+    /// narrow because, generations being what they are, misses only happen after a publish.
+    /// </remarks>
+    private async Task<Result<T>> ResolveCoalescedAsync(
+        string domain,
+        string key,
+        string? requested,
+        string spelling,
+        string redisKey,
+        Activity? activity,
+        CancellationToken cancellationToken)
     {
-        var redisKey = CreateArtifactKey(domain, key, artifactVersion);
+        var resolution = _inFlightResolutions.GetOrAdd(
+            redisKey,
+            _ => new Lazy<Task<Result<T>>>(
+                () => ResolveFromBackendAsync(domain, key, requested, spelling, redisKey, cancellationToken),
+                LazyThreadSafetyMode.ExecutionAndPublication));
 
-        using var activity = CacheActivityHelper.StartActivity(
-            CacheActivityHelper.OperationGet, redisKey, ComponentKeyName);
+        CacheActivityHelper.SetCoalesced(activity, resolution.IsValueCreated);
 
-        // 1) Try Redis
-        var entity = await TryGetFromRedisAsync(redisKey, activity, cancellationToken);
-        if (entity is not null)
-            return Result<T>.Ok(entity);
+        try
+        {
+            return await resolution.Value;
+        }
+        finally
+        {
+            _inFlightResolutions.TryRemove(redisKey, out _);
+        }
+    }
 
-        CacheActivityHelper.SetCacheHit(activity, false);
-
-        // 2) Fallback to DB: load all versions for the key, find best match for artifact
+    private async Task<Result<T>> ResolveFromBackendAsync(
+        string domain,
+        string key,
+        string? requested,
+        string spelling,
+        string redisKey,
+        CancellationToken cancellationToken)
+    {
         var allResult = await backend.LoadAllByKeyAsync(domain, key, cancellationToken);
         if (!allResult.IsSuccess || allResult.Value!.Count == 0)
-            return Result<T>.Fail(CacheErrors.ItemNotFoundInBackend<T>(domain, key, artifactVersion));
+            return await CacheNegativeAsync(domain, key, requested, spelling, redisKey, cancellationToken);
 
         var allVersions = allResult.Value!;
+
+        // The normalized spelling is what the answer gets filed under, so it has to be what the answer
+        // was computed from — otherwise a padded or differently-cased request could cache one component
+        // under the key another request reads. Normalization only trims and lowercases, and every
+        // comparison in FindBestMatch that can see letters is already case-insensitive, so resolution
+        // semantics are unchanged.
         var bestMatch = InstanceDataVersionComparer.FindBestMatch(
-            allVersions.Select(e => e.Version), artifactVersion);
+            allVersions.Select(e => e.Version), spelling);
 
         if (string.IsNullOrEmpty(bestMatch))
-            return Result<T>.Fail(CacheErrors.ItemNotFoundInBackend<T>(domain, key, artifactVersion));
+            return await CacheNegativeAsync(domain, key, requested, spelling, redisKey, cancellationToken);
 
         var matched = allVersions.FirstOrDefault(e =>
             string.Equals(e.Version, bestMatch, StringComparison.OrdinalIgnoreCase));
 
         if (matched is null)
-            return Result<T>.Fail(CacheErrors.ItemNotFoundInBackend<T>(domain, key, artifactVersion));
+            return await CacheNegativeAsync(domain, key, requested, spelling, redisKey, cancellationToken);
 
-        // Populate artifact key in Redis
-        try
-        {
-            await distributedCache.SetAsync(redisKey, CreateEnvelope(matched), cancellationToken: cancellationToken);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error writing artifact cache for {Domain}/{Key}@{Version}", domain, key, artifactVersion);
-        }
+        var envelope = CreateEnvelope(matched);
+
+        // Only the spelling that was asked for. Writing the other spellings here would be guessing at
+        // resolutions nobody requested, and one of those guesses being wrong is how a resolution cache
+        // goes stale in the first place.
+        await TryWriteAsync(redisKey, envelope, ResolutionEntryOptions(), cancellationToken);
+
+        // The body is immutable and was loaded anyway, so a pinned read of this exact version can reuse
+        // it instead of going back to the database.
+        await TryWriteAsync(
+            CreateFullKey(domain, key, matched.Version),
+            envelope,
+            FullEntryOptions(),
+            cancellationToken);
+
+        logger.ComponentCacheResolvedFromBackend(ComponentKeyName, domain, key, spelling, matched.Version);
 
         return Result<T>.Ok(matched);
     }
 
+    private async Task<Result<T>> CacheNegativeAsync(
+        string domain,
+        string key,
+        string? requested,
+        string spelling,
+        string redisKey,
+        CancellationToken cancellationToken)
+    {
+        // Short-lived, so a reference to a version that is about to be published starts working promptly
+        // even without a generation bump; a bump clears it immediately.
+        await TryWriteAsync(
+            redisKey,
+            new CacheEnvelope<T> { Domain = domain, Key = key, IsNegative = true },
+            NegativeEntryOptions(),
+            cancellationToken);
+
+        logger.ComponentCacheNegativeStored(ComponentKeyName, domain, key, spelling);
+
+        return Result<T>.Fail(CacheErrors.ItemNotFoundInBackend<T>(domain, key, requested));
+    }
+
     private async Task<Result<T>> GetFullVersionAsync(string domain, string key, string fullVersion, CancellationToken cancellationToken)
     {
+        // Build metadata (+packageName) does not participate in comparison, so "1.5.6-pkg.1.1.56" and
+        // "1.5.6-pkg.1.1.56+core" are the same version and must share one entry.
         var redisKey = CreateFullKey(domain, key, fullVersion);
 
         using var activity = CacheActivityHelper.StartActivity(
             CacheActivityHelper.OperationGet, redisKey, ComponentKeyName);
 
-        // 1) Try Redis
-        var entity = await TryGetFromRedisAsync(redisKey, activity, cancellationToken);
-        if (entity is not null)
-            return Result<T>.Ok(entity);
+        var envelope = await TryGetEnvelopeAsync(redisKey, activity, cancellationToken);
+        if (envelope?.Entity is not null)
+        {
+            CacheActivityHelper.SetCacheHit(activity, true);
+            HydrateReference(envelope);
+            return Result<T>.Ok(envelope.Entity);
+        }
 
         CacheActivityHelper.SetCacheHit(activity, false);
 
-        // 2) Fallback to DB: load specific version
         var dbResult = await backend.LoadAsync(domain, key, fullVersion, cancellationToken);
         if (!dbResult.IsSuccess)
             return dbResult;
 
         var loaded = dbResult.Value!;
 
-        // Populate full version key in Redis with TTL
+        await TryWriteAsync(redisKey, CreateEnvelope(loaded), FullEntryOptions(), cancellationToken);
+
+        return Result<T>.Ok(loaded);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Private: write paths
+    // ────────────────────────────────────────────────────────────────────
+
+    private async Task WarmResolutionsAsync(
+        string domain,
+        string key,
+        T entity,
+        string generation,
+        Activity? activity,
+        CancellationToken cancellationToken)
+    {
+        List<T> candidates;
         try
         {
-            await distributedCache.SetAsync(
-                redisKey,
-                CreateEnvelope(loaded),
-                new DistributedCacheEntryOptions { AbsoluteExpiration = DateTimeOffset.UtcNow.Add(FullVersionTtl) },
-                cancellationToken);
+            var allResult = await backend.LoadAllByKeyAsync(domain, key, cancellationToken);
+            candidates = allResult.IsSuccess ? allResult.Value! : [];
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error writing full version cache for {Domain}/{Key}@{Version}", domain, key, fullVersion);
+            // Warming is an optimization; reads will resolve on demand. Publishing must not fail for it.
+            CacheActivityHelper.SetError(activity, ex);
+            logger.ComponentCacheOperationFailed(ex, CacheActivityHelper.OperationWarmup, CreateFullKey(domain, key, entity.Version));
+            return;
         }
 
-        return Result<T>.Ok(loaded);
+        // The entity may not be visible to a fresh query yet, depending on where the publish sits
+        // relative to its transaction. Adding it makes the resolution below correct either way — and
+        // because the winner is re-resolved rather than assumed, it stays correct when the published
+        // version is older than something already stored.
+        if (!candidates.Any(e => string.Equals(e.Version, entity.Version, StringComparison.OrdinalIgnoreCase)))
+            candidates = [.. candidates, entity];
+
+        var versions = candidates.Select(e => e.Version).ToList();
+
+        foreach (var spelling in DeriveCommonSpellings(entity.Version))
+        {
+            var bestMatch = InstanceDataVersionComparer.FindBestMatch(versions, spelling);
+            if (string.IsNullOrEmpty(bestMatch))
+                continue;
+
+            var winner = candidates.FirstOrDefault(e =>
+                string.Equals(e.Version, bestMatch, StringComparison.OrdinalIgnoreCase));
+            if (winner is null)
+                continue;
+
+            await TryWriteAsync(
+                CreateResolutionKey(domain, key, generation, spelling),
+                CreateEnvelope(winner),
+                ResolutionEntryOptions(),
+                cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// The request spellings components are actually authored with: <c>latest</c>, the artifact version,
+    /// MAJOR.MINOR and MAJOR.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately not a claim about which spellings a publish affects — that set is not enumerable,
+    /// which is why resolutions are generation-scoped rather than individually invalidated. Used for
+    /// warming (so a deploy does not hand the first request of each a database load) and for purging the
+    /// pre-generation layout, whose keys were named after exactly these forms.
+    /// </remarks>
+    private static IEnumerable<string> DeriveCommonSpellings(string fullVersion)
+    {
+        var spellings = new List<string> { InstanceDataVersionComparer.LatestKeyword };
+
+        var artifactVersion = InstanceDataVersionComparer.GetArtifactVersion(fullVersion);
+        if (!string.IsNullOrEmpty(artifactVersion))
+            spellings.Add(InstanceDataVersionComparer.NormalizeRequest(artifactVersion));
+
+        if (InstanceDataVersionComparer.GetMajorMinor(fullVersion) is { Length: > 0 } majorMinor)
+            spellings.Add(majorMinor);
+
+        if (InstanceDataVersionComparer.GetMajor(fullVersion) is { Length: > 0 } major)
+            spellings.Add(major);
+
+        return spellings.Distinct(StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Deletes keys written by the pre-generation layout, which had no expiration and so would otherwise
+    /// linger — and, during a rolling deployment, keep being served by pods running the old build.
+    /// </summary>
+    private async Task PurgeLegacyKeysAsync(string domain, string key, string version, CancellationToken cancellationToken)
+    {
+        await TryRemoveAsync(LegacyLatestKey(domain, key), cancellationToken);
+
+        foreach (var spelling in DeriveCommonSpellings(version))
+        {
+            if (spelling == InstanceDataVersionComparer.LatestKeyword)
+                continue;
+
+            await TryRemoveAsync(LegacyArtifactKey(domain, key, spelling), cancellationToken);
+        }
     }
 
     // ────────────────────────────────────────────────────────────────────
     // Private: helpers
     // ────────────────────────────────────────────────────────────────────
 
-    private async Task<T?> TryGetFromRedisAsync(
+    private async Task<CacheEnvelope<T>?> TryGetEnvelopeAsync(
         string redisKey,
-        System.Diagnostics.Activity? activity,
+        Activity? activity,
         CancellationToken cancellationToken)
     {
         try
         {
-            var envelope = await distributedCache.GetAsync<CacheEnvelope<T>>(redisKey, cancellationToken);
-            if (envelope?.Entity is not null)
-            {
-                CacheActivityHelper.SetCacheHit(activity, true);
-                HydrateReference(envelope);
-                return envelope.Entity;
-            }
+            return await distributedCache.GetAsync<CacheEnvelope<T>>(redisKey, cancellationToken);
         }
         catch (Exception ex)
         {
             CacheActivityHelper.SetError(activity, ex);
-            logger.LogError(ex, "Error reading from distributed cache key {RedisKey}", redisKey);
+            logger.ComponentCacheOperationFailed(ex, CacheActivityHelper.OperationGet, redisKey);
+            return null;
         }
+    }
 
-        return null;
+    private async Task TryWriteAsync(
+        string redisKey,
+        CacheEnvelope<T> envelope,
+        DistributedCacheEntryOptions entryOptions,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await distributedCache.SetAsync(redisKey, envelope, entryOptions, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.ComponentCacheOperationFailed(ex, CacheActivityHelper.OperationSet, redisKey);
+        }
+    }
+
+    private async Task TryRemoveAsync(string redisKey, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await distributedCache.RemoveAsync(redisKey, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.ComponentCacheOperationFailed(ex, CacheActivityHelper.OperationRemove, redisKey);
+        }
     }
 
     private static void HydrateReference(CacheEnvelope<T> envelope)
@@ -305,25 +493,30 @@ public class CacheSet<T>(
         };
     }
 
-    private async Task PopulateCacheAsync(T entity, CancellationToken cancellationToken)
+    private DistributedCacheEntryOptions FullEntryOptions() => new()
     {
-        try
-        {
-            await SetAsync(entity, cancellationToken);
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning(ex, "Failed to populate cache after DB load for {Domain}/{Key}@{Version}",
-                entity.Domain, entity.Key, entity.Version);
-        }
-    }
+        AbsoluteExpiration = timeProvider.GetUtcNow().AddSeconds(options.Value.FullVersionTtlSeconds)
+    };
 
-    private static string CreateLatestKey(string domain, string key)
-        => $"{ComponentKeyName}:{domain}:{key}:latest";
+    private DistributedCacheEntryOptions ResolutionEntryOptions() => new()
+    {
+        AbsoluteExpiration = timeProvider.GetUtcNow().AddSeconds(options.Value.ResolutionTtlSeconds)
+    };
 
-    private static string CreateArtifactKey(string domain, string key, string artifactVersion)
-        => $"{ComponentKeyName}:{domain}:{key}:artifact:{artifactVersion}";
+    private DistributedCacheEntryOptions NegativeEntryOptions() => new()
+    {
+        AbsoluteExpiration = timeProvider.GetUtcNow().AddSeconds(options.Value.NegativeTtlSeconds)
+    };
 
     private static string CreateFullKey(string domain, string key, string fullVersion)
-        => $"{ComponentKeyName}:{domain}:{key}:full:{fullVersion}";
+        => $"{ComponentKeyName}:{domain}:{key}:full:{InstanceDataVersionComparer.CanonicalFullVersion(fullVersion)}";
+
+    private static string CreateResolutionKey(string domain, string key, string generation, string spelling)
+        => $"{ComponentKeyName}:{domain}:{key}:res:{generation}:{spelling}";
+
+    private static string LegacyLatestKey(string domain, string key)
+        => $"{ComponentKeyName}:{domain}:{key}:latest";
+
+    private static string LegacyArtifactKey(string domain, string key, string spelling)
+        => $"{ComponentKeyName}:{domain}:{key}:artifact:{spelling}";
 }

--- a/src/BBT.Workflow.Application/Caching/ComponentCacheOptions.cs
+++ b/src/BBT.Workflow.Application/Caching/ComponentCacheOptions.cs
@@ -1,0 +1,116 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace BBT.Workflow.Caching;
+
+/// <summary>
+/// Configuration options for the component definition cache (workflows, tasks, schemas, functions,
+/// views, extensions, mappings).
+/// </summary>
+/// <remarks>
+/// The cache holds two categories of entry, and they have different correctness rules:
+/// <list type="bullet">
+///     <item><description>
+///         <b>Immutable bodies</b> — keyed by a canonical full version
+///         (<c>MAJOR.MINOR.PATCH-pkg.PKG_VERSION</c>). A full version identifies exactly one component
+///         revision forever, so these may be written unconditionally and their TTL is nothing more
+///         than a memory bound.
+///     </description></item>
+///     <item><description>
+///         <b>Resolution entries</b> — the answer to a version <i>request</i> such as <c>latest</c>,
+///         <c>1</c>, <c>1.2</c> or <c>2.3.5</c>. Their value is a function of the whole set of
+///         published versions, so publishing or deactivating any version can change them. They must
+///         never be written as though the component being published wins the range: a publish is not
+///         monotonic (a lower version may be released, and a version may be deactivated).
+///     </description></item>
+/// </list>
+/// Resolution entries are therefore keyed under a per-component <b>generation token</b>. Publishing or
+/// invalidating writes a fresh token, which makes every prior resolution entry for that component
+/// unreachable at once — including request spellings no publish could have enumerated, such as the
+/// leading-zero package-version aliases accepted by
+/// <see cref="Instances.InstanceDataVersionComparer.FindBestMatch"/>. Because invalidation is complete,
+/// <see cref="ResolutionTtlSeconds"/> is garbage collection rather than a correctness backstop, and
+/// there is no recurring database load to keep resolutions fresh.
+/// <para>
+/// Determinism is unaffected by any of this: a running instance is pinned to its
+/// <c>Instance.FlowVersion</c>, which is a full version, so it reads an immutable body. Only component
+/// references that were <i>authored</i> with a range version (for example <c>view.version: "1"</c>)
+/// resolve dynamically, and they would do so with or without a cache.
+/// </para>
+/// </remarks>
+public sealed class ComponentCacheOptions
+{
+    /// <summary>
+    /// Configuration section name for component cache options.
+    /// </summary>
+    public const string SectionName = "ComponentCache";
+
+    /// <summary>
+    /// Gets or sets the TTL in seconds for immutable full-version bodies. Default is 1800.
+    /// Purely a memory bound — the content behind a full version never changes.
+    /// </summary>
+    [Range(60, 86400)]
+    public int FullVersionTtlSeconds { get; set; } = 1800;
+
+    /// <summary>
+    /// Gets or sets the TTL in seconds for a component's generation token. Default is 3600.
+    /// </summary>
+    /// <remarks>
+    /// Any token value is valid; only its <i>change</i> on publish carries meaning. This TTL exists
+    /// solely as a last-resort backstop for the one failure mode that can reintroduce staleness: a
+    /// publish whose token write fails after the body was written. Expiry forces a fresh token, which
+    /// re-resolves everything. Lowering it buys a tighter staleness ceiling at the cost of one
+    /// version-list load per component per interval.
+    /// </remarks>
+    [Range(60, 86400)]
+    public int GenerationTtlSeconds { get; set; } = 3600;
+
+    /// <summary>
+    /// Gets or sets the TTL in seconds for resolution entries. Default is 3600.
+    /// </summary>
+    /// <remarks>
+    /// This is garbage collection, not correctness: a generation bump already makes stale entries
+    /// unreachable, and this bound just stops orphaned entries from older generations occupying memory
+    /// indefinitely. It is safe to raise; raising it does not extend how long stale data can be served.
+    /// </remarks>
+    [Range(60, 86400)]
+    public int ResolutionTtlSeconds { get; set; } = 3600;
+
+    /// <summary>
+    /// Gets or sets the TTL in seconds for negative (no matching version) resolution entries.
+    /// Default is 30.
+    /// </summary>
+    /// <remarks>
+    /// Short-lived on purpose: it exists so a bad or not-yet-published reference under load cannot
+    /// repeatedly trigger a full version-list load, while still letting a genuinely new publish be
+    /// picked up promptly. A generation bump clears negative entries as well, so a publish that
+    /// satisfies the request takes effect immediately rather than after this interval.
+    /// </remarks>
+    [Range(1, 300)]
+    public int NegativeTtlSeconds { get; set; } = 30;
+
+    /// <summary>
+    /// Gets or sets how long, in seconds, a generation token may be memoized in process.
+    /// Default is 0 (disabled).
+    /// </summary>
+    /// <remarks>
+    /// Resolving a range version costs one extra distributed-cache read to fetch the generation token.
+    /// Setting this above zero removes that read for the configured interval, at the cost of serving a
+    /// stale resolution for up to that long after a publish. It is off by default because correctness
+    /// comes first and because in-process state is otherwise avoided in this codebase for cache data —
+    /// enable it deliberately, and only if the extra read is shown to matter.
+    /// </remarks>
+    [Range(0, 60)]
+    public int GenerationMemoSeconds { get; set; } = 0;
+
+    /// <summary>
+    /// Gets or sets whether publishing also deletes cache keys written by the pre-generation key
+    /// layout. Default is true.
+    /// </summary>
+    /// <remarks>
+    /// The previous layout wrote <c>:latest</c> and <c>:artifact:{version}</c> keys with no expiration.
+    /// Nothing reads them any more, but they would otherwise linger, and during a rolling deployment
+    /// pods still running the old build would keep serving them. Remove this option once no such pod
+    /// can exist.
+    /// </remarks>
+    public bool PurgeLegacyKeysOnPublish { get; set; } = true;
+}

--- a/src/BBT.Workflow.Application/Caching/ComponentGenerationProvider.cs
+++ b/src/BBT.Workflow.Application/Caching/ComponentGenerationProvider.cs
@@ -1,0 +1,168 @@
+using System.Collections.Concurrent;
+using BBT.Aether.DistributedCache;
+using BBT.Aether.Guids;
+using BBT.Workflow.Logging;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace BBT.Workflow.Caching;
+
+/// <summary>
+/// Redis-backed <see cref="IComponentGenerationProvider"/>. Stores one small token per component key,
+/// shared by every pod, so a bump takes effect cluster-wide the moment it is written.
+/// </summary>
+/// <param name="distributedCache">The distributed cache holding the tokens.</param>
+/// <param name="guidGenerator">Source of fresh token values.</param>
+/// <param name="options">Component cache options (token TTL and optional in-process memoization).</param>
+/// <param name="timeProvider">Time source for in-process memoization expiry.</param>
+/// <param name="logger">Logger for bump outcomes.</param>
+public sealed class ComponentGenerationProvider(
+    IDistributedCacheService distributedCache,
+    IGuidGenerator guidGenerator,
+    IOptions<ComponentCacheOptions> options,
+    TimeProvider timeProvider,
+    ILogger<ComponentGenerationProvider> logger) : IComponentGenerationProvider
+{
+    private readonly ConcurrentDictionary<string, MemoizedToken> _memo = new();
+
+    /// <inheritdoc />
+    public async Task<string> GetAsync(
+        string componentTypeKey,
+        string domain,
+        string key,
+        CancellationToken cancellationToken = default)
+    {
+        var redisKey = CreateGenerationKey(componentTypeKey, domain, key);
+
+        if (TryReadMemo(redisKey, out var memoized))
+            return memoized;
+
+        try
+        {
+            var entry = await distributedCache.GetAsync<ComponentGenerationEntry>(redisKey, cancellationToken);
+            if (!string.IsNullOrEmpty(entry?.Token))
+            {
+                WriteMemo(redisKey, entry.Token);
+                return entry.Token;
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.ComponentCacheOperationFailed(ex, CacheActivityHelper.OperationGenerationGet, redisKey);
+
+            // Deliberately not written back. A failed read is no evidence the token is absent, and
+            // replacing it would invalidate every pod's resolutions for no reason — worse, if reads keep
+            // failing while writes succeed, every request would do so in turn. An unshared token instead
+            // degrades just this call to a backend load, which is the right answer for a cache we cannot
+            // read.
+            return CreateToken();
+        }
+
+        var token = CreateToken();
+
+        try
+        {
+            await distributedCache.SetAsync(redisKey, new ComponentGenerationEntry(token), EntryOptions(), cancellationToken);
+            logger.ComponentCacheGenerationBootstrapped(componentTypeKey, domain, key, token);
+        }
+        catch (Exception ex)
+        {
+            // The token is still usable for this call; it just will not be shared with other callers,
+            // so they resolve from the backend too. Correct, only slower.
+            logger.ComponentCacheOperationFailed(ex, CacheActivityHelper.OperationGenerationSet, redisKey);
+            return token;
+        }
+
+        WriteMemo(redisKey, token);
+        return token;
+    }
+
+    /// <inheritdoc />
+    public async Task<string> BumpAsync(
+        string componentTypeKey,
+        string domain,
+        string key,
+        CancellationToken cancellationToken = default)
+    {
+        var redisKey = CreateGenerationKey(componentTypeKey, domain, key);
+        var token = CreateToken();
+
+        // Drop the memo first: if the write below fails we must not keep serving the previous token
+        // from this pod on the strength of a bump that never landed.
+        _memo.TryRemove(redisKey, out _);
+
+        try
+        {
+            await distributedCache.SetAsync(redisKey, new ComponentGenerationEntry(token), EntryOptions(), cancellationToken);
+            logger.ComponentCacheGenerationBumped(componentTypeKey, domain, key, token);
+            WriteMemo(redisKey, token);
+            return token;
+        }
+        catch (Exception writeException)
+        {
+            try
+            {
+                // Removing the token invalidates just as effectively — the next reader bootstraps a
+                // token nobody's stale entries were written under.
+                await distributedCache.RemoveAsync(redisKey, cancellationToken);
+                logger.ComponentCacheGenerationBumpFellBackToRemove(writeException, componentTypeKey, domain, key);
+            }
+            catch (Exception removeException)
+            {
+                // The previous token survives, so previously cached resolutions stay reachable. This is
+                // the one path that can serve stale definitions, and it is bounded only by the token TTL.
+                logger.ComponentCacheGenerationBumpFailed(removeException, componentTypeKey, domain, key);
+            }
+
+            return token;
+        }
+    }
+
+    private string CreateToken() => guidGenerator.Create().ToString("N");
+
+    private DistributedCacheEntryOptions EntryOptions() => new()
+    {
+        AbsoluteExpiration = timeProvider.GetUtcNow().AddSeconds(options.Value.GenerationTtlSeconds)
+    };
+
+    private bool TryReadMemo(string redisKey, out string token)
+    {
+        token = string.Empty;
+
+        if (options.Value.GenerationMemoSeconds <= 0)
+            return false;
+
+        if (!_memo.TryGetValue(redisKey, out var entry))
+            return false;
+
+        if (entry.ExpiresAt <= timeProvider.GetUtcNow())
+        {
+            _memo.TryRemove(redisKey, out _);
+            return false;
+        }
+
+        token = entry.Token;
+        return true;
+    }
+
+    private void WriteMemo(string redisKey, string token)
+    {
+        var memoSeconds = options.Value.GenerationMemoSeconds;
+        if (memoSeconds <= 0)
+            return;
+
+        _memo[redisKey] = new MemoizedToken(token, timeProvider.GetUtcNow().AddSeconds(memoSeconds));
+    }
+
+    private static string CreateGenerationKey(string componentTypeKey, string domain, string key)
+        => $"{componentTypeKey}:{domain}:{key}:gen";
+
+    private readonly record struct MemoizedToken(string Token, DateTimeOffset ExpiresAt);
+
+    /// <summary>
+    /// Cache payload wrapper. The token is stored as a property rather than a bare string so the entry
+    /// round-trips through the cache serializer the same way every other cached value does.
+    /// </summary>
+    /// <param name="Token">The generation token.</param>
+    public sealed record ComponentGenerationEntry(string Token);
+}

--- a/src/BBT.Workflow.Application/Caching/DomainCacheContext.cs
+++ b/src/BBT.Workflow.Application/Caching/DomainCacheContext.cs
@@ -1,6 +1,7 @@
 using BBT.Aether.DistributedCache;
 using BBT.Workflow.Definitions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace BBT.Workflow.Caching;
 
@@ -10,6 +11,8 @@ namespace BBT.Workflow.Caching;
 /// </summary>
 public class DomainCacheContext : IDomainCacheContext, IDisposable
 {
+    private readonly Dictionary<string, ICacheSet> _setsByComponentTypeKey;
+
     public ICacheSet<Definitions.Workflow> Workflows { get; }
     public ICacheSet<WorkflowTask> Tasks { get; }
     public ICacheSet<SchemaDefinition> Schemas { get; }
@@ -27,42 +30,77 @@ public class DomainCacheContext : IDomainCacheContext, IDisposable
         ICacheBackend<View> viewBackend,
         ICacheBackend<Extension> extensionBackend,
         ICacheBackend<Mapping> mappingBackend,
+        IComponentGenerationProvider generationProvider,
+        IOptions<ComponentCacheOptions> options,
+        TimeProvider timeProvider,
         ILoggerFactory loggerFactory)
     {
         Workflows = new CacheSet<Definitions.Workflow>(
             distributedCache,
             workflowBackend,
+            generationProvider,
+            options,
+            timeProvider,
             loggerFactory.CreateLogger<CacheSet<Definitions.Workflow>>());
 
         Tasks = new CacheSet<WorkflowTask>(
             distributedCache,
             taskBackend,
+            generationProvider,
+            options,
+            timeProvider,
             loggerFactory.CreateLogger<CacheSet<WorkflowTask>>());
 
         Schemas = new CacheSet<SchemaDefinition>(
             distributedCache,
             schemaBackend,
+            generationProvider,
+            options,
+            timeProvider,
             loggerFactory.CreateLogger<CacheSet<SchemaDefinition>>());
 
         Functions = new CacheSet<Function>(
             distributedCache,
             functionBackend,
+            generationProvider,
+            options,
+            timeProvider,
             loggerFactory.CreateLogger<CacheSet<Function>>());
 
         Views = new CacheSet<View>(
             distributedCache,
             viewBackend,
+            generationProvider,
+            options,
+            timeProvider,
             loggerFactory.CreateLogger<CacheSet<View>>());
 
         Extensions = new CacheSet<Extension>(
             distributedCache,
             extensionBackend,
+            generationProvider,
+            options,
+            timeProvider,
             loggerFactory.CreateLogger<CacheSet<Extension>>());
 
         Mappings = new CacheSet<Mapping>(
             distributedCache,
             mappingBackend,
+            generationProvider,
+            options,
+            timeProvider,
             loggerFactory.CreateLogger<CacheSet<Mapping>>());
+
+        _setsByComponentTypeKey = new Dictionary<string, ICacheSet>(StringComparer.OrdinalIgnoreCase)
+        {
+            [Definitions.Workflow.ComponentTypeKey] = Workflows,
+            [WorkflowTask.ComponentTypeKey] = Tasks,
+            [SchemaDefinition.ComponentTypeKey] = Schemas,
+            [Function.ComponentTypeKey] = Functions,
+            [View.ComponentTypeKey] = Views,
+            [Extension.ComponentTypeKey] = Extensions,
+            [Mapping.ComponentTypeKey] = Mappings
+        };
     }
 
     public ICacheSet<T> Set<T>() where T : class, IDomainEntity, IReferenceSetter
@@ -76,6 +114,15 @@ public class DomainCacheContext : IDomainCacheContext, IDisposable
         if (typeof(T) == typeof(Mapping)) return (ICacheSet<T>)Mappings;
 
         throw new NotSupportedException($"Type {typeof(T).Name} is not supported in DomainCacheContext.");
+    }
+
+    /// <inheritdoc />
+    public ICacheSet? Set(string componentTypeKey)
+    {
+        if (string.IsNullOrWhiteSpace(componentTypeKey))
+            return null;
+
+        return _setsByComponentTypeKey.GetValueOrDefault(componentTypeKey);
     }
 
     public void Dispose()

--- a/src/BBT.Workflow.Application/Caching/ICacheSet.cs
+++ b/src/BBT.Workflow.Application/Caching/ICacheSet.cs
@@ -11,6 +11,29 @@ public interface ICacheSet : IDisposable
     /// Gets the type of entity managed by this cache set.
     /// </summary>
     Type EntityType { get; }
+
+    /// <summary>
+    /// Invalidates cached data for a component, so the next read re-resolves it from the database.
+    /// </summary>
+    /// <param name="domain">The domain identifier</param>
+    /// <param name="key">The entity key</param>
+    /// <param name="version">
+    /// The version that changed. A full version additionally drops that version's immutable body;
+    /// any other form only invalidates resolutions.
+    /// </param>
+    /// <param name="cancellationToken">Token to monitor for cancellation requests</param>
+    /// <returns>A <see cref="Result"/> indicating success or failure of the invalidation operation.</returns>
+    /// <remarks>
+    /// Every cached answer to a version <i>request</i> is invalidated, not just the ones derivable from
+    /// <paramref name="version"/> — adding or removing any version can change what <c>latest</c>,
+    /// <c>1</c> or <c>1.2</c> resolve to. Call this when a version is deactivated or deleted; publishing
+    /// already invalidates as part of <see cref="ICacheSet{T}.SetAsync"/>.
+    /// <para>
+    /// Declared on the non-generic interface so callers holding only a component type key (for example a
+    /// cast handler dispatching on <c>sys-views</c>) can invalidate without knowing the entity type.
+    /// </para>
+    /// </remarks>
+    Task<Result> InvalidateAsync(string domain, string key, string version, CancellationToken cancellationToken = default);
 }
 
 /// <summary>
@@ -35,10 +58,14 @@ public interface ICacheSet<T> : ICacheSet where T : class, IDomainEntity, IRefer
     /// <param name="key">The entity key/name</param>
     /// <param name="version">The version to search for. Supports multiple formats:
     /// <list type="bullet">
-    ///     <item><description>null/empty/"latest": Returns the latest version</description></item>
-    ///     <item><description>Full version (e.g., "1.0.0-pkg.1.17.0+account"): Exact match from Redis/DB</description></item>
-    ///     <item><description>Artifact version (e.g., "1.0.0"): Returns highest pkg version for that artifact</description></item>
+    ///     <item><description>null/empty/"latest": the highest available version</description></item>
+    ///     <item><description>Full version (e.g., "1.5.6-pkg.1.1.56+core"): that exact revision. Build metadata is ignored, so "1.5.6-pkg.1.1.56" resolves identically</description></item>
+    ///     <item><description>Artifact version (e.g., "2.3.5"): the highest package version of that artifact</description></item>
+    ///     <item><description>Partial version (e.g., "1.2"): the highest version whose artifact major and minor match</description></item>
+    ///     <item><description>Major-only version (e.g., "1"): the highest version whose artifact major matches</description></item>
     /// </list>
+    /// The artifact version dominates the package version when ranking, so "1.6.0-pkg.1.0.0" outranks
+    /// "1.5.0-pkg.9.9.9".
     /// </param>
     /// <param name="cancellationToken">Token to monitor for cancellation requests</param>
     /// <returns>
@@ -47,24 +74,17 @@ public interface ICacheSet<T> : ICacheSet where T : class, IDomainEntity, IRefer
     Task<Result<T>> GetByVersionAsync(string domain, string key, string? version, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Stores an entity in the cache. Writes to Redis under full, latest, and artifact keys.
-    /// Used by CastHandlers on publish to immediately populate cache for all pods.
+    /// Stores a published entity in the cache and invalidates every stale version resolution for its
+    /// component. Called by CastHandlers on publish, so the effect is immediately visible to all pods.
     /// </summary>
     /// <returns>
     /// A <see cref="Result"/> indicating success or failure of the cache operation.
     /// </returns>
+    /// <remarks>
+    /// The entity's own body is written under its immutable full-version key. Cached answers to version
+    /// <i>requests</i> are then invalidated wholesale and the common ones re-resolved, because the entity
+    /// being published is not necessarily the winner of the ranges it belongs to — publishes are not
+    /// monotonic, and a lower version may be released deliberately.
+    /// </remarks>
     Task<Result> SetAsync(T entity, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Invalidates (removes) cache entries for a component version.
-    /// Removes the latest, artifact, and full version keys from Redis.
-    /// </summary>
-    /// <param name="domain">The domain identifier</param>
-    /// <param name="key">The entity key</param>
-    /// <param name="version">The version to invalidate</param>
-    /// <param name="cancellationToken">Token to monitor for cancellation requests</param>
-    /// <returns>
-    /// A <see cref="Result"/> indicating success or failure of the invalidation operation.
-    /// </returns>
-    Task<Result> InvalidateAsync(string domain, string key, string version, CancellationToken cancellationToken = default);
 }

--- a/src/BBT.Workflow.Application/Caching/IComponentGenerationProvider.cs
+++ b/src/BBT.Workflow.Application/Caching/IComponentGenerationProvider.cs
@@ -1,0 +1,69 @@
+namespace BBT.Workflow.Caching;
+
+/// <summary>
+/// Supplies and replaces the per-component <b>generation token</b> that scopes cached version
+/// resolutions.
+/// </summary>
+/// <remarks>
+/// A resolution entry answers a version <i>request</i> (<c>latest</c>, <c>1</c>, <c>1.2</c>,
+/// <c>2.3.5</c>), so its value depends on the whole set of published versions rather than on any single
+/// component revision. Publishing or deactivating a version can therefore change it, and a publish is
+/// not monotonic — a lower version may be released.
+/// <para>
+/// Rather than try to work out which cached answers a publish invalidates, resolution entries are keyed
+/// under this token and the token is replaced whenever the published set changes. Every prior entry for
+/// that component becomes unreachable at once, including request spellings that could never have been
+/// enumerated from the published version (for example the leading-zero package-version aliases
+/// <see cref="Instances.InstanceDataVersionComparer.FindBestMatch"/> accepts).
+/// </para>
+/// <para>
+/// The token only has to <i>differ</i> from its predecessor; it carries no ordering. That is what makes
+/// concurrent publishes safe: whichever write lands last, the resulting token differs from the one the
+/// stale entries were written under, so invalidation holds either way. A race costs at most one
+/// duplicate backend load — never a stale read.
+/// </para>
+/// </remarks>
+public interface IComponentGenerationProvider
+{
+    /// <summary>
+    /// Gets the component's current generation token, creating one if none exists.
+    /// </summary>
+    /// <param name="componentTypeKey">The component type key (e.g. <c>sys-views</c>)</param>
+    /// <param name="domain">The domain identifier</param>
+    /// <param name="key">The component key</param>
+    /// <param name="cancellationToken">Token to monitor for cancellation requests</param>
+    /// <returns>The current token. Never null or empty.</returns>
+    /// <remarks>
+    /// Two callers bootstrapping concurrently may produce two different tokens. This is harmless: each
+    /// resolves correctly against the backend, and at worst one extra load is performed. If the
+    /// distributed cache is unreachable this returns a fresh token per call, which degrades reads to
+    /// backend loads rather than serving anything stale.
+    /// </remarks>
+    Task<string> GetAsync(
+        string componentTypeKey,
+        string domain,
+        string key,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Replaces the component's generation token, invalidating every cached version resolution for it.
+    /// </summary>
+    /// <param name="componentTypeKey">The component type key (e.g. <c>sys-views</c>)</param>
+    /// <param name="domain">The domain identifier</param>
+    /// <param name="key">The component key</param>
+    /// <param name="cancellationToken">Token to monitor for cancellation requests</param>
+    /// <returns>
+    /// The new token, so a caller that already holds freshly resolved values can write them under it.
+    /// </returns>
+    /// <remarks>
+    /// If the token cannot be written it is removed instead, since an absent token forces the next
+    /// reader to bootstrap and therefore invalidates just as effectively. Only when both the write and
+    /// the removal fail can stale resolutions remain reachable; that case is logged at error level and
+    /// is bounded by <see cref="ComponentCacheOptions.GenerationTtlSeconds"/>.
+    /// </remarks>
+    Task<string> BumpAsync(
+        string componentTypeKey,
+        string domain,
+        string key,
+        CancellationToken cancellationToken = default);
+}

--- a/src/BBT.Workflow.Application/Caching/IDomainCacheContext.cs
+++ b/src/BBT.Workflow.Application/Caching/IDomainCacheContext.cs
@@ -22,4 +22,12 @@ public interface IDomainCacheContext
     /// <typeparam name="T">The entity type</typeparam>
     /// <returns>The cache set for the entity type</returns>
     ICacheSet<T> Set<T>() where T : class, IDomainEntity, IReferenceSetter;
+
+    /// <summary>
+    /// Gets the cache set for the specified component type key, for callers that only have the key as a
+    /// string (for example a cast handler dispatching on <c>sys-views</c>).
+    /// </summary>
+    /// <param name="componentTypeKey">The component type key (e.g. <c>sys-views</c>, <c>sys-flows</c>)</param>
+    /// <returns>The matching cache set, or null when the key does not name a cached component type.</returns>
+    ICacheSet? Set(string componentTypeKey);
 }

--- a/src/BBT.Workflow.Application/Caching/RuntimeCacheBackend.cs
+++ b/src/BBT.Workflow.Application/Caching/RuntimeCacheBackend.cs
@@ -1,7 +1,9 @@
 using BBT.Aether.Results;
 using BBT.Workflow.Instances;
+using BBT.Workflow.Logging;
 using BBT.Workflow.Runtime;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace BBT.Workflow.Caching;
 
@@ -12,25 +14,18 @@ namespace BBT.Workflow.Caching;
 /// </summary>
 /// <typeparam name="T">The type of entity to load from the runtime backend</typeparam>
 public sealed class RuntimeCacheBackend<T>(
-    IServiceScopeFactory scopeFactory)
+    IServiceScopeFactory scopeFactory,
+    ILogger<RuntimeCacheBackend<T>> logger)
     : ICacheBackend<T>
     where T : class, IDomainEntity, IReferenceSetter
 {
     /// <summary>
-    /// Loads an entity from the backend with smart version matching.
+    /// Loads every active version of a component key in the given domain.
     /// </summary>
     /// <param name="domain">The domain identifier</param>
     /// <param name="key">The entity key/name</param>
-    /// <param name="version">The version to search for. Supports:
-    /// <list type="bullet">
-    ///     <item><description>null/empty: Returns the latest version</description></item>
-    ///     <item><description>Full version (e.g., "1.0.0-pkg.1.17.0+account"): Exact match</description></item>
-    ///     <item><description>Artifact version (e.g., "1.0.0" or "1.0.0-alpha.1"): Returns highest pkg version for that artifact</description></item>
-    ///     <item><description>Partial version (e.g., "1.0"): Returns highest version matching the prefix</description></item>
-    /// </list>
-    /// </param>
     /// <param name="cancellationToken">Token to monitor for cancellation requests</param>
-    /// <returns>A Result containing the matched entity or an error</returns>
+    /// <returns>A Result containing all active versions, which may be empty</returns>
     public async Task<Result<List<T>>> LoadAllByKeyAsync(
         string domain,
         string key,
@@ -70,13 +65,17 @@ public sealed class RuntimeCacheBackend<T>(
         if (InstanceDataVersionComparer.IsFullVersion(version))
         {
             var entity = await runtimeService.GetAsync<T>(key, version!, cancellationToken);
-            
-            if (entity is null)
+
+            if (entity is not null)
             {
-                return Result<T>.Fail(CacheErrors.ItemNotFoundInBackend<T>(domain, key, version));
+                return Result<T>.Ok(entity);
             }
-            
-            return Result<T>.Ok(entity);
+
+            // Build metadata (+packageName) does not participate in comparison, so a request that omits
+            // it names the same version as a stored value that carries it. The exact single-row lookup
+            // above covers the common case where the caller echoes a stored version verbatim; only when
+            // that misses is it worth loading the version list to compare canonical identities.
+            return await LoadByCanonicalFullVersionAsync(runtimeService, domain, key, version!, cancellationToken);
         }
 
         // For null/empty, artifact, or partial version → key-filtered load + smart matching
@@ -109,6 +108,52 @@ public sealed class RuntimeCacheBackend<T>(
         }
 
         return Result<T>.Ok(matched);
+    }
+
+    /// <summary>
+    /// Resolves a full-version request by canonical identity, ignoring build metadata.
+    /// </summary>
+    /// <remarks>
+    /// Two stored versions can share an artifact and package version while differing in build metadata
+    /// (for example <c>+core</c> and <c>+customer</c>). Version comparison cannot separate them — they
+    /// compare equal — so one is picked by a stable rule and the collision is logged rather than left to
+    /// vary between calls.
+    /// </remarks>
+    private async Task<Result<T>> LoadByCanonicalFullVersionAsync(
+        IRuntimeService runtimeService,
+        string domain,
+        string key,
+        string version,
+        CancellationToken cancellationToken)
+    {
+        var canonicalVersion = InstanceDataVersionComparer.CanonicalFullVersion(version);
+
+        var all = await runtimeService.GetAsync<T>(key, cancellationToken);
+        var matches = all
+            .Where(e => e is not null &&
+                        string.Equals(e.Domain, domain, StringComparison.OrdinalIgnoreCase) &&
+                        string.Equals(
+                            InstanceDataVersionComparer.CanonicalFullVersion(e.Version),
+                            canonicalVersion,
+                            StringComparison.OrdinalIgnoreCase))
+            .Select(e => e!)
+            .OrderBy(e => e.Version, StringComparer.Ordinal)
+            .ToList();
+
+        if (matches.Count == 0)
+        {
+            return Result<T>.Fail(CacheErrors.ItemNotFoundInBackend<T>(domain, key, version));
+        }
+
+        var resolved = matches[0];
+
+        if (matches.Count > 1)
+        {
+            logger.ComponentCacheBuildMetadataAmbiguity(
+                T.ComponentTypeKey, domain, key, matches.Count, canonicalVersion, resolved.Version);
+        }
+
+        return Result<T>.Ok(resolved);
     }
 }
 

--- a/src/BBT.Workflow.Application/Definitions/DefinitionAppService.cs
+++ b/src/BBT.Workflow.Application/Definitions/DefinitionAppService.cs
@@ -25,6 +25,7 @@ public sealed class DefinitionAppService(
     IInstanceRepository instanceRepository,
     ComponentValidatorProcessor componentValidatorProcessor,
     WorkflowCastProcessor castProcessor,
+    IDomainCacheContext cacheContext,
     IWorkflowMetrics workflowMetrics,
     IServiceScopeFactory scopeFactory,
     IServiceProvider serviceProvider)
@@ -302,6 +303,14 @@ public sealed class DefinitionAppService(
                 return Result.Fail(WorkflowErrors.InstanceDataNotFound(input.Key, input.Version));
             }
 
+            // Drop cached version resolutions first. Re-casting alone is not enough: it writes the body
+            // of this version, but what "latest" or "1" should resolve to may have changed to a
+            // different version entirely — including to an older one, if this version was deactivated.
+            if (cacheContext.Set(input.Flow) is { } cacheSet)
+            {
+                await cacheSet.InvalidateAsync(input.Domain, input.Key, input.Version, cancellationToken);
+            }
+
             if (instanceData.Data.JsonElement.ValueKind != JsonValueKind.Null)
             {
                 await castProcessor.ProcessAsync(
@@ -311,6 +320,8 @@ public sealed class DefinitionAppService(
                     cancellationToken
                 );
             }
+
+            // A null body is the delete case; the invalidation above is the whole point of the call.
 
             return Result.Ok();
         }

--- a/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.Application/Microsoft/Extensions/DependencyInjection/WorkflowApplicationModuleServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@ using BBT.Workflow.Events;
 using BBT.Workflow.Functions;
 using BBT.Workflow.Functions.Validation;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Extensions.DependencyInjection;
@@ -139,6 +140,17 @@ public static class WorkflowApplicationModuleServiceCollectionExtensions
         services.AddSingleton<ICacheBackend<View>, RuntimeCacheBackend<View>>();
         services.AddSingleton<ICacheBackend<Extension>, RuntimeCacheBackend<Extension>>();
         services.AddSingleton<ICacheBackend<Mapping>, RuntimeCacheBackend<Mapping>>();
+
+        // Registered here rather than with the other application options so read-only hosts, which wire
+        // only the cache module, still bind configuration instead of silently falling back to defaults.
+        services.AddOptions<ComponentCacheOptions>()
+            .BindConfiguration(ComponentCacheOptions.SectionName)
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        // Scopes cached version resolutions so a publish invalidates them all at once.
+        services.TryAddSingleton(TimeProvider.System);
+        services.AddSingleton<IComponentGenerationProvider, ComponentGenerationProvider>();
 
         // Domain Cache Context
         services.AddSingleton<DomainCacheContext>();

--- a/src/BBT.Workflow.Domain/Instances/InstanceDataVersionComparer.cs
+++ b/src/BBT.Workflow.Domain/Instances/InstanceDataVersionComparer.cs
@@ -43,6 +43,11 @@ namespace BBT.Workflow.Instances;
 public partial class InstanceDataVersionComparer : IComparer<InstanceData>
 {
     /// <summary>
+    /// The reserved version keyword that resolves to the highest available version.
+    /// </summary>
+    public const string LatestKeyword = "latest";
+
+    /// <summary>
     /// Singleton instance of the comparer.
     /// </summary>
     public static InstanceDataVersionComparer Instance { get; } = new();
@@ -101,10 +106,7 @@ public partial class InstanceDataVersionComparer : IComparer<InstanceData>
     public static ParsedVersion ParseVersion(string version)
     {
         // Remove build metadata (+PKG_NAME) as it doesn't affect comparison
-        var buildMetadataIndex = version.IndexOf('+');
-        var versionWithoutMetadata = buildMetadataIndex >= 0
-            ? version[..buildMetadataIndex]
-            : version;
+        var versionWithoutMetadata = CanonicalFullVersion(version);
 
         // Try to match extended format: MAJOR.MINOR.PATCH-pkg.PKG_VERSION
         var match = ExtendedVersionRegex().Match(versionWithoutMetadata);
@@ -316,7 +318,7 @@ public partial class InstanceDataVersionComparer : IComparer<InstanceData>
     /// <returns>True if the version is "latest" (case-insensitive)</returns>
     public static bool IsLatestKeyword(string? version)
     {
-        return string.Equals(version, "latest", StringComparison.OrdinalIgnoreCase);
+        return string.Equals(version, LatestKeyword, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>
@@ -395,15 +397,9 @@ public partial class InstanceDataVersionComparer : IComparer<InstanceData>
         if (string.IsNullOrWhiteSpace(fullVersion) || string.IsNullOrWhiteSpace(partialVersion))
             return false;
 
-        var parsed = ParseVersion(fullVersion);
-
-        // Extract MAJOR.MINOR from artifact version
-        var parts = parsed.ArtifactVersion.Split('.');
-        if (parts.Length < 2)
-            return false;
-
-        var artifactMajorMinor = $"{parts[0]}.{parts[1]}";
-        return string.Equals(artifactMajorMinor, partialVersion, StringComparison.Ordinal);
+        var artifactMajorMinor = GetMajorMinor(fullVersion);
+        return artifactMajorMinor is not null &&
+               string.Equals(artifactMajorMinor, partialVersion, StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -423,15 +419,9 @@ public partial class InstanceDataVersionComparer : IComparer<InstanceData>
         if (string.IsNullOrWhiteSpace(fullVersion) || string.IsNullOrWhiteSpace(majorVersion))
             return false;
 
-        var parsed = ParseVersion(fullVersion);
-        
-        // Extract the major version from artifact (first segment before '.')
-        var dotIndex = parsed.ArtifactVersion.IndexOf('.');
-        if (dotIndex < 0)
-            return false;
-
-        var artifactMajor = parsed.ArtifactVersion[..dotIndex];
-        return string.Equals(artifactMajor, majorVersion, StringComparison.Ordinal);
+        var artifactMajor = GetMajor(fullVersion);
+        return artifactMajor is not null &&
+               string.Equals(artifactMajor, majorVersion, StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -536,6 +526,77 @@ public partial class InstanceDataVersionComparer : IComparer<InstanceData>
 
         var parsed = ParseVersion(version);
         return parsed.ArtifactVersion;
+    }
+
+    /// <summary>
+    /// Strips build metadata (everything from the first '+') from a version string.
+    /// </summary>
+    /// <param name="version">Version string (e.g., "1.5.6-pkg.1.1.56+core")</param>
+    /// <returns>The version without build metadata (e.g., "1.5.6-pkg.1.1.56")</returns>
+    /// <remarks>
+    /// Build metadata (+PKG_NAME, +build.xxx) does not participate in comparison, so two versions that
+    /// differ only in build metadata are the same version. This is the canonical identity to key a
+    /// version by: "1.5.6-pkg.1.1.56" and "1.5.6-pkg.1.1.56+core" both canonicalize to the former.
+    /// </remarks>
+    public static string CanonicalFullVersion(string? version)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+            return version ?? string.Empty;
+
+        var buildMetadataIndex = version.IndexOf('+');
+        return buildMetadataIndex >= 0
+            ? version[..buildMetadataIndex]
+            : version;
+    }
+
+    /// <summary>
+    /// Normalizes a requested version into the canonical spelling used to identify a resolution.
+    /// </summary>
+    /// <param name="version">The version as requested by the caller (may be null, empty or "latest")</param>
+    /// <returns><see cref="LatestKeyword"/> for latest-requests, otherwise the trimmed, lowercased request</returns>
+    /// <remarks>
+    /// Two requests that resolve to the same entity must normalize to the same spelling, otherwise a
+    /// cache keyed on the request would hold duplicate — and independently staleable — entries.
+    /// Lowercasing is safe because every spelling comparison in <see cref="FindBestMatch"/> that can
+    /// see letters (exact match, <see cref="MatchesArtifact"/>) is case-insensitive; the numeric forms
+    /// have no case to lose.
+    /// </remarks>
+    public static string NormalizeRequest(string? version)
+    {
+        return IsRequestingLatest(version)
+            ? LatestKeyword
+            : version!.Trim().ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Extracts the major component of a version's artifact part.
+    /// </summary>
+    /// <param name="version">Version string (e.g., "1.2.3-pkg.1.0.0+account")</param>
+    /// <returns>The major component (e.g., "1"), or null when the artifact part has no major.minor separator</returns>
+    public static string? GetMajor(string? version)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+            return null;
+
+        var artifactVersion = ParseVersion(version).ArtifactVersion;
+
+        // Extract the major version from artifact (first segment before '.')
+        var dotIndex = artifactVersion.IndexOf('.');
+        return dotIndex < 0 ? null : artifactVersion[..dotIndex];
+    }
+
+    /// <summary>
+    /// Extracts the MAJOR.MINOR components of a version's artifact part.
+    /// </summary>
+    /// <param name="version">Version string (e.g., "1.2.3-pkg.1.0.0+account")</param>
+    /// <returns>The MAJOR.MINOR components (e.g., "1.2"), or null when the artifact part has fewer than two segments</returns>
+    public static string? GetMajorMinor(string? version)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+            return null;
+
+        var parts = ParseVersion(version).ArtifactVersion.Split('.');
+        return parts.Length < 2 ? null : $"{parts[0]}.{parts[1]}";
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
+++ b/src/BBT.Workflow.Domain/Logging/WorkflowLogs.cs
@@ -3117,4 +3117,129 @@ public static partial class WorkflowLogs
         string schemaKey);
 
     #endregion
+
+    #region Component Cache
+
+    /// <summary>
+    /// Logs when a component's generation token is replaced, making every prior resolution entry for
+    /// that component unreachable.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 70001,
+        Level = LogLevel.Debug,
+        Message = "Component cache generation bumped for {ComponentType} {Domain}/{Key} (token {Token})")]
+    public static partial void ComponentCacheGenerationBumped(
+        this ILogger logger,
+        string componentType,
+        string domain,
+        string key,
+        string token);
+
+    /// <summary>
+    /// Logs when writing a new generation token failed but the token was successfully removed instead.
+    /// An absent token forces the next reader to bootstrap a fresh one, so invalidation still holds.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 70002,
+        Level = LogLevel.Warning,
+        Message = "Component cache generation write failed for {ComponentType} {Domain}/{Key}; removed the token instead, invalidation still applies")]
+    public static partial void ComponentCacheGenerationBumpFellBackToRemove(
+        this ILogger logger,
+        Exception exception,
+        string componentType,
+        string domain,
+        string key);
+
+    /// <summary>
+    /// Logs when a generation token could be neither written nor removed. This is the only condition
+    /// that leaves stale resolution entries reachable, so it is an error rather than a warning.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 70003,
+        Level = LogLevel.Error,
+        Message = "Component cache generation could not be bumped or removed for {ComponentType} {Domain}/{Key}; previously cached version resolutions remain reachable until the generation TTL expires")]
+    public static partial void ComponentCacheGenerationBumpFailed(
+        this ILogger logger,
+        Exception exception,
+        string componentType,
+        string domain,
+        string key);
+
+    /// <summary>
+    /// Logs when a component's generation token was absent and a fresh one was created.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 70004,
+        Level = LogLevel.Debug,
+        Message = "Component cache generation bootstrapped for {ComponentType} {Domain}/{Key} (token {Token})")]
+    public static partial void ComponentCacheGenerationBootstrapped(
+        this ILogger logger,
+        string componentType,
+        string domain,
+        string key,
+        string token);
+
+    /// <summary>
+    /// Logs when a version request was resolved from the backend because no cached resolution existed.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 70010,
+        Level = LogLevel.Debug,
+        Message = "Component cache resolved {ComponentType} {Domain}/{Key}@{Requested} to {Resolved}")]
+    public static partial void ComponentCacheResolvedFromBackend(
+        this ILogger logger,
+        string componentType,
+        string domain,
+        string key,
+        string requested,
+        string resolved);
+
+    /// <summary>
+    /// Logs when a version request matched no published version and a short-lived negative entry
+    /// was cached to stop repeated backend loads.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 70011,
+        Level = LogLevel.Debug,
+        Message = "Component cache stored a negative entry for {ComponentType} {Domain}/{Key}@{Requested}")]
+    public static partial void ComponentCacheNegativeStored(
+        this ILogger logger,
+        string componentType,
+        string domain,
+        string key,
+        string requested);
+
+    /// <summary>
+    /// Logs when more than one stored version shares an artifact and package version, differing only in
+    /// build metadata. Build metadata does not participate in ordering, so such versions are
+    /// indistinguishable to version resolution and one is chosen deterministically.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 70012,
+        Level = LogLevel.Warning,
+        Message = "Component {ComponentType} {Domain}/{Key} has {Count} versions matching {CanonicalVersion} that differ only in build metadata; resolved to {Resolved}")]
+    public static partial void ComponentCacheBuildMetadataAmbiguity(
+        this ILogger logger,
+        string componentType,
+        string domain,
+        string key,
+        int count,
+        string canonicalVersion,
+        string resolved);
+
+    /// <summary>
+    /// Logs when a component cache read or write failed. Reads degrade to a backend load and writes
+    /// are dropped, so neither is fatal.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 70020,
+        Level = LogLevel.Warning,
+        Message = "Component cache {Operation} failed for key {CacheKey}")]
+    public static partial void ComponentCacheOperationFailed(
+        this ILogger logger,
+        Exception exception,
+        string operation,
+        string cacheKey);
+
+    #endregion
 }

--- a/test/BBT.Workflow.Application.Tests/Caching/CacheSetTestHarness.cs
+++ b/test/BBT.Workflow.Application.Tests/Caching/CacheSetTestHarness.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.Guids;
+using BBT.Aether.Results;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Instances;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace BBT.Workflow.Caching;
+
+/// <summary>
+/// Wires a <see cref="CacheSet{T}"/> for <see cref="View"/> to in-memory doubles, using the real
+/// <see cref="ComponentGenerationProvider"/> so generation semantics are exercised end to end rather
+/// than stubbed out.
+/// </summary>
+public sealed class CacheSetTestHarness
+{
+    public const string TestDomain = "core";
+    public const string TestKey = "account-type-selection-view";
+    public const string ComponentType = "sys-views";
+
+    public CacheSetTestHarness()
+    {
+        Time = new AdjustableTimeProvider(new DateTimeOffset(2026, 8, 3, 12, 0, 0, TimeSpan.Zero));
+        Cache = new FakeDistributedCacheService(Time);
+        Backend = new FakeCacheBackend();
+        Options = new ComponentCacheOptions();
+
+        var optionsAccessor = new StaticOptions(Options);
+
+        Generations = new ComponentGenerationProvider(
+            Cache,
+            new SequentialGuidGenerator(),
+            optionsAccessor,
+            Time,
+            NullLogger<ComponentGenerationProvider>.Instance);
+
+        Sut = new CacheSet<View>(
+            Cache,
+            Backend,
+            Generations,
+            optionsAccessor,
+            Time,
+            NullLogger<CacheSet<View>>.Instance);
+    }
+
+    public AdjustableTimeProvider Time { get; }
+    public FakeDistributedCacheService Cache { get; }
+    public FakeCacheBackend Backend { get; }
+    public ComponentCacheOptions Options { get; }
+    public ComponentGenerationProvider Generations { get; }
+    public CacheSet<View> Sut { get; }
+
+    /// <summary>Builds a <see cref="View"/> carrying the given version.</summary>
+    public static View CreateView(string version, string key = TestKey, string domain = TestDomain)
+    {
+        const string viewJson = """
+        {
+            "type": 1,
+            "target": 1,
+            "content": "{}"
+        }
+        """;
+
+        var view = JsonSerializer.Deserialize<View>(viewJson, JsonSerializerConstants.JsonOptions)!;
+        view.SetReference(new Reference(key, domain, ComponentType, version));
+        return view;
+    }
+
+    /// <summary>Replaces the versions the backend reports as published.</summary>
+    public void Publish(params string[] versions)
+        => Backend.Versions = versions.Select(v => CreateView(v)).ToList();
+
+    /// <summary>Adds a version to what the backend reports as published.</summary>
+    public void AddPublished(string version)
+        => Backend.Versions = [.. Backend.Versions, CreateView(version)];
+
+    /// <summary>Removes a version from the backend, as a deactivation would.</summary>
+    public void Deactivate(string version)
+        => Backend.Versions = Backend.Versions
+            .Where(v => !string.Equals(v.Version, version, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+    /// <summary>Reads the component's current generation token straight from the cache.</summary>
+    public Task<string> CurrentGenerationAsync()
+        => Generations.GetAsync(ComponentType, TestDomain, TestKey);
+
+    public string FullKey(string version)
+        => $"{ComponentType}:{TestDomain}:{TestKey}:full:{InstanceDataVersionComparer.CanonicalFullVersion(version)}";
+
+    public string ResolutionKey(string generation, string spelling)
+        => $"{ComponentType}:{TestDomain}:{TestKey}:res:{generation}:{spelling}";
+
+    public string GenerationKey()
+        => $"{ComponentType}:{TestDomain}:{TestKey}:gen";
+
+    public string LegacyLatestKey()
+        => $"{ComponentType}:{TestDomain}:{TestKey}:latest";
+
+    public string LegacyArtifactKey(string spelling)
+        => $"{ComponentType}:{TestDomain}:{TestKey}:artifact:{spelling}";
+
+    /// <summary>Live resolution keys, with the generation segment stripped to the trailing spelling.</summary>
+    public IReadOnlyList<string> ResolutionSpellingsInCache()
+    {
+        var prefix = $"{ComponentType}:{TestDomain}:{TestKey}:res:";
+        return Cache.Keys
+            .Where(k => k.StartsWith(prefix, StringComparison.Ordinal))
+            .Select(k => k[prefix.Length..])
+            .Select(rest => rest[(rest.IndexOf(':') + 1)..])
+            .OrderBy(s => s, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    /// <summary>
+    /// <see cref="ICacheBackend{T}"/> double reporting a settable version list and counting loads, so
+    /// "this served zero database queries" can be asserted rather than assumed.
+    /// </summary>
+    public sealed class FakeCacheBackend : ICacheBackend<View>
+    {
+        private int _loadAllCallCount;
+
+        public List<View> Versions { get; set; } = [];
+
+        public int LoadAllCallCount => Volatile.Read(ref _loadAllCallCount);
+
+        public int LoadCallCount { get; private set; }
+
+        /// <summary>Blocks each load until released, to construct concurrent-miss scenarios.</summary>
+        public TaskCompletionSource? Gate { get; set; }
+
+        /// <summary>When true, loads throw — used to prove behaviour that must not depend on warming.</summary>
+        public bool FailLoadAll { get; set; }
+
+        public async Task<Result<List<View>>> LoadAllByKeyAsync(
+            string domain,
+            string key,
+            CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref _loadAllCallCount);
+
+            if (FailLoadAll)
+                throw new InvalidOperationException("Simulated backend load failure.");
+
+            if (Gate is not null)
+                await Gate.Task;
+
+            return Result<List<View>>.Ok(Versions
+                .Where(v => string.Equals(v.Domain, domain, StringComparison.OrdinalIgnoreCase) &&
+                            string.Equals(v.Key, key, StringComparison.OrdinalIgnoreCase))
+                .ToList());
+        }
+
+        public Task<Result<View>> LoadAsync(
+            string domain,
+            string key,
+            string? version,
+            CancellationToken cancellationToken = default)
+        {
+            LoadCallCount++;
+
+            var match = Versions.FirstOrDefault(v =>
+                string.Equals(v.Version, version, StringComparison.OrdinalIgnoreCase));
+
+            return Task.FromResult(match is null
+                ? Result<View>.Fail(CacheErrors.ItemNotFoundInBackend<View>(domain, key, version))
+                : Result<View>.Ok(match));
+        }
+
+        public void ResetCounts()
+        {
+            Interlocked.Exchange(ref _loadAllCallCount, 0);
+            LoadCallCount = 0;
+        }
+    }
+
+    /// <summary>A <see cref="TimeProvider"/> whose clock only moves when a test moves it.</summary>
+    public sealed class AdjustableTimeProvider(DateTimeOffset start) : TimeProvider
+    {
+        private DateTimeOffset _now = start;
+
+        public override DateTimeOffset GetUtcNow() => _now;
+
+        public void Advance(TimeSpan by) => _now = _now.Add(by);
+    }
+
+    private sealed class StaticOptions(ComponentCacheOptions value) : IOptions<ComponentCacheOptions>
+    {
+        public ComponentCacheOptions Value { get; } = value;
+    }
+
+    private sealed class SequentialGuidGenerator : IGuidGenerator
+    {
+        private int _counter;
+
+        public Guid Create()
+        {
+            var next = Interlocked.Increment(ref _counter);
+            return new Guid(next, 0, 0, new byte[8]);
+        }
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/Caching/CacheSetTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Caching/CacheSetTests.cs
@@ -1,0 +1,734 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+using static BBT.Workflow.Caching.CacheSetTestHarness;
+
+namespace BBT.Workflow.Caching;
+
+/// <summary>
+/// Unit tests for <see cref="CacheSet{T}"/>, focused on version resolution staying correct across
+/// publishes.
+/// </summary>
+/// <remarks>
+/// The bug these were written for: a request for <c>"1"</c> was cached under a key derived from the
+/// request string with no expiration, and publishing a newer 1.x never touched it — so the cache served
+/// 1.5.0 forever after 1.6.0 shipped. The interesting assertions are therefore about which key a read
+/// consults after a publish, and about how many backend loads that costs.
+/// </remarks>
+public class CacheSetTests
+{
+    private const string V150 = "1.5.0-pkg.1.0.0+core";
+    private const string V151 = "1.5.1-pkg.1.0.0+core";
+    private const string V160 = "1.6.0-pkg.1.0.0+core";
+
+    // ────────────────────────────────────────────────────────────────────
+    // The reported bug
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Publish_NewerVersion_ShouldReplaceMajorOnlyResolution()
+    {
+        // Arrange - "1" resolves to 1.5.0 and is cached.
+        var harness = new CacheSetTestHarness();
+        harness.Publish(V150);
+        (await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "1")).Value!.Version.ShouldBe(V150);
+
+        // Act - 1.6.0 ships.
+        harness.AddPublished(V160);
+        await harness.Sut.SetAsync(CreateView(V160));
+
+        // Assert
+        var result = await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "1");
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.Version.ShouldBe(V160);
+    }
+
+    [Fact]
+    public async Task Publish_NewerVersion_ShouldReplaceMajorOnlyResolution_EvenWithoutWarming()
+    {
+        // Arrange - the same scenario as above, but with warming unavailable, so only invalidation can
+        // produce the right answer. Without this the headline test above passes even with invalidation
+        // removed, because warming happens to overwrite the same key.
+        var harness = new CacheSetTestHarness();
+        harness.Publish(V150);
+        (await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "1")).Value!.Version.ShouldBe(V150);
+
+        // Act
+        harness.AddPublished(V160);
+        harness.Backend.FailLoadAll = true;
+        var publishResult = await harness.Sut.SetAsync(CreateView(V160));
+        harness.Backend.FailLoadAll = false;
+
+        // Assert
+        publishResult.IsSuccess.ShouldBeTrue("a failed warm must not fail the publish");
+        (await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "1")).Value!.Version.ShouldBe(V160);
+    }
+
+    [Theory]
+    [InlineData("1")]
+    [InlineData("1.6")]
+    [InlineData("latest")]
+    [InlineData(null)]
+    public async Task Publish_NewerVersion_ShouldReplaceEveryRangeResolution(string? requested)
+    {
+        // Arrange
+        var harness = new CacheSetTestHarness();
+        harness.Publish(V150);
+        await harness.Sut.GetByVersionAsync(TestDomain, TestKey, requested);
+
+        // Act
+        harness.AddPublished(V160);
+        await harness.Sut.SetAsync(CreateView(V160));
+
+        // Assert
+        var result = await harness.Sut.GetByVersionAsync(TestDomain, TestKey, requested);
+        result.Value!.Version.ShouldBe(V160);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Publishes are not monotonic
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Publish_OlderVersion_ShouldNotDisplaceLatest()
+    {
+        // Arrange - 1.6.0 is the winner and is cached as such.
+        var harness = new CacheSetTestHarness();
+        harness.Publish(V150, V160);
+        (await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "latest")).Value!.Version.ShouldBe(V160);
+
+        // Act - an emergency 1.5.1 is released after 1.6.0 already exists.
+        harness.AddPublished(V151);
+        await harness.Sut.SetAsync(CreateView(V151));
+
+        // Assert - the published version is not automatically the winner of any range it belongs to.
+        (await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "latest")).Value!.Version.ShouldBe(V160);
+        (await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "1")).Value!.Version.ShouldBe(V160);
+        (await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "1.5")).Value!.Version.ShouldBe(V151);
+    }
+
+    [Fact]
+    public async Task Publish_LowerPackageVersion_ShouldNotDisplaceArtifactResolution()
+    {
+        // Arrange
+        const string highPackage = "1.5.0-pkg.3.0.0+core";
+        const string lowPackage = "1.5.0-pkg.2.0.0+core";
+
+        var harness = new CacheSetTestHarness();
+        harness.Publish(highPackage);
+        (await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "1.5.0")).Value!.Version.ShouldBe(highPackage);
+
+        // Act
+        harness.AddPublished(lowPackage);
+        await harness.Sut.SetAsync(CreateView(lowPackage));
+
+        // Assert - the highest package version of an artifact wins, regardless of publish order.
+        (await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "1.5.0")).Value!.Version.ShouldBe(highPackage);
+    }
+
+    [Fact]
+    public async Task Publish_ShouldNotRankPackageVersionAboveArtifactVersion()
+    {
+        // Arrange - a lower artifact carrying a much higher package version must still lose.
+        const string lowArtifactHighPackage = "1.5.0-pkg.9.9.9+core";
+
+        var harness = new CacheSetTestHarness();
+        harness.Publish(V160);
+        await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "1");
+
+        // Act
+        harness.AddPublished(lowArtifactHighPackage);
+        await harness.Sut.SetAsync(CreateView(lowArtifactHighPackage));
+
+        // Assert
+        (await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "1")).Value!.Version.ShouldBe(V160);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Generation scoping
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Publish_ShouldChangeGenerationToken()
+    {
+        // Arrange
+        var harness = new CacheSetTestHarness();
+        harness.Publish(V150);
+        var before = await harness.CurrentGenerationAsync();
+
+        // Act
+        await harness.Sut.SetAsync(CreateView(V160));
+
+        // Assert
+        var after = await harness.CurrentGenerationAsync();
+        after.ShouldNotBe(before);
+    }
+
+    [Fact]
+    public async Task Publish_ShouldInvalidateSpellingsNoPublishCouldEnumerate()
+    {
+        // Arrange - a package-version request. Nothing derivable from a published version's own
+        // artifact/major/minor would ever name this spelling, which is why resolutions are scoped to a
+        // generation rather than invalidated key by key.
+        const string packageAliasRequest = "00.01.417";
+        const string stored = "1.0.0-pkg.00.01.417+onboarding";
+
+        var harness = new CacheSetTestHarness();
+        harness.Publish(stored);
+        (await harness.Sut.GetByVersionAsync(TestDomain, TestKey, packageAliasRequest)).Value!.Version.ShouldBe(stored);
+
+        harness.Backend.ResetCounts();
+        (await harness.Sut.GetByVersionAsync(TestDomain, TestKey, packageAliasRequest)).IsSuccess.ShouldBeTrue();
+        harness.Backend.LoadAllCallCount.ShouldBe(0, "the alias resolution should be cached");
+
+        // Act
+        harness.AddPublished(V160);
+        await harness.Sut.SetAsync(CreateView(V160));
+        harness.Backend.ResetCounts();
+        await harness.Sut.GetByVersionAsync(TestDomain, TestKey, packageAliasRequest);
+
+        // Assert - the previously cached alias answer is unreachable, so it was re-resolved.
+        harness.Backend.LoadAllCallCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task GenerationExpiry_ShouldForceReResolution()
+    {
+        // Arrange
+        var harness = new CacheSetTestHarness();
+        harness.Publish(V150);
+        await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "1");
+
+        // Act - the token TTL lapses without any publish having happened.
+        harness.Time.Advance(TimeSpan.FromSeconds(harness.Options.GenerationTtlSeconds + 1));
+        harness.AddPublished(V160);
+        harness.Backend.ResetCounts();
+
+        // Assert - a fresh token means nothing cached under the old one is consulted.
+        (await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "1")).Value!.Version.ShouldBe(V160);
+        harness.Backend.LoadAllCallCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Publish_WhenGenerationWriteFails_ShouldRemoveTokenSoInvalidationStillHolds()
+    {
+        // Arrange
+        var harness = new CacheSetTestHarness();
+        harness.Publish(V150);
+        await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "1");
+        var originalGeneration = await harness.CurrentGenerationAsync();
+
+        // Act - the token write fails, which is the one path that could leave stale answers reachable.
+        harness.Cache.FailWrites = key => key.EndsWith(":gen", StringComparison.Ordinal);
+        harness.AddPublished(V160);
+        await harness.Sut.SetAsync(CreateView(V160));
+        harness.Cache.FailWrites = null;
+
+        // Assert - falling back to removal invalidates just as effectively.
+        harness.Cache.Removes.ShouldContain(harness.GenerationKey());
+        harness.Cache.Keys.ShouldNotContain(harness.GenerationKey());
+
+        var bootstrapped = await harness.CurrentGenerationAsync();
+        bootstrapped.ShouldNotBe(originalGeneration);
+        (await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "1")).Value!.Version.ShouldBe(V160);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Deactivation — the case a compare-and-swap could not fix
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Invalidate_AfterDeactivation_ShouldResolveToTheLowerVersion()
+    {
+        // Arrange
+        var harness = new CacheSetTestHarness();
+        harness.Publish(V150, V160);
+        (await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "latest")).Value!.Version.ShouldBe(V160);
+
+        // Act - 1.6.0 turns out to be bad and is deactivated.
+        harness.Deactivate(V160);
+        await harness.Sut.InvalidateAsync(TestDomain, TestKey, V160);
+
+        // Assert - resolution moves *down*, which is only possible because the answer is recomputed
+        // rather than compared against what was already cached.
+        (await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "latest")).Value!.Version.ShouldBe(V150);
+        (await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "1")).Value!.Version.ShouldBe(V150);
+    }
+
+    [Fact]
+    public async Task Invalidate_WithPartialVersion_ShouldNotRemoveTheFullVersionBody()
+    {
+        // Arrange
+        var harness = new CacheSetTestHarness();
+        harness.Publish(V160);
+        await harness.Sut.SetAsync(CreateView(V160));
+        harness.Cache.Keys.ShouldContain(harness.FullKey(V160));
+
+        // Act - a range version names no single revision, so no body can be identified for removal.
+        await harness.Sut.InvalidateAsync(TestDomain, TestKey, "1");
+
+        // Assert
+        harness.Cache.Keys.ShouldContain(harness.FullKey(V160));
+    }
+
+    [Fact]
+    public async Task Invalidate_WithFullVersion_ShouldRemoveThatBody()
+    {
+        // Arrange
+        var harness = new CacheSetTestHarness();
+        harness.Publish(V160);
+        await harness.Sut.SetAsync(CreateView(V160));
+
+        // Act
+        await harness.Sut.InvalidateAsync(TestDomain, TestKey, V160);
+
+        // Assert
+        harness.Cache.Keys.ShouldNotContain(harness.FullKey(V160));
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Cost: the cache has to actually spare the database
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AfterPublish_CommonSpellingsShouldServeWithoutAnyBackendLoad()
+    {
+        // Arrange
+        var harness = new CacheSetTestHarness();
+        harness.Publish(V160);
+        await harness.Sut.SetAsync(CreateView(V160));
+        harness.Backend.ResetCounts();
+
+        // Act
+        var results = new[]
+        {
+            await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "latest"),
+            await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "1"),
+            await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "1.6"),
+            await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "1.6.0")
+        };
+
+        // Assert - publishing pre-resolves these, so a deploy does not hand the first request of each a
+        // full version-list load.
+        results.ShouldAllBe(r => r.IsSuccess);
+        harness.Backend.LoadAllCallCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task RepeatedReads_ShouldNotReloadAsTimePasses()
+    {
+        // Arrange
+        var harness = new CacheSetTestHarness();
+        harness.Publish(V160);
+        await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "1");
+        harness.Backend.ResetCounts();
+
+        // Act - well past any resolution TTL, but with no publish in between.
+        harness.Time.Advance(TimeSpan.FromSeconds(harness.Options.ResolutionTtlSeconds - 1));
+        await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "1");
+
+        // Assert - resolution entries are not on a refresh treadmill; only a publish invalidates them.
+        harness.Backend.LoadAllCallCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task ConcurrentMisses_ShouldShareOneBackendLoad()
+    {
+        // Arrange
+        var harness = new CacheSetTestHarness();
+        harness.Publish(V160);
+        await harness.CurrentGenerationAsync(); // bootstrap the token so only the resolution misses
+        harness.Backend.ResetCounts();
+        harness.Backend.Gate = new TaskCompletionSource();
+
+        // Act - the fake cache completes synchronously, so all five reach the coalescing point while the
+        // first is parked on the gate.
+        var reads = Enumerable.Range(0, 5)
+            .Select(_ => harness.Sut.GetByVersionAsync(TestDomain, TestKey, "1"))
+            .ToArray();
+
+        harness.Backend.LoadAllCallCount.ShouldBe(1);
+        harness.Backend.Gate.SetResult();
+        var results = await Task.WhenAll(reads);
+
+        // Assert
+        results.ShouldAllBe(r => r.IsSuccess);
+        results.ShouldAllBe(r => r.Value!.Version == V160);
+        harness.Backend.LoadAllCallCount.ShouldBe(1);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Warming
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Publish_ShouldWarmEvenWhenTheBackendCannotSeeTheNewVersionYet()
+    {
+        // Arrange - the publish has not become visible to a fresh query.
+        var harness = new CacheSetTestHarness();
+        harness.Publish();
+
+        // Act
+        await harness.Sut.SetAsync(CreateView(V160));
+        harness.Backend.ResetCounts();
+
+        // Assert - warming unions the published entity into the candidate set, so it does not cache an
+        // answer computed from a list that is missing it.
+        var result = await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "latest");
+        result.Value!.Version.ShouldBe(V160);
+        harness.Backend.LoadAllCallCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task Publish_ShouldWarmOnlyTheAuthorableSpellings()
+    {
+        // Arrange
+        var harness = new CacheSetTestHarness();
+        harness.Publish(V160);
+
+        // Act
+        await harness.Sut.SetAsync(CreateView(V160));
+
+        // Assert
+        harness.ResolutionSpellingsInCache()
+            .ShouldBe(["1", "1.6", "1.6.0", "latest"]);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Negative caching
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UnmatchedRequest_ShouldBeCachedSoItDoesNotReloadEveryTime()
+    {
+        // Arrange
+        var harness = new CacheSetTestHarness();
+        harness.Publish(V160);
+        await harness.CurrentGenerationAsync();
+        harness.Backend.ResetCounts();
+
+        // Act
+        var first = await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "9");
+        var loadsAfterFirst = harness.Backend.LoadAllCallCount;
+        var second = await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "9");
+
+        // Assert
+        first.IsSuccess.ShouldBeFalse();
+        second.IsSuccess.ShouldBeFalse();
+        loadsAfterFirst.ShouldBe(1);
+        harness.Backend.LoadAllCallCount.ShouldBe(1, "the negative answer should be served from cache");
+    }
+
+    [Fact]
+    public async Task NegativeEntry_ShouldNotSurviveAPublishThatSatisfiesTheRequest()
+    {
+        // Arrange
+        const string v900 = "9.0.0-pkg.1.0.0+core";
+
+        var harness = new CacheSetTestHarness();
+        harness.Publish(V160);
+        (await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "9")).IsSuccess.ShouldBeFalse();
+
+        // Act
+        harness.AddPublished(v900);
+        await harness.Sut.SetAsync(CreateView(v900));
+
+        // Assert - the generation bump clears negatives too, so the reference starts working at once
+        // rather than after the negative TTL.
+        var result = await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "9");
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.Version.ShouldBe(v900);
+    }
+
+    [Fact]
+    public async Task NegativeEntry_ShouldExpireOnItsOwnShortTtl()
+    {
+        // Arrange
+        var harness = new CacheSetTestHarness();
+        harness.Publish(V160);
+        (await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "9")).IsSuccess.ShouldBeFalse();
+
+        // Act - a version appears without going through this cache set (for example published by another
+        // pod whose bump this pod has already applied).
+        harness.AddPublished("9.0.0-pkg.1.0.0+core");
+        harness.Time.Advance(TimeSpan.FromSeconds(harness.Options.NegativeTtlSeconds + 1));
+
+        // Assert
+        (await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "9")).IsSuccess.ShouldBeTrue();
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Build metadata
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task FullVersionRequests_ShouldIgnoreBuildMetadata()
+    {
+        // Arrange
+        const string withMetadata = "1.5.6-pkg.1.1.56+core";
+        const string withoutMetadata = "1.5.6-pkg.1.1.56";
+
+        var harness = new CacheSetTestHarness();
+        harness.Publish(withMetadata);
+        await harness.Sut.SetAsync(CreateView(withMetadata));
+        harness.Backend.ResetCounts();
+
+        // Act
+        var qualified = await harness.Sut.GetByVersionAsync(TestDomain, TestKey, withMetadata);
+        var bare = await harness.Sut.GetByVersionAsync(TestDomain, TestKey, withoutMetadata);
+
+        // Assert - build metadata does not participate in comparison, so both name the same revision and
+        // must share one cache entry.
+        qualified.Value!.Version.ShouldBe(withMetadata);
+        bare.Value!.Version.ShouldBe(withMetadata);
+        harness.Backend.LoadCallCount.ShouldBe(0);
+        harness.Cache.Keys.ShouldContain(harness.FullKey(withoutMetadata));
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // TestKey layout
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task LatestSpellings_ShouldCollapseToASingleEntry()
+    {
+        // Arrange
+        var harness = new CacheSetTestHarness();
+        harness.Publish(V160);
+        await harness.CurrentGenerationAsync();
+        harness.Backend.ResetCounts();
+
+        // Act
+        foreach (var spelling in new[] { null, "", "latest", "LATEST", "  Latest  " })
+        {
+            (await harness.Sut.GetByVersionAsync(TestDomain, TestKey, spelling)).IsSuccess.ShouldBeTrue();
+        }
+
+        // Assert - equivalent requests must not produce independently staleable entries.
+        harness.ResolutionSpellingsInCache().ShouldBe(["latest"]);
+        harness.Backend.LoadAllCallCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task ResolvingOneSpelling_ShouldNotWriteAnswersForOthers()
+    {
+        // Arrange - no publish, so nothing is warmed and only the read populates.
+        var harness = new CacheSetTestHarness();
+        harness.Publish(V160);
+
+        // Act
+        await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "1");
+
+        // Assert - guessing at resolutions nobody asked for is how a resolution cache goes wrong.
+        harness.ResolutionSpellingsInCache().ShouldBe(["1"]);
+    }
+
+    [Fact]
+    public async Task Read_ShouldAlsoWarmTheImmutableBody()
+    {
+        // Arrange
+        var harness = new CacheSetTestHarness();
+        harness.Publish(V160);
+
+        // Act
+        await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "1");
+
+        // Assert - the body was loaded anyway, so a pinned read of that exact version can reuse it.
+        harness.Cache.Keys.ShouldContain(harness.FullKey(V160));
+    }
+
+    [Fact]
+    public async Task EveryCachedKey_ShouldCarryAnExpiry()
+    {
+        // Arrange
+        var harness = new CacheSetTestHarness();
+        harness.Publish(V150, V160);
+        await harness.Sut.SetAsync(CreateView(V160));
+        await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "1.5");
+        await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "9");
+        await harness.Sut.GetByVersionAsync(TestDomain, TestKey, V150);
+
+        // Act
+        var keysWithoutExpiry = harness.Cache.Keys.Where(harness.Cache.HasNoExpiry).ToList();
+
+        // Assert - the original defect was an entry that never expired and was never invalidated. Even
+        // with invalidation now complete, nothing should be able to outlive its bound.
+        keysWithoutExpiry.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Publish_ShouldApplyTheConfiguredTtlToEachKeyClass()
+    {
+        // Arrange
+        var harness = new CacheSetTestHarness();
+        var start = harness.Time.GetUtcNow();
+        harness.Publish(V160);
+
+        // Act
+        await harness.Sut.SetAsync(CreateView(V160));
+        var generation = await harness.CurrentGenerationAsync();
+
+        // Assert
+        harness.Cache.ExpiryOf(harness.FullKey(V160))
+            .ShouldBe(start.AddSeconds(harness.Options.FullVersionTtlSeconds));
+        harness.Cache.ExpiryOf(harness.ResolutionKey(generation, "latest"))
+            .ShouldBe(start.AddSeconds(harness.Options.ResolutionTtlSeconds));
+        harness.Cache.ExpiryOf(harness.GenerationKey())
+            .ShouldBe(start.AddSeconds(harness.Options.GenerationTtlSeconds));
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Legacy key purge
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Publish_ShouldPurgeKeysFromThePreGenerationLayout()
+    {
+        // Arrange
+        var harness = new CacheSetTestHarness();
+        harness.Publish(V160);
+
+        // Act
+        await harness.Sut.SetAsync(CreateView(V160));
+
+        // Assert - those keys had no expiration, so a rolling deployment would otherwise keep serving
+        // them from pods running the old build.
+        harness.Cache.Removes.ShouldContain(harness.LegacyLatestKey());
+        harness.Cache.Removes.ShouldContain(harness.LegacyArtifactKey("1.6.0"));
+        harness.Cache.Removes.ShouldContain(harness.LegacyArtifactKey("1.6"));
+        harness.Cache.Removes.ShouldContain(harness.LegacyArtifactKey("1"));
+    }
+
+    [Fact]
+    public async Task Publish_ShouldLeaveLegacyKeysAloneWhenPurgeIsDisabled()
+    {
+        // Arrange
+        var harness = new CacheSetTestHarness();
+        harness.Options.PurgeLegacyKeysOnPublish = false;
+        harness.Publish(V160);
+
+        // Act
+        await harness.Sut.SetAsync(CreateView(V160));
+
+        // Assert
+        harness.Cache.Removes.ShouldNotContain(harness.LegacyLatestKey());
+        harness.Cache.Removes.ShouldNotContain(harness.LegacyArtifactKey("1"));
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Resilience
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Read_WhenTheCacheIsUnreadable_ShouldFallBackToTheBackend()
+    {
+        // Arrange
+        var harness = new CacheSetTestHarness();
+        harness.Publish(V160);
+        await harness.Sut.SetAsync(CreateView(V160));
+
+        // Act
+        harness.Cache.FailReads = _ => true;
+        var result = await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "1");
+
+        // Assert - an unreachable cache degrades to database reads, never to stale answers.
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.Version.ShouldBe(V160);
+    }
+
+    [Fact]
+    public async Task GenerationRead_WhenTheCacheIsUnreadable_ShouldNotReplaceTheSharedToken()
+    {
+        // Arrange
+        var harness = new CacheSetTestHarness();
+        harness.Publish(V160);
+        await harness.CurrentGenerationAsync();
+
+        // Act
+        harness.Cache.FailReads = key => key.EndsWith(":gen", StringComparison.Ordinal);
+        harness.Cache.ClearLog();
+        await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "1");
+
+        // Assert - a failed read is not evidence the token is gone. Writing a replacement would
+        // invalidate every other pod's resolutions, and would do so on every request for as long as
+        // reads keep failing.
+        harness.Cache.Writes.ShouldNotContain(harness.GenerationKey());
+    }
+
+    [Fact]
+    public async Task Publish_WhenTheCacheIsUnwritable_ShouldStillSucceed()
+    {
+        // Arrange
+        var harness = new CacheSetTestHarness();
+        harness.Publish(V160);
+        harness.Cache.FailWrites = _ => true;
+
+        // Act
+        var result = await harness.Sut.SetAsync(CreateView(V160));
+
+        // Assert - publishing must not fail because a cache write did.
+        result.IsSuccess.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Publish_WithNullEntity_ShouldFail()
+    {
+        // Arrange
+        var harness = new CacheSetTestHarness();
+
+        // Act
+        var result = await harness.Sut.SetAsync(null!);
+
+        // Assert
+        result.IsSuccess.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task Read_WhenNothingIsPublished_ShouldFail()
+    {
+        // Arrange
+        var harness = new CacheSetTestHarness();
+        harness.Publish();
+
+        // Act
+        var result = await harness.Sut.GetByVersionAsync(TestDomain, TestKey, "latest");
+
+        // Assert
+        result.IsSuccess.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task GetLatestByName_ShouldResolveTheHighestVersion()
+    {
+        // Arrange
+        var harness = new CacheSetTestHarness();
+        harness.Publish(V150, V160);
+
+        // Act
+        var result = await harness.Sut.GetLatestByNameAsync(TestDomain, TestKey);
+
+        // Assert
+        result.Value!.Version.ShouldBe(V160);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Options
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Options_ShouldDefaultToBoundedTtlsAndLegacyPurgeEnabled()
+    {
+        // Act
+        var options = new ComponentCacheOptions();
+
+        // Assert
+        options.FullVersionTtlSeconds.ShouldBe(1800);
+        options.GenerationTtlSeconds.ShouldBe(3600);
+        options.ResolutionTtlSeconds.ShouldBe(3600);
+        options.NegativeTtlSeconds.ShouldBe(30);
+        options.GenerationMemoSeconds.ShouldBe(0, "memoization trades correctness for latency");
+        options.PurgeLegacyKeysOnPublish.ShouldBeTrue();
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/Caching/DomainCacheContextTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Caching/DomainCacheContextTests.cs
@@ -1,0 +1,75 @@
+using System;
+using BBT.Workflow.Definitions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Caching;
+
+/// <summary>
+/// Unit tests for <see cref="DomainCacheContext"/>'s component-type-key dispatch.
+/// </summary>
+/// <remarks>
+/// The string overload exists so a caller holding only a component type key — for example
+/// <c>DefinitionAppService.InvalidateCacheAsync</c>, which receives the flow as a string — can invalidate
+/// without knowing the entity type. If the mapping is wrong the caller silently invalidates nothing, so
+/// the keys are pinned here rather than assumed.
+/// </remarks>
+public class DomainCacheContextTests
+{
+    private readonly DomainCacheContext _context = new(
+        Substitute.For<BBT.Aether.DistributedCache.IDistributedCacheService>(),
+        Substitute.For<ICacheBackend<Definitions.Workflow>>(),
+        Substitute.For<ICacheBackend<WorkflowTask>>(),
+        Substitute.For<ICacheBackend<SchemaDefinition>>(),
+        Substitute.For<ICacheBackend<Function>>(),
+        Substitute.For<ICacheBackend<View>>(),
+        Substitute.For<ICacheBackend<Extension>>(),
+        Substitute.For<ICacheBackend<Mapping>>(),
+        Substitute.For<IComponentGenerationProvider>(),
+        Options.Create(new ComponentCacheOptions()),
+        TimeProvider.System,
+        NullLoggerFactory.Instance);
+
+    [Fact]
+    public void Set_ByComponentTypeKey_ShouldResolveEveryCachedComponentType()
+    {
+        _context.Set(Definitions.Workflow.ComponentTypeKey).ShouldBeSameAs(_context.Workflows);
+        _context.Set(WorkflowTask.ComponentTypeKey).ShouldBeSameAs(_context.Tasks);
+        _context.Set(SchemaDefinition.ComponentTypeKey).ShouldBeSameAs(_context.Schemas);
+        _context.Set(Function.ComponentTypeKey).ShouldBeSameAs(_context.Functions);
+        _context.Set(View.ComponentTypeKey).ShouldBeSameAs(_context.Views);
+        _context.Set(Extension.ComponentTypeKey).ShouldBeSameAs(_context.Extensions);
+        _context.Set(Mapping.ComponentTypeKey).ShouldBeSameAs(_context.Mappings);
+    }
+
+    [Fact]
+    public void Set_ByComponentTypeKey_ShouldMatchTheFlowNamesCallersActuallyPass()
+    {
+        // The cast processor and DefinitionAppService both pass the flow name, so these literals are the
+        // real contract rather than the ComponentTypeKey constants restated.
+        _context.Set("sys-views").ShouldBeSameAs(_context.Views);
+        _context.Set("sys-flows").ShouldBeSameAs(_context.Workflows);
+        _context.Set("sys-tasks").ShouldBeSameAs(_context.Tasks);
+        _context.Set("sys-schemas").ShouldBeSameAs(_context.Schemas);
+        _context.Set("sys-functions").ShouldBeSameAs(_context.Functions);
+        _context.Set("sys-extensions").ShouldBeSameAs(_context.Extensions);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-a-component-type")]
+    public void Set_ByUnknownComponentTypeKey_ShouldReturnNull(string componentTypeKey)
+    {
+        _context.Set(componentTypeKey).ShouldBeNull();
+    }
+
+    [Fact]
+    public void Set_ByComponentTypeKey_ShouldIgnoreCase()
+    {
+        _context.Set("SYS-VIEWS").ShouldBeSameAs(_context.Views);
+    }
+}

--- a/test/BBT.Workflow.Application.Tests/Caching/FakeDistributedCacheService.cs
+++ b/test/BBT.Workflow.Application.Tests/Caching/FakeDistributedCacheService.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.DistributedCache;
+
+namespace BBT.Workflow.Caching;
+
+/// <summary>
+/// In-memory <see cref="IDistributedCacheService"/> for cache tests.
+/// </summary>
+/// <remarks>
+/// Hand-written rather than substituted because the behaviour under test is the <i>interaction between
+/// keys</i> — which key a publish invalidates, which key a read then misses — and a per-call mock cannot
+/// express that. Values are serialized on write and deserialized on read so envelope round-tripping
+/// (which is why <see cref="CacheEnvelope{T}"/> exists at all) is exercised rather than bypassed.
+/// </remarks>
+public sealed class FakeDistributedCacheService(TimeProvider timeProvider) : IDistributedCacheService
+{
+    private readonly ConcurrentDictionary<string, Entry> _store = new();
+
+    /// <summary>Keys read, in order, including misses.</summary>
+    public List<string> Reads { get; } = [];
+
+    /// <summary>Keys written, in order, including overwrites.</summary>
+    public List<string> Writes { get; } = [];
+
+    /// <summary>Keys removed, in order, including removals of absent keys.</summary>
+    public List<string> Removes { get; } = [];
+
+    /// <summary>When set, reads of matching keys throw, simulating an unreachable cache.</summary>
+    public Func<string, bool>? FailReads { get; set; }
+
+    /// <summary>When set, writes of matching keys throw, simulating an unreachable cache.</summary>
+    public Func<string, bool>? FailWrites { get; set; }
+
+    /// <summary>When set, removals of matching keys throw.</summary>
+    public Func<string, bool>? FailRemoves { get; set; }
+
+    /// <summary>Live (unexpired) keys currently held.</summary>
+    public IReadOnlyList<string> Keys => _store
+        .Where(kvp => !IsExpired(kvp.Value))
+        .Select(kvp => kvp.Key)
+        .OrderBy(k => k, StringComparer.Ordinal)
+        .ToList();
+
+    public Task<T?> GetAsync<T>(string key, CancellationToken cancellationToken = default)
+        where T : class
+    {
+        lock (Reads)
+        {
+            Reads.Add(key);
+        }
+
+        if (FailReads?.Invoke(key) == true)
+            throw new InvalidOperationException($"Simulated cache read failure for '{key}'.");
+
+        if (!_store.TryGetValue(key, out var entry) || IsExpired(entry))
+            return Task.FromResult<T?>(default);
+
+        return Task.FromResult(JsonSerializer.Deserialize<T>(entry.Json));
+    }
+
+    public Task SetAsync<T>(
+        string key,
+        T value,
+        DistributedCacheEntryOptions? options = null,
+        CancellationToken cancellationToken = default)
+        where T : class
+    {
+        lock (Writes)
+        {
+            Writes.Add(key);
+        }
+
+        if (FailWrites?.Invoke(key) == true)
+            throw new InvalidOperationException($"Simulated cache write failure for '{key}'.");
+
+        _store[key] = new Entry(JsonSerializer.Serialize(value), options?.AbsoluteExpiration);
+        return Task.CompletedTask;
+    }
+
+    public Task RemoveAsync(string key, CancellationToken cancellationToken = default)
+    {
+        lock (Removes)
+        {
+            Removes.Add(key);
+        }
+
+        if (FailRemoves?.Invoke(key) == true)
+            throw new InvalidOperationException($"Simulated cache remove failure for '{key}'.");
+
+        _store.TryRemove(key, out _);
+        return Task.CompletedTask;
+    }
+
+    public Task RefreshAsync(string key, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    public async Task<T?> GetOrSetAsync<T>(
+        string key,
+        Func<Task<T>> factory,
+        DistributedCacheEntryOptions? options = null,
+        CancellationToken cancellationToken = default)
+        where T : class
+    {
+        var existing = await GetAsync<T>(key, cancellationToken);
+        if (existing is not null)
+            return existing;
+
+        var created = await factory();
+        await SetAsync(key, created, options, cancellationToken);
+        return created;
+    }
+
+    public async Task<TValue?> GetOrSetAsync<TKey, TValue>(
+        TKey key,
+        Func<TKey, Task<TValue>> factory,
+        Func<TKey, string>? keySelector = null,
+        DistributedCacheEntryOptions? options = null,
+        CancellationToken cancellationToken = default)
+        where TValue : class
+    {
+        var cacheKey = keySelector?.Invoke(key) ?? key?.ToString() ?? string.Empty;
+        var existing = await GetAsync<TValue>(cacheKey, cancellationToken);
+        if (existing is not null)
+            return existing;
+
+        var created = await factory(key);
+        await SetAsync(cacheKey, created, options, cancellationToken);
+        return created;
+    }
+
+    /// <summary>Gets the absolute expiry recorded for a key, or null when the key is absent.</summary>
+    public DateTimeOffset? ExpiryOf(string key)
+        => _store.TryGetValue(key, out var entry) ? entry.ExpiresAt : null;
+
+    /// <summary>True when the key is present and holds no expiry at all.</summary>
+    public bool HasNoExpiry(string key)
+        => _store.TryGetValue(key, out var entry) && entry.ExpiresAt is null;
+
+    /// <summary>Clears the recorded read/write/remove key lists without touching stored values.</summary>
+    public void ClearLog()
+    {
+        lock (Reads)
+        {
+            Reads.Clear();
+        }
+
+        lock (Writes)
+        {
+            Writes.Clear();
+        }
+
+        lock (Removes)
+        {
+            Removes.Clear();
+        }
+    }
+
+    private bool IsExpired(Entry entry)
+        => entry.ExpiresAt is { } expiresAt && expiresAt <= timeProvider.GetUtcNow();
+
+    private sealed record Entry(string Json, DateTimeOffset? ExpiresAt);
+}

--- a/test/BBT.Workflow.Domain.Tests/Instances/InstanceDataVersionComparerTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Instances/InstanceDataVersionComparerTests.cs
@@ -802,6 +802,197 @@ public class InstanceDataVersionComparerTests : DomainTestBase<DomainEntryPoint>
 
     #endregion
 
+    #region Cache Key Algebra (NormalizeRequest / CanonicalFullVersion / GetMajor / GetMajorMinor)
+
+    [Theory]
+    [InlineData(null, "latest")]
+    [InlineData("", "latest")]
+    [InlineData("   ", "latest")]
+    [InlineData("latest", "latest")]
+    [InlineData("LATEST", "latest")]
+    [InlineData("  Latest  ", "latest")]
+    [InlineData("1", "1")]
+    [InlineData(" 1.2 ", "1.2")]
+    [InlineData("2.3.5", "2.3.5")]
+    [InlineData(" 1.5.6-PKG.1.1.56+Core ", "1.5.6-pkg.1.1.56+core")]
+    public void NormalizeRequest_ShouldCollapseEquivalentSpellings(string? requested, string expected)
+    {
+        // Act
+        var result = InstanceDataVersionComparer.NormalizeRequest(requested);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void NormalizeRequest_ShouldAgreeWithCaseInsensitiveMatching()
+    {
+        // Arrange - FindBestMatch resolves these two spellings identically (exact match is
+        // case-insensitive), so they must normalize to the same cache key.
+        var versions = new List<string> { "1.0.0-alpha.1" };
+
+        // Act
+        var lower = InstanceDataVersionComparer.FindBestMatch(versions, "1.0.0-alpha.1");
+        var upper = InstanceDataVersionComparer.FindBestMatch(versions, "1.0.0-ALPHA.1");
+
+        // Assert
+        Assert.Equal(lower, upper);
+        Assert.Equal(
+            InstanceDataVersionComparer.NormalizeRequest("1.0.0-alpha.1"),
+            InstanceDataVersionComparer.NormalizeRequest("1.0.0-ALPHA.1"));
+    }
+
+    [Theory]
+    [InlineData("1.5.6-pkg.1.1.56+core", "1.5.6-pkg.1.1.56")]
+    [InlineData("1.5.6-pkg.1.1.56", "1.5.6-pkg.1.1.56")]
+    [InlineData("1.0.0-pkg.1.17.0+account+build.123", "1.0.0-pkg.1.17.0")]
+    [InlineData("1.0.0", "1.0.0")]
+    [InlineData("1", "1")]
+    [InlineData(null, "")]
+    [InlineData("", "")]
+    public void CanonicalFullVersion_ShouldStripBuildMetadata(string? version, string expected)
+    {
+        // Act
+        var result = InstanceDataVersionComparer.CanonicalFullVersion(version);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void CanonicalFullVersion_ShouldGiveSameIdentityToVersionsThatCompareEqual()
+    {
+        // Arrange - build metadata does not affect ordering, so these are the same version and must
+        // therefore canonicalize to a single identity.
+        const string withMetadata = "1.5.6-pkg.1.1.56+core";
+        const string withoutMetadata = "1.5.6-pkg.1.1.56";
+
+        // Act & Assert
+        Assert.Equal(0, InstanceDataVersionComparer.StringVersionComparer.Instance
+            .Compare(withMetadata, withoutMetadata));
+        Assert.Equal(
+            InstanceDataVersionComparer.CanonicalFullVersion(withMetadata),
+            InstanceDataVersionComparer.CanonicalFullVersion(withoutMetadata));
+    }
+
+    [Theory]
+    [InlineData("1.2.3-pkg.1.0.0+account", "1")]
+    [InlineData("12.0.0-pkg.1.0.0+account", "12")]
+    [InlineData("1.0.0-alpha.1-pkg.1.17.0+account", "1")]
+    [InlineData("2.3.5", "2")]
+    [InlineData("1", null)]
+    [InlineData(null, null)]
+    [InlineData("", null)]
+    public void GetMajor_ShouldExtractArtifactMajor(string? version, string? expected)
+    {
+        // Act
+        var result = InstanceDataVersionComparer.GetMajor(version);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("1.2.3-pkg.1.0.0+account", "1.2")]
+    [InlineData("1.20.0-pkg.1.0.0+account", "1.20")]
+    [InlineData("1.0.0-alpha.1-pkg.1.17.0+account", "1.0")]
+    [InlineData("2.3.5", "2.3")]
+    [InlineData("1", null)]
+    [InlineData(null, null)]
+    [InlineData("", null)]
+    public void GetMajorMinor_ShouldExtractArtifactMajorMinor(string? version, string? expected)
+    {
+        // Act
+        var result = InstanceDataVersionComparer.GetMajorMinor(version);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("1.2.3-pkg.1.0.0+account", "1", true)]
+    [InlineData("12.0.0-pkg.1.0.0+account", "1", false)] // must not be a prefix false-positive
+    [InlineData("12.0.0-pkg.1.0.0+account", "12", true)]
+    public void MatchesMajor_ShouldStillAvoidPrefixFalsePositives(string fullVersion, string major, bool expected)
+    {
+        // Act
+        var result = InstanceDataVersionComparer.MatchesMajor(fullVersion, major);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("1.0.5-pkg.1.0.0+account", "1.0", true)]
+    [InlineData("1.20.0-pkg.1.0.0+account", "1.2", false)] // must not be a prefix false-positive
+    [InlineData("1.2.3-pkg.1.0.0+account", "1.2", true)]
+    public void MatchesPartial_ShouldStillAvoidPrefixFalsePositives(string fullVersion, string partial, bool expected)
+    {
+        // Act
+        var result = InstanceDataVersionComparer.MatchesPartial(fullVersion, partial);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    #endregion
+
+    #region Artifact-Over-Package Priority
+
+    [Fact]
+    public void StringVersionComparer_ShouldRankArtifactVersionAbovePackageVersion()
+    {
+        // Arrange - a lower artifact with a much higher package version must still lose.
+        const string higherArtifactLowerPackage = "1.6.0-pkg.1.0.0+core";
+        const string lowerArtifactHigherPackage = "1.5.0-pkg.9.9.9+core";
+
+        // Act
+        var comparison = InstanceDataVersionComparer.StringVersionComparer.Instance
+            .Compare(higherArtifactLowerPackage, lowerArtifactHigherPackage);
+
+        // Assert
+        Assert.True(comparison > 0);
+    }
+
+    [Theory]
+    [InlineData("1")]
+    [InlineData("latest")]
+    [InlineData(null)]
+    public void FindBestMatch_ShouldPreferHigherArtifactOverHigherPackage(string? requested)
+    {
+        // Arrange
+        var versions = new List<string>
+        {
+            "1.5.0-pkg.9.9.9+core",
+            "1.6.0-pkg.1.0.0+core"
+        };
+
+        // Act
+        var result = InstanceDataVersionComparer.FindBestMatch(versions, requested);
+
+        // Assert
+        Assert.Equal("1.6.0-pkg.1.0.0+core", result);
+    }
+
+    [Fact]
+    public void FindBestMatch_ShouldPreferHighestPackageWithinTheSameArtifact()
+    {
+        // Arrange
+        var versions = new List<string>
+        {
+            "1.5.0-pkg.2.0.0+core",
+            "1.5.0-pkg.3.0.0+core"
+        };
+
+        // Act
+        var result = InstanceDataVersionComparer.FindBestMatch(versions, "1.5.0");
+
+        // Assert
+        Assert.Equal("1.5.0-pkg.3.0.0+core", result);
+    }
+
+    #endregion
+
     private InstanceData CreateInstanceData(string version)
     {
         var instance = InstanceFactory.CreateDefault();


### PR DESCRIPTION
## Problem

Publishing a component left range-resolution cache keys permanently frozen.

Reported symptom — after publishing `1.6.0`, these keys existed for a view:

```
vnext||sys-views:core:account-type-selection-view:artifact:1        <- stuck at 1.5.0
vnext||sys-views:core:account-type-selection-view:artifact:1.5.0
vnext||sys-views:core:account-type-selection-view:artifact:1.6.0
vnext||sys-views:core:account-type-selection-view:latest
```

A workflow referencing `view.version: "1"` kept rendering the 1.5.0 view indefinitely.

`CacheSet.GetByVersionAsync` routed anything that was neither `latest` nor a full version to a key built from **the raw request string** (`artifact:1`), and wrote the resolved body there with **no expiration**. `SetAsync` only ever wrote `full:<exact>`, `latest` and `artifact:<concreteArtifactVersion>` — it never touched `artifact:1`. `InvalidateAsync` had no production callers.

The root cause is a policy one: **write-through assumed the entity being published wins every range it belongs to.** Publishes are not monotonic — a lower version can be released deliberately, and a version can be deactivated. Three further variants followed from the same assumption, all latent:

| | Variant | Effect |
|---|---------|--------|
| a | `latest` overwritten unconditionally | republishing an older version (1.5.1 after 1.6.0) poisoned `latest` |
| b | `artifact:<x.y.z>` overwritten unconditionally | publishing `1.5.0-pkg.2.0.0` while `pkg.3.0.0` existed cached the lower package version |
| c | package-version alias spellings | `00.01.417` / `0.1.417` / `0.01.417` resolve to one entity but produced three keys, **none derivable from a published version** |
| d | deactivation | a deactivated version left database resolution while staying cached forever |

Variant (c) is why this could not be fixed by invalidating derived keys: the set of request spellings that resolve to a given entity is not enumerable from the entity.

## Approach

Answers to version *requests* are now keyed under a per-component **generation token**:

| Key | Contents | TTL |
|-----|----------|-----|
| `{type}:{domain}:{key}:full:{canonicalVersion}` | component body | 1800s (memory bound only — the key names one revision forever) |
| `{type}:{domain}:{key}:gen` | opaque token | 3600s (last-resort backstop, see below) |
| `{type}:{domain}:{key}:res:{gen}:{spelling}` | resolved body, or a negative marker | 3600s positive / 30s negative — **garbage collection, not correctness** |

Publishing or invalidating writes a fresh token, making every prior answer for that component unreachable at once — including spellings no publish could have enumerated. The next read re-resolves through `FindBestMatch`, so the winner comes from the database rather than from a comparison against whatever happened to be cached.

Why a token rather than compare-and-swap on each key:

- **Non-monotonic publish** — variants (a) and (b) disappear instead of being patched. Nothing decides whether the published version "wins".
- **Deactivation / rollback (d)** — resolution can move *down*, which a compare-and-swap structurally cannot do.
- **Unenumerable spellings (c)** — covered without listing them.
- **Races cost work, never wrong data** — concurrent publishes write two different tokens; either way the result differs from the one stale entries were written under. A missing token bootstraps to at worst one duplicate load. (A compare-and-swap lost update would have meant serving a stale version.)
- **No steady-state database load** — resolution entries need no correctness TTL, so there is no refresh treadmill and no expiry stampede.

Pinned reads are unaffected: `Instance.FlowVersion` is a full version, so the pipeline and function paths go straight to the immutable `full:` key with no generation lookup. The extra lookup is paid only by floating references (`"1"`, `"1.2"`), which is where the correctness problem lives.

### Keeping the database spared

- **Warm on publish** — publishing needs the version list once anyway, so it re-resolves `latest` / artifact / MAJOR.MINOR / MAJOR under the new token. The published entity is unioned into the candidate set, since the cast handler may run before the new row is visible to a fresh query. Correct even when the published version is the lower one, because the winner is recomputed rather than assumed.
- **Single-flight coalescing** — concurrent misses for the same component and spelling share one backend load. Per-pod; no distributed lock (`IDistributedLockService` resolves to Postgres, so a package install touching hundreds of components would serialize on the database).
- **Negative caching** — 30s, so a bad or not-yet-published reference cannot repeatedly trigger a full version-list load. Cleared by a generation bump, so a publish that satisfies the request takes effect at once.

### Build metadata

`+packageName` does not participate in comparison, so `1.5.6-pkg.1.1.56` and `1.5.6-pkg.1.1.56+core` now name the same revision and share one entry — previously the bare form returned not-found. The cheap exact single-row lookup stays the first path; only when it misses is the version list consulted to compare canonical identities. Two stored versions differing *only* in build metadata are indistinguishable to version comparison, so one is picked by a stable rule and the collision is logged at `Warning` rather than left to vary between calls.

### The one failure mode

If a publish writes the body but its **generation write fails**, old answers stay reachable. Contained in order: the token is removed instead (an absent token forces a fresh bootstrap, which invalidates just as effectively); if that also fails it is logged at `Error` with a dedicated event id, since this is the only path that can serve stale definitions; and `GenerationTtlSeconds` bounds it regardless. This is the one place the code deliberately does not swallow a cache error.

A failed generation *read* does **not** write a replacement — a failed read is no evidence the token is absent, and replacing it would invalidate every pod's resolutions on every request for as long as reads keep failing.

## Changes

- `Caching/CacheSet.cs` — generation-scoped resolution keys, canonical full-version keys, merged read path with single-flight and negative caching, publish bumps then warms, invalidate bumps. Removes `PopulateCacheAsync`, which was the read-path half of the bug (a read called `SetAsync`, writing `latest` and `artifact:<x>` with no TTL, fire-and-forget on a request-scoped `CancellationToken`, discarding the `Result`).
- `Caching/IComponentGenerationProvider.cs` + `ComponentGenerationProvider.cs` — new.
- `Caching/ComponentCacheOptions.cs` — new. Registered in `AddCacheServices` rather than beside the other application options, so read-only hosts (Monitor) bind configuration instead of silently falling back to defaults.
- `Caching/RuntimeCacheBackend.cs` — build-metadata-insensitive fallback for full-version lookups.
- `Caching/ICacheSet.cs` — `InvalidateAsync` moved to the non-generic interface so a caller holding only a component type key can invalidate.
- `Caching/DomainCacheContext.cs` — options/provider plumbing, plus `Set(string componentTypeKey)`.
- `Definitions/DefinitionAppService.cs` — `InvalidateAsync` gains its first production caller; the null-body (delete) branch is no longer a silent no-op.
- `Instances/InstanceDataVersionComparer.cs` — additive helpers (`NormalizeRequest`, `CanonicalFullVersion`, `GetMajor`, `GetMajorMinor`); `MatchesMajor` / `MatchesPartial` refactored onto them. **No matching semantics changed.**
- `Logging/WorkflowLogs.cs` — `70xxx` event id block for component cache logging.

`FindBestMatch` resolution semantics are untouched. Artifact version already dominated package version (`CompareVersionStrings:86-93`) and is now pinned by tests rather than assumed.

## Verification

| Suite | master | this branch |
|---|---|---|
| Application.Tests | 26F / 960P | 26F / **1005P** |
| Domain.Tests | 153F / 1742P | 153F / **1786P** |
| Infrastructure.Tests | 12F / 234P | 12F / 234P |
| Monitor.Application.Tests | — | 0F / 80P |

Failure counts are identical to the master baseline (all pre-existing, largely `AmbientServiceProvider` parallel-collection leakage). 89 new tests, all passing. Full solution builds clean.

**The suite was falsified, not just run.** With the generation bump removed, 4 tests fail. That exercise found a real gap: the headline regression test still passed without invalidation, because warm-on-publish happened to overwrite the same key. `Publish_NewerVersion_ShouldReplaceMajorOnlyResolution_EvenWithoutWarming` now guards the invalidation path independently.

## Reviewer notes

- **Extra distributed-cache read per floating resolution.** `GenerationMemoSeconds` can remove it by memoizing the token in process, but it is **off by default**: it trades a window of post-publish staleness for latency and departs from the "always `IDistributedCache`" rule. Enable deliberately, if at all.
- **One-off ops sweep after deploy.** Pre-generation `:latest` / `:artifact:*` keys had no expiration. `PurgeLegacyKeysOnPublish` (default on) deletes them as components are republished; components never republished need a manual sweep, since Aether's cache API exposes no SCAN:
  ```
  redis-cli --scan --pattern 'vnext||sys-*:*:artifact:*' | xargs -r redis-cli DEL
  ```
  Remove the flag once no pod can be running the old build.
- **Publishing now costs one extra version-list load per component** (the warm). Deploys are infrequent and this replaces loads that would otherwise happen lazily on first read, but it is a real change to deploy-time database work.
- **Not covered by tests:** the two-line wiring in `DefinitionAppService.InvalidateCacheAsync`. No test harness exists for that service and standing one up needs ~9 substitutes plus a real `Instance`; the pieces it depends on are covered by `DomainCacheContextTests` and `CacheSetTests`.
- **Not yet run:** end-to-end verification against local infrastructure (docker + `redis-cli KEYS`). Worth doing before merge — publish 1.5.0, read `"1"`, publish 1.6.0, confirm the immediate flip and the changed `gen` value, then publish 1.5.1 and confirm `latest` stays at 1.6.0.

## Follow-ups (not in this PR)

- `WorkflowValidator` warning on component references whose version is not a full version — floating is intentional, but it should be a visible choice. This is where a determinism guarantee belongs.
- Ask the Aether team for an atomic `SetIfGreaterAsync` / Lua CAS if the generation approach ever needs tightening.
- A real "component deactivated" hook — there is no deactivation path in Application today, so variant (d) is reachable only via `InvalidateCacheAsync`.
- Push domain filtering into `GetActiveDataListByKeyAsync`, which filters on `Key` only and discards other domains in memory.
- Document the key layout and the request-form contract in `vnext-docs` / `vnext-meta`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Scope component version resolution cache entries to per-component generation tokens so publishes and invalidations comprehensively invalidate range-based version keys without assuming publish monotonicity.

New Features:
- Introduce a generation token service and options to control component cache behaviour, including TTLs, memoization, and legacy key purging.
- Add support for build-metadata-insensitive full-version lookups so requests with or without +build metadata resolve to the same component revision.

Bug Fixes:
- Fix component cache range-resolution keys that previously remained permanently stale after publishes, causing floating version references (e.g. "1") to serve outdated component versions.
- Ensure deactivation or rollback of a version correctly shifts latest and range-based resolutions down to the remaining highest version.

Enhancements:
- Refactor cache read/write paths to use generation-scoped resolution keys, negative caching, and single-flight backend loading to avoid stampedes and reduce database load.
- Extend version comparison utilities with helpers for canonical full versions, normalization of requests, and major/major-minor extraction while preserving existing matching semantics.
- Add detailed logging and activity tagging for component cache operations, including generation token lifecycle, backend resolutions, negative entries, and cache failures.
- Allow cache invalidation via non-generic cache interfaces and component-type-key lookups so services with only flow keys can invalidate component caches.

Tests:
- Add extensive unit tests for CacheSet generation behaviour, resolution correctness across publishes, negative caching, TTLs, legacy key purging, and cache resilience.
- Add tests for DomainCacheContext component-type-key dispatch and for new InstanceDataVersionComparer helpers and artifact-vs-package priority semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved component caching with generation-based invalidation and configurable expiration settings.
  * Added negative caching to distinguish unavailable versions from cache misses.
  * Added support for resolving component caches by type key, including case-insensitive matching.
* **Bug Fixes**
  * Improved version matching for partial, major, and build-metadata variants.
  * Prevented stale resolutions after publishing or deactivating versions.
  * Improved resilience when cache or backend operations fail.
* **Documentation**
  * Clarified cache invalidation, version resolution, and storage behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->