### PR TITLE
Propagate workflow correlation context across remote task execution

### DIFF
--- a/execution/BBT.Workflow.Execution.HttpApi.Host/Controllers/Executions/ExecutionController.cs
+++ b/execution/BBT.Workflow.Execution.HttpApi.Host/Controllers/Executions/ExecutionController.cs
@@ -44,25 +44,71 @@ public sealed class ExecutionController(
     {
         var envelope = request.Envelope;
         var traceContext = request.TraceContext;
+        var subject = TelemetryConstants.TryNormalizeIdentityClaim(traceContext?.Sub, out var normalizedSubject)
+            ? normalizedSubject
+            : null;
+        var actSub = TelemetryConstants.TryNormalizeIdentityClaim(traceContext?.ActSub, out var normalizedActSub)
+            ? normalizedActSub
+            : null;
 
         var activity = Activity.Current;
         activity?.SetTag(TelemetryConstants.TagNames.Domain, traceContext?.Domain ?? "unknown");
         activity?.SetTag(TelemetryConstants.TagNames.Flow, traceContext?.WorkflowKey ?? "unknown");
         activity?.SetTag(TelemetryConstants.TagNames.FlowVersion, traceContext?.WorkflowVersion ?? "unknown");
         activity?.SetTag(TelemetryConstants.TagNames.InstanceId, traceContext?.InstanceId.ToString() ?? Guid.Empty.ToString());
+        activity?.SetTag(
+            TelemetryConstants.TagNames.WorkflowInstanceId,
+            traceContext?.InstanceId.ToString("D").ToLowerInvariant() ?? Guid.Empty.ToString("D"));
+        activity?.SetTag(TelemetryConstants.TagNames.CorrelationId, traceContext?.CorrelationId);
+        activity?.SetTag(TelemetryConstants.TagNames.Sub, subject);
+        activity?.SetTag(TelemetryConstants.TagNames.ActSub, actSub);
         activity?.SetTag(TelemetryConstants.TagNames.TaskKey, envelope.TaskKey);
         activity?.SetTag(TelemetryConstants.TagNames.TaskType, envelope.TaskType);
         activity?.SetTag(TelemetryConstants.TagNames.Layer, TelemetryConstants.Layers.Execution);
         activity?.SetTag(TelemetryConstants.TagNames.SpanCategory, TelemetryConstants.SpanCategories.Business);
 
-        using (logger.BeginScope(new Dictionary<string, object>
+        if (traceContext?.InstanceId is { } instanceId && instanceId != Guid.Empty)
+        {
+            activity?.SetBaggage(TelemetryConstants.TagNames.InstanceId, instanceId.ToString("D").ToLowerInvariant());
+            activity?.SetBaggage(TelemetryConstants.TagNames.WorkflowInstanceId, instanceId.ToString("D").ToLowerInvariant());
+        }
+
+        if (Guid.TryParseExact(traceContext?.CorrelationId, "N", out var correlationId)
+            && correlationId != Guid.Empty)
+        {
+            activity?.SetBaggage(TelemetryConstants.TagNames.CorrelationId, correlationId.ToString("N"));
+        }
+
+        if (subject is not null)
+        {
+            activity?.SetBaggage(TelemetryConstants.TagNames.Sub, subject);
+        }
+
+        if (actSub is not null)
+        {
+            activity?.SetBaggage(TelemetryConstants.TagNames.ActSub, actSub);
+        }
+
+        var scope = new Dictionary<string, object>
         {
             [TelemetryConstants.TagNames.Domain] = traceContext?.Domain ?? "unknown",
             [TelemetryConstants.TagNames.Flow] = traceContext?.WorkflowKey ?? "unknown",
             [TelemetryConstants.TagNames.InstanceId] = traceContext?.InstanceId ?? Guid.Empty,
+            [TelemetryConstants.TagNames.WorkflowInstanceId] = traceContext?.InstanceId.ToString("D").ToLowerInvariant() ?? Guid.Empty.ToString("D"),
+            [TelemetryConstants.TagNames.CorrelationId] = traceContext?.CorrelationId ?? "unknown",
             [TelemetryConstants.TagNames.TaskKey] = envelope.TaskKey,
             [TelemetryConstants.TagNames.TaskType] = envelope.TaskType
-        }))
+        };
+        if (subject is not null)
+        {
+            scope[TelemetryConstants.TagNames.Sub] = subject;
+        }
+        if (actSub is not null)
+        {
+            scope[TelemetryConstants.TagNames.ActSub] = actSub;
+        }
+
+        using (logger.BeginScope(scope))
         {
             var result = await invokerRegistry.InvokeAsync(envelope, cancellationToken);
             return Ok(new TaskInvokeResponse

--- a/src/BBT.Workflow.Application/Execution/Transitions/Strategy/AsyncTransitionStrategy.cs
+++ b/src/BBT.Workflow.Application/Execution/Transitions/Strategy/AsyncTransitionStrategy.cs
@@ -333,6 +333,12 @@ public sealed class AsyncTransitionStrategy(
         activity.SetTag(TelemetryConstants.TagNames.Flow, ctx.Workflow.Key);
         activity.SetTag(TelemetryConstants.TagNames.FlowVersion, ctx.Workflow.Version);
         activity.SetTag(TelemetryConstants.TagNames.InstanceId, ctx.InstanceId);
+        activity.SetTag(TelemetryConstants.TagNames.WorkflowInstanceId, ctx.InstanceId.ToString("D").ToLowerInvariant());
+        activity.SetTag(TelemetryConstants.TagNames.CorrelationId, ctx.CorrelationId);
+        var subject = GetIdentityClaim(ctx.Headers, TelemetryConstants.HeaderNames.Sub);
+        var actSub = GetIdentityClaim(ctx.Headers, TelemetryConstants.HeaderNames.ActSub);
+        activity.SetTag(TelemetryConstants.TagNames.Sub, subject);
+        activity.SetTag(TelemetryConstants.TagNames.ActSub, actSub);
         activity.SetTag(TelemetryConstants.TagNames.TransitionKey, ctx.TransitionKey);
         activity.SetTag(TelemetryConstants.TagNames.JobName, jobName);
 
@@ -341,8 +347,33 @@ public sealed class AsyncTransitionStrategy(
         activity.SetBaggage(TelemetryConstants.TagNames.Flow, ctx.Workflow.Key);
         activity.SetBaggage(TelemetryConstants.TagNames.FlowVersion, ctx.Workflow.Version);
         activity.SetBaggage(TelemetryConstants.TagNames.InstanceId, ctx.InstanceId.ToString());
+        activity.SetBaggage(TelemetryConstants.TagNames.WorkflowInstanceId, ctx.InstanceId.ToString("D").ToLowerInvariant());
+        activity.SetBaggage(TelemetryConstants.TagNames.CorrelationId, ctx.CorrelationId);
+        if (subject is not null)
+        {
+            activity.SetBaggage(TelemetryConstants.TagNames.Sub, subject);
+        }
+        if (actSub is not null)
+        {
+            activity.SetBaggage(TelemetryConstants.TagNames.ActSub, actSub);
+        }
         activity.SetBaggage(TelemetryConstants.TagNames.TransitionKey, ctx.TransitionKey);
         activity.SetBaggage(TelemetryConstants.TagNames.JobName, jobName);
+    }
+
+    private static string? GetIdentityClaim(
+        IReadOnlyDictionary<string, string?> headers,
+        string headerName)
+    {
+        var rawValue = headers
+            .FirstOrDefault(header => string.Equals(
+                header.Key,
+                headerName,
+                StringComparison.OrdinalIgnoreCase))
+            .Value;
+        return TelemetryConstants.TryNormalizeIdentityClaim(rawValue, out var normalized)
+            ? normalized
+            : null;
     }
 
     /// <summary>

--- a/src/BBT.Workflow.Application/Tasks/Executors/Remote/RemoteInvokerService.cs
+++ b/src/BBT.Workflow.Application/Tasks/Executors/Remote/RemoteInvokerService.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Net.Http.Json;
 using System.Text.Json;
 using BBT.Aether.Results;
 using BBT.Workflow.Logging;
@@ -72,15 +73,49 @@ public sealed class RemoteInvokerService : IRemoteInvokerService
         try
         {
             var httpRequest = _daprClient.CreateInvokeMethodRequest(
+                HttpMethod.Post,
                 _executionServiceAppId,
-                $"/api/v1/execution/invoke/{taskType}/{taskKey}",
-                request);
+                $"/api/v1/execution/invoke/{taskType}/{taskKey}");
+            httpRequest.Content = JsonContent.Create(request);
 
             httpRequest.Headers.Add(WorkflowInfo.Name, WorkflowInfo.Generate(
                 traceContext.Domain ?? "unknown",
                 traceContext.WorkflowKey ?? "unknown",
                 traceContext.WorkflowVersion ?? "latest",
                 traceContext.InstanceId));
+
+            if (traceContext.InstanceId != Guid.Empty)
+            {
+                httpRequest.Headers.Remove(TelemetryConstants.HeaderNames.WorkflowInstanceId);
+                httpRequest.Headers.TryAddWithoutValidation(
+                    TelemetryConstants.HeaderNames.WorkflowInstanceId,
+                    traceContext.InstanceId.ToString("D").ToLowerInvariant());
+            }
+
+            if (Guid.TryParseExact(traceContext.CorrelationId, "N", out var correlationId)
+                && correlationId != Guid.Empty)
+            {
+                httpRequest.Headers.Remove(TelemetryConstants.HeaderNames.CorrelationId);
+                httpRequest.Headers.TryAddWithoutValidation(
+                    TelemetryConstants.HeaderNames.CorrelationId,
+                    correlationId.ToString("N"));
+            }
+
+            if (TelemetryConstants.TryNormalizeIdentityClaim(traceContext.Sub, out var subject))
+            {
+                httpRequest.Headers.Remove(TelemetryConstants.HeaderNames.Sub);
+                httpRequest.Headers.TryAddWithoutValidation(
+                    TelemetryConstants.HeaderNames.Sub,
+                    subject);
+            }
+
+            if (TelemetryConstants.TryNormalizeIdentityClaim(traceContext.ActSub, out var actSub))
+            {
+                httpRequest.Headers.Remove(TelemetryConstants.HeaderNames.ActSub);
+                httpRequest.Headers.TryAddWithoutValidation(
+                    TelemetryConstants.HeaderNames.ActSub,
+                    actSub);
+            }
 
             // Forward root instance ID from Activity baggage (set by TransitionExecutor for subflow instances)
             var rootIdBaggage = Activity.Current?.GetBaggageItem(TelemetryConstants.TagNames.RootInstanceId);
@@ -151,14 +186,52 @@ public sealed class RemoteInvokerService : IRemoteInvokerService
             ? workflow!.Domain
             : scriptContext.Runtime.Domain;
 
+        var correlationId = Activity.Current?.GetBaggageItem(
+            TelemetryConstants.TagNames.CorrelationId);
+
+        // Some interception activities preserve the W3C parent context but do not copy
+        // baggage. Keep the outbound correlation contract deterministic and opaque by
+        // falling back to the current trace ID instead of dropping the header entirely.
+        if (!Guid.TryParseExact(correlationId, "N", out var parsedCorrelationId)
+            || parsedCorrelationId == Guid.Empty)
+        {
+            var traceId = Activity.Current?.TraceId.ToString();
+            correlationId = Guid.TryParseExact(traceId, "N", out var parsedTraceId)
+                && parsedTraceId != Guid.Empty
+                    ? parsedTraceId.ToString("N")
+                    : Guid.NewGuid().ToString("N");
+        }
+
+        var requestHeaders = scriptContext.Headers != null
+            ? scriptContext.GetHeadersAsDictionary()
+            : null;
+        var subject = GetIdentityClaim(requestHeaders, TelemetryConstants.HeaderNames.Sub);
+        var actSub = GetIdentityClaim(requestHeaders, TelemetryConstants.HeaderNames.ActSub);
+
         return TaskTraceContext.Create(
             instanceId: instance?.Id ?? Guid.Empty,
             domain: domain,
             workflowKey: workflow?.Key ?? string.Empty,
             workflowVersion: workflow?.Version ?? string.Empty,
-            headers: scriptContext.Headers != null
-                ? scriptContext.GetHeadersAsDictionary()
-                : null,
+            correlationId: correlationId,
+            sub: subject,
+            actSub: actSub,
+            headers: requestHeaders,
             instanceDataJson: instance?.LatestData?.Data?.Json);
+    }
+
+    private static string? GetIdentityClaim(
+        IReadOnlyDictionary<string, string>? headers,
+        string headerName)
+    {
+        var rawValue = headers?
+            .FirstOrDefault(header => string.Equals(
+                header.Key,
+                headerName,
+                StringComparison.OrdinalIgnoreCase))
+            .Value;
+        return TelemetryConstants.TryNormalizeIdentityClaim(rawValue, out var normalized)
+            ? normalized
+            : null;
     }
 }

--- a/src/BBT.Workflow.Domain/Logging/TelemetryConstants.cs
+++ b/src/BBT.Workflow.Domain/Logging/TelemetryConstants.cs
@@ -15,6 +15,25 @@ public static class TelemetryConstants
         public const string Flow = "vnext.flow.key";
         public const string FlowVersion = "vnext.flow.version";
         public const string InstanceId = "vnext.instance.id";
+        /// <summary>
+        /// Vendor-neutral workflow instance identifier used to correlate telemetry
+        /// emitted by dependencies that are not part of vNext.
+        /// </summary>
+        public const string WorkflowInstanceId = "workflow.instance.id";
+        /// <summary>
+        /// Business-operation correlation identifier. This is intentionally separate
+        /// from the per-request X-Request-Id and the W3C trace identifier.
+        /// </summary>
+        public const string CorrelationId = "correlation.id";
+        /// <summary>
+        /// Primary subject exposed by the gateway authentication chain.
+        /// It is propagated as correlation metadata only.
+        /// </summary>
+        public const string Sub = "sub";
+        /// <summary>
+        /// Actor subject exposed by the gateway authentication chain.
+        /// </summary>
+        public const string ActSub = "act.sub";
         public const string InstanceKey = "vnext.instance.key";
         public const string TransitionKey = "vnext.transition.key";
         public const string TriggerType = "vnext.trigger.type";
@@ -67,6 +86,22 @@ public static class TelemetryConstants
     public static class HeaderNames
     {
         /// <summary>
+        /// Canonical workflow instance identifier propagated to trusted HTTP dependencies.
+        /// </summary>
+        public const string WorkflowInstanceId = "X-Workflow-Instance-Id";
+        /// <summary>
+        /// Canonical business correlation identifier propagated to trusted HTTP dependencies.
+        /// </summary>
+        public const string CorrelationId = "X-Correlation-Id";
+        /// <summary>
+        /// Primary subject emitted by the gateway after authentication.
+        /// </summary>
+        public const string Sub = "sub";
+        /// <summary>
+        /// Actor subject emitted by the gateway after authentication.
+        /// </summary>
+        public const string ActSub = "act_sub";
+        /// <summary>
         /// Request header carrying the parent instance ID when invoking subflow/subprocess remotely.
         /// </summary>
         public const string ParentInstanceId = "X-Parent-Instance-Id";
@@ -75,5 +110,29 @@ public static class TelemetryConstants
         /// Remains constant at A's ID regardless of nesting depth.
         /// </summary>
         public const string RootInstanceId = "X-Root-Instance-Id";
+    }
+
+    /// <summary>
+    /// Accepts a constrained actor claim emitted by the gateway authentication chain.
+    /// The exact value is retained; unsafe or unexpectedly large values are omitted.
+    /// </summary>
+    public static bool TryNormalizeIdentityClaim(string? value, out string normalized)
+    {
+        normalized = string.Empty;
+        if (string.IsNullOrEmpty(value) || value.Length > 128)
+        {
+            return false;
+        }
+
+        foreach (var character in value)
+        {
+            if (!char.IsAsciiLetterOrDigit(character) && character is not '_' and not '-')
+            {
+                return false;
+            }
+        }
+
+        normalized = value;
+        return true;
     }
 }

--- a/src/BBT.Workflow.Execution.Abstractions/TaskEnvelope.cs
+++ b/src/BBT.Workflow.Execution.Abstractions/TaskEnvelope.cs
@@ -57,6 +57,21 @@ public sealed class TaskTraceContext
     public string? WorkflowVersion { get; init; }
 
     /// <summary>
+    /// Safe correlation ID propagated from orchestration for cross-service log correlation.
+    /// </summary>
+    public string? CorrelationId { get; init; }
+
+    /// <summary>
+    /// Gateway-authenticated primary subject propagated for dependency log correlation.
+    /// </summary>
+    public string? Sub { get; init; }
+
+    /// <summary>
+    /// Gateway-authenticated actor subject propagated for dependency log correlation.
+    /// </summary>
+    public string? ActSub { get; init; }
+
+    /// <summary>
     /// Original HTTP request headers forwarded from orchestration.
     /// Used for <c>{HEADER.*}</c> placeholder resolution.
     /// </summary>
@@ -84,4 +99,3 @@ public sealed class TaskInvokeRequest
     /// </summary>
     public TaskTraceContext? TraceContext { get; init; }
 }
-

--- a/src/BBT.Workflow.Execution/Invokers/HttpTaskInvoker.cs
+++ b/src/BBT.Workflow.Execution/Invokers/HttpTaskInvoker.cs
@@ -18,6 +18,17 @@ public sealed class HttpTaskInvoker(
     ITaskMetrics? metrics = null)
     : ITaskInvoker<HttpTaskBinding>
 {
+    // Kept local so the stateless Execution package does not acquire a Domain dependency.
+    // These names are the public HTTP contract defined by TelemetryConstants in vNext Domain.
+    private const string WorkflowInstanceHeader = "X-Workflow-Instance-Id";
+    private const string CorrelationHeader = "X-Correlation-Id";
+    private const string SubHeader = "sub";
+    private const string ActSubHeader = "act_sub";
+    private const string WorkflowInstanceBaggage = "workflow.instance.id";
+    private const string CorrelationBaggage = "correlation.id";
+    private const string SubBaggage = "sub";
+    private const string ActSubBaggage = "act.sub";
+
     private readonly ITaskMetrics _metrics = metrics ?? NullTaskMetrics.Instance;
 
     /// <inheritdoc />
@@ -80,6 +91,8 @@ public sealed class HttpTaskInvoker(
                     }
                 }
             }
+
+            ApplyTrustedCorrelationHeaders(request);
 
             // Add body for non-GET requests. Resolution: explicit ContentType → Content-Type header → json.
             if (request.Method != HttpMethod.Get && !string.IsNullOrEmpty(binding.Body))
@@ -200,6 +213,62 @@ public sealed class HttpTaskInvoker(
         var client = httpClientFactory.CreateClient(clientName);
         client.Timeout = TimeSpan.FromSeconds(binding.TimeoutSeconds);
         return client;
+    }
+
+    private static void ApplyTrustedCorrelationHeaders(HttpRequestMessage request)
+    {
+        // Mapping-provided values are untrusted and must never be allowed to spoof
+        // the workflow context established by vNext.
+        request.Headers.Remove(WorkflowInstanceHeader);
+        request.Headers.Remove(CorrelationHeader);
+        request.Headers.Remove(SubHeader);
+        request.Headers.Remove(ActSubHeader);
+
+        var workflowInstance = Activity.Current?.GetBaggageItem(WorkflowInstanceBaggage);
+        if (Guid.TryParse(workflowInstance, out var workflowInstanceId)
+            && workflowInstanceId != Guid.Empty)
+        {
+            request.Headers.TryAddWithoutValidation(
+                WorkflowInstanceHeader,
+                workflowInstanceId.ToString("D").ToLowerInvariant());
+        }
+
+        var correlation = Activity.Current?.GetBaggageItem(CorrelationBaggage);
+        if (Guid.TryParseExact(correlation, "N", out var correlationId)
+            && correlationId != Guid.Empty)
+        {
+            request.Headers.TryAddWithoutValidation(CorrelationHeader, correlationId.ToString("N"));
+        }
+
+        var subject = Activity.Current?.GetBaggageItem(SubBaggage);
+        if (IsSafeIdentityClaim(subject))
+        {
+            request.Headers.TryAddWithoutValidation(SubHeader, subject);
+        }
+
+        var actSub = Activity.Current?.GetBaggageItem(ActSubBaggage);
+        if (IsSafeIdentityClaim(actSub))
+        {
+            request.Headers.TryAddWithoutValidation(ActSubHeader, actSub);
+        }
+    }
+
+    private static bool IsSafeIdentityClaim(string? value)
+    {
+        if (string.IsNullOrEmpty(value) || value.Length > 128)
+        {
+            return false;
+        }
+
+        foreach (var character in value)
+        {
+            if (!char.IsAsciiLetterOrDigit(character) && character is not '_' and not '-')
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
 }

--- a/src/BBT.Workflow.Tasks.Abstractions/Core/TaskTraceContext.cs
+++ b/src/BBT.Workflow.Tasks.Abstractions/Core/TaskTraceContext.cs
@@ -32,6 +32,16 @@ public sealed record TaskTraceContext
     public string? CorrelationId { get; init; }
 
     /// <summary>
+    /// Gateway-authenticated primary subject propagated for dependency log correlation.
+    /// </summary>
+    public string? Sub { get; init; }
+
+    /// <summary>
+    /// Gateway-authenticated actor subject propagated for dependency log correlation.
+    /// </summary>
+    public string? ActSub { get; init; }
+
+    /// <summary>
     /// Original HTTP request headers forwarded from orchestration.
     /// </summary>
     public IReadOnlyDictionary<string, string>? RequestHeaders { get; init; }
@@ -51,15 +61,18 @@ public sealed record TaskTraceContext
         string workflowVersion,
         string? correlationId = null,
         IReadOnlyDictionary<string, string>? headers = null,
-        string? instanceDataJson = null) => new()
+        string? instanceDataJson = null,
+        string? sub = null,
+        string? actSub = null) => new()
     {
         InstanceId = instanceId,
         Domain = domain,
         WorkflowKey = workflowKey,
         WorkflowVersion = workflowVersion,
         CorrelationId = correlationId,
+        Sub = sub,
+        ActSub = actSub,
         RequestHeaders = headers,
         InstanceDataJson = instanceDataJson
     };
 }
-

--- a/test/BBT.Workflow.Application.Tests/Tasks/Executors/RemoteInvokerServiceTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Tasks/Executors/RemoteInvokerServiceTests.cs
@@ -1,17 +1,25 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using BBT.Workflow.Tasks.Executors;
+using BBT.Workflow.Definitions;
+using BBT.Workflow.Instances;
+using BBT.Workflow.Logging;
+using BBT.Workflow.Scripting;
+using BBT.Workflow.Shared;
 using TaskEnvelope = BBT.Workflow.Tasks.TaskEnvelope;
 using TaskTraceContext = BBT.Workflow.Tasks.TaskTraceContext;
-using TaskInvokeResponse = BBT.Workflow.Execution.TaskInvokeResponse;
-using TaskInvocationResult = BBT.Workflow.Execution.TaskInvocationResult;
+using TaskInvokeResponse = BBT.Workflow.Tasks.TaskInvokeResponse;
+using TaskInvocationResult = BBT.Workflow.Tasks.TaskInvocationResult;
 using Dapr.Client;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Shouldly;
 using Xunit;
@@ -57,14 +65,14 @@ public class RemoteInvokerServiceTests
 
     private void SetupDaprCreateRequest()
     {
-        // CreateInvokeMethodRequest(HttpMethod, string, string) is the abstract base.
-        // The concrete generic overload delegates to it, then attaches the serialized body.
+        // CreateInvokeMethodRequest(HttpMethod, string, string) is the mockable base overload.
+        // RemoteInvokerService attaches the serialized body after creating the request.
         _daprClient
             .Setup(d => d.CreateInvokeMethodRequest(
-                HttpMethod.Post,
+                It.IsAny<HttpMethod>(),
                 It.IsAny<string>(),
                 It.IsAny<string>()))
-            .Returns(new HttpRequestMessage());
+            .Returns(new HttpRequestMessage(HttpMethod.Post, "http://test-execution/invoke"));
     }
 
     /// <summary>
@@ -180,5 +188,93 @@ public class RemoteInvokerServiceTests
         result.IsSuccess.ShouldBeTrue();
         result.Value!.IsSuccess.ShouldBeTrue();
         result.Value.StatusCode.ShouldBe(200);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WithTraceContext_PropagatesCanonicalCorrelationHeaders()
+    {
+        SetupDaprCreateRequest();
+        HttpRequestMessage? capturedRequest = null;
+        _daprClient
+            .Setup(d => d.InvokeMethodAsync<TaskInvokeResponse>(
+                It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+            .Callback<HttpRequestMessage, CancellationToken>((request, _) => capturedRequest = request)
+            .ReturnsAsync(new TaskInvokeResponse
+            {
+                Success = true,
+                Result = TaskInvocationResult.Success(statusCode: 200, taskType: "HttpTask")
+            });
+
+        var instanceId = Guid.NewGuid();
+        var correlationId = Guid.NewGuid();
+        var traceContext = TaskTraceContext.Create(
+            instanceId,
+            "test",
+            "test-flow",
+            "1.0.0",
+            correlationId.ToString("N"),
+            sub: "12345678901",
+            actSub: "U0B006");
+
+        var result = await CreateService().InvokeAsync(
+            "HttpTask", "call-api", CreateEnvelope(), traceContext, CancellationToken.None);
+
+        result.Value!.ErrorMessage.ShouldBeNull();
+        capturedRequest.ShouldNotBeNull();
+        capturedRequest.Headers.GetValues(TelemetryConstants.HeaderNames.WorkflowInstanceId)
+            .Single().ShouldBe(instanceId.ToString("D").ToLowerInvariant());
+        capturedRequest.Headers.GetValues(TelemetryConstants.HeaderNames.CorrelationId)
+            .Single().ShouldBe(correlationId.ToString("N"));
+        capturedRequest.Headers.GetValues(TelemetryConstants.HeaderNames.Sub)
+            .Single().ShouldBe("12345678901");
+        capturedRequest.Headers.GetValues(TelemetryConstants.HeaderNames.ActSub)
+            .Single().ShouldBe("U0B006");
+    }
+
+    [Fact]
+    public void CreateTraceContext_WithBusinessCorrelationBaggage_CopiesCorrelationId()
+    {
+        var instance = Instance.Create(Guid.NewGuid(), "test-flow", "1.0.0", "instance-key");
+        var workflow = BBT.Workflow.Definitions.Workflow.Create();
+        workflow.SetReference(new Reference("test-flow", "test", "sys-flows", "1.0.0"));
+        using var scriptContext = new ScriptContext.Builder(NullLogger<ScriptContext>.Instance)
+            .SetInstance(instance)
+            .SetWorkflow(workflow)
+            .SetHeaders(new Dictionary<string, string>
+            {
+                ["sub"] = "12345678901",
+                ["act_sub"] = "U0B006"
+            })
+            .Build();
+        var correlationId = Guid.NewGuid().ToString("N");
+
+        using var activity = new Activity("create-trace-context-test").Start();
+        activity.SetBaggage(TelemetryConstants.TagNames.CorrelationId, correlationId);
+
+        var result = CreateService().CreateTraceContext(scriptContext);
+
+        result.InstanceId.ShouldBe(instance.Id);
+        result.CorrelationId.ShouldBe(correlationId);
+        result.Sub.ShouldBe("12345678901");
+        result.ActSub.ShouldBe("U0B006");
+    }
+
+    [Fact]
+    public void CreateTraceContext_WithoutBusinessCorrelationBaggage_UsesCurrentTraceId()
+    {
+        var instance = Instance.Create(Guid.NewGuid(), "test-flow", "1.0.0", "instance-key");
+        var workflow = BBT.Workflow.Definitions.Workflow.Create();
+        workflow.SetReference(new Reference("test-flow", "test", "sys-flows", "1.0.0"));
+        using var scriptContext = new ScriptContext.Builder(NullLogger<ScriptContext>.Instance)
+            .SetInstance(instance)
+            .SetWorkflow(workflow)
+            .Build();
+
+        using var activity = new Activity("create-trace-context-fallback-test").Start();
+
+        var result = CreateService().CreateTraceContext(scriptContext);
+
+        result.InstanceId.ShouldBe(instance.Id);
+        result.CorrelationId.ShouldBe(activity.TraceId.ToString());
     }
 }

--- a/test/BBT.Workflow.Application.Tests/Tasks/Invokers/HttpTaskInvokerContentTypeTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Tasks/Invokers/HttpTaskInvokerContentTypeTests.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -61,6 +64,48 @@ public sealed class HttpTaskInvokerContentTypeTests
         handler.CapturedContentType.ShouldBe("application/x-www-form-urlencoded");
     }
 
+    [Fact]
+    public async Task InvokeAsync_WithWorkflowBaggage_OverridesMappingCorrelationHeaders()
+    {
+        var handler = new CapturingHttpMessageHandler();
+        var invoker = CreateInvoker(handler);
+        var instanceId = Guid.NewGuid();
+        var correlationId = Guid.NewGuid();
+
+        using var activity = new Activity("http-task-test").Start();
+        activity.SetBaggage("workflow.instance.id", instanceId.ToString("D"));
+        activity.SetBaggage("correlation.id", correlationId.ToString("N"));
+        activity.SetBaggage("sub", "12345678901");
+        activity.SetBaggage("act.sub", "U0B006");
+
+        await invoker.InvokeAsync(CreateDescriptor(
+            body: "{}",
+            headers: """{"X-Workflow-Instance-Id":"spoofed","X-Correlation-Id":"spoofed","sub":"spoofed.value","act_sub":"spoofed.value"}"""));
+
+        handler.GetRequestHeader("X-Workflow-Instance-Id")
+            .ShouldBe(instanceId.ToString("D").ToLowerInvariant());
+        handler.GetRequestHeader("X-Correlation-Id")
+            .ShouldBe(correlationId.ToString("N"));
+        handler.GetRequestHeader("sub").ShouldBe("12345678901");
+        handler.GetRequestHeader("act_sub").ShouldBe("U0B006");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WithoutValidWorkflowBaggage_RemovesMappingCorrelationHeaders()
+    {
+        var handler = new CapturingHttpMessageHandler();
+        var invoker = CreateInvoker(handler);
+
+        await invoker.InvokeAsync(CreateDescriptor(
+            body: "{}",
+            headers: """{"X-Workflow-Instance-Id":"spoofed","X-Correlation-Id":"spoofed","sub":"spoofed.value","act_sub":"spoofed.value"}"""));
+
+        handler.RequestHeaderContains("X-Workflow-Instance-Id").ShouldBeFalse();
+        handler.RequestHeaderContains("X-Correlation-Id").ShouldBeFalse();
+        handler.RequestHeaderContains("sub").ShouldBeFalse();
+        handler.RequestHeaderContains("act_sub").ShouldBeFalse();
+    }
+
     private static HttpTaskInvoker CreateInvoker(CapturingHttpMessageHandler handler) =>
         new(new FakeHttpClientFactory(handler), NullLogger<HttpTaskInvoker>.Instance);
 
@@ -97,6 +142,11 @@ public sealed class HttpTaskInvokerContentTypeTests
         // NonValidated allows querying any header name (including content-header names) without throwing.
         public bool RequestHeaderContains(string name) =>
             _requestHeaders?.NonValidated.Contains(name) ?? false;
+
+        public string? GetRequestHeader(string name) =>
+            _requestHeaders?.NonValidated.TryGetValues(name, out var values) == true
+                ? values.ToString()
+                : null;
 
         protected override async Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,


### PR DESCRIPTION
## Summary

This change propagates stable workflow and identity correlation metadata from orchestration through the remote execution boundary and into outbound HTTP tasks. It allows vNext telemetry to be correlated with dependent-service traces and logs while keeping the business correlation ID separate from W3C trace and request identifiers.

Outbound task mappings can no longer override canonical correlation headers. Mapping-provided values are removed and replaced only with normalized values carried by the trusted vNext activity context.

## Key Changes

- **Workflow correlation:** Adds `workflow.instance.id` and `correlation.id` to orchestration and execution activities, baggage, and structured log scopes.
- **Identity context:** Propagates the primary `sub` and acting subject `act.sub` values without forwarding the complete `act` claim.
- **Remote execution envelope:** Extends task trace contexts so correlation and identity metadata survive the orchestration-to-execution boundary.
- **Dependency propagation:** Adds canonical workflow, correlation, and identity headers to outbound HTTP task requests.
- **Header hardening:** Removes mapping-provided correlation and identity headers before applying values from validated activity baggage.
- **Correlation fallback:** Uses the current W3C trace ID as the business correlation ID when valid correlation baggage is unavailable, with an opaque generated GUID as the final fallback.
- **Test coverage:** Adds tests for context creation, Dapr request propagation, outbound HTTP header replacement, invalid context removal, and updated asynchronous transition behavior.

## Implementation Details

### Correlation Contract

| OpenTelemetry attribute | HTTP header | Purpose |
|---|---|---|
| `workflow.instance.id` | `X-Workflow-Instance-Id` | Stable workflow instance identifier across vNext and dependent services |
| `correlation.id` | `X-Correlation-Id` | Business-operation correlation identifier |
| `sub` | `sub` | Primary authenticated subject |
| `act.sub` | `act_sub` | Acting subject associated with the request |

Workflow instance IDs are emitted in canonical lowercase UUID format. Correlation IDs use the non-zero 32-character UUID `N` format.

Identity values are accepted only when they:

- Contain `A-Z`, `a-z`, `0-9`, `_`, or `-`
- Are no longer than 128 characters
- Originate from the vNext trace context rather than task mapping headers

The complete `act` claim is intentionally not propagated or logged.

### Remote Execution

`RemoteInvokerService` now creates an explicit `HttpRequestMessage` and attaches the serialized task envelope with `JsonContent`. This allows canonical correlation headers to be added before the request crosses the Dapr service invocation boundary.

The execution API restores the received values as activity tags, baggage, and structured logging scope properties. `HttpTaskInvoker` then forwards the context to trusted HTTP dependencies.

Task-defined headers with the following names are always removed before propagation:

```text
X-Workflow-Instance-Id
X-Correlation-Id
sub
act_sub
```
<p>A header is added again only when a valid value exists in the current activity baggage.</p><h3>Workflow Labels</h3><p>When exported through Elastic APM, the new OpenTelemetry attributes are available in Discover as:</p><div><div><div>
OpenTelemetry attribute | Elastic field
-- | --
workflow.instance.id | labels.workflow_instance_id
correlation.id | labels.correlation_id
sub | labels.sub
act.sub | labels.act_sub

</div></div></div><p>The W3C trace identifier remains available as the native <code dir="ltr">trace.id</code> field.</p><h3>Kibana Discover Queries</h3><p>Find all telemetry associated with a workflow instance:</p><pre dir="ltr"><code>labels.workflow_instance_id : "&lt;workflow-instance-id&gt;"</code></pre><p>Correlate orchestration and execution services:</p><pre dir="ltr"><code>labels.correlation_id : "&lt;correlation-id&gt;"
  and service.name : ("vnext-app-morph-touch" or "vnext-execution-app-morph-touch")</code></pre><p>Filter by the primary and acting subjects:</p><pre dir="ltr"><code>labels.sub : "&lt;subject&gt;"
  and labels.act_sub : "&lt;acting-subject&gt;"</code></pre><p>Find the complete distributed trace:</p><pre dir="ltr"><code>trace.id : "&lt;trace-id&gt;"</code></pre><p>Correlate downstream application logs using the shared context:</p><pre dir="ltr"><code>labels.workflow_instance_id : "&lt;workflow-instance-id&gt;"
  and labels.correlation_id : "&lt;correlation-id&gt;"</code></pre><p>Validation completed:</p><ul><li>26 focused application, remote invocation, HTTP task, and async transition tests passed.</li><li><code dir="ltr">git diff --check</code> completed successfully.</li><li>Local end-to-end validation confirmed the same workflow instance, correlation ID, <code dir="ltr">sub</code>, and <code dir="ltr">act.sub</code> values across vNext app, vNext execution, APISIX, Synapse, and LiveKit telemetry.</li><li>Outbound workflow request returned HTTP <code dir="ltr">200</code>.</li><li>LiveKit signaling completed with HTTP <code dir="ltr">101 Switching Protocols</code>.</li><li>Elastic verification found no <code dir="ltr">labels.act</code> or <code dir="ltr">labels.user_reference</code> fields in the resulting trace.</li></ul></body></html>

## Summary by Sourcery

Propagate workflow, correlation, and identity context from orchestration through remote execution into outbound HTTP tasks for consistent cross-service telemetry.

New Features:
- Include workflow instance, business correlation ID, and identity claims in task trace contexts and execution envelopes.
- Attach canonical workflow, correlation, and identity headers to remote execution and outbound HTTP task requests.

Enhancements:
- Normalize and validate identity claims before adding them to telemetry tags, baggage, and headers.
- Use deterministic correlation ID fallbacks based on the current W3C trace ID when business correlation baggage is unavailable.
- Harden outbound HTTP header handling so mapping-provided correlation and identity headers are removed and replaced only with trusted activity context values.

Tests:
- Add unit tests covering remote invocation header propagation, correlation ID fallback behavior, and HTTP task header overriding/removal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved telemetry across workflow executions and remote task calls with workflow, correlation, subject, and acting-subject context.
  * Propagated validated correlation and identity information across asynchronous transitions and outbound HTTP requests.
  * Added safeguards to reject invalid or spoofed correlation and identity headers.
* **Bug Fixes**
  * Ensured correlation IDs consistently derive from available workflow context, tracing data, or a generated identifier.
  * Prevented invalid or missing context from being forwarded in requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->