### PR TITLE
fix

### DIFF
--- a/src/BBT.Workflow.Application/Instances/Managers/InstanceBusyManager.cs
+++ b/src/BBT.Workflow.Application/Instances/Managers/InstanceBusyManager.cs
@@ -15,6 +15,12 @@ public sealed class InstanceBusyManager(
     /// <inheritdoc />
     public async Task<bool> MarkBusyAsync(Guid instanceId, CancellationToken cancellationToken = default)
     {
+        await using var uow = uowManager.Begin(
+            new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew, IsTransactional = true });
+
+        // This method is called with the instance status lock held. Read inside the isolated UoW
+        // so the decision below is based on the database state observed under that lock, rather
+        // than on an entity tracked by the caller's ambient UoW before the lock was acquired.
         var result = await instanceRepository.GetResultAsync(
             instanceId.ToString(), includeDetails: false, cancellationToken);
 
@@ -28,9 +34,6 @@ public sealed class InstanceBusyManager(
         if (instance.IsBusy || instance.IsCompleted)
             return false;
 
-        await using var uow = uowManager.Begin(
-            new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew, IsTransactional = true });
-
         instance.Busy();
         await instanceRepository.UpdateAsync(instance, false, cancellationToken);
         await uow.CommitAsync(cancellationToken);
@@ -42,14 +45,24 @@ public sealed class InstanceBusyManager(
     /// <inheritdoc />
     public async Task MarkBusyWithPropagationAsync(Guid instanceId, CancellationToken cancellationToken = default)
     {
-        var instance = await instanceRepository.FindWithActiveSubFlowAsync(instanceId, cancellationToken);
+        Instance? instance;
 
-        if (instance is null)
-            return;
-
-        if (instance is { IsBusy: false, IsCompleted: false })
+        await using (var uow = uowManager.Begin(
+                         new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew, IsTransactional = true }))
         {
-            await MarkBusyCoreAsync(instance, cancellationToken);
+            instance = await instanceRepository.FindWithActiveSubFlowAsync(instanceId, cancellationToken);
+
+            if (instance is null)
+                return;
+
+            if (instance is { IsBusy: false, IsCompleted: false })
+            {
+                instance.Busy();
+                await instanceRepository.UpdateAsync(instance, false, cancellationToken);
+                await uow.CommitAsync(cancellationToken);
+
+                logger.InstanceMarkedBusy(instance.Id);
+            }
         }
 
         await PropagateToSubflowAsync(instance, cancellationToken);
@@ -59,15 +72,29 @@ public sealed class InstanceBusyManager(
     public async Task<BusyMarkOutcome> TryMarkBusyWithPropagationAsync(
         Guid instanceId, CancellationToken cancellationToken = default)
     {
-        var instance = await instanceRepository.FindWithActiveSubFlowAsync(instanceId, cancellationToken);
+        Instance instance;
 
-        if (instance is null || instance.IsCompleted)
-            return BusyMarkOutcome.Skipped;
+        await using (var uow = uowManager.Begin(
+                         new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew, IsTransactional = true }))
+        {
+            var current = await instanceRepository.FindWithActiveSubFlowAsync(instanceId, cancellationToken);
 
-        if (instance.IsBusy)
-            return BusyMarkOutcome.AlreadyBusy;
+            if (current is null || current.IsCompleted)
+                return BusyMarkOutcome.Skipped;
 
-        await MarkBusyCoreAsync(instance, cancellationToken);
+            // Authoritative second check: callers hold the distributed status lock while this
+            // transaction is active. A concurrent request that won the race is observed here.
+            if (current.IsBusy)
+                return BusyMarkOutcome.AlreadyBusy;
+
+            current.Busy();
+            await instanceRepository.UpdateAsync(current, false, cancellationToken);
+            await uow.CommitAsync(cancellationToken);
+
+            logger.InstanceMarkedBusy(current.Id);
+            instance = current;
+        }
+
         await PropagateToSubflowAsync(instance, cancellationToken);
 
         return BusyMarkOutcome.Marked;
@@ -76,6 +103,9 @@ public sealed class InstanceBusyManager(
     /// <inheritdoc />
     public async Task<bool> TryReleaseAsync(Guid instanceId, CancellationToken cancellationToken = default)
     {
+        await using var uow = uowManager.Begin(
+            new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew, IsTransactional = true });
+
         var result = await instanceRepository.GetResultAsync(
             instanceId.ToString(), includeDetails: false, cancellationToken);
 
@@ -85,9 +115,6 @@ public sealed class InstanceBusyManager(
         var instance = result.Value;
         if (!instance.IsBusy || instance.IsCompleted)
             return false;
-
-        await using var uow = uowManager.Begin(
-            new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew, IsTransactional = true });
 
         instance.Active();
         await instanceRepository.UpdateAsync(instance, false, cancellationToken);
@@ -114,21 +141,6 @@ public sealed class InstanceBusyManager(
         }
 
         await TryReleaseAsync(instanceId, cancellationToken);
-    }
-
-    /// <summary>
-    /// Persists the Busy flip for an already-loaded instance in an isolated RequiresNew transaction.
-    /// </summary>
-    private async Task MarkBusyCoreAsync(Instance instance, CancellationToken cancellationToken)
-    {
-        await using var uow = uowManager.Begin(
-            new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew, IsTransactional = true });
-
-        instance.Busy();
-        await instanceRepository.UpdateAsync(instance, false, cancellationToken);
-        await uow.CommitAsync(cancellationToken);
-
-        logger.InstanceMarkedBusy(instance.Id);
     }
 
     /// <summary>

--- a/test/BBT.Workflow.Application.Tests/Instances/Managers/InstanceBusyManagerTests.cs
+++ b/test/BBT.Workflow.Application.Tests/Instances/Managers/InstanceBusyManagerTests.cs
@@ -52,8 +52,8 @@ public sealed class InstanceBusyManagerTests
         // Act
         await CreateSut().MarkBusyAsync(instanceId);
 
-        // Assert — no UoW opened, no throw
-        _uowManager.Verify(m => m.Begin(It.IsAny<UnitOfWorkOptions>()), Times.Never);
+        // Assert — the authoritative read happens inside the isolated UoW, but no write occurs
+        _uowManager.Verify(m => m.Begin(It.IsAny<UnitOfWorkOptions>()), Times.Once);
         _instanceRepository.Verify(r => r.UpdateAsync(It.IsAny<Instance>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
@@ -73,7 +73,7 @@ public sealed class InstanceBusyManagerTests
         await CreateSut().MarkBusyAsync(instanceId);
 
         // Assert
-        _uowManager.Verify(m => m.Begin(It.IsAny<UnitOfWorkOptions>()), Times.Never);
+        _uowManager.Verify(m => m.Begin(It.IsAny<UnitOfWorkOptions>()), Times.Once);
         _instanceRepository.Verify(r => r.UpdateAsync(It.IsAny<Instance>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
@@ -118,7 +118,7 @@ public sealed class InstanceBusyManagerTests
         await CreateSut().MarkBusyWithPropagationAsync(instanceId);
 
         // Assert
-        _uowManager.Verify(m => m.Begin(It.IsAny<UnitOfWorkOptions>()), Times.Never);
+        _uowManager.Verify(m => m.Begin(It.IsAny<UnitOfWorkOptions>()), Times.Once);
         _instanceCommandGateway.Verify(g => g.MarkBusyAsync(It.IsAny<MarkBusyInput>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
@@ -220,7 +220,7 @@ public sealed class InstanceBusyManagerTests
 
         // Assert
         outcome.ShouldBe(BusyMarkOutcome.Skipped);
-        _uowManager.Verify(m => m.Begin(It.IsAny<UnitOfWorkOptions>()), Times.Never);
+        _uowManager.Verify(m => m.Begin(It.IsAny<UnitOfWorkOptions>()), Times.Once);
         _instanceCommandGateway.Verify(g => g.MarkBusyAsync(It.IsAny<MarkBusyInput>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
@@ -239,9 +239,9 @@ public sealed class InstanceBusyManagerTests
         // Act
         var outcome = await CreateSut().TryMarkBusyWithPropagationAsync(instanceId);
 
-        // Assert — short-circuits: no UoW, no gateway propagation
+        // Assert — the second check runs inside the UoW and short-circuits without a write
         outcome.ShouldBe(BusyMarkOutcome.AlreadyBusy);
-        _uowManager.Verify(m => m.Begin(It.IsAny<UnitOfWorkOptions>()), Times.Never);
+        _uowManager.Verify(m => m.Begin(It.IsAny<UnitOfWorkOptions>()), Times.Once);
         _instanceCommandGateway.Verify(g => g.MarkBusyAsync(It.IsAny<MarkBusyInput>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
@@ -290,7 +290,7 @@ public sealed class InstanceBusyManagerTests
         await CreateSut().MarkBusyWithPropagationAsync(parentId);
 
         parent.IsBusy.ShouldBeTrue();
-        _uowManager.Verify(m => m.Begin(It.IsAny<UnitOfWorkOptions>()), Times.Never); // no re-flip
+        _uowManager.Verify(m => m.Begin(It.IsAny<UnitOfWorkOptions>()), Times.Once); // read-only re-check
         _instanceCommandGateway.Verify(g => g.MarkBusyAsync(
             It.Is<MarkBusyInput>(i => i.InstanceId == subInstanceId && i.Workflow == "child-flow"),
             It.IsAny<CancellationToken>()), Times.Once);


### PR DESCRIPTION
## Summary by Sourcery

Use isolated transactions for authoritative instance status checks and busy-state updates to prevent concurrent state races.

Bug Fixes:
- Ensure instance busy and release decisions use authoritative database state within an isolated transaction while the status lock is held, preventing stale ambient-unit-of-work state from winning races.

Enhancements:
- Perform busy-state persistence and propagation from the isolated transaction for all busy-marking paths, including the outcome-returning variant.

Tests:
- Update manager tests to verify that isolated units of work are opened for authoritative state checks, including no-op and already-busy cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved instance busy-state marking and release operations by ensuring related reads and updates are handled consistently.
  * Preserved expected behavior for missing, already-busy, skipped, and propagated marking scenarios.
  * Prevented unnecessary writes and propagation when no state change is required.

* **Tests**
  * Updated coverage for transactional handling across direct and propagated busy-state operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->