### PR TITLE
feat(validators): reject script slots published without a body

### DIFF
--- a/docs/custom-script-helpers.md
+++ b/docs/custom-script-helpers.md
@@ -90,6 +90,39 @@ plain `NAT`/`B64` — no REF chaining). This lets tasks reuse published mapping 
 }
 ```
 
+### Every script slot must resolve to a body
+
+`location` is authoring metadata only — the runtime never reads the `.csx` file it names. The body is
+inlined into `code` by the domain build step, so a slot published with **only** a `location` has no body
+at all, and nothing downstream is able to say so: the encoding defaults to `B64`, empty Base64 decodes
+without error, and `HasMappingCode` turns false. A bodyless *mapping* is then silently skipped (the HTTP
+task fires with no body mapping, a script task returns null), while a bodyless *rule* blows up
+mid-transition when Roslyn compiles an empty script.
+
+`ScriptCodeValidator` closes that gap at publish time for every slot a definition can carry — transition
+`timer`/`rule`/`mapping`, `onExecutionTasks[].mapping`, state `onEntries`/`onExits`/`notifications`,
+`subFlow.mapping`, view- and schema-selection `rule`s, workflow and function `output`, function
+`cache.keyExpression`/`generationKeyExpression`, and `CacheAsideTask`'s `sourceMapping`/`keyExpression`.
+Matching the `vnext-schema` guard:
+
+| Slot | Verdict |
+|------|---------|
+| `{ "location": "./src/X.csx" }` | ✗ no `code` — never executed |
+| `{ "type": "L", "location": "./x.csx" }` | ✗ same, `L` is the default type |
+| `{ "type": "G", "location": "./x.csx" }` | ✓ `G` declares the body lives elsewhere |
+| `{ "location": "./x.csx", "code": "<base64>" }` | ✓ |
+| `code` present but not decodable under `encoding` | ✗ |
+| `code` decoding to whitespace | ✗ |
+| `encoding: "REF"` without a `sys-mappings` reference (key/domain/version) | ✗ unresolvable at compile time |
+
+When a definition object gains a new `ScriptCode` property, add its path to the traversal in
+`WorkflowValidator.ValidateWorkflowScriptCodes` / `ValidateTransitionScriptCodes` (or the matching
+component validator) — an unlisted slot is an unguarded slot.
+
+One deliberate exception: a transition `rule` whose `location` is `dynamicExpresso` is an inline boolean
+expression, not a `.csx` body, so `ValidateDynamicExpressoRule` owns its emptiness check and reports it
+in Dynamic Expresso terms instead.
+
 ## 3. Configuration
 
 ```json

--- a/src/BBT.Workflow.Application/Definitions/Validators/ExtensionComponentValidator.cs
+++ b/src/BBT.Workflow.Application/Definitions/Validators/ExtensionComponentValidator.cs
@@ -43,6 +43,13 @@ public sealed class ExtensionComponentValidator : IComponentValidator
             {
                 result.AddError("Extension task is required.", $"{nameof(Extension)}.{nameof(Extension.Task)}");
             }
+            else
+            {
+                ScriptCodeValidator.Validate(
+                    extension.Task.Mapping,
+                    $"{nameof(Extension)}.{nameof(Extension.Task)}.{nameof(OnExecuteTask.Mapping)}",
+                    result.ValidationErrors);
+            }
 
             return result;
         }

--- a/src/BBT.Workflow.Application/Definitions/Validators/FunctionComponentValidator.cs
+++ b/src/BBT.Workflow.Application/Definitions/Validators/FunctionComponentValidator.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json;
 using BBT.Workflow.Runtime;
 
@@ -48,6 +49,7 @@ public sealed class FunctionComponentValidator : IComponentValidator
 
             ValidateVerbs(function, result);
             ValidateContractReferences(function, result);
+            ValidateScriptCodes(function, result);
 
             return result;
         }
@@ -84,6 +86,79 @@ public sealed class FunctionComponentValidator : IComponentValidator
                 "carry a request body, so the schema would never be applied. Declare a body-carrying " +
                 $"verb ({FunctionVerb.Post}, {FunctionVerb.Patch} or {FunctionVerb.Delete}) or remove inputSchema.",
                 $"{nameof(Function)}.{nameof(Function.InputSchema)}");
+        }
+    }
+
+    /// <summary>
+    /// Validates every script slot a function can carry. A slot published with only a <c>location</c> is
+    /// silently skipped (mappings) or fails mid-request (rules and key expressions) — see
+    /// <see cref="ScriptCodeValidator"/>.
+    /// </summary>
+    private static void ValidateScriptCodes(Function function, ComponentValidationResult result)
+    {
+        var errors = result.ValidationErrors;
+
+        ScriptCodeValidator.Validate(
+            function.Task?.Mapping,
+            $"{nameof(Function)}.{nameof(Function.Task)}.{nameof(OnExecuteTask.Mapping)}",
+            errors);
+
+        foreach (var (task, index) in function.OnExecutionTasks.Select((t, i) => (t, i)))
+        {
+            ScriptCodeValidator.Validate(
+                task.Mapping,
+                $"{nameof(Function)}.{nameof(Function.OnExecutionTasks)}[{index}].{nameof(OnExecuteTask.Mapping)}",
+                errors);
+        }
+
+        ScriptCodeValidator.Validate(
+            function.Output, $"{nameof(Function)}.{nameof(Function.Output)}", errors);
+
+        ScriptCodeValidator.Validate(
+            function.Cache?.KeyExpression,
+            $"{nameof(Function)}.{nameof(Function.Cache)}.{nameof(FunctionCache.KeyExpression)}",
+            errors);
+
+        ScriptCodeValidator.Validate(
+            function.Cache?.GenerationKeyExpression,
+            $"{nameof(Function)}.{nameof(Function.Cache)}.{nameof(FunctionCache.GenerationKeyExpression)}",
+            errors);
+
+        ValidateSchemaSlotRules(function.InputSchema, nameof(Function.InputSchema), errors);
+        ValidateSchemaSlotRules(function.OutputSchema, nameof(Function.OutputSchema), errors);
+        ValidateViewSlotRules(function.InputView, nameof(Function.InputView), errors);
+        ValidateViewSlotRules(function.OutputView, nameof(Function.OutputView), errors);
+    }
+
+    /// <summary>Validates the selection rule of each entry in a schema contract slot.</summary>
+    private static void ValidateSchemaSlotRules(
+        SchemaSelection? selection,
+        string propertyName,
+        IList<ValidationResult> errors)
+    {
+        if (selection is null)
+            return;
+
+        foreach (var (entry, index) in selection.Schemas.Select((e, i) => (e, i)))
+        {
+            ScriptCodeValidator.Validate(
+                entry.Rule, $"{nameof(Function)}.{propertyName}[{index}].{nameof(SchemaEntry.Rule)}", errors);
+        }
+    }
+
+    /// <summary>Validates the selection rule of each entry in a view contract slot.</summary>
+    private static void ValidateViewSlotRules(
+        ViewDefinition? definition,
+        string propertyName,
+        IList<ValidationResult> errors)
+    {
+        if (definition is null)
+            return;
+
+        foreach (var (entry, index) in definition.Views.Select((e, i) => (e, i)))
+        {
+            ScriptCodeValidator.Validate(
+                entry.Rule, $"{nameof(Function)}.{propertyName}[{index}].{nameof(ViewEntry.Rule)}", errors);
         }
     }
 

--- a/src/BBT.Workflow.Application/Definitions/Validators/TaskComponentValidator.cs
+++ b/src/BBT.Workflow.Application/Definitions/Validators/TaskComponentValidator.cs
@@ -42,6 +42,21 @@ public sealed class TaskComponentValidator : IComponentValidator
                 }
             }
 
+            // CacheAside is the only task type whose own config carries script slots; every other task
+            // gets its mapping from the OnExecuteTask that references it, validated with the flow.
+            if (task is CacheAsideTask cacheAside)
+            {
+                ScriptCodeValidator.Validate(
+                    cacheAside.SourceMapping,
+                    $"{nameof(CacheAsideTask)}.{nameof(CacheAsideTask.SourceMapping)}",
+                    result.ValidationErrors);
+
+                ScriptCodeValidator.Validate(
+                    cacheAside.KeyExpression,
+                    $"{nameof(CacheAsideTask)}.{nameof(CacheAsideTask.KeyExpression)}",
+                    result.ValidationErrors);
+            }
+
             return result;
         }
         catch (JsonException ex)

--- a/src/BBT.Workflow.Domain/Definitions/Validators/ScriptCodeValidator.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Validators/ScriptCodeValidator.cs
@@ -1,0 +1,141 @@
+using System.ComponentModel.DataAnnotations;
+using BBT.Workflow.Runtime;
+
+namespace BBT.Workflow.Definitions.Validators;
+
+/// <summary>
+/// Shared publish-time validation for every <see cref="ScriptCode"/> slot a component definition can
+/// carry (mappings, rules, timers, key expressions, output handlers).
+/// <para>
+/// The slot exists because a script body was authored somewhere; the body itself is inlined into
+/// <c>code</c> by the domain build step. A slot that survives publish with only a <c>location</c> is
+/// therefore always a build accident, and nothing downstream reports it: the converter defaults the
+/// encoding to Base64 (<see cref="ScriptCodeJsonConverter"/>), <c>Convert.FromBase64String("")</c>
+/// succeeds, and <see cref="ScriptCode.HasMappingCode"/> turns false — so every executor silently skips
+/// the mapping, while a rule blows up mid-transition when Roslyn compiles an empty script. This
+/// validator is the only place that gap is visible, so it must run for every slot.
+/// </para>
+/// <para>
+/// Rules mirror the <c>vnext-schema</c> guard: a <see cref="MappingType.Global"/> slot carries no body
+/// and is always accepted; anything else must resolve to a non-empty body, either inline
+/// (Native/Base64) or through a <c>sys-mappings</c> reference (<see cref="CodeEncoding.Reference"/>).
+/// </para>
+/// </summary>
+public static class ScriptCodeValidator
+{
+    /// <summary>
+    /// Validates a single script slot, appending one error per problem found.
+    /// </summary>
+    /// <param name="script">The slot to validate. A null slot is valid — optionality is the holder's concern.</param>
+    /// <param name="member">
+    /// Dotted path of the slot for the error's member name (e.g.
+    /// <c>Workflow.States[approval].OnEntries[0].Mapping</c>).
+    /// </param>
+    /// <param name="errors">Error sink; both validation result types expose their list directly.</param>
+    public static void Validate(ScriptCode? script, string member, IList<ValidationResult> errors)
+    {
+        if (script is null)
+        {
+            return;
+        }
+
+        // Global declares that the body lives outside this slot: HasMappingCode is false and DecodedCode
+        // returns empty by design, so there is nothing to require here whatever the encoding says.
+        if (script.Type.Equals(MappingType.Global))
+        {
+            return;
+        }
+
+        if (script.Encoding.Equals(CodeEncoding.Reference))
+        {
+            ValidateReference(script, member, errors);
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(script.Code))
+        {
+            errors.Add(Error(
+                $"Script '{member}' declares only 'location' ('{script.Location}') and no 'code', so it is " +
+                "never executed. The script body must be inlined into 'code' by the domain build step. " +
+                $"Use type '{MappingType.Global.Code}' if the slot is intentionally empty.",
+                member));
+            return;
+        }
+
+        string decoded;
+        try
+        {
+            decoded = script.DecodedCode;
+        }
+        catch (InvalidOperationException)
+        {
+            errors.Add(Error(
+                $"Script '{member}' ('{script.Location}') declares '{script.Encoding.Code}' encoding but its " +
+                "'code' is not valid Base64.",
+                member));
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(decoded))
+        {
+            errors.Add(Error(
+                $"Script '{member}' ('{script.Location}') decodes to an empty body, so it is never executed.",
+                member));
+        }
+    }
+
+    /// <summary>
+    /// Validates a <c>REF</c> slot. The body is resolved from the <c>sys-mappings</c> component store at
+    /// compile time by key/domain/version, so an incomplete reference is an unresolvable mapping that only
+    /// surfaces mid-transition.
+    /// </summary>
+    private static void ValidateReference(ScriptCode script, string member, IList<ValidationResult> errors)
+    {
+        var reference = script.CodeReference;
+        if (reference is null)
+        {
+            errors.Add(Error(
+                $"Script '{member}' ('{script.Location}') declares '{CodeEncoding.Reference.Code}' encoding but " +
+                $"'code' is not a reference object. Provide a {RuntimeSysSchemaInfo.Mappings} reference " +
+                "(key/domain/flow/version) or switch the encoding to an inline one.",
+                member));
+            return;
+        }
+
+        var missing = new List<string>(3);
+        if (string.IsNullOrWhiteSpace(reference.Key))
+        {
+            missing.Add("key");
+        }
+
+        if (string.IsNullOrWhiteSpace(reference.Domain))
+        {
+            missing.Add("domain");
+        }
+
+        if (string.IsNullOrWhiteSpace(reference.Version))
+        {
+            missing.Add("version");
+        }
+
+        if (missing.Count > 0)
+        {
+            errors.Add(Error(
+                $"Script '{member}' reference is incomplete; missing {string.Join(", ", missing)}.",
+                member));
+        }
+
+        // An empty flow is tolerated (the store is always read under the sys-mappings schema), but a
+        // populated one pointing elsewhere means the author referenced the wrong component type.
+        if (!string.IsNullOrWhiteSpace(reference.Flow) &&
+            !string.Equals(reference.Flow, RuntimeSysSchemaInfo.Mappings, StringComparison.OrdinalIgnoreCase))
+        {
+            errors.Add(Error(
+                $"Script '{member}' reference must point at the '{RuntimeSysSchemaInfo.Mappings}' flow but " +
+                $"points at '{reference.Flow}'.",
+                member));
+        }
+    }
+
+    private static ValidationResult Error(string message, string member) => new(message, [member]);
+}

--- a/src/BBT.Workflow.Domain/Definitions/Validators/WorkflowValidator.cs
+++ b/src/BBT.Workflow.Domain/Definitions/Validators/WorkflowValidator.cs
@@ -48,6 +48,9 @@ public class WorkflowValidator
         ValidateTransitionLabels(workflow, result);
         ValidateTransitionRules(workflow, result);
 
+        // Script slot validations (transition-level slots run inside ValidateSingleTransition)
+        ValidateWorkflowScriptCodes(workflow, result);
+
         // Error boundary validations
         ValidateErrorBoundaries(workflow, result, stateKeys);
 
@@ -489,6 +492,7 @@ public class WorkflowValidator
         }
 
         ValidateRoleGrants(transition.Roles, $"{basePath}.{nameof(Transition.Roles)}", result);
+        ValidateTransitionScriptCodes(transition, basePath, result);
 
         switch (transition.TriggerType)
         {
@@ -559,6 +563,12 @@ public class WorkflowValidator
 
     /// <summary>
     /// When rule location selects Dynamic Expresso, the decoded expression must be non-empty and within length limits.
+    /// <para>
+    /// This owns the emptiness/decodability checks for a Dynamic Expresso rule rather than deferring to
+    /// <see cref="ScriptCodeValidator"/>: the generic advice ("inline the script body into 'code'") is
+    /// wrong for an inline boolean expression. <see cref="ValidateTransitionScriptCodes"/> therefore skips
+    /// the rule slot for this location so the author gets one accurate error, not two.
+    /// </para>
     /// </summary>
     private static void ValidateDynamicExpressoRule(Transition transition, string basePath, WorkflowValidationResult result)
     {
@@ -750,6 +760,115 @@ public class WorkflowValidator
 
             if (message != null)
                 result.AddError(new ValidationResult(message, [context]));
+        }
+    }
+
+    #endregion
+
+    #region Script Slot Validations
+
+    /// <summary>
+    /// Validates every workflow- and state-level script slot. Transition slots are covered by
+    /// <see cref="ValidateTransitionScriptCodes"/>, which runs for each transition family
+    /// (start / cancel / updateData / exit / shared / state) from <see cref="ValidateSingleTransition"/>.
+    /// <para>
+    /// A slot published with only a <c>location</c> is never executed and nothing downstream complains —
+    /// see <see cref="ScriptCodeValidator"/>. Every slot the runtime can compile must be listed here, so
+    /// add the new path whenever a definition object gains a <see cref="ScriptCode"/> property.
+    /// </para>
+    /// </summary>
+    private static void ValidateWorkflowScriptCodes(Workflow workflow, WorkflowValidationResult result)
+    {
+        var errors = result.ValidationErrors;
+
+        ScriptCodeValidator.Validate(
+            workflow.Output, $"{nameof(Workflow)}.{nameof(Workflow.Output)}", errors);
+
+        ScriptCodeValidator.Validate(
+            workflow.Timeout?.Mapping,
+            $"{nameof(Workflow)}.{nameof(Workflow.Timeout)}.{nameof(WorkflowTimeout.Mapping)}",
+            errors);
+
+        foreach (var state in workflow.States)
+        {
+            var statePath = $"{nameof(Workflow)}.States[{state.Key}]";
+
+            ValidateTaskScriptCodes(state.OnEntries, $"{statePath}.{nameof(State.OnEntries)}", errors);
+            ValidateTaskScriptCodes(state.OnExits, $"{statePath}.{nameof(State.OnExits)}", errors);
+
+            ScriptCodeValidator.Validate(
+                state.SubFlow?.Mapping,
+                $"{statePath}.{nameof(State.SubFlow)}.{nameof(SubFlow.Mapping)}",
+                errors);
+
+            foreach (var (notification, index) in state.Notifications.Select((n, i) => (n, i)))
+            {
+                var path = $"{statePath}.{nameof(State.Notifications)}[{index}]";
+                ScriptCodeValidator.Validate(notification.Rule, $"{path}.{nameof(StateNotification.Rule)}", errors);
+                ScriptCodeValidator.Validate(notification.Mapping, $"{path}.{nameof(StateNotification.Mapping)}", errors);
+            }
+
+            ValidateViewRules(state.View, $"{statePath}.{nameof(State.View)}", errors);
+        }
+    }
+
+    /// <summary>
+    /// Validates the script slots a single transition can carry, including its OnExecute task mappings
+    /// and view-selection rules.
+    /// </summary>
+    private static void ValidateTransitionScriptCodes(
+        Transition transition,
+        string basePath,
+        WorkflowValidationResult result)
+    {
+        var errors = result.ValidationErrors;
+
+        ScriptCodeValidator.Validate(transition.Timer, $"{basePath}.{nameof(Transition.Timer)}", errors);
+        ScriptCodeValidator.Validate(transition.Mapping, $"{basePath}.{nameof(Transition.Mapping)}", errors);
+
+        // ValidateDynamicExpressoRule already covers the Dynamic Expresso rule form with an accurate
+        // message; only the script-body form is this pass's business.
+        if (!ConditionScriptLocations.IsDynamicExpresso(transition.Rule?.Location))
+        {
+            ScriptCodeValidator.Validate(transition.Rule, $"{basePath}.{nameof(Transition.Rule)}", errors);
+        }
+
+        ValidateTaskScriptCodes(
+            transition.OnExecutionTasks, $"{basePath}.{nameof(Transition.OnExecutionTasks)}", errors);
+
+        ValidateViewRules(transition.View, $"{basePath}.{nameof(Transition.View)}", errors);
+    }
+
+    /// <summary>
+    /// Validates the mapping of each task in an OnExecute collection.
+    /// </summary>
+    private static void ValidateTaskScriptCodes(
+        IEnumerable<OnExecuteTask> tasks,
+        string basePath,
+        IList<ValidationResult> errors)
+    {
+        foreach (var (task, index) in tasks.Select((t, i) => (t, i)))
+        {
+            ScriptCodeValidator.Validate(
+                task.Mapping, $"{basePath}[{index}].{nameof(OnExecuteTask.Mapping)}", errors);
+        }
+    }
+
+    /// <summary>
+    /// Validates the selection rule of each entry in a view definition. A broken rule here does not
+    /// degrade gracefully: view selection compiles the rule mid-request.
+    /// </summary>
+    private static void ValidateViewRules(
+        ViewDefinition? viewDefinition,
+        string basePath,
+        IList<ValidationResult> errors)
+    {
+        if (viewDefinition is null)
+            return;
+
+        foreach (var (entry, index) in viewDefinition.Views.Select((v, i) => (v, i)))
+        {
+            ScriptCodeValidator.Validate(entry.Rule, $"{basePath}[{index}].{nameof(ViewEntry.Rule)}", errors);
         }
     }
 

--- a/test/BBT.Workflow.Application.Tests/Definitions/Validators/ExtensionComponentValidatorTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Definitions/Validators/ExtensionComponentValidatorTests.cs
@@ -68,6 +68,55 @@ public class ExtensionComponentValidatorTests
     }
 
     [Fact]
+    public void Validate_ShouldReturnError_WhenTaskMappingDeclaresOnlyLocation()
+    {
+        // Arrange - the build step never inlined the .csx body, so the mapping would be silently skipped.
+        var extensionJson = """
+        {
+            "type": "global",
+            "scope": "everywhere",
+            "task": {
+                "order": 1,
+                "task": {"key": "t", "domain": "d", "flow": "sys-tasks", "version": "1.0.0"},
+                "mapping": { "location": "./src/EnrichMapping.csx" }
+            }
+        }
+        """;
+        var attributes = JsonDocument.Parse(extensionJson).RootElement;
+
+        // Act
+        var result = _validator.Validate(attributes);
+
+        // Assert
+        result.IsValid.ShouldBeFalse();
+        result.ValidationErrors.ShouldContain(e => e.MemberNames.Contains("Extension.Task.Mapping"));
+    }
+
+    [Fact]
+    public void Validate_ShouldReturnSuccess_WhenTaskMappingCarriesCode()
+    {
+        // Arrange - "cmV0dXJuIHRydWU7" == "return true;"
+        var extensionJson = """
+        {
+            "type": "global",
+            "scope": "everywhere",
+            "task": {
+                "order": 1,
+                "task": {"key": "t", "domain": "d", "flow": "sys-tasks", "version": "1.0.0"},
+                "mapping": { "location": "./src/EnrichMapping.csx", "code": "cmV0dXJuIHRydWU7" }
+            }
+        }
+        """;
+        var attributes = JsonDocument.Parse(extensionJson).RootElement;
+
+        // Act
+        var result = _validator.Validate(attributes);
+
+        // Assert
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
     public void Validate_ShouldReturnError_ForMissingTask()
     {
         // Arrange

--- a/test/BBT.Workflow.Application.Tests/Definitions/Validators/FunctionComponentValidatorTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Definitions/Validators/FunctionComponentValidatorTests.cs
@@ -67,6 +67,95 @@ public class FunctionComponentValidatorTests
     }
 
     [Fact]
+    public void Validate_ShouldReturnError_WhenTaskMappingDeclaresOnlyLocation()
+    {
+        // Arrange
+        var functionJson = """
+        {
+            "scope": "F",
+            "task": {
+                "order": 1,
+                "task": {"key": "t", "domain": "d", "flow": "sys-tasks", "version": "1.0.0"},
+                "mapping": { "location": "./src/FnMapping.csx" }
+            }
+        }
+        """;
+        var attributes = JsonDocument.Parse(functionJson).RootElement;
+
+        // Act
+        var result = _validator.Validate(attributes);
+
+        // Assert
+        result.IsValid.ShouldBeFalse();
+        result.ValidationErrors.ShouldContain(e => e.MemberNames.Contains("Function.Task.Mapping"));
+    }
+
+    [Fact]
+    public void Validate_ShouldReturnError_WhenOutputAndCacheKeyExpressionDeclareOnlyLocation()
+    {
+        // Arrange - a multi-task function reports every broken slot in one pass.
+        var functionJson = """
+        {
+            "scope": "F",
+            "onExecutionTasks": [
+                {
+                    "order": 1,
+                    "task": {"key": "t", "domain": "d", "flow": "sys-tasks", "version": "1.0.0"},
+                    "mapping": { "location": "./src/Step1.csx" }
+                }
+            ],
+            "output": { "location": "./src/Output.csx" },
+            "cache": {
+                "storeName": "statestore",
+                "keyExpression": { "location": "dynamicExpresso" }
+            }
+        }
+        """;
+        var attributes = JsonDocument.Parse(functionJson).RootElement;
+
+        // Act
+        var result = _validator.Validate(attributes);
+
+        // Assert
+        result.IsValid.ShouldBeFalse();
+        result.ValidationErrors.ShouldContain(e => e.MemberNames.Contains("Function.OnExecutionTasks[0].Mapping"));
+        result.ValidationErrors.ShouldContain(e => e.MemberNames.Contains("Function.Output"));
+        result.ValidationErrors.ShouldContain(e => e.MemberNames.Contains("Function.Cache.KeyExpression"));
+    }
+
+    [Fact]
+    public void Validate_ShouldReturnError_WhenContractSlotRuleDeclaresOnlyLocation()
+    {
+        // Arrange - a view-selection rule with no body throws mid-request instead of being skipped.
+        var functionJson = """
+        {
+            "scope": "F",
+            "task": {
+                "order": 1,
+                "task": {"key": "t", "domain": "d", "flow": "sys-tasks", "version": "1.0.0"},
+                "mapping": { "location": "./src/FnMapping.csx", "code": "cmV0dXJuIHRydWU7" }
+            },
+            "outputView": [
+                {
+                    "view": {"key": "v1", "domain": "d", "flow": "sys-views", "version": "1.0.0"},
+                    "rule": { "location": "./src/ViewRule.csx" }
+                },
+                {
+                    "view": {"key": "v2", "domain": "d", "flow": "sys-views", "version": "1.0.0"}
+                }
+            ]
+        }
+        """;
+        var attributes = JsonDocument.Parse(functionJson).RootElement;
+
+        // Act
+        var result = _validator.Validate(attributes);
+
+        // Assert
+        result.ValidationErrors.ShouldContain(e => e.MemberNames.Contains("Function.OutputView[0].Rule"));
+    }
+
+    [Fact]
     public void Validate_ShouldReturnError_ForMissingTask()
     {
         // Arrange

--- a/test/BBT.Workflow.Application.Tests/Definitions/Validators/TaskComponentValidatorTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Definitions/Validators/TaskComponentValidatorTests.cs
@@ -83,6 +83,59 @@ public class TaskComponentValidatorTests
         result.ValidationErrors.ShouldContain(e => e.MemberNames.Contains("WorkflowTask.Type"));
     }
 
+    [Theory]
+    [InlineData("sourceMapping", "CacheAsideTask.SourceMapping")]
+    [InlineData("keyExpression", "CacheAsideTask.KeyExpression")]
+    public void Validate_ShouldReturnError_WhenCacheAsideScriptSlotDeclaresOnlyLocation(
+        string slot,
+        string expectedMember)
+    {
+        // Arrange - CacheAside (type 18) is the only task whose own config carries script slots.
+        var taskJson = $$"""
+        {
+            "type": "18",
+            "config": {
+                "key": "customer-profile",
+                "storeName": "statestore",
+                "sourceTask": {"key": "t", "domain": "d", "flow": "sys-tasks", "version": "1.0.0"},
+                "{{slot}}": { "location": "./src/CacheMapping.csx" }
+            }
+        }
+        """;
+        var attributes = JsonDocument.Parse(taskJson).RootElement;
+
+        // Act
+        var result = _validator.Validate(attributes);
+
+        // Assert
+        result.IsValid.ShouldBeFalse();
+        result.ValidationErrors.ShouldContain(e => e.MemberNames.Contains(expectedMember));
+    }
+
+    [Fact]
+    public void Validate_ShouldReturnSuccess_WhenCacheAsideScriptSlotsCarryCode()
+    {
+        // Arrange - "cmV0dXJuIHRydWU7" == "return true;"
+        var taskJson = """
+        {
+            "type": "18",
+            "config": {
+                "key": "customer-profile",
+                "storeName": "statestore",
+                "sourceTask": {"key": "t", "domain": "d", "flow": "sys-tasks", "version": "1.0.0"},
+                "sourceMapping": { "location": "./src/CacheMapping.csx", "code": "cmV0dXJuIHRydWU7" }
+            }
+        }
+        """;
+        var attributes = JsonDocument.Parse(taskJson).RootElement;
+
+        // Act
+        var result = _validator.Validate(attributes);
+
+        // Assert
+        result.IsValid.ShouldBeTrue();
+    }
+
     [Fact]
     public void Validate_ShouldReturnError_ForInvalidJson()
     {

--- a/test/BBT.Workflow.Domain.Tests/Definitions/Validators/ScriptCodeValidatorTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Definitions/Validators/ScriptCodeValidatorTests.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Definitions.Validators;
+using BBT.Workflow.Runtime;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Workflow.Domain.Tests.Definitions.Validators;
+
+/// <summary>
+/// Unit tests for <see cref="ScriptCodeValidator"/>. The cases mirror the vnext-schema guard so the
+/// runtime validator and the authoring schema agree on what a publishable script slot looks like.
+/// </summary>
+public class ScriptCodeValidatorTests
+{
+    private const string Member = "Workflow.Transitions[x].Mapping";
+
+    private static ScriptCode Parse(string json) =>
+        JsonSerializer.Deserialize<ScriptCode>(json, JsonSerializerConstants.JsonOptions)!;
+
+    private static string Base64(string code) =>
+        Convert.ToBase64String(Encoding.UTF8.GetBytes(code));
+
+    private static List<ValidationResult> Validate(ScriptCode? script)
+    {
+        var errors = new List<ValidationResult>();
+        ScriptCodeValidator.Validate(script, Member, errors);
+        return errors;
+    }
+
+    [Fact]
+    public void Validate_ShouldPass_WhenScriptIsNull()
+    {
+        Validate(null).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Validate_ShouldFail_WhenOnlyLocationIsDeclared()
+    {
+        // The exact shape produced when the domain build step never inlined the .csx body.
+        var errors = Validate(Parse("""{"location":"./src/NsNotifySpawnMapping.csx"}"""));
+
+        errors.ShouldHaveSingleItem();
+        errors[0].MemberNames.ShouldContain(Member);
+        errors[0].ErrorMessage!.ShouldContain("./src/NsNotifySpawnMapping.csx");
+        errors[0].ErrorMessage!.ShouldContain("'code'");
+    }
+
+    [Fact]
+    public void Validate_ShouldFail_WhenLocalTypeDeclaresNoCode()
+    {
+        Validate(Parse("""{"type":"L","location":"./x.csx"}""")).ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public void Validate_ShouldPass_WhenGlobalTypeDeclaresNoCode()
+    {
+        // Global carries no body by design - HasMappingCode is false and the runtime never compiles it.
+        Validate(Parse("""{"type":"G","location":"./x.csx"}""")).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Validate_ShouldPass_ForValidBase64Code()
+    {
+        var json = $$"""{"location":"./x.csx","code":"{{Base64("return true;")}}","encoding":"B64"}""";
+
+        Validate(Parse(json)).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Validate_ShouldPass_ForNativeCode()
+    {
+        Validate(Parse("""{"location":"./x.csx","code":"return true;","encoding":"NAT"}""")).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Validate_ShouldFail_WhenCodeIsWhitespace()
+    {
+        Validate(Parse("""{"location":"./x.csx","code":"   ","encoding":"NAT"}""")).ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public void Validate_ShouldFail_WhenBase64DecodesToWhitespace()
+    {
+        var json = $$"""{"location":"./x.csx","code":"{{Base64("  \n ")}}","encoding":"B64"}""";
+
+        var errors = Validate(Parse(json));
+
+        errors.ShouldHaveSingleItem();
+        errors[0].ErrorMessage!.ShouldContain("empty");
+    }
+
+    [Fact]
+    public void Validate_ShouldFail_WhenBase64IsNotDecodable()
+    {
+        var errors = Validate(Parse("""{"location":"./x.csx","code":"not-base64!","encoding":"B64"}"""));
+
+        errors.ShouldHaveSingleItem();
+        errors[0].ErrorMessage!.ShouldContain("Base64");
+    }
+
+    [Fact]
+    public void Validate_ShouldFail_WhenReferenceEncodingHasNoReference()
+    {
+        // encoding REF with a string body: the converter drops the string, leaving nothing to resolve.
+        var errors = Validate(Parse("""{"location":"./x.csx","code":"abc","encoding":"REF"}"""));
+
+        errors.ShouldHaveSingleItem();
+        errors[0].ErrorMessage!.ShouldContain("REF");
+    }
+
+    [Fact]
+    public void Validate_ShouldPass_ForCompleteReference()
+    {
+        var json = $$"""
+        {
+            "location": "./x.csx",
+            "encoding": "REF",
+            "code": {
+                "key": "json-helper",
+                "domain": "core",
+                "flow": "{{RuntimeSysSchemaInfo.Mappings}}",
+                "version": "1.0.0"
+            }
+        }
+        """;
+
+        Validate(Parse(json)).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Validate_ShouldFail_WhenReferenceIsMissingVersion()
+    {
+        var json = $$"""
+        {
+            "encoding": "REF",
+            "code": { "key": "json-helper", "domain": "core", "flow": "{{RuntimeSysSchemaInfo.Mappings}}" }
+        }
+        """;
+
+        Validate(Parse(json)).ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public void Validate_ShouldFail_WhenReferencePointsAtAnotherFlow()
+    {
+        var json = """
+        {
+            "encoding": "REF",
+            "code": { "key": "some-task", "domain": "core", "flow": "sys-tasks", "version": "1.0.0" }
+        }
+        """;
+
+        var errors = Validate(Parse(json));
+
+        errors.ShouldHaveSingleItem();
+        errors[0].ErrorMessage!.ShouldContain(RuntimeSysSchemaInfo.Mappings);
+    }
+
+    [Fact]
+    public void Validate_ShouldPass_WhenGlobalTypeUsesReferenceEncodingWithoutReference()
+    {
+        // Global short-circuits before any body check, whatever the declared encoding.
+        Validate(Parse("""{"type":"G","encoding":"REF"}""")).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ValidateMany_ShouldReportEveryBrokenSlot()
+    {
+        var errors = new List<ValidationResult>();
+
+        ScriptCodeValidator.Validate(Parse("""{"location":"./a.csx"}"""), "A", errors);
+        ScriptCodeValidator.Validate(Parse("""{"location":"./b.csx"}"""), "B", errors);
+
+        errors.Count.ShouldBe(2);
+        errors.Select(e => e.MemberNames.Single()).ShouldBe(new[] { "A", "B" });
+    }
+}

--- a/test/BBT.Workflow.Domain.Tests/Definitions/Validators/WorkflowValidatorTests.cs
+++ b/test/BBT.Workflow.Domain.Tests/Definitions/Validators/WorkflowValidatorTests.cs
@@ -1161,5 +1161,239 @@ public class WorkflowValidatorTests : DomainTestBase<DomainEntryPoint>
     """;
 
     #endregion
+
+    #region Script Slot Validation Tests
+
+    /// <summary>
+    /// The regression these tests exist for: a script slot published with only a 'location' (the domain
+    /// build step never inlined the .csx body) used to pass validation and then silently no-op at runtime.
+    /// </summary>
+    [Theory]
+    [InlineData("Transitions[submit].Mapping")]
+    [InlineData("Transitions[submit].Rule")]
+    [InlineData("OnEntries[0].Mapping")]
+    [InlineData("OnExits[0].Mapping")]
+    [InlineData("Notifications[0].Mapping")]
+    [InlineData("View[0].Rule")]
+    [InlineData("SubFlow.Mapping")]
+    public void Validate_ShouldFail_WhenStateScriptSlotDeclaresOnlyLocation(string slotPath)
+    {
+        // Arrange
+        var workflow = DeserializeWorkflow(ScriptSlotWorkflowJson(slotPath));
+
+        // Act
+        var result = _validator.Validate(workflow);
+
+        // Assert
+        result.ValidationErrors.ShouldContain(
+            e => e.MemberNames.Contains($"Workflow.States[waiting].{slotPath}"),
+            $"No location-only error for '{slotPath}'. Errors: " +
+            string.Join(" | ", result.ValidationErrors.Select(e => e.ErrorMessage)));
+    }
+
+    [Fact]
+    public void Validate_ShouldFail_WhenWorkflowOutputDeclaresOnlyLocation()
+    {
+        // Arrange
+        var workflow = DeserializeWorkflow($$"""
+        {
+            "type": "F",
+            "labels": [{"label": "Test", "language": "en"}],
+            "output": { "location": "./src/Output.csx" },
+            "states": [
+                {
+                    "key": "initial",
+                    "stateType": "initial",
+                    "labels": [{"label": "Initial", "language": "en"}],
+                    "transitions": []
+                }
+            ],
+            "startTransition": {
+                "key": "start",
+                "target": "initial",
+                "triggerType": "manual",
+                "labels": [{"label": "Start", "language": "en"}]
+            }
+        }
+        """);
+
+        // Act
+        var result = _validator.Validate(workflow);
+
+        // Assert
+        result.ValidationErrors.ShouldContain(e => e.MemberNames.Contains("Workflow.Output"));
+    }
+
+    [Fact]
+    public void Validate_ShouldFail_WhenStartTransitionMappingDeclaresOnlyLocation()
+    {
+        // Arrange - StartTransition is validated on its own path, not under a state.
+        var workflow = DeserializeWorkflow("""
+        {
+            "type": "F",
+            "labels": [{"label": "Test", "language": "en"}],
+            "states": [
+                {
+                    "key": "initial",
+                    "stateType": "initial",
+                    "labels": [{"label": "Initial", "language": "en"}],
+                    "transitions": []
+                }
+            ],
+            "startTransition": {
+                "key": "start",
+                "target": "initial",
+                "triggerType": "manual",
+                "labels": [{"label": "Start", "language": "en"}],
+                "mapping": { "location": "./src/StartMapping.csx" }
+            }
+        }
+        """);
+
+        // Act
+        var result = _validator.Validate(workflow);
+
+        // Assert
+        result.ValidationErrors.ShouldContain(e => e.MemberNames.Contains("Workflow.StartTransition.Mapping"));
+    }
+
+    [Fact]
+    public void Validate_ShouldPass_WhenScriptSlotsCarryCode()
+    {
+        // Arrange - same shape as the failing cases, with the body inlined as the build step would.
+        var workflow = DeserializeWorkflow(ScriptSlotWorkflowJson(slotPath: null));
+
+        // Act
+        var result = _validator.Validate(workflow);
+
+        // Assert
+        var scriptErrors = result.ValidationErrors
+            .Where(e => e.ErrorMessage!.StartsWith("Script "))
+            .ToList();
+        scriptErrors.ShouldBeEmpty($"Unexpected script errors: {string.Join(" | ", scriptErrors.Select(e => e.ErrorMessage))}");
+    }
+
+    [Fact]
+    public void Validate_ShouldPass_WhenMappingIsGlobalTypeWithoutCode()
+    {
+        // Arrange - type "G" declares the body lives elsewhere; the runtime never compiles it.
+        var workflow = DeserializeWorkflow("""
+        {
+            "type": "F",
+            "labels": [{"label": "Test", "language": "en"}],
+            "states": [
+                {
+                    "key": "initial",
+                    "stateType": "initial",
+                    "labels": [{"label": "Initial", "language": "en"}],
+                    "onEntries": [
+                        {
+                            "order": 1,
+                            "task": {"key": "t", "domain": "d", "flow": "sys-tasks", "version": "1.0.0"},
+                            "mapping": { "type": "G", "location": "./src/Noop.csx" }
+                        }
+                    ],
+                    "transitions": []
+                }
+            ],
+            "startTransition": {
+                "key": "start",
+                "target": "initial",
+                "triggerType": "manual",
+                "labels": [{"label": "Start", "language": "en"}]
+            }
+        }
+        """);
+
+        // Act
+        var result = _validator.Validate(workflow);
+
+        // Assert
+        result.ValidationErrors
+            .ShouldNotContain(e => e.MemberNames.Contains("Workflow.States[initial].OnEntries[0].Mapping"));
+    }
+
+    /// <summary>
+    /// Builds a workflow whose 'waiting' state carries every script slot family. The slot named by
+    /// <paramref name="slotPath"/> is authored location-only; all others carry an inlined body.
+    /// Passing null makes every slot valid.
+    /// </summary>
+    private static string ScriptSlotWorkflowJson(string? slotPath)
+    {
+        // "cmV0dXJuIHRydWU7" == "return true;"
+        string Slot(string path) =>
+            path == slotPath
+                ? """{ "location": "./src/X.csx" }"""
+                : """{ "location": "./src/X.csx", "code": "cmV0dXJuIHRydWU7" }""";
+
+        return $$"""
+        {
+            "type": "F",
+            "labels": [{"label": "Test", "language": "en"}],
+            "states": [
+                {
+                    "key": "waiting",
+                    "stateType": "subflow",
+                    "labels": [{"label": "Waiting", "language": "en"}],
+                    "subFlow": {
+                        "type": "S",
+                        "process": {"key": "sub", "domain": "d", "flow": "sys-flows", "version": "1.0.0"},
+                        "mapping": {{Slot("SubFlow.Mapping")}}
+                    },
+                    "onEntries": [
+                        {
+                            "order": 1,
+                            "task": {"key": "t", "domain": "d", "flow": "sys-tasks", "version": "1.0.0"},
+                            "mapping": {{Slot("OnEntries[0].Mapping")}}
+                        }
+                    ],
+                    "onExits": [
+                        {
+                            "order": 1,
+                            "task": {"key": "t", "domain": "d", "flow": "sys-tasks", "version": "1.0.0"},
+                            "mapping": {{Slot("OnExits[0].Mapping")}}
+                        }
+                    ],
+                    "notifications": [
+                        {
+                            "type": "state",
+                            "mapping": {{Slot("Notifications[0].Mapping")}}
+                        }
+                    ],
+                    "views": [
+                        {
+                            "view": {"key": "v", "domain": "d", "flow": "sys-views", "version": "1.0.0"},
+                            "rule": {{Slot("View[0].Rule")}}
+                        }
+                    ],
+                    "transitions": [
+                        {
+                            "key": "submit",
+                            "target": "done",
+                            "triggerType": "manual",
+                            "labels": [{"label": "Submit", "language": "en"}],
+                            "mapping": {{Slot("Transitions[submit].Mapping")}},
+                            "rule": {{Slot("Transitions[submit].Rule")}}
+                        }
+                    ]
+                },
+                {
+                    "key": "done",
+                    "stateType": "finish",
+                    "labels": [{"label": "Done", "language": "en"}],
+                    "transitions": []
+                }
+            ],
+            "startTransition": {
+                "key": "start",
+                "target": "waiting",
+                "triggerType": "manual",
+                "labels": [{"label": "Start", "language": "en"}]
+            }
+        }
+        """;
+    }
+
+    #endregion
 }
 


### PR DESCRIPTION
## What

A script slot authored with only a `location` — i.e. the domain build step never inlined the `.csx` body into `code` — passed publish validation and then failed silently at runtime. This PR closes that gap for **every** `ScriptCode` slot a component definition can carry.

```jsonc
"mapping": { "location": "./src/NsNotifySpawnMapping.csx" }   // published fine, never executed
"rule":    { "location": "./src/NsAllSubsDoneRule.csx" }      // published fine, throws mid-transition
```

## Why it was invisible

Three things line up to swallow it:

1. `ScriptCodeJsonConverter` defaults a missing `encoding` to `B64`.
2. `Convert.FromBase64String("")` returns an empty array — no `FormatException`, so the existing decode checks pass.
3. `ScriptCode.HasMappingCode` turns `false`.

The result differs by slot kind, and both failure modes are bad:

| Slot | Runtime behaviour |
|---|---|
| `mapping` (task / subflow / output / timeout / cache) | Executor **silently skips** it. HTTP task fires with no body mapping; `ScriptTaskExecutor` returns `Success(data: null)`. No log line. |
| `rule` (transition / view / schema selection) | `ScriptConditionEvaluator` compiles an empty script into `IConditionMapping` → **Roslyn failure mid-transition**. |

Before this PR only two narrow guards existed: `MappingComponentValidator` (requires `code`, but only for `sys-mappings` components) and `ValidateDynamicExpressoRule` (only for auto-transition rules located at `dynamicExpresso`). Everything else was unguarded.

## How

New `ScriptCodeValidator` in the Domain layer is the single rule, mirroring the `vnext-schema` guard that was added separately:

| Slot | Verdict |
|---|---|
| `{ "location": "./src/X.csx" }` | ✗ no `code` |
| `{ "type": "L", "location": "./x.csx" }` | ✗ same — `L` is the default |
| `{ "type": "G", "location": "./x.csx" }` | ✓ `G` declares the body lives elsewhere |
| `{ "location": ..., "code": "<base64>" }` | ✓ |
| `code` not decodable under `encoding` | ✗ |
| `code` decoding to whitespace | ✗ |
| `encoding: "REF"` without a complete `sys-mappings` reference | ✗ unresolvable at compile time |

The error message names the actual cause rather than the symptom: *"declares only 'location' … the script body must be inlined into 'code' by the domain build step."*

Wired into every slot:

- **`WorkflowValidator`** — `ValidateTransitionScriptCodes` hangs off `ValidateSingleTransition`, so it covers all six transition families (start / cancel / updateData / exit / shared / state) for `timer`, `rule`, `mapping`, `onExecutionTasks[].mapping` and view rules. `ValidateWorkflowScriptCodes` covers `output`, `timeout.mapping`, state `onEntries` / `onExits` / `notifications` / `subFlow.mapping` and state view rules.
- **`FunctionComponentValidator`** — `task` / `onExecutionTasks[]` mappings, `output`, `cache.keyExpression` / `generationKeyExpression`, and input/output schema + view selection rules.
- **`TaskComponentValidator`** — `CacheAsideTask.sourceMapping` / `keyExpression` (the only task type whose own config carries script slots).
- **`ExtensionComponentValidator`** — `task.mapping`.

## Reviewer notes

- **`dynamicExpresso` is a deliberate exception.** A transition rule located at `dynamicExpresso` is an inline boolean expression, not a `.csx` body, so the generic advice would be wrong. `ValidateDynamicExpressoRule` keeps ownership of its emptiness/decodability check and the generic pass skips that slot — one accurate error instead of two. This is called out in both files' doc comments.
- **View and schema components carry no `ScriptCode`**, so `ViewComponentValidator` / `SchemaComponentValidator` are untouched. `MappingComponentValidator` already required `code` and is unchanged.
- **Adding a new `ScriptCode` property to a definition object now requires adding its path** to the traversal. An unlisted slot is an unguarded slot; the doc comments and `docs/custom-script-helpers.md` both say so.
- **Decodability is now enforced at publish time**, consistent with what `MappingComponentValidator` has always done for `sys-mappings`. A definition carrying malformed Base64 that previously only failed at transition time will now be rejected at publish. That is the intent, but it is the one behaviour change that could surface an existing broken definition.

## Verification

- `dotnet build vnext.sln` → succeeds.
- 34 new tests, all passing: 15 `ScriptCodeValidatorTests`, 11 `WorkflowValidatorTests`, 8 across the component validators.
- No regressions. Failure counts are byte-identical to the pre-change baseline on both suites — Domain 153, Application 26 (the repo's known pre-existing failures). One regression appeared mid-work (`Validate_ShouldFail_WhenDynamicExpressoRuleIsWhitespace`) and was fixed by the `dynamicExpresso` carve-out above.
- Docs: `docs/custom-script-helpers.md` gains the rule table and the "add the path when you add a slot" note.

Spotted in passing and **not** addressed here: four component-validator tests fail on `master` because their JSON fixtures use enum codes the models cannot deserialize (e.g. `ExtensionType` / `ExtensionScope` receive `"O"`). Worth checking separately whether real domain packages author those codes — if they do, it is a runtime bug, not fixture rot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce publish-time validation of all script slots to ensure they carry executable bodies and extend coverage across workflows, functions, tasks, and extensions.

Bug Fixes:
- Prevent script mappings and rules authored with only a location from silently being skipped or failing at runtime by validating their bodies at publish time.

Enhancements:
- Introduce a shared ScriptCodeValidator and wire it into workflow, function, task, and extension validators to cover all script-capable slots.
- Extend domain and application validator tests to cover script slot validation scenarios across workflows, functions, cache-aside tasks, and extensions.
- Document the new script slot validation rules and the requirement to register new ScriptCode paths in validator traversals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened workflow definition validation for script-based mappings, rules, expressions, and outputs.
  - Detects missing, invalid, or empty script content before publishing.
  - Validates script references, including required metadata and supported flow requirements.
  - Preserves support for global mappings and dynamic expression rules where applicable.

- **Documentation**
  - Added guidance on valid script definitions, reference requirements, and validation coverage.

- **Tests**
  - Added comprehensive coverage for invalid script slots, references, encoded content, and supported workflow scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->