### PR TITLE
feat(url-templates): collapse per-endpoint templates into a single BasePath

### DIFF
--- a/docs/contracts/api-and-service-contracts.md
+++ b/docs/contracts/api-and-service-contracts.md
@@ -131,6 +131,35 @@ concurrent completion its active subset can be a moment fresher than `activeCorr
 Changes to the correlation set participate in the state ETag — see
 [state-function cache and fingerprint ETag](../runtime/state-function-cache-and-etag.md).
 
+### Client-facing hrefs and the `UrlTemplates` section
+
+Every `href` a client receives — `availableTransitions[].href`, `data`, `view`, `schema`, `master`,
+the function catalog entries, the long-poll `ack` — is a **relative path** built by
+`IUrlTemplateBuilder`. The path below the prefix is fixed by the controller routes and lives in code
+(`UrlTemplateDefaults`); the only per-deployment variable is the prefix, because an href must point at
+the API gateway route rather than at the pod.
+
+So a host configures **one key**:
+
+```json
+"UrlTemplates": { "BasePath": "/api/v1/monitor" }
+```
+
+Omit the section entirely and the application serves its own prefix, `/api/v1` — the same one its
+controllers are routed under (`[Route("api/v{version:apiVersion}")]`). The orchestration host relies
+on exactly that and declares nothing. An empty `BasePath` emits prefix-less paths, for a host mounted
+at the root; a leading slash is added and a trailing one trimmed, so `api/v1/` and `/api/v1` are
+equivalent.
+
+The nineteen per-endpoint keys (`Start`, `Transition`, `Data`, …) remain available as optional
+overrides for a gateway that routes one endpoint differently from its siblings. **An override is a
+complete path and is used verbatim — `BasePath` is not prepended to it.** Overriding a template with
+exactly what `BasePath` already yields is a test failure, so the section cannot drift back into
+restating every route.
+
+Note that `InstanceUrlTemplates` is a separate mechanism for internal service-to-service calls and
+takes its version prefix from `vNextApi:ApiVersion`; it is unaffected by this section.
+
 ## Internal-Only Endpoints
 
 Several routes on `InstanceController` exist purely for runtime-to-runtime calls and carry
@@ -202,6 +231,8 @@ available. Current-user and correlation headers should be forwarded across remot
 - `orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Instances/InstanceController.cs`
 - `orchestration/BBT.Workflow.Orchestration.HttpApi.Host/Controllers/Functions/FunctionController.cs`
 - `src/BBT.Workflow.Domain/Definitions/InstanceUrlTemplates.cs`
+- `src/BBT.Workflow.Domain/Definitions/UrlTemplateOptions.cs`
+- `src/BBT.Workflow.Domain/Definitions/UrlTemplateDefaults.cs`
 - `src/BBT.Workflow.Execution.Abstractions/TaskEnvelope.cs`
 - `src/BBT.Workflow.Events.Contracts/`
 - `src/BBT.Workflow.Domain/Validation/SchemaValidationProblemDetails.cs`

--- a/docs/monitoring/claude_yonlendirmleri/CLAUDE.md
+++ b/docs/monitoring/claude_yonlendirmleri/CLAUDE.md
@@ -310,7 +310,7 @@ Kullanıcıya dönük yetenek dokümanı: `docs/features/monitoring-features.md`
 | `ApplicationName` | `vnext-monitor` |
 | `ConnectionStrings:Default` | PostgreSQL (same DB as orchestration) |
 | `Redis` | Distributed cache (`Mode`, `InstanceName`, `Standalone`) |
-| `UrlTemplates` | HATEOAS URL templates for link generation |
+| `UrlTemplates` | HATEOAS link generation. One key — `BasePath: "/api/v1/monitor"` — because the monitor serves its endpoints under that route prefix; per-endpoint templates are optional overrides |
 | `Telemetry` | OpenTelemetry config (OTLP, tracing, metrics, logging) |
 | `Vault:Enabled` | Dapr secret store toggle (default: false) |
 

--- a/monitoring/BBT.Workflow.Monitor.HttpApi.Host/appsettings.json
+++ b/monitoring/BBT.Workflow.Monitor.HttpApi.Host/appsettings.json
@@ -36,25 +36,7 @@
         }
     },
     "UrlTemplates": {
-        "Start": "/api/v1/monitor/{0}/workflows/{1}/instances/start",
-        "Transition": "/api/v1/monitor/{0}/workflows/{1}/instances/{2}/transitions/{3}",
-        "FunctionList": "/api/v1/monitor/{0}/workflows/{1}/functions/{2}",
-        "InstanceList": "/api/v1/monitor/{0}/workflows/{1}/instances",
-        "Instance": "/api/v1/monitor/{0}/workflows/{1}/instances/{2}",
-        "InstanceHistory": "/api/v1/monitor/{0}/workflows/{1}/instances/{2}/transitions",
-        "Data": "/api/v1/monitor/{0}/workflows/{1}/instances/{2}/functions/data",
-        "View": "/api/v1/monitor/{0}/workflows/{1}/instances/{2}/functions/view",
-        "Schema": "/api/v1/monitor/{0}/workflows/{1}/instances/{2}/functions/schema?transitionKey={3}",
-        "Master": "/api/v1/monitor/{0}/workflows/{1}/instances/{2}/functions/master",
-        "DomainFunction": "/api/v1/monitor/{0}/functions/{1}",
-        "DomainFunctionInfo": "/api/v1/monitor/{0}/functions/{1}/info",
-        "DomainFunctionView": "/api/v1/monitor/{0}/functions/{1}/view?target={2}",
-        "DomainFunctionSchema": "/api/v1/monitor/{0}/functions/{1}/schema?target={2}",
-        "InstanceFunction": "/api/v1/monitor/{0}/workflows/{1}/instances/{2}/functions/{3}",
-        "InstanceFunctionInfo": "/api/v1/monitor/{0}/workflows/{1}/instances/{2}/functions/{3}/info",
-        "FunctionCatalog": "/api/v1/monitor/{0}/workflows/{1}/instances/{2}/functions/catalog",
-        "InstanceFunctionView": "/api/v1/monitor/{0}/workflows/{1}/instances/{2}/functions/{3}/view?target={4}",
-        "InstanceFunctionSchema": "/api/v1/monitor/{0}/workflows/{1}/instances/{2}/functions/{3}/schema?target={4}"
+        "BasePath": "/api/v1/monitor"
     },
     "Telemetry": {
         "ServiceName": "vnext-monitor",

--- a/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/appsettings.json
+++ b/orchestration/BBT.Workflow.Orchestration.HttpApi.Host/appsettings.json
@@ -30,27 +30,6 @@
     "InternalOperationHeader": "X-Internal-Operation",
     "ValidateSsl": false
   },
-  "UrlTemplates": {
-    "Start": "/api/{0}/workflows/{1}/instances/start",
-    "Transition": "/api/{0}/workflows/{1}/instances/{2}/transitions/{3}",
-    "FunctionList": "/api/{0}/workflows/{1}/functions/{2}",
-    "InstanceList": "/api/{0}/workflows/{1}/instances",
-    "Instance": "/api/{0}/workflows/{1}/instances/{2}",
-    "InstanceHistory": "/api/{0}/workflows/{1}/instances/{2}/transitions",
-    "Data": "/api/{0}/workflows/{1}/instances/{2}/functions/data",
-    "View": "/api/{0}/workflows/{1}/instances/{2}/functions/view",
-    "Schema": "/api/{0}/workflows/{1}/instances/{2}/functions/schema?transitionKey={3}",
-    "Master": "/api/{0}/workflows/{1}/instances/{2}/functions/master",
-    "DomainFunction": "/api/{0}/functions/{1}",
-    "DomainFunctionInfo": "/api/{0}/functions/{1}/info",
-    "DomainFunctionView": "/api/{0}/functions/{1}/view?target={2}",
-    "DomainFunctionSchema": "/api/{0}/functions/{1}/schema?target={2}",
-    "InstanceFunction": "/api/{0}/workflows/{1}/instances/{2}/functions/{3}",
-    "InstanceFunctionInfo": "/api/{0}/workflows/{1}/instances/{2}/functions/{3}/info",
-    "FunctionCatalog": "/api/{0}/workflows/{1}/instances/{2}/functions/catalog",
-    "InstanceFunctionView": "/api/{0}/workflows/{1}/instances/{2}/functions/{3}/view?target={4}",
-    "InstanceFunctionSchema": "/api/{0}/workflows/{1}/instances/{2}/functions/{3}/schema?target={4}"
-  },
   "ResponseCompression": {
     "Enable": true,
     "Providers": [

--- a/src/BBT.Workflow.Domain/Definitions/UrlTemplateDefaults.cs
+++ b/src/BBT.Workflow.Domain/Definitions/UrlTemplateDefaults.cs
@@ -1,0 +1,83 @@
+namespace BBT.Workflow.Definitions;
+
+/// <summary>
+/// The application's own client-facing route shape, as built-in defaults for
+/// <see cref="UrlTemplateOptions"/>.
+/// <para>
+/// Each template here is the path <b>below</b> the base prefix — it mirrors the controller routes
+/// exactly (<c>[Route("api/v{version:apiVersion}")]</c> plus <c>{domain}/workflows/…</c>), minus the
+/// prefix. The effective template is <see cref="BasePath"/> (or the operator's override of it) plus
+/// one of these. They are consts rather than property initializers so that
+/// <see cref="UrlTemplateOptions"/>' own properties can stay null-by-default and thereby carry the
+/// "did the operator override this?" answer.
+/// </para>
+/// <para>
+/// Placeholders are positional <see cref="string.Format(string, object?[])"/> arguments; the meaning
+/// of each index is documented on the matching <see cref="UrlTemplateOptions"/> property.
+/// </para>
+/// </summary>
+public static class UrlTemplateDefaults
+{
+    /// <summary>
+    /// The prefix the application serves its own endpoints under. Every template below hangs off it
+    /// unless the operator declares a base path of their own (typically an API gateway route).
+    /// </summary>
+    public const string BasePath = "/api/v1";
+
+    /// <summary>Instance start endpoint (POST).</summary>
+    public const string Start = "/{0}/workflows/{1}/instances/start";
+
+    /// <summary>Instance transition endpoint (PATCH).</summary>
+    public const string Transition = "/{0}/workflows/{1}/instances/{2}/transitions/{3}";
+
+    /// <summary>Workflow-scoped function list endpoint (GET).</summary>
+    public const string FunctionList = "/{0}/workflows/{1}/functions/{2}";
+
+    /// <summary>Instance list endpoint (GET).</summary>
+    public const string InstanceList = "/{0}/workflows/{1}/instances";
+
+    /// <summary>Single instance endpoint (GET).</summary>
+    public const string Instance = "/{0}/workflows/{1}/instances/{2}";
+
+    /// <summary>Instance history/transitions endpoint (GET).</summary>
+    public const string InstanceHistory = "/{0}/workflows/{1}/instances/{2}/transitions";
+
+    /// <summary>Instance data endpoint (GET).</summary>
+    public const string Data = "/{0}/workflows/{1}/instances/{2}/functions/data";
+
+    /// <summary>Instance view endpoint (GET).</summary>
+    public const string View = "/{0}/workflows/{1}/instances/{2}/functions/view";
+
+    /// <summary>Instance transition schema endpoint (GET).</summary>
+    public const string Schema = "/{0}/workflows/{1}/instances/{2}/functions/schema?transitionKey={3}";
+
+    /// <summary>Instance master schema endpoint (GET).</summary>
+    public const string Master = "/{0}/workflows/{1}/instances/{2}/functions/master";
+
+    /// <summary>Domain-scoped function execution endpoint.</summary>
+    public const string DomainFunction = "/{0}/functions/{1}";
+
+    /// <summary>Domain-scoped function info endpoint (GET).</summary>
+    public const string DomainFunctionInfo = "/{0}/functions/{1}/info";
+
+    /// <summary>Domain-scoped function view endpoint (GET).</summary>
+    public const string DomainFunctionView = "/{0}/functions/{1}/view?target={2}";
+
+    /// <summary>Domain-scoped function schema endpoint (GET).</summary>
+    public const string DomainFunctionSchema = "/{0}/functions/{1}/schema?target={2}";
+
+    /// <summary>Instance-scoped function execution endpoint.</summary>
+    public const string InstanceFunction = "/{0}/workflows/{1}/instances/{2}/functions/{3}";
+
+    /// <summary>Instance-scoped function info endpoint (GET).</summary>
+    public const string InstanceFunctionInfo = "/{0}/workflows/{1}/instances/{2}/functions/{3}/info";
+
+    /// <summary>Instance function catalog endpoint (GET).</summary>
+    public const string FunctionCatalog = "/{0}/workflows/{1}/instances/{2}/functions/catalog";
+
+    /// <summary>Instance-scoped function view endpoint (GET).</summary>
+    public const string InstanceFunctionView = "/{0}/workflows/{1}/instances/{2}/functions/{3}/view?target={4}";
+
+    /// <summary>Instance-scoped function schema endpoint (GET).</summary>
+    public const string InstanceFunctionSchema = "/{0}/workflows/{1}/instances/{2}/functions/{3}/schema?target={4}";
+}

--- a/src/BBT.Workflow.Domain/Definitions/UrlTemplateOptions.cs
+++ b/src/BBT.Workflow.Domain/Definitions/UrlTemplateOptions.cs
@@ -4,19 +4,27 @@ namespace BBT.Workflow.Definitions;
 /// Configuration for client-facing URL templates used in HATEOAS responses.
 /// Internal service-to-service URLs remain static in InstanceUrlTemplates as they map to controller routes.
 /// <para>
-/// These defaults are the <b>base paths only</b> — deliberately with no gateway prefix. The prefix is a
-/// deployment concern the operator declares in the <c>UrlTemplates</c> config section, and it differs
-/// per host: the orchestration host serves <c>/api/{domain}/…</c> while the monitor host serves
-/// <c>/api/v1/monitor/{domain}/…</c>. Hard-coding either here would be wrong for the other and would
-/// put a hosting detail into the domain layer.
+/// <b>One base entry is normally enough.</b> The application already knows its own route shape — it lives
+/// in <see cref="UrlTemplateDefaults"/>, mirroring the controller routes. What differs per deployment is
+/// only the prefix an API gateway exposes, because an href handed to a client must point at the gateway
+/// rather than at the pod. So a host declares <see cref="BasePath"/> and nothing else; omit the section
+/// entirely and the application serves its own <c>/api/v1</c> prefix.
 /// </para>
 /// <para>
-/// <b>Consequence when adding a template:</b> add the matching key to every host's <c>UrlTemplates</c>
-/// section as well. A template present here but missing from config silently falls back to the
-/// prefix-less base path, which is how the function catalog / info / view / schema hrefs came to be
-/// emitted as <c>/{domain}/…</c> while every sibling href carried the prefix.
-/// <c>UrlTemplateConfigCompletenessTests</c> pins that every property here has a key in each host's
-/// configuration, so the omission fails the build instead of reaching a client.
+/// The nineteen template properties below stay available as <b>optional per-endpoint overrides</b> for
+/// the case where a gateway routes one endpoint differently from its siblings. An override is a
+/// <b>complete path</b> and is used verbatim — <see cref="BasePath"/> is <i>not</i> prepended to it, so an
+/// override must spell out the prefix it wants. That keeps a value authored against the previous
+/// all-templates-listed configuration style working unchanged.
+/// </para>
+/// <para>
+/// <b>Consequence when adding a template:</b> add the built-in relative path to
+/// <see cref="UrlTemplateDefaults"/> and read it in <c>UrlTemplateBuilder</c>'s constructor. Nothing needs
+/// to be added to any host's configuration — a template with no override simply inherits
+/// <see cref="BasePath"/>, which is what removed the old failure mode where a forgotten config key
+/// silently emitted a prefix-less <c>/{domain}/…</c> href (that is how the function catalog / info / view /
+/// schema hrefs once regressed). <c>UrlTemplateConfigCompletenessTests</c> pins that every override
+/// property is actually wired into the builder and that every href carries the configured base.
 /// </para>
 /// </summary>
 public sealed class UrlTemplateOptions
@@ -25,118 +33,127 @@ public sealed class UrlTemplateOptions
     /// Configuration section name in appsettings.json
     /// </summary>
     public const string SectionName = "UrlTemplates";
-    
+
     /// <summary>
-    /// Template for instance start endpoint (POST)
+    /// Prefix prepended to every template that has no explicit override. Defaults to the prefix the
+    /// application itself serves (<see cref="UrlTemplateDefaults.BasePath"/>); set it to the API gateway
+    /// route when hrefs must point at the gateway (for example <c>/api/v1/monitor</c>). A leading slash is
+    /// added and a trailing slash trimmed, so <c>api/v1/</c> and <c>/api/v1</c> are equivalent. An empty
+    /// value emits prefix-less paths, for a host mounted at the root.
+    /// </summary>
+    public string BasePath { get; set; } = UrlTemplateDefaults.BasePath;
+
+    /// <summary>
+    /// Override for the instance start endpoint (POST). Complete path, used verbatim.
     /// Parameters: {0}=domain, {1}=workflow
     /// </summary>
-    public string Start { get; set; } = "/{0}/workflows/{1}/instances/start";
-    
+    public string? Start { get; set; }
+
     /// <summary>
-    /// Template for instance transition endpoint (PATCH)
+    /// Override for the instance transition endpoint (PATCH). Complete path, used verbatim.
     /// Parameters: {0}=domain, {1}=workflow, {2}=instanceId, {3}=transitionKey
     /// </summary>
-    public string Transition { get; set; } = "/{0}/workflows/{1}/instances/{2}/transitions/{3}";
-    
+    public string? Transition { get; set; }
+
     /// <summary>
-    /// Template for function list endpoint (GET)
+    /// Override for the workflow-scoped function list endpoint (GET). Complete path, used verbatim.
     /// Parameters: {0}=domain, {1}=workflow, {2}=function
     /// </summary>
-    public string FunctionList { get; set; } = "/{0}/workflows/{1}/functions/{2}";
-    
+    public string? FunctionList { get; set; }
+
     /// <summary>
-    /// Template for instance list endpoint (GET)
+    /// Override for the instance list endpoint (GET). Complete path, used verbatim.
     /// Parameters: {0}=domain, {1}=workflow
     /// </summary>
-    public string InstanceList { get; set; } = "/{0}/workflows/{1}/instances";
-    
+    public string? InstanceList { get; set; }
+
     /// <summary>
-    /// Template for single instance endpoint (GET)
+    /// Override for the single instance endpoint (GET). Complete path, used verbatim.
     /// Parameters: {0}=domain, {1}=workflow, {2}=instance
     /// </summary>
-    public string Instance { get; set; } = "/{0}/workflows/{1}/instances/{2}";
-    
+    public string? Instance { get; set; }
+
     /// <summary>
-    /// Template for instance history/transitions endpoint (GET)
+    /// Override for the instance history/transitions endpoint (GET). Complete path, used verbatim.
     /// Parameters: {0}=domain, {1}=workflow, {2}=instance
     /// </summary>
-    public string InstanceHistory { get; set; } = "/{0}/workflows/{1}/instances/{2}/transitions";
-    
+    public string? InstanceHistory { get; set; }
+
     /// <summary>
-    /// Template for instance data endpoint (GET)
+    /// Override for the instance data endpoint (GET). Complete path, used verbatim.
     /// Parameters: {0}=domain, {1}=workflow, {2}=instance
     /// </summary>
-    public string Data { get; set; } = "/{0}/workflows/{1}/instances/{2}/functions/data";
-    
+    public string? Data { get; set; }
+
     /// <summary>
-    /// Template for instance view endpoint (GET)
+    /// Override for the instance view endpoint (GET). Complete path, used verbatim.
     /// Parameters: {0}=domain, {1}=workflow, {2}=instance
     /// </summary>
-    public string View { get; set; } = "/{0}/workflows/{1}/instances/{2}/functions/view";
-    
+    public string? View { get; set; }
+
     /// <summary>
-    /// Template for instance schema endpoint (GET)
+    /// Override for the instance transition schema endpoint (GET). Complete path, used verbatim.
     /// Parameters: {0}=domain, {1}=workflow, {2}=instanceId, {3}=transitionKey
     /// </summary>
-    public string Schema { get; set; } = "/{0}/workflows/{1}/instances/{2}/functions/schema?transitionKey={3}";
+    public string? Schema { get; set; }
 
     /// <summary>
-    /// Template for instance master schema endpoint (GET)
+    /// Override for the instance master schema endpoint (GET). Complete path, used verbatim.
     /// Parameters: {0}=domain, {1}=workflow, {2}=instance
     /// </summary>
-    public string Master { get; set; } = "/{0}/workflows/{1}/instances/{2}/functions/master";
+    public string? Master { get; set; }
 
     /// <summary>
-    /// Template for the domain-scoped function execution endpoint
+    /// Override for the domain-scoped function execution endpoint. Complete path, used verbatim.
     /// Parameters: {0}=domain, {1}=function
     /// </summary>
-    public string DomainFunction { get; set; } = "/{0}/functions/{1}";
+    public string? DomainFunction { get; set; }
 
     /// <summary>
-    /// Template for the domain-scoped function info endpoint (GET)
+    /// Override for the domain-scoped function info endpoint (GET). Complete path, used verbatim.
     /// Parameters: {0}=domain, {1}=function
     /// </summary>
-    public string DomainFunctionInfo { get; set; } = "/{0}/functions/{1}/info";
+    public string? DomainFunctionInfo { get; set; }
 
     /// <summary>
-    /// Template for the domain-scoped function view endpoint (GET)
+    /// Override for the domain-scoped function view endpoint (GET). Complete path, used verbatim.
     /// Parameters: {0}=domain, {1}=function, {2}=target (input|output)
     /// </summary>
-    public string DomainFunctionView { get; set; } = "/{0}/functions/{1}/view?target={2}";
+    public string? DomainFunctionView { get; set; }
 
     /// <summary>
-    /// Template for the domain-scoped function schema endpoint (GET)
+    /// Override for the domain-scoped function schema endpoint (GET). Complete path, used verbatim.
     /// Parameters: {0}=domain, {1}=function, {2}=target (input|output)
     /// </summary>
-    public string DomainFunctionSchema { get; set; } = "/{0}/functions/{1}/schema?target={2}";
+    public string? DomainFunctionSchema { get; set; }
 
     /// <summary>
-    /// Template for the instance-scoped function execution endpoint
+    /// Override for the instance-scoped function execution endpoint. Complete path, used verbatim.
     /// Parameters: {0}=domain, {1}=workflow, {2}=instance, {3}=function
     /// </summary>
-    public string InstanceFunction { get; set; } = "/{0}/workflows/{1}/instances/{2}/functions/{3}";
+    public string? InstanceFunction { get; set; }
 
     /// <summary>
-    /// Template for the instance-scoped function info endpoint (GET)
+    /// Override for the instance-scoped function info endpoint (GET). Complete path, used verbatim.
     /// Parameters: {0}=domain, {1}=workflow, {2}=instance, {3}=function
     /// </summary>
-    public string InstanceFunctionInfo { get; set; } = "/{0}/workflows/{1}/instances/{2}/functions/{3}/info";
+    public string? InstanceFunctionInfo { get; set; }
 
     /// <summary>
-    /// Template for the instance function catalog endpoint (GET)
+    /// Override for the instance function catalog endpoint (GET). Complete path, used verbatim.
     /// Parameters: {0}=domain, {1}=workflow, {2}=instance
     /// </summary>
-    public string FunctionCatalog { get; set; } = "/{0}/workflows/{1}/instances/{2}/functions/catalog";
+    public string? FunctionCatalog { get; set; }
 
     /// <summary>
-    /// Template for the instance-scoped function view endpoint (GET)
+    /// Override for the instance-scoped function view endpoint (GET). Complete path, used verbatim.
     /// Parameters: {0}=domain, {1}=workflow, {2}=instance, {3}=function, {4}=target (input|output)
     /// </summary>
-    public string InstanceFunctionView { get; set; } = "/{0}/workflows/{1}/instances/{2}/functions/{3}/view?target={4}";
+    public string? InstanceFunctionView { get; set; }
 
     /// <summary>
-    /// Template for the instance-scoped function schema endpoint (GET)
+    /// Override for the instance-scoped function schema endpoint (GET). Complete path, used verbatim.
     /// Parameters: {0}=domain, {1}=workflow, {2}=instance, {3}=function, {4}=target (input|output)
     /// </summary>
-    public string InstanceFunctionSchema { get; set; } = "/{0}/workflows/{1}/instances/{2}/functions/{3}/schema?target={4}";
+    public string? InstanceFunctionSchema { get; set; }
 }

--- a/src/BBT.Workflow.Infrastructure/Definitions/UrlTemplateBuilder.cs
+++ b/src/BBT.Workflow.Infrastructure/Definitions/UrlTemplateBuilder.cs
@@ -7,69 +7,117 @@ namespace BBT.Workflow.Infrastructure.Definitions;
 /// Builds client-facing URLs from configurable templates.
 /// Used by controllers to generate HATEOAS links with optional gateway routing.
 /// Lifecycle: Singleton - stateless service using configured templates.
+/// <para>
+/// Each template is resolved once in the constructor: an operator's per-endpoint override wins verbatim,
+/// otherwise the configured <see cref="UrlTemplateOptions.BasePath"/> is prepended to the application's
+/// own route shape from <see cref="UrlTemplateDefaults"/>. Options are not monitored for change, matching
+/// the singleton lifetime.
+/// </para>
 /// </summary>
 public sealed class UrlTemplateBuilder : IUrlTemplateBuilder
 {
-    private readonly UrlTemplateOptions _options;
-    
+    private readonly string _start;
+    private readonly string _transition;
+    private readonly string _functionList;
+    private readonly string _instanceList;
+    private readonly string _instance;
+    private readonly string _instanceHistory;
+    private readonly string _data;
+    private readonly string _view;
+    private readonly string _schema;
+    private readonly string _master;
+    private readonly string _domainFunction;
+    private readonly string _domainFunctionInfo;
+    private readonly string _domainFunctionView;
+    private readonly string _domainFunctionSchema;
+    private readonly string _instanceFunction;
+    private readonly string _instanceFunctionInfo;
+    private readonly string _functionCatalog;
+    private readonly string _instanceFunctionView;
+    private readonly string _instanceFunctionSchema;
+
     /// <summary>
     /// Initializes a new instance of UrlTemplateBuilder with configured templates.
     /// </summary>
     /// <param name="options">URL template configuration options</param>
     public UrlTemplateBuilder(IOptions<UrlTemplateOptions> options)
     {
-        _options = options.Value;
+        var configured = options.Value;
+        var basePath = NormalizeBasePath(configured.BasePath);
+
+        string Resolve(string? @override, string relative)
+            => string.IsNullOrWhiteSpace(@override) ? basePath + relative : @override;
+
+        _start = Resolve(configured.Start, UrlTemplateDefaults.Start);
+        _transition = Resolve(configured.Transition, UrlTemplateDefaults.Transition);
+        _functionList = Resolve(configured.FunctionList, UrlTemplateDefaults.FunctionList);
+        _instanceList = Resolve(configured.InstanceList, UrlTemplateDefaults.InstanceList);
+        _instance = Resolve(configured.Instance, UrlTemplateDefaults.Instance);
+        _instanceHistory = Resolve(configured.InstanceHistory, UrlTemplateDefaults.InstanceHistory);
+        _data = Resolve(configured.Data, UrlTemplateDefaults.Data);
+        _view = Resolve(configured.View, UrlTemplateDefaults.View);
+        _schema = Resolve(configured.Schema, UrlTemplateDefaults.Schema);
+        _master = Resolve(configured.Master, UrlTemplateDefaults.Master);
+        _domainFunction = Resolve(configured.DomainFunction, UrlTemplateDefaults.DomainFunction);
+        _domainFunctionInfo = Resolve(configured.DomainFunctionInfo, UrlTemplateDefaults.DomainFunctionInfo);
+        _domainFunctionView = Resolve(configured.DomainFunctionView, UrlTemplateDefaults.DomainFunctionView);
+        _domainFunctionSchema = Resolve(configured.DomainFunctionSchema, UrlTemplateDefaults.DomainFunctionSchema);
+        _instanceFunction = Resolve(configured.InstanceFunction, UrlTemplateDefaults.InstanceFunction);
+        _instanceFunctionInfo = Resolve(configured.InstanceFunctionInfo, UrlTemplateDefaults.InstanceFunctionInfo);
+        _functionCatalog = Resolve(configured.FunctionCatalog, UrlTemplateDefaults.FunctionCatalog);
+        _instanceFunctionView = Resolve(configured.InstanceFunctionView, UrlTemplateDefaults.InstanceFunctionView);
+        _instanceFunctionSchema = Resolve(configured.InstanceFunctionSchema, UrlTemplateDefaults.InstanceFunctionSchema);
     }
-    
+
     /// <inheritdoc />
     public string BuildStartUrl(string domain, string workflow, string? apiVersionPrefix = null)
     {
-        var path = string.Format(_options.Start, domain, workflow);
+        var path = string.Format(_start, domain, workflow);
         return BuildUrl(path, apiVersionPrefix);
     }
-    
+
     /// <inheritdoc />
     public string BuildTransitionUrl(string domain, string workflow, string instanceId, string transitionKey, string? apiVersionPrefix = null)
     {
-        var path = string.Format(_options.Transition, domain, workflow, instanceId, transitionKey);
+        var path = string.Format(_transition, domain, workflow, instanceId, transitionKey);
         return BuildUrl(path, apiVersionPrefix);
     }
-    
+
     /// <inheritdoc />
     public string BuildFunctionListUrl(string domain, string workflow, string function, string? apiVersionPrefix = null)
     {
-        var path = string.Format(_options.FunctionList, domain, workflow, function);
+        var path = string.Format(_functionList, domain, workflow, function);
         return BuildUrl(path, apiVersionPrefix);
     }
-    
+
     /// <inheritdoc />
     public string BuildInstanceListUrl(string domain, string workflow, string? apiVersionPrefix = null)
     {
-        var path = string.Format(_options.InstanceList, domain, workflow);
+        var path = string.Format(_instanceList, domain, workflow);
         return BuildUrl(path, apiVersionPrefix);
     }
-    
+
     /// <inheritdoc />
     public string BuildInstanceUrl(string domain, string workflow, string instance, string? apiVersionPrefix = null)
     {
-        var path = string.Format(_options.Instance, domain, workflow, instance);
+        var path = string.Format(_instance, domain, workflow, instance);
         return BuildUrl(path, apiVersionPrefix);
     }
-    
+
     /// <inheritdoc />
     public string BuildInstanceHistoryUrl(string domain, string workflow, string instance, string? apiVersionPrefix = null)
     {
-        var path = string.Format(_options.InstanceHistory, domain, workflow, instance);
+        var path = string.Format(_instanceHistory, domain, workflow, instance);
         return BuildUrl(path, apiVersionPrefix);
     }
-    
+
     /// <inheritdoc />
     public string BuildDataUrl(string domain, string workflow, string instance, string? apiVersionPrefix = null)
     {
-        var path = string.Format(_options.Data, domain, workflow, instance);
+        var path = string.Format(_data, domain, workflow, instance);
         return BuildUrl(path, apiVersionPrefix);
     }
-    
+
     /// <inheritdoc />
     public string BuildDataWithExtensionsUrl(string domain, string workflow, string instance, IEnumerable<string> extensions, string? apiVersionPrefix = null)
     {
@@ -77,103 +125,128 @@ public sealed class UrlTemplateBuilder : IUrlTemplateBuilder
         var extensionParams = string.Join("&", extensions.Where(e => !string.IsNullOrEmpty(e)).Select(e => $"extensions={Uri.EscapeDataString(e)}"));
         return string.IsNullOrEmpty(extensionParams) ? basePath : $"{basePath}?{extensionParams}";
     }
-    
+
     /// <inheritdoc />
     public string BuildViewUrl(string domain, string workflow, string instance, string? transitionKey = null, string? apiVersionPrefix = null)
     {
-        var path = string.Format(_options.View, domain, workflow, instance);
+        var path = string.Format(_view, domain, workflow, instance);
         if (!string.IsNullOrEmpty(transitionKey))
             path += "?transitionKey=" + Uri.EscapeDataString(transitionKey);
         return BuildUrl(path, apiVersionPrefix);
     }
-    
+
     /// <inheritdoc />
     public string BuildSchemaUrl(string domain, string workflow, string instanceId, string transitionKey, string? apiVersionPrefix = null)
     {
-        var path = string.Format(_options.Schema, domain, workflow, instanceId, transitionKey);
+        var path = string.Format(_schema, domain, workflow, instanceId, transitionKey);
         return BuildUrl(path, apiVersionPrefix);
     }
 
     /// <inheritdoc />
     public string BuildMasterUrl(string domain, string workflow, string instance, string? apiVersionPrefix = null)
     {
-        var path = string.Format(_options.Master, domain, workflow, instance);
+        var path = string.Format(_master, domain, workflow, instance);
         return BuildUrl(path, apiVersionPrefix);
     }
-    
+
     /// <inheritdoc />
     public string BuildDomainFunctionUrl(string domain, string function, string? apiVersionPrefix = null)
     {
-        var path = string.Format(_options.DomainFunction, domain, function);
+        var path = string.Format(_domainFunction, domain, function);
         return BuildUrl(path, apiVersionPrefix);
     }
 
     /// <inheritdoc />
     public string BuildDomainFunctionInfoUrl(string domain, string function, string? apiVersionPrefix = null)
     {
-        var path = string.Format(_options.DomainFunctionInfo, domain, function);
+        var path = string.Format(_domainFunctionInfo, domain, function);
         return BuildUrl(path, apiVersionPrefix);
     }
 
     /// <inheritdoc />
     public string BuildDomainFunctionViewUrl(string domain, string function, string target, string? apiVersionPrefix = null)
     {
-        var path = string.Format(_options.DomainFunctionView, domain, function, Uri.EscapeDataString(target));
+        var path = string.Format(_domainFunctionView, domain, function, Uri.EscapeDataString(target));
         return BuildUrl(path, apiVersionPrefix);
     }
 
     /// <inheritdoc />
     public string BuildDomainFunctionSchemaUrl(string domain, string function, string target, string? apiVersionPrefix = null)
     {
-        var path = string.Format(_options.DomainFunctionSchema, domain, function, Uri.EscapeDataString(target));
+        var path = string.Format(_domainFunctionSchema, domain, function, Uri.EscapeDataString(target));
         return BuildUrl(path, apiVersionPrefix);
     }
 
     /// <inheritdoc />
     public string BuildInstanceFunctionUrl(string domain, string workflow, string instance, string function, string? apiVersionPrefix = null)
     {
-        var path = string.Format(_options.InstanceFunction, domain, workflow, instance, function);
+        var path = string.Format(_instanceFunction, domain, workflow, instance, function);
         return BuildUrl(path, apiVersionPrefix);
     }
 
     /// <inheritdoc />
     public string BuildInstanceFunctionInfoUrl(string domain, string workflow, string instance, string function, string? apiVersionPrefix = null)
     {
-        var path = string.Format(_options.InstanceFunctionInfo, domain, workflow, instance, function);
+        var path = string.Format(_instanceFunctionInfo, domain, workflow, instance, function);
         return BuildUrl(path, apiVersionPrefix);
     }
 
     /// <inheritdoc />
     public string BuildFunctionCatalogUrl(string domain, string workflow, string instance, string? apiVersionPrefix = null)
     {
-        var path = string.Format(_options.FunctionCatalog, domain, workflow, instance);
+        var path = string.Format(_functionCatalog, domain, workflow, instance);
         return BuildUrl(path, apiVersionPrefix);
     }
 
     /// <inheritdoc />
     public string BuildInstanceFunctionViewUrl(string domain, string workflow, string instance, string function, string target, string? apiVersionPrefix = null)
     {
-        var path = string.Format(_options.InstanceFunctionView, domain, workflow, instance, function, Uri.EscapeDataString(target));
+        var path = string.Format(_instanceFunctionView, domain, workflow, instance, function, Uri.EscapeDataString(target));
         return BuildUrl(path, apiVersionPrefix);
     }
 
     /// <inheritdoc />
     public string BuildInstanceFunctionSchemaUrl(string domain, string workflow, string instance, string function, string target, string? apiVersionPrefix = null)
     {
-        var path = string.Format(_options.InstanceFunctionSchema, domain, workflow, instance, function, Uri.EscapeDataString(target));
+        var path = string.Format(_instanceFunctionSchema, domain, workflow, instance, function, Uri.EscapeDataString(target));
         return BuildUrl(path, apiVersionPrefix);
     }
 
     /// <summary>
+    /// Brings a configured base path to the canonical form the templates expect: a leading slash and no
+    /// trailing one, so <c>api/v1/</c> and <c>/api/v1</c> compose identically. An empty or whitespace value
+    /// yields no prefix at all, for a host mounted at the root.
+    /// </summary>
+    /// <param name="basePath">The configured base path</param>
+    /// <returns>Normalized prefix, possibly empty</returns>
+    private static string NormalizeBasePath(string? basePath)
+    {
+        if (string.IsNullOrWhiteSpace(basePath))
+            return string.Empty;
+
+        var trimmed = basePath.Trim().TrimEnd('/');
+
+        if (trimmed.Length == 0)
+            return string.Empty;
+
+        return trimmed.StartsWith('/') ? trimmed : "/" + trimmed;
+    }
+
+    /// <summary>
     /// Combines the relative path with optional API version prefix.
+    /// <para>
+    /// This is a second prefix applied on top of the one already baked into the template by
+    /// <see cref="UrlTemplateOptions.BasePath"/>. No client-facing call site passes it — every HATEOAS
+    /// caller leaves it null and takes the prefix from configuration.
+    /// </para>
     /// </summary>
     /// <param name="path">The relative path generated from template</param>
     /// <param name="apiVersionPrefix">Optional API version prefix (e.g., "api/v1")</param>
     /// <returns>Final URL path</returns>
     private static string BuildUrl(string path, string? apiVersionPrefix)
     {
-        return string.IsNullOrEmpty(apiVersionPrefix) 
-            ? path 
+        return string.IsNullOrEmpty(apiVersionPrefix)
+            ? path
             : apiVersionPrefix + path;
     }
 }

--- a/test/BBT.Workflow.Application.Tests/Functions/FunctionInfoAppServiceTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Functions/FunctionInfoAppServiceTests.cs
@@ -13,12 +13,14 @@ using BBT.Workflow.Authorization;
 using BBT.Workflow.Caching;
 using BBT.Workflow.Definitions;
 using BBT.Workflow.Functions.Contracts;
+using BBT.Workflow.Infrastructure.Definitions;
 using BBT.Workflow.Instances;
 using BBT.Workflow.Runtime;
 using BBT.Workflow.Scripting;
 using BBT.Workflow.Tasks.Coordinator;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using Shouldly;
 using Xunit;
@@ -37,6 +39,12 @@ public sealed class FunctionInfoAppServiceTests : IDisposable
     private const string TestVersion = FunctionTestFactory.Version;
     private const string FunctionKey = "my-fn";
     private const string TestFlow = "my-flow";
+
+    /// <summary>
+    /// The prefix the real builder emits when nothing is configured — the same one a client sees from a
+    /// host that declares no <c>UrlTemplates</c> section.
+    /// </summary>
+    private const string BasePath = UrlTemplateDefaults.BasePath;
 
     private readonly IComponentCacheStore _componentCacheStore = Substitute.For<IComponentCacheStore>();
     private readonly IInstanceRepository _instanceRepository = Substitute.For<IInstanceRepository>();
@@ -79,7 +87,7 @@ public sealed class FunctionInfoAppServiceTests : IDisposable
             scriptContextFactory: scriptContextFactory,
             componentCacheStore: _componentCacheStore,
             currentSchema: Substitute.For<ICurrentSchema>(),
-            urlTemplateBuilder: new StubUrlTemplateBuilder(),
+            urlTemplateBuilder: new UrlTemplateBuilder(Options.Create(new UrlTemplateOptions())),
             functionAccessPolicy: new FunctionAccessPolicy(
                 Substitute.For<ICurrentUser>(), _authorizationManager),
             contractResolver: new FunctionContractResolver(
@@ -165,7 +173,7 @@ public sealed class FunctionInfoAppServiceTests : IDisposable
         info.RawResponse.ShouldBeTrue();
         info.Cacheable.ShouldBeFalse();
         info.Function.Verbs.ShouldBe(["POST", "PATCH"]);
-        info.Function.Href.ShouldBe($"/{TestDomain}/functions/{FunctionKey}");
+        info.Function.Href.ShouldBe($"{BasePath}/{TestDomain}/functions/{FunctionKey}");
     }
 
     [Fact]
@@ -180,10 +188,10 @@ public sealed class FunctionInfoAppServiceTests : IDisposable
         info.InputSchema.HasSchema.ShouldBeFalse();
         info.OutputSchema.HasSchema.ShouldBeFalse();
 
-        info.InputView.Href.ShouldBe($"/{TestDomain}/functions/{FunctionKey}/view?target=input");
-        info.OutputView.Href.ShouldBe($"/{TestDomain}/functions/{FunctionKey}/view?target=output");
-        info.InputSchema.Href.ShouldBe($"/{TestDomain}/functions/{FunctionKey}/schema?target=input");
-        info.OutputSchema.Href.ShouldBe($"/{TestDomain}/functions/{FunctionKey}/schema?target=output");
+        info.InputView.Href.ShouldBe($"{BasePath}/{TestDomain}/functions/{FunctionKey}/view?target=input");
+        info.OutputView.Href.ShouldBe($"{BasePath}/{TestDomain}/functions/{FunctionKey}/view?target=output");
+        info.InputSchema.Href.ShouldBe($"{BasePath}/{TestDomain}/functions/{FunctionKey}/schema?target=input");
+        info.OutputSchema.Href.ShouldBe($"{BasePath}/{TestDomain}/functions/{FunctionKey}/schema?target=output");
     }
 
     [Fact]
@@ -247,9 +255,9 @@ public sealed class FunctionInfoAppServiceTests : IDisposable
             TestDomain, TestFlow, instance.Id.ToString(), FunctionKey)).Value.ShouldNotBeNull();
 
         info.Function.Href.ShouldBe(
-            $"/{TestDomain}/workflows/{TestFlow}/instances/{instance.Id}/functions/{FunctionKey}");
+            $"{BasePath}/{TestDomain}/workflows/{TestFlow}/instances/{instance.Id}/functions/{FunctionKey}");
         info.InputView.Href.ShouldBe(
-            $"/{TestDomain}/workflows/{TestFlow}/instances/{instance.Id}/functions/{FunctionKey}/view?target=input");
+            $"{BasePath}/{TestDomain}/workflows/{TestFlow}/instances/{instance.Id}/functions/{FunctionKey}/view?target=input");
     }
 
     // ─── Content endpoints ──────────────────────────────────────────────────────
@@ -347,8 +355,8 @@ public sealed class FunctionInfoAppServiceTests : IDisposable
         entry.Version.ShouldBe(TestVersion);
         entry.Scope.ShouldBe(scope);
         entry.Href.ShouldBe(instanceScoped
-            ? $"/{TestDomain}/workflows/{TestFlow}/instances/{instance.Id}/functions/get-branches/info"
-            : $"/{TestDomain}/functions/get-branches/info");
+            ? $"{BasePath}/{TestDomain}/workflows/{TestFlow}/instances/{instance.Id}/functions/get-branches/info"
+            : $"{BasePath}/{TestDomain}/functions/get-branches/info");
     }
 
     /// <summary>
@@ -502,81 +510,5 @@ public sealed class FunctionInfoAppServiceTests : IDisposable
         _componentCacheStore
             .GetSchemaAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(Result<SchemaDefinition>.Ok(schema));
-    }
-
-    /// <summary>
-    /// Emits the default templates verbatim so the tests assert the shape clients actually receive
-    /// rather than a mock's placeholder.
-    /// <para>
-    /// It formats the <see cref="UrlTemplateOptions"/> defaults, which are base paths with no gateway
-    /// prefix — the prefix is supplied per host by the <c>UrlTemplates</c> config section and is not in
-    /// scope here. So the expectations above are correctly prefix-less; what a client receives in a
-    /// deployment additionally carries that host's prefix. Config completeness is pinned separately by
-    /// <c>UrlTemplateConfigCompletenessTests</c>.
-    /// </para>
-    /// </summary>
-    private sealed class StubUrlTemplateBuilder : IUrlTemplateBuilder
-    {
-        private readonly UrlTemplateOptions _options = new();
-
-        public string BuildStartUrl(string domain, string workflow, string? apiVersionPrefix = null)
-            => string.Format(_options.Start, domain, workflow);
-
-        public string BuildTransitionUrl(string domain, string workflow, string instanceId, string transitionKey, string? apiVersionPrefix = null)
-            => string.Format(_options.Transition, domain, workflow, instanceId, transitionKey);
-
-        public string BuildFunctionListUrl(string domain, string workflow, string function, string? apiVersionPrefix = null)
-            => string.Format(_options.FunctionList, domain, workflow, function);
-
-        public string BuildInstanceListUrl(string domain, string workflow, string? apiVersionPrefix = null)
-            => string.Format(_options.InstanceList, domain, workflow);
-
-        public string BuildInstanceUrl(string domain, string workflow, string instance, string? apiVersionPrefix = null)
-            => string.Format(_options.Instance, domain, workflow, instance);
-
-        public string BuildInstanceHistoryUrl(string domain, string workflow, string instance, string? apiVersionPrefix = null)
-            => string.Format(_options.InstanceHistory, domain, workflow, instance);
-
-        public string BuildDataUrl(string domain, string workflow, string instance, string? apiVersionPrefix = null)
-            => string.Format(_options.Data, domain, workflow, instance);
-
-        public string BuildDataWithExtensionsUrl(string domain, string workflow, string instance, IEnumerable<string> extensions, string? apiVersionPrefix = null)
-            => BuildDataUrl(domain, workflow, instance, apiVersionPrefix);
-
-        public string BuildViewUrl(string domain, string workflow, string instance, string? transitionKey = null, string? apiVersionPrefix = null)
-            => string.Format(_options.View, domain, workflow, instance);
-
-        public string BuildSchemaUrl(string domain, string workflow, string instanceId, string transitionKey, string? apiVersionPrefix = null)
-            => string.Format(_options.Schema, domain, workflow, instanceId, transitionKey);
-
-        public string BuildMasterUrl(string domain, string workflow, string instance, string? apiVersionPrefix = null)
-            => string.Format(_options.Master, domain, workflow, instance);
-
-        public string BuildFunctionCatalogUrl(string domain, string workflow, string instance, string? apiVersionPrefix = null)
-            => string.Format(_options.FunctionCatalog, domain, workflow, instance);
-
-        public string BuildDomainFunctionUrl(string domain, string function, string? apiVersionPrefix = null)
-            => string.Format(_options.DomainFunction, domain, function);
-
-        public string BuildDomainFunctionInfoUrl(string domain, string function, string? apiVersionPrefix = null)
-            => string.Format(_options.DomainFunctionInfo, domain, function);
-
-        public string BuildDomainFunctionViewUrl(string domain, string function, string target, string? apiVersionPrefix = null)
-            => string.Format(_options.DomainFunctionView, domain, function, target);
-
-        public string BuildDomainFunctionSchemaUrl(string domain, string function, string target, string? apiVersionPrefix = null)
-            => string.Format(_options.DomainFunctionSchema, domain, function, target);
-
-        public string BuildInstanceFunctionUrl(string domain, string workflow, string instance, string function, string? apiVersionPrefix = null)
-            => string.Format(_options.InstanceFunction, domain, workflow, instance, function);
-
-        public string BuildInstanceFunctionInfoUrl(string domain, string workflow, string instance, string function, string? apiVersionPrefix = null)
-            => string.Format(_options.InstanceFunctionInfo, domain, workflow, instance, function);
-
-        public string BuildInstanceFunctionViewUrl(string domain, string workflow, string instance, string function, string target, string? apiVersionPrefix = null)
-            => string.Format(_options.InstanceFunctionView, domain, workflow, instance, function, target);
-
-        public string BuildInstanceFunctionSchemaUrl(string domain, string workflow, string instance, string function, string target, string? apiVersionPrefix = null)
-            => string.Format(_options.InstanceFunctionSchema, domain, workflow, instance, function, target);
     }
 }

--- a/test/BBT.Workflow.Infrastructure.Tests/Definitions/UrlTemplateConfigCompletenessTests.cs
+++ b/test/BBT.Workflow.Infrastructure.Tests/Definitions/UrlTemplateConfigCompletenessTests.cs
@@ -5,25 +5,28 @@ using System.Linq;
 using System.Reflection;
 using System.Text.Json;
 using BBT.Workflow.Definitions;
+using BBT.Workflow.Infrastructure.Definitions;
+using Microsoft.Extensions.Options;
 using Shouldly;
 using Xunit;
 
 namespace BBT.Workflow.Infrastructure.Tests.Definitions;
 
 /// <summary>
-/// Pins that every client-facing URL template has a key in every host's <c>UrlTemplates</c>
-/// configuration.
+/// Pins that every client-facing URL template carries the host's base prefix, and that a template added
+/// to <see cref="UrlTemplateOptions"/> is actually wired into <see cref="UrlTemplateBuilder"/>.
 /// <para>
-/// <see cref="UrlTemplateOptions"/> holds base paths with no gateway prefix, because the prefix is a
-/// deployment concern and differs per host (<c>/api/…</c> for orchestration, <c>/api/v1/monitor/…</c>
-/// for the monitor). That design is correct, but it makes the config the only place the prefix exists —
-/// so a template added to the options class without a matching config key silently falls back to the
-/// prefix-less base path and emits <c>/{domain}/…</c> while every sibling href carries the prefix.
+/// A host declares one <see cref="UrlTemplateOptions.BasePath"/>; every template inherits it from the
+/// built-in route shape in <see cref="UrlTemplateDefaults"/>. That inheritance is what closed the old
+/// failure mode — a template present on the options class but missing from a host's config used to fall
+/// back to a prefix-less base path and emit <c>/{domain}/…</c> while every sibling href carried the
+/// prefix, which is how the function catalog / info / view / schema hrefs regressed.
 /// </para>
 /// <para>
-/// That is precisely how the function catalog, info, view and schema hrefs regressed. This test makes
-/// the omission a build failure. Reflection is used deliberately so a template added later is covered
-/// without anyone remembering to extend this test.
+/// What can still go wrong is a new property that nobody reads in the builder's constructor, so the
+/// operator's override is silently ignored. That is what <see cref="EveryOverrideProperty_IsWiredIntoTheBuilder"/>
+/// catches. Reflection is used deliberately throughout so a template added later is covered without
+/// anyone remembering to extend this test.
 /// </para>
 /// </summary>
 public class UrlTemplateConfigCompletenessTests
@@ -34,25 +37,80 @@ public class UrlTemplateConfigCompletenessTests
         "monitoring/BBT.Workflow.Monitor.HttpApi.Host/appsettings.json",
     ];
 
-    private static IEnumerable<string> TemplateNames => typeof(UrlTemplateOptions)
+    /// <summary>
+    /// The per-endpoint override properties — every settable string property except the base path itself.
+    /// </summary>
+    private static IEnumerable<PropertyInfo> OverrideProperties => typeof(UrlTemplateOptions)
         .GetProperties(BindingFlags.Public | BindingFlags.Instance)
-        .Where(p => p.PropertyType == typeof(string))
-        .Select(p => p.Name);
+        .Where(p => p.PropertyType == typeof(string) && p.CanWrite)
+        .Where(p => p.Name != nameof(UrlTemplateOptions.BasePath));
 
     public static TheoryData<string> Hosts() => [.. HostAppSettings];
 
-    [Theory]
-    [MemberData(nameof(Hosts))]
-    public void EveryTemplate_HasAConfigKeyInEveryHost(string relativePath)
+    public static TheoryData<string> OverrideNames() => [.. OverrideProperties.Select(p => p.Name)];
+
+    /// <summary>
+    /// With nothing configured at all, the application serves hrefs under its own prefix. This is the
+    /// case for the orchestration host, which no longer declares a <c>UrlTemplates</c> section.
+    /// </summary>
+    [Fact]
+    public void DefaultOptions_PrefixEveryHrefWithApiV1()
     {
-        var configured = ReadUrlTemplates(relativePath);
+        var hrefs = BuildEveryHref(new UrlTemplateOptions());
 
-        var missing = TemplateNames.Where(n => !configured.ContainsKey(n)).ToList();
+        foreach (var (method, href) in hrefs)
+            href.ShouldStartWith(UrlTemplateDefaults.BasePath + "/", customMessage: $"{method} dropped the default base path.");
+    }
 
-        missing.ShouldBeEmpty(
-            $"'{relativePath}' is missing UrlTemplates keys, so these templates would fall back to the " +
-            $"prefix-less base path and emit hrefs without the host's gateway prefix: " +
-            string.Join(", ", missing));
+    /// <summary>
+    /// A single <c>BasePath</c> entry is all a host needs — every href, including the ones with no
+    /// dedicated template such as the long-poll acknowledge URL, must pick it up.
+    /// </summary>
+    [Theory]
+    [InlineData("/api/v1/monitor")]
+    [InlineData("api/v1/monitor/")]
+    [InlineData("/gateway")]
+    public void ConfiguredBasePath_PrefixesEveryHref(string basePath)
+    {
+        var hrefs = BuildEveryHref(new UrlTemplateOptions { BasePath = basePath });
+        var expected = "/" + basePath.Trim('/');
+
+        foreach (var (method, href) in hrefs)
+            href.ShouldStartWith(expected + "/", customMessage: $"{method} did not carry the configured base path.");
+    }
+
+    /// <summary>
+    /// An empty base path is legitimate for a host mounted at the root, and must not leave a stray slash
+    /// or fall back to the default prefix.
+    /// </summary>
+    [Fact]
+    public void EmptyBasePath_EmitsPrefixLessHrefs()
+    {
+        var hrefs = BuildEveryHref(new UrlTemplateOptions { BasePath = "" });
+
+        foreach (var (method, href) in hrefs)
+            href.ShouldStartWith("/domain", customMessage: $"{method} did not emit a prefix-less path.");
+    }
+
+    /// <summary>
+    /// Every override property must be read somewhere in the builder. A property nobody reads looks
+    /// configurable to an operator and does nothing — the quietest kind of failure, since the href stays
+    /// plausible. Setting one property at a time and demanding the sentinel surface in some href proves
+    /// the wiring without hard-coding a property-to-method map that would itself go stale.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(OverrideNames))]
+    public void EveryOverrideProperty_IsWiredIntoTheBuilder(string propertyName)
+    {
+        const string sentinel = "/sentinel-override";
+
+        var options = new UrlTemplateOptions();
+        typeof(UrlTemplateOptions).GetProperty(propertyName)!.SetValue(options, sentinel);
+
+        var hrefs = BuildEveryHref(options);
+
+        hrefs.Any(h => h.Href.StartsWith(sentinel, StringComparison.Ordinal)).ShouldBeTrue(
+            $"'{propertyName}' is never read by UrlTemplateBuilder, so configuring it has no effect.");
     }
 
     [Theory]
@@ -60,7 +118,8 @@ public class UrlTemplateConfigCompletenessTests
     public void NoConfigKey_IsOrphaned(string relativePath)
     {
         var configured = ReadUrlTemplates(relativePath);
-        var known = TemplateNames.ToHashSet(StringComparer.Ordinal);
+        var known = OverrideProperties.Select(p => p.Name).ToHashSet(StringComparer.Ordinal);
+        known.Add(nameof(UrlTemplateOptions.BasePath));
 
         var orphaned = configured.Keys.Where(k => !known.Contains(k)).ToList();
 
@@ -70,26 +129,72 @@ public class UrlTemplateConfigCompletenessTests
     }
 
     /// <summary>
-    /// Every configured template must share one prefix within a host, so sibling hrefs in the same
-    /// response cannot disagree. The prefix itself is the host's business — this only checks agreement.
+    /// A per-endpoint override earns its place only by differing from what the base path already
+    /// produces. Restating the default is how the section grew to nineteen near-identical lines per host,
+    /// and each restated line is another place to forget when a route changes.
     /// </summary>
     [Theory]
     [MemberData(nameof(Hosts))]
-    public void AllTemplatesInAHost_ShareTheSamePrefix(string relativePath)
+    public void HostConfig_DoesNotRestateADefault(string relativePath)
     {
         var configured = ReadUrlTemplates(relativePath);
 
-        // Everything before the "{0}" domain placeholder is the host's prefix.
-        var prefixes = configured
-            .Select(kv => (kv.Key, Prefix: kv.Value[..kv.Value.IndexOf("{0}", StringComparison.Ordinal)]))
+        if (!configured.TryGetValue(nameof(UrlTemplateOptions.BasePath), out var basePath))
+            basePath = UrlTemplateDefaults.BasePath;
+
+        var normalizedBase = basePath.Length == 0 ? "" : "/" + basePath.Trim('/');
+
+        var redundant = configured
+            .Where(kv => kv.Key != nameof(UrlTemplateOptions.BasePath))
+            .Where(kv => kv.Value == normalizedBase + BuiltInDefaultFor(kv.Key))
+            .Select(kv => kv.Key)
             .ToList();
 
-        var distinct = prefixes.Select(p => p.Prefix).Distinct(StringComparer.Ordinal).ToList();
-
-        distinct.Count.ShouldBe(1,
-            $"'{relativePath}' mixes prefixes across templates: " +
-            string.Join(", ", prefixes.Select(p => $"{p.Key}='{p.Prefix}'")));
+        redundant.ShouldBeEmpty(
+            $"'{relativePath}' overrides templates with exactly what BasePath already yields; drop these " +
+            $"keys and let them inherit: " + string.Join(", ", redundant));
     }
+
+    private static string BuiltInDefaultFor(string templateName)
+        => (string)typeof(UrlTemplateDefaults)
+            .GetField(templateName, BindingFlags.Public | BindingFlags.Static)!
+            .GetValue(null)!;
+
+    /// <summary>
+    /// Invokes every <c>Build*Url</c> member of <see cref="IUrlTemplateBuilder"/> with placeholder
+    /// arguments. Going through the interface rather than the class covers the default interface methods
+    /// too — <c>BuildLongPollAckUrl</c> has no backing template and would otherwise escape every
+    /// assertion here.
+    /// </summary>
+    private static List<(string Method, string Href)> BuildEveryHref(UrlTemplateOptions options)
+    {
+        IUrlTemplateBuilder builder = new UrlTemplateBuilder(Options.Create(options));
+
+        var results = typeof(IUrlTemplateBuilder)
+            .GetMethods()
+            .Where(m => m.Name.StartsWith("Build", StringComparison.Ordinal))
+            .Select(m => (m.Name, Href: (string)m.Invoke(builder, ArgumentsFor(m))!))
+            .ToList();
+
+        results.ShouldNotBeEmpty("Reflection found no Build*Url methods — the discovery above is broken.");
+        return results;
+    }
+
+    private static object?[] ArgumentsFor(MethodInfo method) => method
+        .GetParameters()
+        .Select(p => p.ParameterType == typeof(IEnumerable<string>)
+            ? (object?)new[] { "ext" }
+            : p.Name switch
+            {
+                "domain" => "domain",
+                "workflow" => "workflow",
+                "instance" or "instanceId" => "instance",
+                "transitionKey" => "transition",
+                "function" => "function",
+                "target" => "input",
+                _ => null, // apiVersionPrefix — the templates already carry the prefix.
+            })
+        .ToArray();
 
     private static Dictionary<string, string> ReadUrlTemplates(string relativePath)
     {
@@ -98,8 +203,9 @@ public class UrlTemplateConfigCompletenessTests
 
         using var doc = JsonDocument.Parse(File.ReadAllText(full));
 
-        doc.RootElement.TryGetProperty("UrlTemplates", out var section)
-            .ShouldBeTrue($"'{relativePath}' has no UrlTemplates section.");
+        // A host with no section at all is valid — it inherits the application's own prefix.
+        if (!doc.RootElement.TryGetProperty("UrlTemplates", out var section))
+            return [];
 
         return section.EnumerateObject()
             .ToDictionary(p => p.Name, p => p.Value.GetString()!, StringComparer.Ordinal);


### PR DESCRIPTION
## What

`UrlTemplates` collapses from nineteen per-endpoint keys per host to a single `BasePath`:

```json
"UrlTemplates": { "BasePath": "/api/v1/monitor" }
```

Omit the section entirely and the application serves its own `/api/v1` prefix — the orchestration host now relies on exactly that and declares nothing. 38 lines of configuration across two hosts become 1.

## Why

Every host restated all nineteen templates, differing only in the leading prefix. The path below the prefix is fixed by the controller routes (`[Route("api/v{version:apiVersion}")]` + `{domain}/workflows/…`); the only per-deployment variable is the prefix, because an href handed to a client must point at the API gateway route rather than at the pod.

The duplication had a cost: a template added to `UrlTemplateOptions` but forgotten in config silently fell back to a prefix-less `/{domain}/…` path. That is how the function catalog / info / view / schema hrefs regressed, and why `UrlTemplateConfigCompletenessTests` existed. That failure mode is now structurally impossible — a template with no override inherits `BasePath`.

## ⚠️ Client-visible behaviour change

The orchestration host configured `/api/{domain}/…`, **omitting the `v1` segment its routes actually require**. Its hrefs pointed at a path the application itself 404s on. Dropping the section fixes the prefix to `/api/v1`.

Worth a look from whoever owns the gateway config: if a gateway route genuinely serves `/api/{domain}/…`, set `"BasePath": "/api"` on the orchestration host instead of deleting the section. Monitor hrefs (`/api/v1/monitor/…`) are unchanged.

## Design

`Effective(X) = override(X) ?? Normalize(BasePath) + BuiltInRelative(X)`

- New `UrlTemplateDefaults` holds the app's own route shape as consts, plus `BasePath = "/api/v1"`.
- `UrlTemplateOptions` gains `BasePath`; the nineteen templates become `string?` overrides defaulting to null, so the property itself carries "did the operator override this?".
- `UrlTemplateBuilder` resolves all nineteen once in its constructor. `NormalizeBasePath` tolerates `api/v1/` vs `/api/v1`; empty means no prefix, for a host mounted at the root.

**An override is a complete path used verbatim — `BasePath` is not prepended to it.** This keeps any value authored in the previous all-templates-listed style working unchanged, including an out-of-repo `UrlTemplates__Transition` env override, which relative composition would have silently double-prefixed.

Out of scope: `InstanceUrlTemplates` (internal service-to-service, takes its version from `vNextApi:ApiVersion`).

## Tests

The two obsolete completeness tests are replaced by builder-level assertions that reflect over `IUrlTemplateBuilder` — which finally covers `BuildLongPollAckUrl`, a default interface method with no backing property that escaped every previous assertion.

| Test | Pins |
|---|---|
| `DefaultOptions_PrefixEveryHrefWithApiV1` | No config ⇒ every href under `/api/v1/` |
| `ConfiguredBasePath_PrefixesEveryHref` | One `BasePath` reaches every href; slash normalization |
| `EmptyBasePath_EmitsPrefixLessHrefs` | Root-mounted host, no stray slash |
| `EveryOverrideProperty_IsWiredIntoTheBuilder` | Each property set in turn to a sentinel; a property nobody reads in the builder fails the build instead of silently ignoring the operator |
| `HostConfig_DoesNotRestateADefault` | Config cannot drift back into restating every route |

`StubUrlTemplateBuilder` (65 lines reimplementing the whole interface, asserting prefix-less hrefs no client receives — the same duplication that let the catalog hrefs regress) is deleted; `FunctionInfoAppServiceTests` now uses the real builder with prefixed expectations.

## Verification

Full solution builds clean. Per-project runs against a clean `HEAD` worktree baseline:

| Project | Baseline | Branch |
|---|---|---|
| Application.Tests | 26 failed / 1205 passed | 26 failed / 1205 passed (identical test names) |
| Infrastructure.Tests | 12 failed / 240 passed | 12 failed / **262** passed |

Pre-existing failures untouched; the +22 are the new template tests.

Mutation-checked the main new guard: unwiring one template made `EveryOverrideProperty_IsWiredIntoTheBuilder(Master)` plus all four prefix tests fail; reverting restored green.

**Not done:** no live end-to-end run against Docker infra — the hrefs were not curl'd from a running host. Worth doing before merge given the prefix change.

## Follow-up (not in this PR)

`apiVersionPrefix` on all nineteen `IUrlTemplateBuilder` methods is dead — every call site passes null — and now duplicates `BasePath`. Removing it changes the public interface surface, so it belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Collapse per-endpoint URL templates into a single base path–driven system for client-facing href generation and adjust configuration, builder logic, tests, and docs accordingly.

New Features:
- Introduce a BasePath setting and UrlTemplateDefaults to derive all client-facing hrefs from a single route prefix combined with built-in relative paths.

Bug Fixes:
- Ensure newly added URL templates always inherit the configured base prefix, preventing silent fallback to prefix-less hrefs.
- Fix orchestration host hrefs so they align with the actual /api/v1 routing instead of the previously misconfigured /api prefix.

Enhancements:
- Refactor UrlTemplateBuilder to resolve and cache effective templates once in the constructor, respecting optional per-endpoint overrides.
- Simplify host configuration by removing duplicated per-endpoint UrlTemplates entries and relying on BasePath plus built-in defaults.
- Update FunctionInfoAppService tests to assert against the real UrlTemplateBuilder output instead of a stub implementation.
- Strengthen configuration completeness tests to verify every override property is wired into the builder and that configs do not restate default templates.

Documentation:
- Document the UrlTemplates BasePath model, the role of per-endpoint overrides, and the separation from internal InstanceUrlTemplates in the API contracts docs.
- Clarify monitor host configuration docs to describe UrlTemplates as a single BasePath-driven configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable base paths for generated client links.
  * Added optional per-endpoint URL overrides.
  * Standardized default routes for workflow, function, schema, view, data, history, and catalog links.
  * Added consistent base-path normalization, including support for empty prefixes.

* **Documentation**
  * Documented URL construction, configuration inheritance, default routes, and override behavior.
  * Updated monitoring API configuration guidance.

* **Tests**
  * Expanded coverage for default, custom, empty, and endpoint-specific URL configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->