### PR TITLE
fix(observability): export the three missing links that detach a trace subtree in Elastic APM

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,6 +25,9 @@
 
         <!-- OpenTelemetry packages -->
         <OpenTelemetryPackageVersion>1.15.3</OpenTelemetryPackageVersion>
+        <!-- Instrumentation packages that only ship as prerelease. Kept on the same 1.15.x line
+             Aether already pulls for OpenTelemetry.Instrumentation.Process. -->
+        <OpenTelemetryInstrumentationPrereleasePackageVersion>1.15.1-beta.1</OpenTelemetryInstrumentationPrereleasePackageVersion>
       
         <!-- Microsot Test SDK packages -->
         <TestSdkPackageVersion>18.0.1</TestSdkPackageVersion>

--- a/docs/monitoring/correlation-and-tracing.md
+++ b/docs/monitoring/correlation-and-tracing.md
@@ -187,17 +187,55 @@ baggage. Do not re-add them to a log scope.
 
 ## Telemetry configuration
 
-- **OTLP endpoint**: `Telemetry:Otlp:Endpoint` is intentionally NOT set in `appsettings.json` —
-  Aether treats config as stronger than environment, so a hardcoded value would silently override
-  `OTEL_EXPORTER_OTLP_ENDPOINT`. Containers set `OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318`
-  (http/protobuf); bare-metal falls back to `http://localhost:4318`. Elastic APM ingestion is plain
-  OTLP — pointing the collector's exporter at Elastic is an ops-side change only.
+- **OTLP endpoint**: Aether treats configuration as **stronger than the environment** —
+  `Telemetry:Otlp:Endpoint` in `appsettings.json` silently wins over
+  `OTEL_EXPORTER_OTLP_ENDPOINT`. The hosts set it to `http://localhost:4318`, which is correct for
+  the default local flow (`./run-docker.sh` starts infrastructure only, the apps run on the host,
+  and the collector publishes 4318). Anything that runs the apps **in containers** must therefore
+  override the config key, not the OTEL variable: the `etc/docker/.env.*` files set
+  `Telemetry__Otlp__Endpoint=http://otel-collector:4318` for exactly this reason. A deployed
+  environment that only sets `OTEL_EXPORTER_OTLP_ENDPOINT` will export to its own localhost and
+  lose everything.
 - **Workers**: Inbox/Outbox have `TracingEnabled: true` so the subflow completion / continuation
   path is visible in APM (they were previously log-only).
 - **Detail level**: `Telemetry:Tracing:DetailLevel` — `"Business"` (default) keeps production
   traces focused on service boundaries and business spans; `"Verbose"` additionally emits
   task-phase spans (`BBT.Workflow.Tasks`), cache spans (`BBT.Workflow.Cache`), EF Core and Dapr
   state-store spans. Read once at startup — changing it requires a restart.
+
+## Verifying against Elastic APM locally
+
+Production renders traces in Elastic APM, and **Elastic and OpenObserve do not draw the same
+waterfall from the same data**. Elastic resolves nesting strictly through `parent.id`: a span whose
+parent document is absent from the trace is treated as an *orphan* and re-parented to the trace
+root, so it appears at the bottom of the waterfall instead of under its real parent. OpenObserve
+groups by trace id and is far more forgiving, so the same trace can look correct there and broken
+in Elastic. A local trace that only ever gets checked in OpenObserve therefore proves nothing about
+production.
+
+`etc/docker/docker-compose.{yml,dev.yml,stage.yml}` run both backends side by side. The collector
+(`etc/docker/config/otel/otel-config.yaml`) fans traces, metrics and logs out to OpenObserve **and**
+to Elastic APM Server via `otlp/elastic` → `apm-server:8200`; APM Server accepts OTLP natively on
+that port (gRPC and HTTP share it) and writes the `traces-apm-*` / `logs-apm-*` data streams.
+
+| Service | Host port | Where to look |
+|---|---|---|
+| Kibana | 5601 | Observability → APM → Traces (the renderer to trust) |
+| Elasticsearch | 9200 | raw documents, e.g. checking a span's `parent.id` |
+| APM Server | **8201** | intake health only — Vault already owns 8200 on the host |
+| OpenObserve | 5080 | the forgiving second opinion |
+
+Pin the stack version with `ELASTIC_VERSION` (default `8.15.3`) if it needs to match a specific
+production cluster. Security is disabled and APM Server runs with no secret token — local only.
+
+**The Dapr sidecars must load their Configuration for this to be meaningful.** Every
+`etc/*/dapr/config.yaml` sets `samplingRate: "1"` and an OTLP endpoint, but a `daprd` container only
+reads it when started with `--config`; the compose files pass `--config /dapr-config.yaml` and mount
+the file. Without it the sidecars still create and propagate W3C span ids for service invocation
+while exporting none of them — so the Execution transaction's `parent.id` points at a span that
+never reaches Elasticsearch, and Elastic re-roots the whole Execution subtree to the bottom of the
+trace while OpenObserve keeps drawing it in place. That asymmetry is the single most likely cause of
+"the remote call is not under its task span".
 
 ## Diagnostic spans and the Business filter — the creation rule
 
@@ -228,3 +266,10 @@ subflow/subprocess starts have a visible parent.
 5. Spans re-rooted to the top of the trace (e.g. `TaskCoordinator.Execute` not under
    `transition/{key}`) → their parent was created but filtered at export. See "Diagnostic spans
    and the Business filter" above — some span in the chain violates the creation rule.
+6. A subtree that renders correctly in OpenObserve but hangs off the root in Elastic → the parent
+   span id exists on the wire but no document for it reached the backend. Confirm by fetching the
+   orphan's `parent.id` from Elasticsearch and searching the trace for that `span.id`; if it is
+   absent, find who owns that span. For the Orchestration → Execution hop the owner is the Dapr
+   sidecar — see "Verifying against Elastic APM locally". Task-phase spans (`Task.PrepareInput` /
+   `Task.Invoke` / `Task.ProcessOutput`) are Verbose-only by design, so run with
+   `DetailLevel: "Verbose"` while diagnosing or those levels are simply not there to nest under.

--- a/etc/docker/.env.execution.dev
+++ b/etc/docker/.env.execution.dev
@@ -19,6 +19,10 @@ DAPR_PUBSUB_STORE_NAME=vnext-execution-pubsub
 DAPR_PUBSUB_BROADCAST_STORE_NAME=vnext-pubsub-broadcast
 DAPR_LOCK_STORE_NAME=vnext-execution-lock
 OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+# Telemetry:Otlp:Endpoint is set in appsettings.json and Aether treats configuration as
+# stronger than the environment, so OTEL_EXPORTER_OTLP_ENDPOINT alone is ignored inside a
+# container and export would go to this container's own localhost. Override it explicitly.
+Telemetry__Otlp__Endpoint=http://otel-collector:4318
 OTEL_SERVICE_NAME=vnext-execution-app
 ConnectionStrings__Default=Host=vnext-postgres;Port=5432;Database=Aether_WorkflowDb;Username=postgres;Password=postgres;
 Redis__Standalone__EndPoints__0=vnext-redis:6379

--- a/etc/docker/.env.execution.stage
+++ b/etc/docker/.env.execution.stage
@@ -15,6 +15,10 @@ DAPR_PUBSUB_STORE_NAME=vnext-execution-pubsub
 DAPR_PUBSUB_BROADCAST_STORE_NAME=vnext-pubsub-broadcast
 DAPR_LOCK_STORE_NAME=vnext-execution-lock
 OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+# Telemetry:Otlp:Endpoint is set in appsettings.json and Aether treats configuration as
+# stronger than the environment, so OTEL_EXPORTER_OTLP_ENDPOINT alone is ignored inside a
+# container and export would go to this container's own localhost. Override it explicitly.
+Telemetry__Otlp__Endpoint=http://otel-collector:4318
 OTEL_SERVICE_NAME=vnext-execution-app
 ConnectionStrings__Default=Host=vnext-postgres;Port=5432;Database=Aether_WorkflowDb;Username=postgres;Password=postgres;
 Redis__Standalone__EndPoints__0=vnext-redis:6379

--- a/etc/docker/.env.monitoring.dev
+++ b/etc/docker/.env.monitoring.dev
@@ -19,6 +19,10 @@ DAPR_PUBSUB_STORE_NAME=vnext-pubsub
 DAPR_PUBSUB_BROADCAST_STORE_NAME=vnext-pubsub-broadcast
 DAPR_LOCK_STORE_NAME=vnext-lock
 OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+# Telemetry:Otlp:Endpoint is set in appsettings.json and Aether treats configuration as
+# stronger than the environment, so OTEL_EXPORTER_OTLP_ENDPOINT alone is ignored inside a
+# container and export would go to this container's own localhost. Override it explicitly.
+Telemetry__Otlp__Endpoint=http://otel-collector:4318
 OTEL_SERVICE_NAME=vnext-monitoring
 ConnectionStrings__Default=Host=vnext-postgres;Port=5432;Database=Aether_WorkflowDb;Username=postgres;Password=postgres;
 Redis__Standalone__EndPoints__0=vnext-redis:6379

--- a/etc/docker/.env.monitoring.stage
+++ b/etc/docker/.env.monitoring.stage
@@ -15,6 +15,10 @@ DAPR_PUBSUB_STORE_NAME=vnext-pubsub
 DAPR_PUBSUB_BROADCAST_STORE_NAME=vnext-pubsub-broadcast
 DAPR_LOCK_STORE_NAME=vnext-lock
 OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+# Telemetry:Otlp:Endpoint is set in appsettings.json and Aether treats configuration as
+# stronger than the environment, so OTEL_EXPORTER_OTLP_ENDPOINT alone is ignored inside a
+# container and export would go to this container's own localhost. Override it explicitly.
+Telemetry__Otlp__Endpoint=http://otel-collector:4318
 OTEL_SERVICE_NAME=vnext-monitoring
 ConnectionStrings__Default=Host=vnext-postgres;Port=5432;Database=Aether_WorkflowDb;Username=postgres;Password=postgres;
 Redis__Standalone__EndPoints__0=vnext-redis:6379

--- a/etc/docker/.env.orchestration.dev
+++ b/etc/docker/.env.orchestration.dev
@@ -19,6 +19,10 @@ DAPR_PUBSUB_STORE_NAME=vnext-pubsub
 DAPR_PUBSUB_BROADCAST_STORE_NAME=vnext-pubsub-broadcast
 DAPR_LOCK_STORE_NAME=vnext-lock
 OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+# Telemetry:Otlp:Endpoint is set in appsettings.json and Aether treats configuration as
+# stronger than the environment, so OTEL_EXPORTER_OTLP_ENDPOINT alone is ignored inside a
+# container and export would go to this container's own localhost. Override it explicitly.
+Telemetry__Otlp__Endpoint=http://otel-collector:4318
 OTEL_SERVICE_NAME=vnext-app
 ConnectionStrings__Default=Host=vnext-postgres;Port=5432;Database=Aether_WorkflowDb;Username=postgres;Password=postgres;
 Redis__Standalone__EndPoints__0=vnext-redis:6379

--- a/etc/docker/.env.orchestration.stage
+++ b/etc/docker/.env.orchestration.stage
@@ -15,6 +15,10 @@ DAPR_PUBSUB_STORE_NAME=vnext-pubsub
 DAPR_PUBSUB_BROADCAST_STORE_NAME=vnext-pubsub-broadcast
 DAPR_LOCK_STORE_NAME=vnext-lock
 OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+# Telemetry:Otlp:Endpoint is set in appsettings.json and Aether treats configuration as
+# stronger than the environment, so OTEL_EXPORTER_OTLP_ENDPOINT alone is ignored inside a
+# container and export would go to this container's own localhost. Override it explicitly.
+Telemetry__Otlp__Endpoint=http://otel-collector:4318
 OTEL_SERVICE_NAME=vnext-app
 ConnectionStrings__Default=Host=vnext-postgres;Port=5432;Database=Aether_WorkflowDb;Username=postgres;Password=postgres;
 Redis__Standalone__EndPoints__0=vnext-redis:6379

--- a/etc/docker/config/apm/apm-server.yml
+++ b/etc/docker/config/apm/apm-server.yml
@@ -1,0 +1,25 @@
+# Elastic APM Server — local development only.
+#
+# Purpose: give the local stack the same trace renderer that production uses. The
+# OpenTelemetry Collector forwards OTLP to this server on 8200 (gRPC and HTTP share
+# the port), which writes into Elasticsearch data streams that Kibana's APM app reads.
+#
+# Deliberately no `auth.secret_token` and no `auth.api_key`: with neither set the
+# server accepts unauthenticated intake, so the collector needs no credentials. Do
+# not copy this file to any shared or deployed environment.
+apm-server:
+  host: "0.0.0.0:8200"
+
+  # No browser agents talk to this server, and RUM would relax CORS for nothing.
+  rum:
+    enabled: false
+
+output.elasticsearch:
+  hosts: ["http://elasticsearch:9200"]
+
+# The collector already batches, so a small queue is enough and keeps startup light.
+queue.mem.events: 4096
+
+logging:
+  level: warning
+  to_stderr: true

--- a/etc/docker/config/otel/otel-config.yaml
+++ b/etc/docker/config/otel/otel-config.yaml
@@ -63,6 +63,29 @@ exporters:
 processors:
   batch:
 
+  # Drops the sidecar's own span for state-store and lock gRPC calls.
+  #
+  # These are pure duplicates with a broken parent. The app already emits
+  # `dapr.proto.runtime.v1.Dapr/GetState` (GrpcNetClient instrumentation) with the call's
+  # timing, correctly nested under the business span. The sidecar's counterpart adds only
+  # its internal handling time — and arrives orphaned, because the HttpClient activity
+  # between the two puts its id on the wire without ever being exported. Elastic APM
+  # re-roots such a span to the trace root, so a single transition litters the waterfall
+  # with ~50 detached GetState spans (45 -> 173 spans measured on one transition).
+  #
+  # Scoped by instrumentation scope, NOT by name: the app-side client span carries the same
+  # `…/GetState` suffix and must survive. `dapr-diagnostics` is the sidecar's scope.
+  # Service-invocation spans (`CallLocal/*`) are deliberately untouched — those are the ones
+  # that reconnect orchestration to Execution.
+  #
+  # This hides a symptom rather than fixing the missing HttpClient span; the underlying hole
+  # lives in the cache/lock client construction path. Remove this processor when that is fixed.
+  filter/drop-dapr-statestore-spans:
+    error_mode: ignore
+    traces:
+      span:
+        - 'instrumentation_scope.name == "dapr-diagnostics" and IsMatch(name, "/(GetState|GetBulkState|SaveState|DeleteState|DeleteBulkState|QueryStateAlpha1|TryLockAlpha1|UnlockAlpha1)$")'
+
 # Configure pipelines. Pipeline defines a path the data follows in the Collector
 # starting from reception, then further processing or modification and finally
 # exiting the Collector via exporters.
@@ -72,7 +95,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch]
+      processors: [filter/drop-dapr-statestore-spans, batch]
       exporters: [debug, otlphttp/openobserve-traces, otlp/elastic]
     metrics:
       receivers: [otlp]

--- a/etc/docker/config/otel/otel-config.yaml
+++ b/etc/docker/config/otel/otel-config.yaml
@@ -41,6 +41,15 @@ exporters:
     tls:
       insecure: true
 
+  # Elastic APM Server — OTLP/gRPC on the same 8200 port it serves intake on. Traces,
+  # metrics and logs all go here, so Kibana's APM app renders the same data OpenObserve
+  # gets. Kept alongside the OpenObserve exporters on purpose: the two backends
+  # reconstruct a trace waterfall differently, and comparing them is the point.
+  otlp/elastic:
+    endpoint: "apm-server:8200"
+    tls:
+      insecure: true
+
   # log to the console
   debug:
     verbosity: detailed
@@ -64,12 +73,12 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [debug, otlphttp/openobserve-traces]
+      exporters: [debug, otlphttp/openobserve-traces, otlp/elastic]
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [debug, otlphttp/openobserve-metrics]
+      exporters: [debug, otlphttp/openobserve-metrics, otlp/elastic]
     logs:
       receivers: [otlp]
       processors: [batch]
-      exporters: [debug, otlphttp/openobserve-logs]
+      exporters: [debug, otlphttp/openobserve-logs, otlp/elastic]

--- a/etc/docker/docker-compose.dev.yml
+++ b/etc/docker/docker-compose.dev.yml
@@ -102,6 +102,7 @@ services:
     container_name: vnext-orchestration-dapr
     command: [
       "./daprd",
+      "--config", "/dapr-config.yaml",
       "--app-id", "vnext-app",
       "--app-port", "5000",
       "--resources-path", "./components",
@@ -112,6 +113,7 @@ services:
     ]
     volumes:
       - "../../etc/orchestration/dapr/components:/components"
+      - "../../etc/orchestration/dapr/config.yaml:/dapr-config.yaml"
     network_mode: "service:vnext-app"
     depends_on:
       - vnext-app
@@ -125,6 +127,7 @@ services:
     container_name: vnext-execution-dapr
     command: [
       "./daprd",
+      "--config", "/dapr-config.yaml",
       "--app-id", "vnext-execution-app",
       "--app-port", "5000",
       "--resources-path", "./components",
@@ -135,6 +138,7 @@ services:
     ]
     volumes:
       - "../../etc/execution/dapr/components:/components"
+      - "../../etc/execution/dapr/config.yaml:/dapr-config.yaml"
     network_mode: "service:vnext-execution-app"
     depends_on:
       - vnext-execution-app
@@ -185,6 +189,7 @@ services:
     container_name: vnext-monitoring-dapr
     command: [
       "./daprd",
+      "--config", "/dapr-config.yaml",
       "--app-id", "vnext-monitoring",
       "--app-port", "5000",
       "--resources-path", "./components",
@@ -195,6 +200,7 @@ services:
     ]
     volumes:
       - "../../etc/monitoring/dapr/components:/components"
+      - "../../etc/monitoring/dapr/config.yaml:/dapr-config.yaml"
     network_mode: "service:vnext-monitoring-app"
     depends_on:
       - vnext-monitoring-app
@@ -208,6 +214,7 @@ services:
     container_name: vnext-db-migrator-dapr
     command: [
       "./daprd",
+      "--config", "/dapr-config.yaml",
       "--app-id", "vnext-db-migrator",
       "--resources-path", "./components",
       "--dapr-grpc-port", "44211",
@@ -217,6 +224,7 @@ services:
     ]
     volumes:
       - "../../etc/workers/db-migrator/dapr/components:/components"
+      - "../../etc/workers/db-migrator/dapr/config.yaml:/dapr-config.yaml"
     ports:
       - "44210:44210"
       - "44211:44211"
@@ -359,6 +367,73 @@ services:
     networks:
       - bbt-development
 
+  # Elasticsearch — local mirror of the production trace backend. OpenObserve and
+  # Elastic APM reconstruct a waterfall differently (Elastic re-parents a span whose
+  # parent was never exported), so a trace that looks correct in OpenObserve can look
+  # broken in Elastic. Both run side by side here so the two renderings can be compared.
+  elasticsearch:
+    container_name: vnext-elasticsearch
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.15.3}
+    environment:
+      discovery.type: single-node
+      xpack.security.enabled: "false"
+      xpack.security.enrollment.enabled: "false"
+      ingest.geoip.downloader.enabled: "false"
+      ES_JAVA_OPTS: "-Xms1g -Xmx1g"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    ports:
+      - "9200:9200"
+    volumes:
+      - elasticsearch:/usr/share/elasticsearch/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS 'http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=1s' >/dev/null"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+    networks:
+      - bbt-development
+
+  # Kibana — the APM app (Observability > APM > Traces) is the renderer to verify against.
+  kibana:
+    container_name: vnext-kibana
+    image: docker.elastic.co/kibana/kibana:${ELASTIC_VERSION:-8.15.3}
+    environment:
+      ELASTICSEARCH_HOSTS: '["http://elasticsearch:9200"]'
+      # Must be at least 32 chars, and stable, or saved objects are re-encrypted on
+      # every restart and the APM app loses its state.
+      XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY: "vnext-local-dev-kibana-encryption-key"
+    ports:
+      - "5601:5601"
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    networks:
+      - bbt-development
+
+  # APM Server — accepts OTLP natively on 8200 (gRPC and HTTP on the same port) and
+  # writes Elastic's traces-apm-* / logs-apm-* data streams.
+  apm-server:
+    container_name: vnext-apm-server
+    image: docker.elastic.co/apm/apm-server:${ELASTIC_VERSION:-8.15.3}
+    # strict.perms is relaxed because the config file is bind-mounted from the repo and
+    # will not be owned by the in-image apm-server user.
+    command: ["--strict.perms=false", "-e"]
+    volumes:
+      - ./config/apm/apm-server.yml:/usr/share/apm-server/apm-server.yml:ro
+    ports:
+      # Vault already publishes 8200 on the host, so this is 8201 outside; inside the
+      # compose network it still listens on 8200, which is what the collector targets.
+      - "8201:8200"
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    networks:
+      - bbt-development
+
   # OpenObserve for observability
   openobserve:
     container_name: vnext-openobserve
@@ -390,6 +465,7 @@ services:
       - "55679:55679" # zpages extension
     depends_on:
       - openobserve
+      - apm-server
     networks:
       - bbt-development
 
@@ -401,6 +477,7 @@ volumes:
   redis:
   postgres:
   openobserve:
+  elasticsearch:
   vnext-app:
   vnext-execution-app:
   vnext-monitoring-app:

--- a/etc/docker/docker-compose.stage.yml
+++ b/etc/docker/docker-compose.stage.yml
@@ -80,6 +80,7 @@ services:
     container_name: vnext-orchestration-dapr
     command: [
       "./daprd",
+      "--config", "/dapr-config.yaml",
       "--app-id", "vnext-app",
       "--app-port", "5000",
       "--resources-path", "./components",
@@ -90,6 +91,7 @@ services:
     ]
     volumes:
       - "../../etc/orchestration/dapr/components:/components"
+      - "../../etc/orchestration/dapr/config.yaml:/dapr-config.yaml"
     network_mode: "service:vnext-app"
     depends_on:
       - vnext-app
@@ -103,6 +105,7 @@ services:
     container_name: vnext-execution-dapr
     command: [
       "./daprd",
+      "--config", "/dapr-config.yaml",
       "--app-id", "vnext-execution-app",
       "--app-port", "5000",
       "--resources-path", "./components",
@@ -113,6 +116,7 @@ services:
     ]
     volumes:
       - "../../etc/execution/dapr/components:/components"
+      - "../../etc/execution/dapr/config.yaml:/dapr-config.yaml"
     network_mode: "service:vnext-execution-app"
     depends_on:
       - vnext-execution-app
@@ -150,6 +154,7 @@ services:
     container_name: vnext-monitoring-dapr
     command: [
       "./daprd",
+      "--config", "/dapr-config.yaml",
       "--app-id", "vnext-monitoring",
       "--app-port", "5000",
       "--resources-path", "./components",
@@ -160,6 +165,7 @@ services:
     ]
     volumes:
       - "../../etc/monitoring/dapr/components:/components"
+      - "../../etc/monitoring/dapr/config.yaml:/dapr-config.yaml"
     network_mode: "service:vnext-monitoring-app"
     depends_on:
       - vnext-monitoring-app
@@ -173,6 +179,7 @@ services:
     container_name: vnext-db-migrator-dapr
     command: [
       "./daprd",
+      "--config", "/dapr-config.yaml",
       "--app-id", "vnext-db-migrator",
       "--resources-path", "./components",
       "--dapr-grpc-port", "44211",
@@ -182,6 +189,7 @@ services:
     ]
     volumes:
       - "../../etc/workers/db-migrator/dapr/components:/components"
+      - "../../etc/workers/db-migrator/dapr/config.yaml:/dapr-config.yaml"
     ports:
       - "44210:44210"
       - "44211:44211"
@@ -312,6 +320,73 @@ services:
     networks:
       - bbt-development
 
+  # Elasticsearch — local mirror of the production trace backend. OpenObserve and
+  # Elastic APM reconstruct a waterfall differently (Elastic re-parents a span whose
+  # parent was never exported), so a trace that looks correct in OpenObserve can look
+  # broken in Elastic. Both run side by side here so the two renderings can be compared.
+  elasticsearch:
+    container_name: vnext-elasticsearch
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.15.3}
+    environment:
+      discovery.type: single-node
+      xpack.security.enabled: "false"
+      xpack.security.enrollment.enabled: "false"
+      ingest.geoip.downloader.enabled: "false"
+      ES_JAVA_OPTS: "-Xms1g -Xmx1g"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    ports:
+      - "9200:9200"
+    volumes:
+      - elasticsearch:/usr/share/elasticsearch/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS 'http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=1s' >/dev/null"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+    networks:
+      - bbt-development
+
+  # Kibana — the APM app (Observability > APM > Traces) is the renderer to verify against.
+  kibana:
+    container_name: vnext-kibana
+    image: docker.elastic.co/kibana/kibana:${ELASTIC_VERSION:-8.15.3}
+    environment:
+      ELASTICSEARCH_HOSTS: '["http://elasticsearch:9200"]'
+      # Must be at least 32 chars, and stable, or saved objects are re-encrypted on
+      # every restart and the APM app loses its state.
+      XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY: "vnext-local-dev-kibana-encryption-key"
+    ports:
+      - "5601:5601"
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    networks:
+      - bbt-development
+
+  # APM Server — accepts OTLP natively on 8200 (gRPC and HTTP on the same port) and
+  # writes Elastic's traces-apm-* / logs-apm-* data streams.
+  apm-server:
+    container_name: vnext-apm-server
+    image: docker.elastic.co/apm/apm-server:${ELASTIC_VERSION:-8.15.3}
+    # strict.perms is relaxed because the config file is bind-mounted from the repo and
+    # will not be owned by the in-image apm-server user.
+    command: ["--strict.perms=false", "-e"]
+    volumes:
+      - ./config/apm/apm-server.yml:/usr/share/apm-server/apm-server.yml:ro
+    ports:
+      # Vault already publishes 8200 on the host, so this is 8201 outside; inside the
+      # compose network it still listens on 8200, which is what the collector targets.
+      - "8201:8200"
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    networks:
+      - bbt-development
+
   # OpenObserve for observability
   openobserve:
     container_name: vnext-openobserve
@@ -343,6 +418,7 @@ services:
       - "55679:55679" # zpages extension
     depends_on:
       - openobserve
+      - apm-server
     networks:
       - bbt-development
 
@@ -354,5 +430,6 @@ volumes:
   redis:
   postgres:
   openobserve:
+  elasticsearch:
   vnext-monitoring-app:
   npm-cache: {}

--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     container_name: vnext-orchestration-dapr
     command: [
       "./daprd",
+      "--config", "/dapr-config.yaml",
       "--app-id", "vnext-app",
       "--app-port", "4201",
       "--resources-path", "./components",
@@ -41,6 +42,7 @@ services:
     ]
     volumes:
       - "../../etc/orchestration/dapr/components:/components"
+      - "../../etc/orchestration/dapr/config.yaml:/dapr-config.yaml"
     ports:
       - "42110:42110"
       - "42111:42111"
@@ -59,6 +61,7 @@ services:
     container_name: vnext-execution-dapr
     command: [
       "./daprd",
+      "--config", "/dapr-config.yaml",
       "--app-id", "vnext-execution-app",
       "--app-port", "4202",
       "--resources-path", "./components",
@@ -70,6 +73,7 @@ services:
     ]
     volumes:
       - "../../etc/execution/dapr/components:/components"
+      - "../../etc/execution/dapr/config.yaml:/dapr-config.yaml"
     ports:
       - "43110:43110"
       - "43111:43111"
@@ -88,6 +92,7 @@ services:
     container_name: vnext-worker-outbox-dapr
     command: [
       "./daprd",
+      "--config", "/dapr-config.yaml",
       "--app-id", "vnext-worker-outbox",
       "--app-port", "4401",
       "--resources-path", "./components",
@@ -99,6 +104,7 @@ services:
     ]
     volumes:
       - "../../etc/workers/outbox/dapr/components:/components"
+      - "../../etc/workers/outbox/dapr/config.yaml:/dapr-config.yaml"
     ports:
       - "44110:44110"
       - "44111:44111"
@@ -117,6 +123,7 @@ services:
     container_name: vnext-worker-inbox-dapr
     command: [
       "./daprd",
+      "--config", "/dapr-config.yaml",
       "--app-id", "vnext-worker-inbox",
       "--app-port", "4501",
       "--resources-path", "./components",
@@ -128,6 +135,7 @@ services:
     ]
     volumes:
       - "../../etc/workers/inbox/dapr/components:/components"
+      - "../../etc/workers/inbox/dapr/config.yaml:/dapr-config.yaml"
     ports:
       - "45110:45110"
       - "45111:45111"
@@ -146,6 +154,7 @@ services:
     container_name: vnext-db-migrator-dapr
     command: [
       "./daprd",
+      "--config", "/dapr-config.yaml",
       "--app-id", "vnext-db-migrator",
       "--resources-path", "./components",
       "--dapr-grpc-port", "44211",
@@ -156,6 +165,7 @@ services:
     ]
     volumes:
       - "../../etc/workers/db-migrator/dapr/components:/components"
+      - "../../etc/workers/db-migrator/dapr/config.yaml:/dapr-config.yaml"
     ports:
       - "44210:44210"
       - "44211:44211"
@@ -174,6 +184,7 @@ services:
     container_name: vnext-monitoring-dapr
     command: [
       "./daprd",
+      "--config", "/dapr-config.yaml",
       "--app-id", "vnext-monitoring",
       "--app-port", "4203",
       "--resources-path", "./components",
@@ -184,7 +195,8 @@ services:
       "--app-channel-address", "host.orb.local"
     ]
     volumes:
-      - "../../etc/workers/monitoring/dapr/components:/components"
+      - "../../etc/monitoring/dapr/components:/components"
+      - "../../etc/monitoring/dapr/config.yaml:/dapr-config.yaml"
     ports:
       - "42130:42130"
       - "42131:42131"
@@ -298,6 +310,73 @@ services:
     networks:
       - bbt-development
 
+  # Elasticsearch — local mirror of the production trace backend. OpenObserve and
+  # Elastic APM reconstruct a waterfall differently (Elastic re-parents a span whose
+  # parent was never exported), so a trace that looks correct in OpenObserve can look
+  # broken in Elastic. Both run side by side here so the two renderings can be compared.
+  elasticsearch:
+    container_name: vnext-elasticsearch
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.15.3}
+    environment:
+      discovery.type: single-node
+      xpack.security.enabled: "false"
+      xpack.security.enrollment.enabled: "false"
+      ingest.geoip.downloader.enabled: "false"
+      ES_JAVA_OPTS: "-Xms1g -Xmx1g"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    ports:
+      - "9200:9200"
+    volumes:
+      - elasticsearch:/usr/share/elasticsearch/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS 'http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=1s' >/dev/null"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+    networks:
+      - bbt-development
+
+  # Kibana — the APM app (Observability > APM > Traces) is the renderer to verify against.
+  kibana:
+    container_name: vnext-kibana
+    image: docker.elastic.co/kibana/kibana:${ELASTIC_VERSION:-8.15.3}
+    environment:
+      ELASTICSEARCH_HOSTS: '["http://elasticsearch:9200"]'
+      # Must be at least 32 chars, and stable, or saved objects are re-encrypted on
+      # every restart and the APM app loses its state.
+      XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY: "vnext-local-dev-kibana-encryption-key"
+    ports:
+      - "5601:5601"
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    networks:
+      - bbt-development
+
+  # APM Server — accepts OTLP natively on 8200 (gRPC and HTTP on the same port) and
+  # writes Elastic's traces-apm-* / logs-apm-* data streams.
+  apm-server:
+    container_name: vnext-apm-server
+    image: docker.elastic.co/apm/apm-server:${ELASTIC_VERSION:-8.15.3}
+    # strict.perms is relaxed because the config file is bind-mounted from the repo and
+    # will not be owned by the in-image apm-server user.
+    command: ["--strict.perms=false", "-e"]
+    volumes:
+      - ./config/apm/apm-server.yml:/usr/share/apm-server/apm-server.yml:ro
+    ports:
+      # Vault already publishes 8200 on the host, so this is 8201 outside; inside the
+      # compose network it still listens on 8200, which is what the collector targets.
+      - "8201:8200"
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    networks:
+      - bbt-development
+
   # OpenObserve for observability
   openobserve:
     container_name: vnext-openobserve
@@ -329,6 +408,7 @@ services:
       - "55679:55679" # zpages extension
     depends_on:
       - openobserve
+      - apm-server
     networks:
       - bbt-development
 
@@ -340,4 +420,5 @@ volumes:
   redis:
   postgres:
   openobserve:
+  elasticsearch:
   npm-cache: {}

--- a/etc/execution/dapr/config.yaml
+++ b/etc/execution/dapr/config.yaml
@@ -6,8 +6,12 @@ metadata:
 spec:
   tracing:
     samplingRate: "1"
-    otlp:
-      endpointAddress: "http://otel-collector:4317"
+    # See etc/orchestration/dapr/config.yaml — `otel` (not `otlp`), plus an explicit
+    # protocol and isSecure, are all three required for the sidecar to export its spans.
+    otel:
+      endpointAddress: "otel-collector:4317"
+      protocol: "grpc"
+      isSecure: false
   secrets:
     scopes:
       - storeName: vnext-execution-secret

--- a/etc/monitoring/dapr/config.yaml
+++ b/etc/monitoring/dapr/config.yaml
@@ -6,8 +6,12 @@ metadata:
 spec:
   tracing:
     samplingRate: "1"
-    otlp:
-      endpointAddress: "http://otel-collector:4317"
+    # See etc/orchestration/dapr/config.yaml — `otel` (not `otlp`), plus an explicit
+    # protocol and isSecure, are all three required for the sidecar to export its spans.
+    otel:
+      endpointAddress: "otel-collector:4317"
+      protocol: "grpc"
+      isSecure: false
   secrets:
     scopes:
       - storeName: vnext-execution-secret

--- a/etc/orchestration/dapr/config.yaml
+++ b/etc/orchestration/dapr/config.yaml
@@ -6,8 +6,17 @@ metadata:
 spec:
   tracing:
     samplingRate: "1"
-    otlp:
-      endpointAddress: "http://otel-collector:4317"
+    # Key MUST be `otel` — Dapr's TracingSpec has no `otlp` field, so an `otlp:` block is
+    # silently ignored: the sampler still initializes and the sidecar still creates and
+    # propagates span ids, but no exporter is built. The callee's transaction then names a
+    # parent span no backend ever saw and Elastic APM re-roots the whole subtree.
+    # `protocol` and `isSecure` are both required, not optional: Dapr builds no exporter
+    # without an explicit protocol, and isSecure defaults to TLS, which a plaintext
+    # collector refuses. All three verified by span-arrival tests.
+    otel:
+      endpointAddress: "otel-collector:4317"
+      protocol: "grpc"
+      isSecure: false
   secrets:
     scopes:
       - storeName: vnext-secret

--- a/etc/workers/db-migrator/dapr/config.yaml
+++ b/etc/workers/db-migrator/dapr/config.yaml
@@ -6,8 +6,12 @@ metadata:
 spec:
   tracing:
     samplingRate: "1"
-    otlp:
-      endpointAddress: "http://otel-collector:4317"
+    # See etc/orchestration/dapr/config.yaml — `otel` (not `otlp`), plus an explicit
+    # protocol and isSecure, are all three required for the sidecar to export its spans.
+    otel:
+      endpointAddress: "otel-collector:4317"
+      protocol: "grpc"
+      isSecure: false
   secrets:
     scopes:
       - storeName: vnext-secret

--- a/etc/workers/inbox/dapr/config.yaml
+++ b/etc/workers/inbox/dapr/config.yaml
@@ -6,8 +6,12 @@ metadata:
 spec:
   tracing:
     samplingRate: "1"
-    otlp:
-      endpointAddress: "http://otel-collector:4317"
+    # See etc/orchestration/dapr/config.yaml — `otel` (not `otlp`), plus an explicit
+    # protocol and isSecure, are all three required for the sidecar to export its spans.
+    otel:
+      endpointAddress: "otel-collector:4317"
+      protocol: "grpc"
+      isSecure: false
   secrets:
     scopes:
       - storeName: vnext-secret

--- a/etc/workers/outbox/dapr/config.yaml
+++ b/etc/workers/outbox/dapr/config.yaml
@@ -6,8 +6,12 @@ metadata:
 spec:
   tracing:
     samplingRate: "1"
-    otlp:
-      endpointAddress: "http://otel-collector:4317"
+    # See etc/orchestration/dapr/config.yaml — `otel` (not `otlp`), plus an explicit
+    # protocol and isSecure, are all three required for the sidecar to export its spans.
+    otel:
+      endpointAddress: "otel-collector:4317"
+      protocol: "grpc"
+      isSecure: false
   secrets:
     scopes:
       - storeName: vnext-secret

--- a/src/BBT.Workflow.HttpApi.Shared/BBT.Workflow.HttpApi.Shared.csproj
+++ b/src/BBT.Workflow.HttpApi.Shared/BBT.Workflow.HttpApi.Shared.csproj
@@ -14,6 +14,10 @@
     <PackageReference Include="Dapr.AspNetCore" Version="$(DaprPackageVersion)" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="$(PrometheusVersion)" />
     <PackageReference Include="prometheus-net.AspNetCore.HealthChecks" Version="$(PrometheusVersion)" />
+    <!-- Exports the Grpc.Net.Client span that Dapr.Client's gRPC calls create. Without it that
+         activity is still created and still becomes the parent of the System.Net.Http span, but is
+         never exported — see AddTelemetry for why that breaks the trace tree. -->
+    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="$(OpenTelemetryInstrumentationPrereleasePackageVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\BBT.Workflow.Domain\BBT.Workflow.Domain.csproj" />

--- a/src/BBT.Workflow.HttpApi.Shared/Microsoft/Extensions/DependencyInjection/WorkflowApiBaseServiceCollectionExtensions.cs
+++ b/src/BBT.Workflow.HttpApi.Shared/Microsoft/Extensions/DependencyInjection/WorkflowApiBaseServiceCollectionExtensions.cs
@@ -241,8 +241,19 @@ public static class WorkflowApiBaseServiceCollectionExtensions
                         new RequestIdLogProcessor(serviceProvider.GetRequiredService<ICorrelationIdProvider>())))
                 // Span counterpart, so a trace filters on the same x_request_id value as the logs.
                 .ConfigureTracing((_, tracing) =>
-                    tracing.AddProcessor(serviceProvider =>
-                        new RequestIdSpanProcessor(serviceProvider.GetRequiredService<ICorrelationIdProvider>()))));
+                    tracing
+                        // Aether registers AspNetCore + HttpClient instrumentation, but nothing for
+                        // gRPC. Grpc.Net.Client — which every Dapr.Client call goes through — creates
+                        // its own activity regardless, and the System.Net.Http span for the HTTP/2
+                        // request nests under it. Unexported, that activity leaves a hole: the
+                        // HttpClient span names a parent no backend ever saw, and Elastic APM
+                        // re-parents such a span to the trace root, detaching it from the pipeline
+                        // that issued the call. Registering the instrumentation exports the parent
+                        // and closes the hole; this is the same failure mode Business-mode span
+                        // filtering causes, documented on PipelineStepActivityHelper.
+                        .AddGrpcClientInstrumentation()
+                        .AddProcessor(serviceProvider =>
+                            new RequestIdSpanProcessor(serviceProvider.GetRequiredService<ICorrelationIdProvider>()))));
         return services;
     }
 


### PR DESCRIPTION
## What

A client's transition now renders as **one unbroken tree** in Kibana's APM waterfall, from the inbound `PATCH …/transitions/{key}` down to the outbound task request. Three separate links between the entry point and the remote call were never exported, and this branch closes all three.

Every one produced the same shape: a span whose parent id was propagated over the wire but whose parent document no backend ever received. Elastic APM re-parents such a span to the trace root (OpenObserve keeps drawing it in place, which is why this was invisible until 7edda306 added Elastic locally). The consequence was that the entire Execution subtree — the sidecar hops, the Execution transaction, and the remote HTTP call inside it — detached from under `Dapr invoke vnext-execution-app`.

`Telemetry:Tracing:DetailLevel` stays **Business** throughout. That is the level the environments run, so the tree has to be correct at that level rather than only at Verbose.

## Measured

One `approve-account-opening` transition, before and after:

| | before | after |
|---|---|---|
| orphans on the business path | Execution subtree detached | **0** |
| orphaned gRPC client spans | 6 | **0** |
| orphaned state-store / lock spans | 55 (invisible — sidecar exported nothing) | **0** |

Resulting chain, verified end to end:

```
Task.Execute.validate-account-policies
└─ Dapr invoke vnext-execution-app                     (app)
   └─ CallLocal/…validate-account-policies              (dapr, vnext-app sidecar)
      └─ CallLocal/…validate-account-policies           (dapr, execution sidecar)
         └─ POST …/execution/invoke/{type}/{key}        (execution app)
            └─ POST                                     ← the remote request, 23 ms
```

## The three fixes

**1. Dapr sidecars exported nothing** — `etc/*/dapr/config.yaml` (6 files)

The tracing block was authored under `otlp:`, a key Dapr's `TracingSpec` does not have, so it was silently ignored. The sampler still initialized and the sidecar still created and propagated span ids while building no exporter — which is exactly why there was no error to find. 7edda306 passing `--config` was necessary but not sufficient.

The field is `otel`, and `protocol` and `isSecure` turned out to be required rather than optional: Dapr builds no exporter without an explicit protocol, and `isSecure` defaults to TLS, which the plaintext collector refuses. Each was isolated with a span-arrival test:

| config | dapr spans |
|---|---|
| `otlp:` (original, and with the scheme stripped, and with both extra fields) | none |
| `otel:` + endpoint | none |
| `otel:` + `isSecure` | none |
| `otel:` + `protocol` | none |
| `otel:` + `protocol` + `isSecure` | **arrive, 0 orphans** |

**2. No gRPC client instrumentation** — `Directory.Build.props`, `BBT.Workflow.HttpApi.Shared.csproj`, `WorkflowApiBaseServiceCollectionExtensions.cs`

Aether registers AspNetCore and HttpClient instrumentation only. `Grpc.Net.Client` — which every `Dapr.Client` call goes through — creates its activity regardless, and the `System.Net.Http` span nests under it, so the unexported gRPC activity was a hole. The discriminator was exact: **every** HTTP/2 client span in a trace was orphaned and **every** HTTP/1.1 one correctly parented.

Registering `OpenTelemetry.Instrumentation.GrpcNetClient` exports the parent. The single `AddTelemetry` feeds all five hosts, so one registration covers orchestration, execution, inbox, outbox and db-migrator. The package only ships prerelease; pinned to the same 1.15.x line Aether already pulls for `OpenTelemetry.Instrumentation.Process`.

**3. 55 state-store / lock holes surfaced** — `etc/docker/config/otel/otel-config.yaml`

Turning on sidecar export revealed 55 pre-existing holes, all state-store or lock calls (`GetState` ×47, `TryLock`/`Unlock`, `SaveState`). These were always broken; the sidecar exporting nothing had hidden them. Here the app's gRPC span *is* exported and correctly nested — the `HttpClient` activity below it puts its id on the wire without being exported, and the sidecar parents onto that.

The collector now drops the sidecar's duplicate. It carries only the sidecar's own internal handling time, the app already reports the call with its timing, and it cost ~50 detached spans per transition (45 → 173 spans on one request).

## Reviewer notes

- **The filter is symptom suppression, and says so.** The real defect is the missing HttpClient span. I could not explain why it exports for `ScheduleJobAlpha1`/`InvokeBinding` but not for `GetState`/lock — the difference lies in the client-construction path (`Dapr.Jobs`/`DaprClient` vs Aether's `AddDaprDistributedCache`/`AddDaprDistributedLock`), and chasing it likely means an Aether change. The processor comment marks it for removal once that lands. Happy to split it out if you'd rather not carry it.
- **The filter is scoped by instrumentation scope, deliberately not by name.** The app-side client span carries the same `…/GetState` suffix; matching on the name would delete the span we want to keep. `dapr-diagnostics` is the sidecar's scope. `CallLocal/*` is untouched — those are the spans that reconnect Orchestration to Execution. Verified none of the 55 dropped spans had children, so dropping them orphans nothing.
- **`isSecure: false` is right for a plaintext local collector, not universally.** A TLS collector needs that line changed.
- **Span volume still rises**, 45 → ~118 per transition even after the filter, because the app-side gRPC spans are new. Related and worth a separate look: a single transition makes ~50 `GetState` calls.
- **Out of scope, noticed in passing:** `docker-compose.dev.yml` and `.stage.yml` mount only the orchestration, execution, monitoring and db-migrator sidecar configs — inbox and outbox are mounted by `docker-compose.yml` alone, so in dev/stage those two sidecars run without a Configuration. All six files are fixed here regardless.

## Verification

- `dotnet build` clean on all four consuming hosts (0 errors; only pre-existing CS0618/CS1573 warnings).
- Sidecar fix and filter verified by querying Elasticsearch directly for span/parent id closure rather than by eyeballing the waterfall.
- Filter verified on live traffic: app-side `GetState` spans preserved (6), sidecar counterparts dropped (0), orphans 0.
- Three probe traces used a fabricated task key and returned 500 (`probe-span-test`, `final-smoke`, `d1db1161…` predecessors) — they exercise span emission only; the 500s are the probes, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align local and containerized telemetry with Elastic APM so Dapr sidecar spans are exported correctly and trace trees remain attached end to end.

Enhancements:
- Enable Dapr sidecars across all services to load their tracing Configuration and export spans via the correct OTEL settings.
- Add gRPC client instrumentation to the shared HTTP API telemetry pipeline so Dapr gRPC client spans are exported and HTTP client spans remain correctly parented.
- Fan OpenTelemetry Collector outputs to both OpenObserve and Elastic APM Server, filtering duplicate Dapr state-store/lock spans to reduce orphaned noise.
- Introduce a local Elastic stack (Elasticsearch, Kibana, APM Server) in docker-compose to mirror production trace rendering and support side-by-side comparison with OpenObserve.
- Clarify telemetry configuration and add guidance for validating traces against Elastic APM and diagnosing Elastic-vs-OpenObserve discrepancies in documentation.

Build:
- Extend docker-compose configurations (default, dev, stage) to mount Dapr config files into sidecar containers and wire OTLP exporters to the local Elastic stack.