### PR TITLE
Add business-focused workflow tracing with Aether 1.0.34

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+switch.json
 
 
 # User-specific files (MonoDevelop/Xamarin Studio)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
     <PropertyGroup>
 
         <!-- All Prism packages -->
-        <AetherPackageVersion>1.0.33</AetherPackageVersion>
+        <AetherPackageVersion>1.0.34</AetherPackageVersion>
         <!-- Overrides transitive PostSharp 2026.0.7 from BBT.Aether.Aspects; >=2026.0.10 required to read project.assets.json v4 written by .NET SDK 10.0.300+ -->
         <PostSharpPackageVersion>2026.0.12</PostSharpPackageVersion>
         <!-- Elastic Apm packages -->

--- a/execution/BBT.Workflow.Execution.HttpApi.Host/Controllers/Executions/ExecutionController.cs
+++ b/execution/BBT.Workflow.Execution.HttpApi.Host/Controllers/Executions/ExecutionController.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using BBT.Aether.AspNetCore.Controllers;
 using BBT.Workflow.Execution.Services;
 using BBT.Workflow.Logging;
@@ -43,6 +44,16 @@ public sealed class ExecutionController(
     {
         var envelope = request.Envelope;
         var traceContext = request.TraceContext;
+
+        var activity = Activity.Current;
+        activity?.SetTag(TelemetryConstants.TagNames.Domain, traceContext?.Domain ?? "unknown");
+        activity?.SetTag(TelemetryConstants.TagNames.Flow, traceContext?.WorkflowKey ?? "unknown");
+        activity?.SetTag(TelemetryConstants.TagNames.FlowVersion, traceContext?.WorkflowVersion ?? "unknown");
+        activity?.SetTag(TelemetryConstants.TagNames.InstanceId, traceContext?.InstanceId.ToString() ?? Guid.Empty.ToString());
+        activity?.SetTag(TelemetryConstants.TagNames.TaskKey, envelope.TaskKey);
+        activity?.SetTag(TelemetryConstants.TagNames.TaskType, envelope.TaskType);
+        activity?.SetTag(TelemetryConstants.TagNames.Layer, TelemetryConstants.Layers.Execution);
+        activity?.SetTag(TelemetryConstants.TagNames.SpanCategory, TelemetryConstants.SpanCategories.Business);
 
         using (logger.BeginScope(new Dictionary<string, object>
         {

--- a/src/BBT.Workflow.Application/Caching/CacheActivityHelper.cs
+++ b/src/BBT.Workflow.Application/Caching/CacheActivityHelper.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics;
+using BBT.Workflow.Logging;
+using BBT.Aether.Telemetry;
 
 namespace BBT.Workflow.Caching;
 
@@ -42,6 +44,9 @@ public static class CacheActivityHelper
         string? cacheKey = null,
         string? componentType = null)
     {
+        if (!AetherTracingRuntime.IsVerbose)
+            return null;
+
         var activity = ActivitySource.StartActivity(
             operationName,
             ActivityKind.Client,
@@ -50,6 +55,8 @@ public static class CacheActivityHelper
         if (activity is not null)
         {
             activity.SetTag(TagCacheStore, "dapr");
+            activity.SetTag(TelemetryConstants.TagNames.Layer, TelemetryConstants.Layers.Orchestration);
+            activity.SetTag(TelemetryConstants.TagNames.SpanCategory, TelemetryConstants.SpanCategories.Diagnostic);
             if (!string.IsNullOrEmpty(cacheKey))
                 activity.SetTag(TagCacheKey, cacheKey);
             if (!string.IsNullOrEmpty(componentType))

--- a/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/TransitionExecutor.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Pipeline/TransitionExecutor.cs
@@ -25,7 +25,6 @@ public sealed class TransitionExecutor
 {
     private readonly IReadOnlyList<ITransitionStep> _steps;
     private readonly ILogger<TransitionExecutor> _logger;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="TransitionExecutor"/>.
     /// </summary>
@@ -176,6 +175,8 @@ public sealed class TransitionExecutor
         activity.SetTag(TelemetryConstants.TagNames.FlowVersion, context.Workflow.Version);
         activity.SetTag(TelemetryConstants.TagNames.InstanceId, context.InstanceId.ToString());
         activity.SetTag(TelemetryConstants.TagNames.TransitionKey, context.TransitionKey);
+        activity.SetTag(TelemetryConstants.TagNames.Layer, TelemetryConstants.Layers.Orchestration);
+        activity.SetTag(TelemetryConstants.TagNames.SpanCategory, TelemetryConstants.SpanCategories.Business);
         if (context.Transition != null)
         {
             activity.SetTag(TelemetryConstants.TagNames.TriggerType, context.Transition.TriggerType.ToString());

--- a/src/BBT.Workflow.Application/Tasks/Coordinator/TaskCoordinator.cs
+++ b/src/BBT.Workflow.Application/Tasks/Coordinator/TaskCoordinator.cs
@@ -152,6 +152,8 @@ public sealed class TaskCoordinator : ITaskCoordinatorExtended
             activity.SetTag(TelemetryConstants.TagNames.InstanceId, context.Instance?.Id.ToString());
             activity.SetTag(TelemetryConstants.TagNames.Flow, context.Workflow?.Key);
             activity.SetTag("vnext.task.count", tasks.Count);
+            activity.SetTag(TelemetryConstants.TagNames.Layer, TelemetryConstants.Layers.Orchestration);
+            activity.SetTag(TelemetryConstants.TagNames.SpanCategory, TelemetryConstants.SpanCategories.Business);
         }
 
         if (!tasks.Any())

--- a/src/BBT.Workflow.Application/Tasks/Coordinator/TaskExecutionActivityHelper.cs
+++ b/src/BBT.Workflow.Application/Tasks/Coordinator/TaskExecutionActivityHelper.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using BBT.Aether.Telemetry;
 using BBT.Workflow.Logging;
 
 namespace BBT.Workflow.Tasks.Coordinator;
@@ -45,6 +46,9 @@ public static class TaskExecutionActivityHelper
         string? taskKey = null,
         string? taskType = null)
     {
+        if (!AetherTracingRuntime.IsVerbose)
+            return null;
+
         var parentContext = Activity.Current?.Context ?? default;
 
         var activity = ActivitySource.StartActivity(
@@ -58,6 +62,8 @@ public static class TaskExecutionActivityHelper
                 activity.SetTag(TelemetryConstants.TagNames.TaskKey, taskKey);
             if (!string.IsNullOrEmpty(taskType))
                 activity.SetTag(TelemetryConstants.TagNames.TaskType, taskType);
+            activity.SetTag(TelemetryConstants.TagNames.Layer, TelemetryConstants.Layers.Orchestration);
+            activity.SetTag(TelemetryConstants.TagNames.SpanCategory, TelemetryConstants.SpanCategories.Diagnostic);
         }
 
         return activity;

--- a/src/BBT.Workflow.Application/Tasks/Coordinator/TaskExecutionEngine.cs
+++ b/src/BBT.Workflow.Application/Tasks/Coordinator/TaskExecutionEngine.cs
@@ -91,6 +91,8 @@ public sealed class TaskExecutionEngine : ITaskExecutionEngine
             activity.SetTag(TelemetryConstants.TagNames.TaskKey, onExecuteTask.Task.Key);
             activity.SetTag(TelemetryConstants.TagNames.InstanceId, context.Instance?.Id.ToString());
             activity.SetTag(TelemetryConstants.TagNames.Flow, context.Workflow?.Key);
+            activity.SetTag(TelemetryConstants.TagNames.Layer, TelemetryConstants.Layers.Orchestration);
+            activity.SetTag(TelemetryConstants.TagNames.SpanCategory, TelemetryConstants.SpanCategories.Business);
         }
 
         _logger.LogInformation(

--- a/src/BBT.Workflow.Domain/Logging/ActivityExtensions.cs
+++ b/src/BBT.Workflow.Domain/Logging/ActivityExtensions.cs
@@ -14,9 +14,35 @@ public static class ActivityExtensions
     {
         if (activity != null)
         {
+            // Pipeline step spans may be suppressed by the Business profile. In that case
+            // Activity.Current is the transition parent; never rename that parent to a step.
+            if (TryGetPipelineStepOperationName(displayName, out var expectedOperationName) &&
+                !string.Equals(activity.OperationName, expectedOperationName, StringComparison.Ordinal))
+            {
+                return activity;
+            }
+
             activity.DisplayName = displayName;
         }
         return activity;
+    }
+
+    private static bool TryGetPipelineStepOperationName(string displayName, out string operationName)
+    {
+        operationName = string.Empty;
+        if (string.IsNullOrEmpty(displayName) || displayName[0] != '[')
+            return false;
+
+        var separatorIndex = displayName.IndexOf("] ", StringComparison.Ordinal);
+        if (separatorIndex < 0 || separatorIndex + 2 >= displayName.Length)
+            return false;
+
+        var stepName = displayName[(separatorIndex + 2)..];
+        if (!stepName.EndsWith("Step", StringComparison.Ordinal))
+            return false;
+
+        operationName = $"{stepName}.ExecuteAsync";
+        return true;
     }
 
     /// <summary>
@@ -33,4 +59,3 @@ public static class ActivityExtensions
         return activity;
     }
 }
-

--- a/src/BBT.Workflow.Domain/Logging/TelemetryConstants.cs
+++ b/src/BBT.Workflow.Domain/Logging/TelemetryConstants.cs
@@ -21,6 +21,8 @@ public static class TelemetryConstants
         public const string HandlerName = "vnext.handler.name";
         public const string TaskKey = "vnext.task.key";
         public const string TaskType = "vnext.task.type";
+        public const string Layer = "vnext.layer";
+        public const string SpanCategory = "vnext.span.category";
         public const string StateFrom = "vnext.state.from";
         public const string StateTo = "vnext.state.to";
         public const string JobName = "vnext.job.name";
@@ -41,6 +43,22 @@ public static class TelemetryConstants
         public const string TerminationOrigin = "vnext.termination.origin";
         public const string TerminationInitiator = "vnext.termination.initiator";
         public const string TerminationCascadeId = "vnext.termination.cascade_id";
+    }
+
+    /// <summary>
+    /// Well-known values used to group workflow spans into a compact business view
+    /// or the full diagnostic view.
+    /// </summary>
+    public static class Layers
+    {
+        public const string Orchestration = "orchestration";
+        public const string Execution = "execution";
+    }
+
+    public static class SpanCategories
+    {
+        public const string Business = "business";
+        public const string Diagnostic = "diagnostic";
     }
 
     /// <summary>

--- a/test/BBT.Workflow.Domain.Tests/Logging/ActivityExtensionsTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Logging/ActivityExtensionsTests.cs
@@ -1,0 +1,28 @@
+using System.Diagnostics;
+using BBT.Workflow.Logging;
+using Xunit;
+
+namespace BBT.Workflow.Domain.Tests.Logging;
+
+public sealed class ActivityExtensionsTests
+{
+    [Fact]
+    public void Suppressed_pipeline_step_does_not_rename_parent_activity()
+    {
+        using var parent = new Activity("TransitionExecutor.ExecuteOneAsync").Start();
+
+        parent.SetDisplayName("[5] CreateTransitionRecordStep");
+
+        Assert.Equal("TransitionExecutor.ExecuteOneAsync", parent.DisplayName);
+    }
+
+    [Fact]
+    public void Pipeline_step_activity_keeps_verbose_display_name()
+    {
+        using var step = new Activity("CreateTransitionRecordStep.ExecuteAsync").Start();
+
+        step.SetDisplayName("[5] CreateTransitionRecordStep");
+
+        Assert.Equal("[5] CreateTransitionRecordStep", step.DisplayName);
+    }
+}


### PR DESCRIPTION
## Summary

Adds business-focused tracing semantics to the vNext workflow orchestration and execution layers and upgrades the Aether packages to `1.0.34`. Workflow spans are categorized with consistent business metadata, while low-level diagnostic spans follow Aether’s globally configured `DetailLevel`.

The default waterfall remains focused on transitions, task coordination, task execution, and service boundaries. Full diagnostic tracing can still be enabled when required.

## Key Changes

- **Added workflow span taxonomy**: Introduces `vnext.layer` and `vnext.span.category` attributes with standardized `orchestration`, `execution`, `business`, and `diagnostic` values.
- **Enriched orchestration spans**: Transition, task coordinator, and task execution spans now carry workflow, instance, task, layer, and category metadata.
- **Enriched execution transactions**: Incoming execution requests include domain, flow, version, instance, task key, task type, execution layer, and business category attributes.
- **Connected diagnostic spans to the global profile**: Cache operations and detailed task execution phases are created only when `AetherTracingRuntime.IsVerbose` is enabled.
- **Protected parent span names**: Prevents suppressed pipeline-step instrumentation from renaming the active transition span when running with the `Business` profile.
- **Upgraded Aether packages**: Updates all centrally managed `BBT.Aether.*` dependencies from `1.0.33` to `1.0.34`.
- **Added regression coverage**: Verifies that suppressed pipeline steps do not rename their parent activity while verbose step activities retain their detailed display names.
- **Improved local development setup**: Ignores the machine-specific `switch.json` used by DNT for switching between local Aether projects and NuGet packages.

## Implementation Details

Aether `1.0.34` uses `Business` as the default tracing detail level when no explicit configuration is provided.

The profile can be configured globally through `appsettings.json`:

```json
{
  "Telemetry": {
    "Tracing": {
      "DetailLevel": "Business"
    }
  }
}
```

To enable the full diagnostic waterfall:

```json
{
  "Telemetry": {
    "Tracing": {
      "DetailLevel": "Verbose"
    }
  }
}
```

Profile behavior:

- `Business` keeps service boundaries, transitions, task coordinators, task execution spans, and other `[Trace]` business spans.
- `Business` suppresses low-level cache spans, detailed task execution phases, and ordered pipeline-step spans.
- `Verbose` restores the complete configured diagnostic instrumentation.

### Workflow Labels

The new classification attributes introduced by this PR are:

| OpenTelemetry attribute | Values | Purpose |
|---|---|---|
| `vnext.layer` | `orchestration`, `execution` | Identifies the vNext processing layer |
| `vnext.span.category` | `business`, `diagnostic` | Separates business waterfall items from low-level diagnostic detail |

The enriched spans also use the following workflow attributes:

| OpenTelemetry attribute | Purpose |
|---|---|
| `vnext.domain` | Workflow domain |
| `vnext.flow.key` | Workflow key |
| `vnext.flow.version` | Workflow version |
| `vnext.instance.id` | Workflow instance identifier |
| `vnext.instance.key` | Business instance key |
| `vnext.transition.key` | Executed transition |
| `vnext.trigger.type` | Manual, automatic, or other trigger type |
| `vnext.task.key` | Executed task key |
| `vnext.task.type` | Task implementation type |
| `vnext.state.from` | Source state |
| `vnext.state.to` | Target state |

Elastic normalizes dots in OpenTelemetry attribute names to underscores under the `labels` object. For example:

```text
vnext.layer           -> labels.vnext_layer
vnext.span.category   -> labels.vnext_span_category
vnext.flow.key        -> labels.vnext_flow_key
vnext.instance.id     -> labels.vnext_instance_id
vnext.transition.key  -> labels.vnext_transition_key
vnext.task.key        -> labels.vnext_task_key
```

### Kibana Discover Queries

The queries below can be used with the `APM` data view in Kibana Discover.

Show all business spans:

```kql
data_stream.type: "traces"
and labels.vnext_span_category: "business"
```

Show only orchestration-layer spans:

```kql
data_stream.type: "traces"
and labels.vnext_layer: "orchestration"
```

Show only execution-layer transactions and spans:

```kql
data_stream.type: "traces"
and labels.vnext_layer: "execution"
```

Show the business waterfall for a specific workflow:

```kql
data_stream.type: "traces"
and labels.vnext_span_category: "business"
and labels.vnext_flow_key: "start-video-call"
```

Find a specific transition:

```kql
data_stream.type: "traces"
and labels.vnext_transition_key: "to-creating-token-staff"
```

Find a specific task:

```kql
data_stream.type: "traces"
and labels.vnext_task_key: "get-video-call-url"
```

Find all trace documents for a workflow instance:

```kql
data_stream.type: "traces"
and labels.vnext_instance_id: "<INSTANCE_ID>"
```

Find correlated application logs for the same instance:

```kql
data_stream.type: "logs"
and labels.vnext_instance_id: "<INSTANCE_ID>"
and message: *
```

Find all documents belonging to an exact distributed trace:

```kql
trace.id: "<TRACE_ID>"
```

No workflow API contract or business execution behavior is changed.

Validation completed:

- NuGet restore: 23 projects, 0 errors
- Solution build: 23 projects, 0 errors
- `ActivityExtensionsTests`: 2 passed
- All `BBT.Aether.*` dependencies resolved to `1.0.34`
- `git diff --check`: clean

## Summary by Sourcery

Introduce business-focused workflow tracing metadata and align execution and orchestration telemetry with Aether’s profiling model while upgrading tracing dependencies.

New Features:
- Tag workflow orchestration, task coordination, task execution, cache, and HTTP execution activities with standardized vNext layer and span category attributes to distinguish business and diagnostic spans.

Enhancements:
- Guard activity display name updates so suppressed pipeline-step instrumentation does not rename parent transition spans under the Business tracing profile.
- Gate low-level cache and detailed task execution activities behind the global verbose tracing profile to keep the default waterfall compact.
- Enrich execution HTTP API activities with workflow domain, flow, version, instance, task, layer, and business span metadata for better traceability.

Tests:
- Add unit tests ensuring pipeline-step display names do not overwrite parent transition activity names and that verbose step activities preserve their detailed display names.

Chores:
- Ignore local DNT switch.json in git to simplify switching between local Aether projects and NuGet packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workflow activity naming so pipeline step details remain accurate without altering parent activity names.

- **Improvements**
  - Enhanced tracing visibility with clearer workflow, task, execution-layer, and business-operation metadata.
  - Reduced unnecessary telemetry activity creation when verbose tracing is disabled.
  - Added more consistent diagnostic categorization for orchestration, execution, caching, and task activities.

- **Maintenance**
  - Updated the shared Aether package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->