### PR TITLE
ci: let a failed release be completed instead of skipped

### DIFF
--- a/.github/workflows/build-and-publish-images.yml
+++ b/.github/workflows/build-and-publish-images.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Base version (e.g. 0.0.50). Required when prerelease_type is not none.'
+        description: 'Version (e.g. 0.0.80). Required for a prerelease; on a stable run it pins the version instead of walking to the next free patch — use with force_publish to re-publish a shipped release whose packages failed.'
         required: false
         type: string
       prerelease_type:
@@ -116,6 +116,33 @@ jobs:
             fi
 
             echo "Resolved prerelease version: $VERSION"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "$INPUT_VERSION" ]]; then
+            # Re-publish an EXACT stable version. The branch path below deliberately walks to the
+            # first unused patch, so it can never target a version that already shipped — which is
+            # exactly what is needed when a release succeeded but one publish job failed (e.g. the
+            # NuGet push), leaving images and packages on different versions. Pinning the version
+            # here lets that release be completed instead of skipped.
+            echo "Pinned stable version requested via workflow_dispatch"
+
+            if [[ ! "$INPUT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "Error: 'version' must match X.Y.Z (got: $INPUT_VERSION)"
+              exit 1
+            fi
+
+            VERSION="$INPUT_VERSION"
+            TAG="v${VERSION}"
+
+            # Re-publishing over a shipped tag is intentional here, but never implicit.
+            if git tag -l "$TAG" | grep -q "^$TAG$"; then
+              if [[ "$INPUT_FORCE_PUBLISH" == "true" ]]; then
+                echo "Warning: Tag $TAG already exists but force_publish=true, re-publishing it"
+              else
+                echo "Error: Tag $TAG already exists. Set force_publish=true to re-publish this version."
+                exit 1
+              fi
+            fi
+
+            echo "Resolved pinned version: $VERSION"
           elif [[ "$BRANCH_NAME" =~ ^release-v([0-9]+\.[0-9]+)$ ]]; then
             BASE_VERSION="${BASH_REMATCH[1]}"
             echo "Base version from branch: $BASE_VERSION"
@@ -771,12 +798,15 @@ jobs:
             -p:Version=${{ env.NUGET_VERSION }} \
             --output ./nuget-artifacts
 
-      # An undefined repository variable is silently the empty string, which would
-      # surface as an opaque token-exchange failure below.
+      # An undefined secret is silently the empty string, which would surface as an
+      # opaque token-exchange failure below. Read through env rather than inlining the
+      # expression, so the value stays masked and cannot be interpolated into the script.
       - name: Verify NuGet trusted publishing is configured
+        env:
+          NUGET_USER: ${{ secrets.NUGET_USER }}
         run: |
-          if [ -z "${{ vars.NUGET_USER }}" ]; then
-            echo "::error::Repository variable NUGET_USER is not set. It must hold the nuget.org username that owns the trusted publishing policy for burgan-tech/vnext."
+          if [ -z "$NUGET_USER" ]; then
+            echo "::error::Repository secret NUGET_USER is not set. It must hold the nuget.org username that owns the trusted publishing policy for burgan-tech/vnext."
             exit 1
           fi
 
@@ -788,7 +818,7 @@ jobs:
         id: nuget-login
         uses: NuGet/login@v1
         with:
-          user: ${{ vars.NUGET_USER }}
+          user: ${{ secrets.NUGET_USER }}
 
       - name: Push all packages to NuGet.org
         run: |
@@ -806,7 +836,10 @@ jobs:
           echo "| Package | NuGet |" >> $GITHUB_STEP_SUMMARY
           echo "|---------|-------|" >> $GITHUB_STEP_SUMMARY
           echo "| BBT.Workflow.Events.Contracts | [nuget.org](https://www.nuget.org/packages/BBT.Workflow.Events.Contracts) |" >> $GITHUB_STEP_SUMMARY
-          echo "| BBT.Workflow.Modules.Scripting | [nuget.org](https://www.nuget.org/packages/BBT.Workflow.Modules.Scripting) |" >> $GITHUB_STEP_SUMMARY
+          # PackageId, not the project name: modules/BBT.Workflow.Modules.Scripting packs as
+          # BBT.Workflow.Scripting, and the old link pointed at an id that does not exist on
+          # nuget.org — every release summary carried a dead link.
+          echo "| BBT.Workflow.Scripting | [nuget.org](https://www.nuget.org/packages/BBT.Workflow.Scripting) |" >> $GITHUB_STEP_SUMMARY
           echo "| BBT.Workflow.Domain | [nuget.org](https://www.nuget.org/packages/BBT.Workflow.Domain) |" >> $GITHUB_STEP_SUMMARY
           echo "| BBT.Workflow.Tasks.Abstractions | [nuget.org](https://www.nuget.org/packages/BBT.Workflow.Tasks.Abstractions) |" >> $GITHUB_STEP_SUMMARY
           echo "| BBT.Workflow.Mcp (dotnet tool: \`vnext-mcp\`) | [nuget.org](https://www.nuget.org/packages/BBT.Workflow.Mcp) |" >> $GITHUB_STEP_SUMMARY
@@ -856,7 +889,26 @@ jobs:
         run: npm install -g npm@latest
 
       - name: Verify npm version
-        run: npm -v 
+        run: npm -v
+
+      # `npm publish` fails hard on an already-published version and has no equivalent of
+      # `dotnet nuget push --skip-duplicate`. That turns a re-publish run — the one used to complete
+      # a release whose package step failed — into a red workflow even though nothing is wrong and
+      # nothing is missing. Check first, and skip rather than fail.
+      - name: Check whether this version is already on npm
+        id: npm_exists
+        run: |
+          NAME=$(node -p "require('./package.json').name")
+          VERSION="${{ needs.prepare.outputs.version }}"
+
+          if npm view "${NAME}@${VERSION}" version >/dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "::notice::${NAME}@${VERSION} is already published on npm; skipping publish."
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "${NAME}@${VERSION} is not on npm yet; publishing."
+          fi
 
       - name: Publish to npm (OIDC)
+        if: steps.npm_exists.outputs.exists != 'true'
         run: npm publish --provenance --access public --tag ${{ steps.dist_tag.outputs.tag }}


### PR DESCRIPTION
## Why

The **v0.0.80** release shipped images and a GitHub release but **no NuGet packages**
([run 32013163433](https://github.com/burgan-tech/vnext/actions/runs/32013163433)), and the pipeline
had no way to repair it. Four independent reasons, all fixed here.

## What changed

### 1. `NUGET_USER` is a secret, not a variable

`vars.NUGET_USER` was the empty string, so `publish-nuget` failed its own configuration guard. The
guard now reads `secrets.NUGET_USER` **through `env:`** rather than inlining the expression, so the
value stays masked in logs and cannot be interpolated into the script.

### 2. A shipped release could not be re-published

Two dead ends, worth stating because they are not obvious:

- **Re-running the failed job cannot pick up a fix** — a re-run uses the workflow file from the
  original commit.
- **A fresh run cannot target the same version** — the stable path walks to the first *unused* patch,
  so it would have produced `0.0.81` and left `0.0.80`'s packages permanently missing, with images on
  one version and packages on another.

`workflow_dispatch` now honours the `version` input on the stable path, pinning the version instead of
walking. Re-publishing over a shipped tag is intentional but **never implicit**: it requires
`force_publish=true`. The push path is untouched and still walks to the next free patch.

### 3. npm went red on a re-publish

`npm publish` fails hard on an already-published version and has no equivalent of
`dotnet nuget push --skip-duplicate`. The run that completed 0.0.80's NuGet packages therefore went
red on npm even though the package was already there and nothing was missing. The version is now
checked against the registry first and the publish step is **skipped rather than failed**.

### 4. Dead link in every release summary

The summary linked `BBT.Workflow.Modules.Scripting` — the *project* name. The project packs as
**`BBT.Workflow.Scripting`**, so that link pointed at an id that does not exist on nuget.org. This is
also what made 0.0.80 look partially unpublished during diagnosis until the push log showed the real
package id.

## Reviewer notes

- These four are already **live on `release-v0.0`** for items 1–2 (commit `6c5da794`), which is how
  v0.0.80's packages finally shipped. `release-v0.0` is deliberately left alone; the branch is cut
  from `master`, so landing this here is what carries the fixes into the next version.
- Item 2 changes release semantics. The guard rails: `version` is validated against `X.Y.Z`, an
  existing tag is refused unless `force_publish=true`, and nothing about the `push` trigger changes.
- Pinning a version deliberately re-pushes images at the same tag (new digest) and updates the
  existing GitHub release. That is the point — completing a release rather than starting a new one.

## Verification

Both new scripts were simulated locally before pushing:

| Scenario | Result |
| --- | --- |
| dispatch, `version=0.0.80`, `force_publish=true` | resolves `0.0.80` |
| dispatch, `version=0.0.80`, no force | refuses with a clear error |
| push on `release-v0.0` (regression check) | still resolves `0.0.81` |
| npm check, version already published | `exists=true` → publish skipped |
| npm check, unpublished version | `exists=false` → publish runs |

Items 1–2 are additionally **proven in production**:
[run 32025105316](https://github.com/burgan-tech/vnext/actions/runs/32025105316) published all five
0.0.80 packages — `BBT.Workflow.Domain`, `BBT.Workflow.Events.Contracts`, `BBT.Workflow.Scripting`,
`BBT.Workflow.Tasks.Abstractions`, `BBT.Workflow.Mcp` — all confirmed live on nuget.org. That run's
only failure was the npm step this PR fixes (item 3).

### Not addressed here

`actions/checkout@v4` and `actions/setup-dotnet@v4` still emit a Node 20 deprecation warning. It does
not affect these runs and is left as separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Allow releases whose package publishing previously failed to be re-run and completed without changing the version, while tightening publishing safeguards.

New Features:
- Support pinning an exact stable version on workflow_dispatch to re-publish an existing release when packages failed without advancing the patch version.

Bug Fixes:
- Read the NuGet trusted publishing owner from a secret instead of a repository variable to avoid silent misconfiguration.
- Fix the NuGet package link in the release summary to point to the correct BBT.Workflow.Scripting package on nuget.org.
- Skip npm publish when the target package version is already present in the registry, avoiding spurious failures on re-publish runs.

Enhancements:
- Clarify workflow_dispatch version input semantics in the image build-and-publish workflow and add guardrails for re-publishing over existing tags.